### PR TITLE
Re-enable group tests 3/3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a PoC Rust implementation of [Messaging Layer Security](https://github.c
 ### Supported ciphersuites
 
 - MLS10_128_HPKEX25519_AES128GCM_SHA256_Ed25519 (MTI)
+- MLS10_128_DHKEMP256_AES128GCM_SHA256_P256
 - MLS10_128_HPKEX25519_CHACHA20POLY1305_SHA256_Ed25519
 
 ## Build
@@ -16,3 +17,7 @@ This is a PoC Rust implementation of [Messaging Layer Security](https://github.c
 ## Test
 
 - run `cargo test`
+
+## Benchmark
+
+- run `cargo bench`

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -7,19 +7,34 @@ use criterion::Criterion;
 use openmls::prelude::*;
 
 fn criterion_kp_bundle(c: &mut Criterion) {
-    c.bench_function("KeyPackage create bundle", |b| {
-        let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-
-        b.iter_with_setup(
-            || {
-                CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, ciphersuite_name)
-                    .unwrap()
-            },
-            |credential_bundle: CredentialBundle| {
-                KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new()).unwrap();
+    for ciphersuite in Config::supported_ciphersuites() {
+        c.bench_function(
+            &format!(
+                "KeyPackage create bundle with ciphersuite: {:?}",
+                ciphersuite.name()
+            ),
+            move |b| {
+                b.iter_with_setup(
+                    || {
+                        CredentialBundle::new(
+                            vec![1, 2, 3],
+                            CredentialType::Basic,
+                            ciphersuite.name(),
+                        )
+                        .unwrap()
+                    },
+                    |credential_bundle: CredentialBundle| {
+                        KeyPackageBundle::new(
+                            &[ciphersuite.name()],
+                            &credential_bundle,
+                            Vec::new(),
+                        )
+                        .unwrap();
+                    },
+                );
             },
         );
-    });
+    }
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/src/ciphersuite/test_ciphersuite.rs
+++ b/src/ciphersuite/test_ciphersuite.rs
@@ -1,6 +1,5 @@
 //! Unit tests for the ciphersuites.
 
-use super::*;
 use crate::config::Config;
 
 // Spot test to make sure hpke seal/open work.
@@ -20,11 +19,10 @@ fn test_hpke_seal_open() {
 
 #[test]
 fn test_sign_verify() {
-    let ciphersuite =
-        Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
-            .unwrap();
-    let keypair = ciphersuite.new_signature_keypair();
-    let payload = &[1, 2, 3];
-    let signature = keypair.sign(payload).unwrap();
-    assert!(keypair.verify(&signature, payload));
+    for ciphersuite in Config::supported_ciphersuites() {
+        let keypair = ciphersuite.new_signature_keypair();
+        let payload = &[1, 2, 3];
+        let signature = keypair.sign(payload).unwrap();
+        assert!(keypair.verify(&signature, payload));
+    }
 }

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -1,86 +1,88 @@
-use crate::config::Config;
 use crate::framing::*;
 
 /// This tests serializing/deserializing MLSPlaintext
 #[test]
 fn codec() {
     use crate::ciphersuite::*;
+    use crate::config::*;
 
-    let ciphersuite =
-        Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
-            .unwrap();
-    let credential_bundle =
-        CredentialBundle::new(vec![7, 8, 9], CredentialType::Basic, ciphersuite.name()).unwrap();
-    let sender = Sender {
-        sender_type: SenderType::Member,
-        sender: LeafIndex::from(2u32),
-    };
-    let mut orig = MLSPlaintext {
-        group_id: GroupId::random(),
-        epoch: GroupEpoch(1u64),
-        sender,
-        authenticated_data: vec![1, 2, 3],
-        content_type: ContentType::Application,
-        content: MLSPlaintextContentType::Application(vec![4, 5, 6]),
-        signature: Signature::new_empty(),
-    };
-    let context = GroupContext {
-        group_id: GroupId::random(),
-        epoch: GroupEpoch(1u64),
-        tree_hash: vec![],
-        confirmed_transcript_hash: vec![],
-    };
-    let serialized_context = context.encode_detached().unwrap();
-    let signature_input = MLSPlaintextTBS::new_from(&orig, Some(serialized_context));
-    orig.signature = signature_input.sign(&credential_bundle);
+    for ciphersuite in Config::supported_ciphersuites() {
+        let credential_bundle =
+            CredentialBundle::new(vec![7, 8, 9], CredentialType::Basic, ciphersuite.name())
+                .unwrap();
+        let sender = Sender {
+            sender_type: SenderType::Member,
+            sender: LeafIndex::from(2u32),
+        };
+        let mut orig = MLSPlaintext {
+            group_id: GroupId::random(),
+            epoch: GroupEpoch(1u64),
+            sender,
+            authenticated_data: vec![1, 2, 3],
+            content_type: ContentType::Application,
+            content: MLSPlaintextContentType::Application(vec![4, 5, 6]),
+            signature: Signature::new_empty(),
+        };
+        let context = GroupContext {
+            group_id: GroupId::random(),
+            epoch: GroupEpoch(1u64),
+            tree_hash: vec![],
+            confirmed_transcript_hash: vec![],
+        };
+        let serialized_context = context.encode_detached().unwrap();
+        let signature_input = MLSPlaintextTBS::new_from(&orig, Some(serialized_context));
+        orig.signature = signature_input.sign(&credential_bundle);
 
-    let enc = orig.encode_detached().unwrap();
-    let copy = MLSPlaintext::from_bytes(&enc).unwrap();
-    assert_eq!(orig, copy);
+        let enc = orig.encode_detached().unwrap();
+        let copy = MLSPlaintext::from_bytes(&enc).unwrap();
+        assert_eq!(orig, copy);
+    }
 }
 
 /// This tests the presence of the group context in MLSPlaintextTBS
 #[test]
 fn context_presence() {
     use crate::ciphersuite::*;
+    use crate::config::*;
 
-    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let credential_bundle = CredentialBundle::new(
-        "Random identity".into(),
-        CredentialType::Basic,
-        ciphersuite_name,
-    )
-    .unwrap();
-    let sender = Sender {
-        sender_type: SenderType::Member,
-        sender: LeafIndex::from(2u32),
-    };
-    let mut orig = MLSPlaintext {
-        group_id: GroupId::random(),
-        epoch: GroupEpoch(1u64),
-        sender,
-        authenticated_data: vec![1, 2, 3],
-        content_type: ContentType::Application,
-        content: MLSPlaintextContentType::Application(vec![4, 5, 6]),
-        signature: Signature::new_empty(),
-    };
-    let context = GroupContext {
-        group_id: GroupId::random(),
-        epoch: GroupEpoch(1u64),
-        tree_hash: vec![],
-        confirmed_transcript_hash: vec![],
-    };
-    let serialized_context = context.encode_detached().unwrap();
-    let signature_input = MLSPlaintextTBS::new_from(&orig, Some(serialized_context.clone()));
-    orig.signature = signature_input.sign(&credential_bundle);
-    assert!(orig.verify(
-        Some(serialized_context.clone()),
-        credential_bundle.credential()
-    ));
-    assert!(!orig.verify(None, credential_bundle.credential()));
+    for ciphersuite in Config::supported_ciphersuites() {
+        let credential_bundle = CredentialBundle::new(
+            "Random identity".into(),
+            CredentialType::Basic,
+            ciphersuite.name(),
+        )
+        .unwrap();
+        let sender = Sender {
+            sender_type: SenderType::Member,
+            sender: LeafIndex::from(2u32),
+        };
+        let mut orig = MLSPlaintext {
+            group_id: GroupId::random(),
+            epoch: GroupEpoch(1u64),
+            sender,
+            authenticated_data: vec![1, 2, 3],
+            content_type: ContentType::Application,
+            content: MLSPlaintextContentType::Application(vec![4, 5, 6]),
+            signature: Signature::new_empty(),
+        };
+        let context = GroupContext {
+            group_id: GroupId::random(),
+            epoch: GroupEpoch(1u64),
+            tree_hash: vec![],
+            confirmed_transcript_hash: vec![],
+        };
+        let serialized_context = context.encode_detached().unwrap();
+        let signature_input = MLSPlaintextTBS::new_from(&orig, Some(serialized_context.clone()));
+        orig.signature = signature_input.sign(&credential_bundle);
+        assert!(orig.verify(
+            Some(serialized_context.clone()),
+            credential_bundle.credential()
+        ));
+        assert!(!orig.verify(None, credential_bundle.credential()));
 
-    let signature_input = MLSPlaintextTBS::new_from(&orig, None);
-    orig.signature = signature_input.sign(&credential_bundle);
-    assert!(!orig.verify(Some(serialized_context), credential_bundle.credential()));
-    assert!(orig.verify(None, credential_bundle.credential()));
+        let signature_input = MLSPlaintextTBS::new_from(&orig, None);
+        orig.signature = signature_input.sign(&credential_bundle);
+        assert!(!orig.verify(Some(serialized_context), credential_bundle.credential()));
+        assert!(orig.verify(None, credential_bundle.credential()));
+    }
 }

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -1,91 +1,98 @@
 #[cfg(test)]
+use crate::config::*;
+#[cfg(test)]
 use crate::{extensions::*, key_packages::*};
 
 #[test]
 fn generate_key_package() {
-    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let credential_bundle =
-        CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, ciphersuite_name).unwrap();
-    let kpb = KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new()).unwrap();
-    // This is invalid because the lifetime extension is missing.
-    assert!(kpb.get_key_package().verify().is_err());
+    for ciphersuite in Config::supported_ciphersuites() {
+        let credential_bundle =
+            CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, ciphersuite.name())
+                .unwrap();
+        let kpb =
+            KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new()).unwrap();
+        // This is invalid because the lifetime extension is missing.
+        assert!(kpb.get_key_package().verify().is_err());
 
-    // Now with a lifetime the key package should be valid.
-    let lifetime_extension = Box::new(LifetimeExtension::new(60));
-    let kpb = KeyPackageBundle::new(
-        &[ciphersuite_name],
-        &credential_bundle,
-        vec![lifetime_extension],
-    )
-    .unwrap();
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    assert!(kpb.get_key_package().verify().is_ok());
+        // Now with a lifetime the key package should be valid.
+        let lifetime_extension = Box::new(LifetimeExtension::new(60));
+        let kpb = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &credential_bundle,
+            vec![lifetime_extension],
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        assert!(kpb.get_key_package().verify().is_ok());
 
-    // Now we add an invalid lifetime.
-    let lifetime_extension = Box::new(LifetimeExtension::new(0));
-    let kpb = KeyPackageBundle::new(
-        &[ciphersuite_name],
-        &credential_bundle,
-        vec![lifetime_extension],
-    )
-    .unwrap();
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    assert!(kpb.get_key_package().verify().is_err());
+        // Now we add an invalid lifetime.
+        let lifetime_extension = Box::new(LifetimeExtension::new(0));
+        let kpb = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &credential_bundle,
+            vec![lifetime_extension],
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        assert!(kpb.get_key_package().verify().is_err());
+    }
 }
 
 #[test]
 fn test_codec() {
-    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let id = vec![1, 2, 3];
-    let credential_bundle =
-        CredentialBundle::new(id, CredentialType::Basic, ciphersuite_name).unwrap();
-    let mut kpb =
-        KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new()).unwrap();
+    for ciphersuite in Config::supported_ciphersuites() {
+        let id = vec![1, 2, 3];
+        let credential_bundle =
+            CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name()).unwrap();
+        let mut kpb =
+            KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new()).unwrap();
 
-    // Encode and decode the key package.
-    let enc = kpb.get_key_package().encode_detached().unwrap();
+        // Encode and decode the key package.
+        let enc = kpb.get_key_package().encode_detached().unwrap();
 
-    // Decoding fails because this is not a valid key package
-    let kp = KeyPackage::decode(&mut Cursor::new(&enc));
-    assert_eq!(kp.err(), Some(CodecError::DecodingError));
+        // Decoding fails because this is not a valid key package
+        let kp = KeyPackage::decode(&mut Cursor::new(&enc));
+        assert_eq!(kp.err(), Some(CodecError::DecodingError));
 
-    // Add lifetime extension to make it valid.
-    let kp = kpb.get_key_package_ref_mut();
-    kp.add_extension(Box::new(LifetimeExtension::new(60)));
-    kp.sign(&credential_bundle);
-    let enc = kpb.get_key_package().encode_detached().unwrap();
+        // Add lifetime extension to make it valid.
+        let kp = kpb.get_key_package_ref_mut();
+        kp.add_extension(Box::new(LifetimeExtension::new(60)));
+        kp.sign(&credential_bundle);
+        let enc = kpb.get_key_package().encode_detached().unwrap();
 
-    // Now it's valid.
-    let kp = KeyPackage::decode(&mut Cursor::new(&enc)).unwrap();
-    assert_eq!(kpb.key_package, kp);
+        // Now it's valid.
+        let kp = KeyPackage::decode(&mut Cursor::new(&enc)).unwrap();
+        assert_eq!(kpb.key_package, kp);
+    }
 }
 
 #[test]
 fn key_package_id_extension() {
-    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let id = vec![1, 2, 3];
-    let credential_bundle =
-        CredentialBundle::new(id, CredentialType::Basic, ciphersuite_name).unwrap();
-    let mut kpb = KeyPackageBundle::new(
-        &[ciphersuite_name],
-        &credential_bundle,
-        vec![Box::new(LifetimeExtension::new(60))],
-    )
-    .unwrap();
-    assert!(kpb.get_key_package().verify().is_ok());
+    for ciphersuite in Config::supported_ciphersuites() {
+        let id = vec![1, 2, 3];
+        let credential_bundle =
+            CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name()).unwrap();
+        let mut kpb = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &credential_bundle,
+            vec![Box::new(LifetimeExtension::new(60))],
+        )
+        .unwrap();
+        assert!(kpb.get_key_package().verify().is_ok());
 
-    // Add an ID to the key package.
-    let id = [1, 2, 3, 4];
-    kpb.get_key_package_ref_mut()
-        .add_extension(Box::new(KeyIDExtension::new(&id)));
+        // Add an ID to the key package.
+        let id = [1, 2, 3, 4];
+        kpb.get_key_package_ref_mut()
+            .add_extension(Box::new(KeyIDExtension::new(&id)));
 
-    // This is invalid now.
-    assert!(kpb.get_key_package().verify().is_err());
+        // This is invalid now.
+        assert!(kpb.get_key_package().verify().is_err());
 
-    // Sign it to make it valid.
-    kpb.get_key_package_ref_mut().sign(&credential_bundle);
-    assert!(kpb.get_key_package().verify().is_ok());
+        // Sign it to make it valid.
+        kpb.get_key_package_ref_mut().sign(&credential_bundle);
+        assert!(kpb.get_key_package().verify().is_ok());
 
-    // Check ID
-    assert_eq!(&id[..], &kpb.get_key_package().get_id().unwrap()[..]);
+        // Check ID
+        assert_eq!(&id[..], &kpb.get_key_package().get_id().unwrap()[..]);
+    }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,6 +5,11 @@ pub use crate::group::Api;
 pub use crate::group::GroupConfig;
 pub use crate::group::ManagedGroup;
 pub use crate::group::MlsGroup;
+// Errors
+pub use crate::group::{ApplyCommitError, DecryptionError, WelcomeError};
+
+// Indexes
+pub use crate::tree::index::LeafIndex;
 
 pub use crate::ciphersuite::*;
 pub use crate::codec::*;

--- a/src/tree/test_private_tree.rs
+++ b/src/tree/test_private_tree.rs
@@ -3,28 +3,20 @@
 #[cfg(test)]
 use super::{index::NodeIndex, private_tree::*, test_util::*};
 #[cfg(test)]
-use crate::{ciphersuite::*, config::Config, creds::*, key_packages::*, utils::*};
+use crate::{ciphersuite::*, creds::*, key_packages::*, utils::*};
 
 #[cfg(test)]
 // Common setup for tests.
-fn setup(
-    len: usize,
-) -> (
-    &'static Ciphersuite,
-    KeyPackageBundle,
-    NodeIndex,
-    Vec<NodeIndex>,
-) {
-    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+fn setup(ciphersuite: &Ciphersuite, len: usize) -> (KeyPackageBundle, NodeIndex, Vec<NodeIndex>) {
     let credential_bundle =
-        CredentialBundle::new("username".into(), CredentialType::Basic, ciphersuite_name).unwrap();
+        CredentialBundle::new("username".into(), CredentialType::Basic, ciphersuite.name())
+            .unwrap();
     let key_package_bundle =
-        KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, vec![]).unwrap();
+        KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, vec![]).unwrap();
     let own_index = NodeIndex::from(0u32);
     let direct_path = generate_path_u8(len);
 
-    (ciphersuite, key_package_bundle, own_index, direct_path)
+    (key_package_bundle, own_index, direct_path)
 }
 
 #[cfg(test)]
@@ -51,19 +43,22 @@ fn test_private_tree(
 
 #[test]
 fn create_private_tree_from_secret() {
+    use crate::config::*;
     const PATH_LENGTH: usize = 33;
-    let (ciphersuite, key_package_bundle, own_index, direct_path) = setup(PATH_LENGTH);
+    for ciphersuite in Config::supported_ciphersuites() {
+        let (key_package_bundle, own_index, direct_path) = setup(ciphersuite, PATH_LENGTH);
 
-    let mut private_tree = PrivateTree::from_key_package_bundle(own_index, &key_package_bundle);
+        let mut private_tree = PrivateTree::from_key_package_bundle(own_index, &key_package_bundle);
 
-    // Compute path secrets from the leaf and generate keypairs
-    let public_keys = private_tree.generate_path_secrets(
-        &ciphersuite,
-        key_package_bundle.leaf_secret(),
-        &direct_path,
-    );
+        // Compute path secrets from the leaf and generate keypairs
+        let public_keys = private_tree.generate_path_secrets(
+            &ciphersuite,
+            key_package_bundle.leaf_secret(),
+            &direct_path,
+        );
 
-    assert_eq!(public_keys.len(), direct_path.len());
+        assert_eq!(public_keys.len(), direct_path.len());
 
-    test_private_tree(&private_tree, &direct_path, &public_keys, &ciphersuite);
+        test_private_tree(&private_tree, &direct_path, &public_keys, &ciphersuite);
+    }
 }

--- a/src/tree/test_secret_tree.rs
+++ b/src/tree/test_secret_tree.rs
@@ -1,121 +1,129 @@
 // This tests the boundaries of the generations from a SecretTree
 #[test]
 fn test_boundaries() {
-    use crate::ciphersuite::*;
-    use crate::config::Config;
+    use crate::config::*;
     use crate::tree::{index::*, secret_tree::*};
 
-    let ciphersuite =
-        Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519)
-            .unwrap();
-    let mut secret_tree = SecretTree::new(&[0u8; 32], LeafIndex::from(2u32));
-    let secret_type = SecretType::ApplicationSecret;
-    assert!(secret_tree
-        .get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 0)
-        .is_ok());
-    assert!(secret_tree
-        .get_secret_for_decryption(ciphersuite, LeafIndex::from(1u32), secret_type, 0)
-        .is_ok());
-    assert!(secret_tree
-        .get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 1)
-        .is_ok());
-    assert!(secret_tree
-        .get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 1_000)
-        .is_ok());
-    assert_eq!(
-        secret_tree.get_secret_for_decryption(
-            ciphersuite,
-            LeafIndex::from(1u32),
-            secret_type,
-            1001
-        ),
-        Err(SecretTreeError::TooDistantInTheFuture)
-    );
-    assert!(secret_tree
-        .get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 996)
-        .is_ok());
-    assert_eq!(
-        secret_tree.get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 995),
-        Err(SecretTreeError::TooDistantInThePast)
-    );
-    assert_eq!(
-        secret_tree.get_secret_for_decryption(ciphersuite, LeafIndex::from(2u32), secret_type, 0),
-        Err(SecretTreeError::IndexOutOfBounds)
-    );
-    let mut largetree = SecretTree::new(&[0u8; 32], LeafIndex::from(100_000u32));
-    assert!(largetree
-        .get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 0)
-        .is_ok());
-    assert!(largetree
-        .get_secret_for_decryption(ciphersuite, LeafIndex::from(99_999u32), secret_type, 0)
-        .is_ok());
-    assert!(largetree
-        .get_secret_for_decryption(ciphersuite, LeafIndex::from(99_999u32), secret_type, 1_000)
-        .is_ok());
-    assert_eq!(
-        largetree.get_secret_for_decryption(
-            ciphersuite,
-            LeafIndex::from(100_000u32),
-            secret_type,
-            0
-        ),
-        Err(SecretTreeError::IndexOutOfBounds)
-    );
+    for ciphersuite in Config::supported_ciphersuites() {
+        let mut secret_tree = SecretTree::new(&[0u8; 32], LeafIndex::from(2u32));
+        let secret_type = SecretType::ApplicationSecret;
+        assert!(secret_tree
+            .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 0)
+            .is_ok());
+        assert!(secret_tree
+            .get_secret_for_decryption(&ciphersuite, LeafIndex::from(1u32), secret_type, 0)
+            .is_ok());
+        assert!(secret_tree
+            .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 1)
+            .is_ok());
+        assert!(secret_tree
+            .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 1_000)
+            .is_ok());
+        assert_eq!(
+            secret_tree.get_secret_for_decryption(
+                &ciphersuite,
+                LeafIndex::from(1u32),
+                secret_type,
+                1001
+            ),
+            Err(SecretTreeError::TooDistantInTheFuture)
+        );
+        assert!(secret_tree
+            .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 996)
+            .is_ok());
+        assert_eq!(
+            secret_tree.get_secret_for_decryption(
+                &ciphersuite,
+                LeafIndex::from(0u32),
+                secret_type,
+                995
+            ),
+            Err(SecretTreeError::TooDistantInThePast)
+        );
+        assert_eq!(
+            secret_tree.get_secret_for_decryption(
+                &ciphersuite,
+                LeafIndex::from(2u32),
+                secret_type,
+                0
+            ),
+            Err(SecretTreeError::IndexOutOfBounds)
+        );
+        let mut largetree = SecretTree::new(&[0u8; 32], LeafIndex::from(100_000u32));
+        assert!(largetree
+            .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 0)
+            .is_ok());
+        assert!(largetree
+            .get_secret_for_decryption(&ciphersuite, LeafIndex::from(99_999u32), secret_type, 0)
+            .is_ok());
+        assert!(largetree
+            .get_secret_for_decryption(&ciphersuite, LeafIndex::from(99_999u32), secret_type, 1_000)
+            .is_ok());
+        assert_eq!(
+            largetree.get_secret_for_decryption(
+                &ciphersuite,
+                LeafIndex::from(100_000u32),
+                secret_type,
+                0
+            ),
+            Err(SecretTreeError::IndexOutOfBounds)
+        );
+    }
 }
 
 // This tests if the generation gets incremented correctly and that the returned values are unique.
 #[test]
 fn increment_generation() {
-    use crate::ciphersuite::CiphersuiteName;
     use crate::config::Config;
     use crate::tree::{secret_tree::*, *};
     use std::collections::HashMap;
 
     const SIZE: usize = 100;
     const MAX_GENERATIONS: usize = 10;
-    let ciphersuite =
-        Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
-            .unwrap();
-    let mut unique_values: HashMap<Vec<u8>, bool> = HashMap::new();
-    let mut secret_tree = SecretTree::new(&[1, 2, 3], LeafIndex::from(SIZE as u32));
-    for i in 0..SIZE {
-        assert_eq!(
-            secret_tree.get_generation(LeafIndex::from(i as u32), SecretType::HandshakeSecret),
-            0
-        );
-        assert_eq!(
-            secret_tree.get_generation(LeafIndex::from(i as u32), SecretType::ApplicationSecret),
-            0
-        );
-    }
-    for i in 0..MAX_GENERATIONS {
-        for j in 0..SIZE {
-            let (next_gen, (handshake_key, handshake_nonce)) = secret_tree
-                .get_secret_for_encryption(
-                    ciphersuite,
-                    LeafIndex::from(j as u32),
-                    SecretType::HandshakeSecret,
-                );
-            assert_eq!(next_gen, i as u32);
-            assert!(unique_values
-                .insert(handshake_key.as_slice().to_vec(), true)
-                .is_none());
-            assert!(unique_values
-                .insert(handshake_nonce.as_slice().to_vec(), true)
-                .is_none());
-            let (next_gen, (application_key, application_nonce)) = secret_tree
-                .get_secret_for_encryption(
-                    ciphersuite,
-                    LeafIndex::from(j as u32),
-                    SecretType::ApplicationSecret,
-                );
-            assert_eq!(next_gen, i as u32);
-            assert!(unique_values
-                .insert(application_key.as_slice().to_vec(), true)
-                .is_none());
-            assert!(unique_values
-                .insert(application_nonce.as_slice().to_vec(), true)
-                .is_none());
+
+    for ciphersuite in Config::supported_ciphersuites() {
+        let mut unique_values: HashMap<Vec<u8>, bool> = HashMap::new();
+        let mut secret_tree = SecretTree::new(&[1, 2, 3], LeafIndex::from(SIZE as u32));
+        for i in 0..SIZE {
+            assert_eq!(
+                secret_tree.get_generation(LeafIndex::from(i as u32), SecretType::HandshakeSecret),
+                0
+            );
+            assert_eq!(
+                secret_tree
+                    .get_generation(LeafIndex::from(i as u32), SecretType::ApplicationSecret),
+                0
+            );
+        }
+        for i in 0..MAX_GENERATIONS {
+            for j in 0..SIZE {
+                let (next_gen, (handshake_key, handshake_nonce)) = secret_tree
+                    .get_secret_for_encryption(
+                        ciphersuite,
+                        LeafIndex::from(j as u32),
+                        SecretType::HandshakeSecret,
+                    );
+                assert_eq!(next_gen, i as u32);
+                assert!(unique_values
+                    .insert(handshake_key.as_slice().to_vec(), true)
+                    .is_none());
+                assert!(unique_values
+                    .insert(handshake_nonce.as_slice().to_vec(), true)
+                    .is_none());
+                let (next_gen, (application_key, application_nonce)) = secret_tree
+                    .get_secret_for_encryption(
+                        ciphersuite,
+                        LeafIndex::from(j as u32),
+                        SecretType::ApplicationSecret,
+                    );
+                assert_eq!(next_gen, i as u32);
+                assert!(unique_values
+                    .insert(application_key.as_slice().to_vec(), true)
+                    .is_none());
+                assert!(unique_values
+                    .insert(application_nonce.as_slice().to_vec(), true)
+                    .is_none());
+            }
         }
     }
 }

--- a/tests/test_framing.rs
+++ b/tests/test_framing.rs
@@ -5,30 +5,32 @@ use openmls::prelude::*;
 
 #[test]
 fn padding() {
-    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let id = vec![1, 2, 3];
-    let credential_bundle =
-        CredentialBundle::new(id.clone(), CredentialType::Basic, ciphersuite_name).unwrap();
-    let kpb = KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new()).unwrap();
+    for ciphersuite in Config::supported_ciphersuites() {
+        let id = vec![1, 2, 3];
+        let credential_bundle =
+            CredentialBundle::new(id.clone(), CredentialType::Basic, ciphersuite.name()).unwrap();
+        let kpb =
+            KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new()).unwrap();
 
-    let mut group_alice =
-        MlsGroup::new(&id, ciphersuite_name, kpb, GroupConfig::default()).unwrap();
-    const PADDING_SIZE: usize = 10;
+        let mut group_alice =
+            MlsGroup::new(&id, ciphersuite.name(), kpb, GroupConfig::default()).unwrap();
+        const PADDING_SIZE: usize = 10;
 
-    for _ in 0..100 {
-        let message = randombytes(random_usize() % 1000);
-        let aad = randombytes(random_usize() % 1000);
-        let encrypted_message = group_alice
-            .create_application_message(&aad, &message, &credential_bundle)
-            .ciphertext;
-        let ciphertext = encrypted_message.as_slice();
-        let length = ciphertext.len();
-        let overflow = length % PADDING_SIZE;
-        if overflow != 0 {
-            panic!(
+        for _ in 0..100 {
+            let message = randombytes(random_usize() % 1000);
+            let aad = randombytes(random_usize() % 1000);
+            let encrypted_message = group_alice
+                .create_application_message(&aad, &message, &credential_bundle)
+                .ciphertext;
+            let ciphertext = encrypted_message.as_slice();
+            let length = ciphertext.len();
+            let overflow = length % PADDING_SIZE;
+            if overflow != 0 {
+                panic!(
                 "Error: padding overflow of {} bytes, message length: {}, padding block size: {}",
                 overflow, length, PADDING_SIZE
             );
+            }
         }
     }
 }

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -109,7 +109,7 @@ fn create_commit_optional_path() {
         let ratchet_tree = group_alice.tree().public_key_tree_copy();
 
         // Bob creates group from Welcome
-        let _group_bob = match MlsGroup::new_from_welcome(
+        let group_bob = match MlsGroup::new_from_welcome(
             welcome_bundle_alice_bob_option.unwrap(),
             Some(ratchet_tree),
             bob_key_package_bundle,
@@ -120,7 +120,7 @@ fn create_commit_optional_path() {
 
         assert_eq!(
             group_alice.tree().public_key_tree(),
-            group_alice.tree().public_key_tree()
+            group_bob.tree().public_key_tree()
         );
 
         // Alice updates
@@ -165,7 +165,7 @@ fn basic_group_setup() {
     for ciphersuite in Config::supported_ciphersuites() {
         let group_aad = b"Alice's test group";
 
-        // Define identities
+        // Define credential bundles
         let alice_credential_bundle =
             CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite.name())
                 .unwrap();
@@ -173,20 +173,14 @@ fn basic_group_setup() {
             CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite.name()).unwrap();
 
         // Generate KeyPackages
-        let bob_key_package_bundle = KeyPackageBundle::new(
-            &[ciphersuite.name()],
-            &bob_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-            Vec::new(),
-        )
-        .unwrap();
+        let bob_key_package_bundle =
+            KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle, Vec::new())
+                .unwrap();
         let bob_key_package = bob_key_package_bundle.get_key_package();
 
-        let alice_key_package_bundle = KeyPackageBundle::new(
-            &[ciphersuite.name()],
-            &alice_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-            Vec::new(),
-        )
-        .unwrap();
+        let alice_key_package_bundle =
+            KeyPackageBundle::new(&[ciphersuite.name()], &alice_credential_bundle, Vec::new())
+                .unwrap();
 
         // Alice creates a group
         let group_id = [1, 2, 3, 4];
@@ -232,7 +226,7 @@ fn group_operations() {
     for ciphersuite in Config::supported_ciphersuites() {
         let group_aad = b"Alice's test group";
 
-        // Define identities
+        // Define credential bundles
         let alice_credential_bundle =
             CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite.name())
                 .unwrap();

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -2,212 +2,219 @@ use openmls::prelude::*;
 
 #[test]
 fn create_commit_optional_path() {
-    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let group_aad = b"Alice's test group";
+    for ciphersuite in Config::supported_ciphersuites() {
+        let group_aad = b"Alice's test group";
 
-    // Define identities
-    let alice_credential_bundle =
-        CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite_name).unwrap();
-    let bob_credential_bundle =
-        CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite_name).unwrap();
+        // Define identities
+        let alice_credential_bundle =
+            CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite.name())
+                .unwrap();
+        let bob_credential_bundle =
+            CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite.name()).unwrap();
 
-    // Mandatory extensions, will be fixed in #164
-    let lifetime_extension = Box::new(LifetimeExtension::new(60));
-    let mandatory_extensions: Vec<Box<dyn Extension>> = vec![lifetime_extension];
+        // Mandatory extensions, will be fixed in #164
+        let lifetime_extension = Box::new(LifetimeExtension::new(60));
+        let mandatory_extensions: Vec<Box<dyn Extension>> = vec![lifetime_extension];
 
-    // Generate KeyPackages
-    let alice_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite_name],
-        &alice_credential_bundle,
-        mandatory_extensions.clone(),
-    )
-    .unwrap();
+        // Generate KeyPackages
+        let alice_key_package_bundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &alice_credential_bundle,
+            mandatory_extensions.clone(),
+        )
+        .unwrap();
 
-    let bob_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite_name],
-        &bob_credential_bundle,
-        mandatory_extensions.clone(),
-    )
-    .unwrap();
-    let bob_key_package = bob_key_package_bundle.get_key_package();
+        let bob_key_package_bundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &bob_credential_bundle,
+            mandatory_extensions.clone(),
+        )
+        .unwrap();
+        let bob_key_package = bob_key_package_bundle.get_key_package();
 
-    let alice_update_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite_name],
-        &alice_credential_bundle,
-        mandatory_extensions,
-    )
-    .unwrap();
-    let alice_update_key_package = alice_update_key_package_bundle.get_key_package();
-    assert!(alice_update_key_package.verify().is_ok());
+        let alice_update_key_package_bundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &alice_credential_bundle,
+            mandatory_extensions,
+        )
+        .unwrap();
+        let alice_update_key_package = alice_update_key_package_bundle.get_key_package();
+        assert!(alice_update_key_package.verify().is_ok());
 
-    // Alice creates a group
-    let group_id = [1, 2, 3, 4];
-    let mut group_alice_1234 = MlsGroup::new(
-        &group_id,
-        ciphersuite_name,
-        alice_key_package_bundle,
-        GroupConfig::default(),
-    )
-    .unwrap();
+        // Alice creates a group
+        let group_id = [1, 2, 3, 4];
+        let mut group_alice_1234 = MlsGroup::new(
+            &group_id,
+            ciphersuite.name(),
+            alice_key_package_bundle,
+            GroupConfig::default(),
+        )
+        .unwrap();
 
-    // Alice proposes to add Bob with forced self-update
-    // Even though there are only Add Proposals, this should generated a path field on the Commit
-    let bob_add_proposal = group_alice_1234.create_add_proposal(
-        group_aad,
-        &alice_credential_bundle,
-        bob_key_package.clone(),
-    );
-    let epoch_proposals = vec![bob_add_proposal];
-    let (mls_plaintext_commit, _welcome_bundle_alice_bob_option, kpb_option) =
-        match group_alice_1234.create_commit(
+        // Alice proposes to add Bob with forced self-update
+        // Even though there are only Add Proposals, this should generated a path field on the Commit
+        let bob_add_proposal = group_alice_1234.create_add_proposal(
             group_aad,
             &alice_credential_bundle,
-            epoch_proposals,
-            true, /* force self-update */
+            bob_key_package.clone(),
+        );
+        let epoch_proposals = vec![bob_add_proposal];
+        let (mls_plaintext_commit, _welcome_bundle_alice_bob_option, kpb_option) =
+            match group_alice_1234.create_commit(
+                group_aad,
+                &alice_credential_bundle,
+                epoch_proposals,
+                true, /* force self-update */
+            ) {
+                Ok(c) => c,
+                Err(e) => panic!("Error creating commit: {:?}", e),
+            };
+        let commit = match &mls_plaintext_commit.content {
+            MLSPlaintextContentType::Commit((commit, _)) => commit,
+            _ => panic!(),
+        };
+        assert!(commit.path.is_some());
+        assert!(commit.path.is_some() && kpb_option.is_some());
+
+        // Alice adds Bob without forced self-update
+        // Since there are only Add Proposals, this does not generate a path field on the Commit
+        // Creating a second proposal to add the same member should not fail, only committing that proposal should fail
+        let bob_add_proposal = group_alice_1234.create_add_proposal(
+            group_aad,
+            &alice_credential_bundle,
+            bob_key_package.clone(),
+        );
+        let epoch_proposals = vec![bob_add_proposal];
+        let (mls_plaintext_commit, welcome_bundle_alice_bob_option, kpb_option) =
+            match group_alice_1234.create_commit(
+                group_aad,
+                &alice_credential_bundle,
+                epoch_proposals.clone(),
+                false, /* don't force selfupdate */
+            ) {
+                Ok(c) => c,
+                Err(e) => panic!("Error creating commit: {:?}", e),
+            };
+        let commit = match &mls_plaintext_commit.content {
+            MLSPlaintextContentType::Commit((commit, _)) => commit,
+            _ => panic!(),
+        };
+        assert!(commit.path.is_none() && kpb_option.is_none());
+
+        // Alice applies the Commit without the forced self-update
+        match group_alice_1234.apply_commit(mls_plaintext_commit, epoch_proposals, &[]) {
+            Ok(_) => {}
+            Err(e) => panic!("Error applying commit: {:?}", e),
+        };
+        let ratchet_tree = group_alice_1234.tree().public_key_tree_copy();
+
+        // Bob creates group from Welcome
+        let _group_bob_1234 = match MlsGroup::new_from_welcome(
+            welcome_bundle_alice_bob_option.unwrap(),
+            Some(ratchet_tree),
+            bob_key_package_bundle,
         ) {
+            Ok(group) => group,
+            Err(e) => panic!("Error creating group from Welcome: {:?}", e),
+        };
+
+        assert_eq!(
+            group_alice_1234.tree().public_key_tree(),
+            group_alice_1234.tree().public_key_tree()
+        );
+
+        // Alice updates
+        let alice_update_proposal = group_alice_1234.create_update_proposal(
+            group_aad,
+            &alice_credential_bundle,
+            alice_update_key_package.clone(),
+        );
+        let proposals = vec![alice_update_proposal];
+
+        // Only UpdateProposal
+        let (commit_mls_plaintext, _welcome_option, kpb_option) = match group_alice_1234
+            .create_commit(
+                group_aad,
+                &alice_credential_bundle,
+                proposals.clone(),
+                false, /* force self update */
+            ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
         };
-    let commit = match &mls_plaintext_commit.content {
-        MLSPlaintextContentType::Commit((commit, _)) => commit,
-        _ => panic!(),
-    };
-    assert!(commit.path.is_some());
-    assert!(commit.path.is_some() && kpb_option.is_some());
+        let (commit, _confirmation_tag) = match &commit_mls_plaintext.content {
+            MLSPlaintextContentType::Commit((commit, confirmation_tag)) => {
+                (commit, confirmation_tag)
+            }
+            _ => panic!(),
+        };
+        assert!(commit.path.is_some() && kpb_option.is_some());
 
-    // Alice adds Bob without forced self-update
-    // Since there are only Add Proposals, this does not generate a path field on the Commit
-    // Creating a second proposal to add the same member should not fail, only committing that proposal should fail
-    let bob_add_proposal = group_alice_1234.create_add_proposal(
-        group_aad,
-        &alice_credential_bundle,
-        bob_key_package.clone(),
-    );
-    let epoch_proposals = vec![bob_add_proposal];
-    let (mls_plaintext_commit, welcome_bundle_alice_bob_option, kpb_option) = match group_alice_1234
-        .create_commit(
-            group_aad,
-            &alice_credential_bundle,
-            epoch_proposals.clone(),
-            false, /* don't force selfupdate */
-        ) {
-        Ok(c) => c,
-        Err(e) => panic!("Error creating commit: {:?}", e),
-    };
-    let commit = match &mls_plaintext_commit.content {
-        MLSPlaintextContentType::Commit((commit, _)) => commit,
-        _ => panic!(),
-    };
-    assert!(commit.path.is_none() && kpb_option.is_none());
-
-    // Alice applies the Commit without the forced self-update
-    match group_alice_1234.apply_commit(mls_plaintext_commit, epoch_proposals, &[]) {
-        Ok(_) => {}
-        Err(e) => panic!("Error applying commit: {:?}", e),
-    };
-    let ratchet_tree = group_alice_1234.tree().public_key_tree_copy();
-
-    // Bob creates group from Welcome
-    let _group_bob_1234 = match MlsGroup::new_from_welcome(
-        welcome_bundle_alice_bob_option.unwrap(),
-        Some(ratchet_tree),
-        bob_key_package_bundle,
-    ) {
-        Ok(group) => group,
-        Err(e) => panic!("Error creating group from Welcome: {:?}", e),
-    };
-
-    assert_eq!(
-        group_alice_1234.tree().public_key_tree(),
-        group_alice_1234.tree().public_key_tree()
-    );
-
-    // Alice updates
-    let alice_update_proposal = group_alice_1234.create_update_proposal(
-        group_aad,
-        &alice_credential_bundle,
-        alice_update_key_package.clone(),
-    );
-    let proposals = vec![alice_update_proposal];
-
-    // Only UpdateProposal
-    let (commit_mls_plaintext, _welcome_option, kpb_option) = match group_alice_1234.create_commit(
-        group_aad,
-        &alice_credential_bundle,
-        proposals.clone(),
-        false, /* force self update */
-    ) {
-        Ok(c) => c,
-        Err(e) => panic!("Error creating commit: {:?}", e),
-    };
-    let (commit, _confirmation_tag) = match &commit_mls_plaintext.content {
-        MLSPlaintextContentType::Commit((commit, confirmation_tag)) => (commit, confirmation_tag),
-        _ => panic!(),
-    };
-    assert!(commit.path.is_some() && kpb_option.is_some());
-
-    // Apply UpdateProposal
-    group_alice_1234
-        .apply_commit(
-            commit_mls_plaintext.clone(),
-            proposals,
-            &[kpb_option.unwrap()],
-        )
-        .expect("Error applying commit");
+        // Apply UpdateProposal
+        group_alice_1234
+            .apply_commit(
+                commit_mls_plaintext.clone(),
+                proposals,
+                &[kpb_option.unwrap()],
+            )
+            .expect("Error applying commit");
+    }
 }
 
 #[test]
 fn basic_group_setup() {
-    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let group_aad = b"Alice's test group";
+    for ciphersuite in Config::supported_ciphersuites() {
+        let group_aad = b"Alice's test group";
 
-    // Define identities
-    let alice_credential_bundle =
-        CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite_name).unwrap();
-    let bob_credential_bundle =
-        CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite_name).unwrap();
+        // Define identities
+        let alice_credential_bundle =
+            CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite.name())
+                .unwrap();
+        let bob_credential_bundle =
+            CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite.name()).unwrap();
 
-    // Generate KeyPackages
-    let bob_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite_name],
-        &bob_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Vec::new(),
-    )
-    .unwrap();
-    let bob_key_package = bob_key_package_bundle.get_key_package();
+        // Generate KeyPackages
+        let bob_key_package_bundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &bob_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
+            Vec::new(),
+        )
+        .unwrap();
+        let bob_key_package = bob_key_package_bundle.get_key_package();
 
-    let alice_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite_name],
-        &alice_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Vec::new(),
-    )
-    .unwrap();
+        let alice_key_package_bundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &alice_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
+            Vec::new(),
+        )
+        .unwrap();
 
-    // Alice creates a group
-    let group_id = [1, 2, 3, 4];
-    let group_alice_1234 = MlsGroup::new(
-        &group_id,
-        ciphersuite_name,
-        alice_key_package_bundle,
-        GroupConfig::default(),
-    )
-    .unwrap();
+        // Alice creates a group
+        let group_id = [1, 2, 3, 4];
+        let group_alice_1234 = MlsGroup::new(
+            &group_id,
+            ciphersuite.name(),
+            alice_key_package_bundle,
+            GroupConfig::default(),
+        )
+        .unwrap();
 
-    // Alice adds Bob
-    let bob_add_proposal = group_alice_1234.create_add_proposal(
-        group_aad,
-        &alice_credential_bundle,
-        bob_key_package.clone(),
-    );
-    let _commit = match group_alice_1234.create_commit(
-        group_aad,
-        &alice_credential_bundle,
-        vec![bob_add_proposal],
-        true,
-    ) {
-        Ok(c) => c,
-        Err(e) => panic!("Error creating commit: {:?}", e),
-    };
+        // Alice adds Bob
+        let bob_add_proposal = group_alice_1234.create_add_proposal(
+            group_aad,
+            &alice_credential_bundle,
+            bob_key_package.clone(),
+        );
+        let _commit = match group_alice_1234.create_commit(
+            group_aad,
+            &alice_credential_bundle,
+            vec![bob_add_proposal],
+            true,
+        ) {
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
+    }
 }
 
 #[test]
@@ -216,19 +223,15 @@ fn basic_group_setup() {
 ///  - Alice invites Bob
 ///  - Alice sends a message to Bob
 fn group_operations() {
-    let supported_ciphersuites = vec![
-        CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
-        CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
-    ];
-
-    for ciphersuite_name in supported_ciphersuites {
+    for ciphersuite in Config::supported_ciphersuites() {
         let group_aad = b"Alice's test group";
 
         // Define identities
         let alice_credential_bundle =
-            CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite_name).unwrap();
+            CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite.name())
+                .unwrap();
         let bob_credential_bundle =
-            CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite_name).unwrap();
+            CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite.name()).unwrap();
 
         // Mandatory extensions
         let capabilities_extension = Box::new(CapabilitiesExtension::default());
@@ -238,14 +241,14 @@ fn group_operations() {
 
         // Generate KeyPackages
         let alice_key_package_bundle = KeyPackageBundle::new(
-            &[ciphersuite_name],
+            &[ciphersuite.name()],
             &alice_credential_bundle,
             mandatory_extensions.clone(),
         )
         .unwrap();
 
         let bob_key_package_bundle = KeyPackageBundle::new(
-            &[ciphersuite_name],
+            &[ciphersuite.name()],
             &bob_credential_bundle,
             mandatory_extensions,
         )
@@ -256,7 +259,7 @@ fn group_operations() {
         let group_id = [1, 2, 3, 4];
         let mut group_alice_1234 = MlsGroup::new(
             &group_id,
-            ciphersuite_name,
+            ciphersuite.name(),
             alice_key_package_bundle,
             GroupConfig::default(),
         )

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -342,7 +342,7 @@ fn group_operations() {
             &bob_credential_bundle,
             bob_update_key_package_bundle.get_key_package().clone(),
         );
-        let (mls_plaintext_commit, _, kpb_option) = match group_bob.create_commit(
+        let (mls_plaintext_commit, welcome_option, kpb_option) = match group_bob.create_commit(
             &[],
             &bob_credential_bundle,
             vec![update_proposal_bob.clone()],
@@ -354,6 +354,8 @@ fn group_operations() {
 
         // Check that there is a new KeyPackageBundle
         assert!(kpb_option.is_some());
+        // Check there is no Welcome message
+        assert!(welcome_option.is_none());
 
         group_alice
             .apply_commit(
@@ -364,7 +366,7 @@ fn group_operations() {
             .expect("Error applying commit (Alice)");
         group_bob
             .apply_commit(
-                mls_plaintext_commit.clone(),
+                mls_plaintext_commit,
                 vec![update_proposal_bob],
                 &[kpb_option.unwrap()],
             )

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -220,8 +220,15 @@ fn basic_group_setup() {
 #[test]
 /// This test simulates various group operations like Add, Update, Remove in a small group
 ///  - Alice creates a group
-///  - Alice invites Bob
+///  - Alice adds Bob
 ///  - Alice sends a message to Bob
+///  - Bob updates and commits
+///  - Alice updates and commits
+///  - Bob updates and Alice commits
+///  - Bob adds Charlie
+///  - Charlie sends a message to the group
+///  - Charlie updates and commits
+///  - Charlie removes Bob
 fn group_operations() {
     for ciphersuite in Config::supported_ciphersuites() {
         let group_aad = b"Alice's test group";
@@ -250,12 +257,12 @@ fn group_operations() {
         let bob_key_package_bundle = KeyPackageBundle::new(
             &[ciphersuite.name()],
             &bob_credential_bundle,
-            mandatory_extensions,
+            mandatory_extensions.clone(),
         )
         .unwrap();
         let bob_key_package = bob_key_package_bundle.get_key_package();
 
-        // Alice creates a group
+        // === Alice creates a group ===
         let group_id = [1, 2, 3, 4];
         let mut group_alice_1234 = MlsGroup::new(
             &group_id,
@@ -265,7 +272,7 @@ fn group_operations() {
         )
         .unwrap();
 
-        // Alice adds Bob
+        // === Alice adds Bob ===
         let bob_add_proposal = group_alice_1234.create_add_proposal(
             group_aad,
             &alice_credential_bundle,
@@ -305,12 +312,12 @@ fn group_operations() {
         };
 
         // Make sure that both groups have the same public tree
-        if group_alice_1234.tree().public_key_tree() != group_alice_1234.tree().public_key_tree() {
+        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
             _print_tree(&group_alice_1234.tree(), "Alice added Bob");
             panic!("Different public trees");
         }
 
-        // Alice sends a message to Bob
+        // === Alice sends a message to Bob ===
         let message_alice = [1, 2, 3];
         let mls_ciphertext_alice = group_alice_1234.create_application_message(
             &[],
@@ -325,106 +332,349 @@ fn group_operations() {
             message_alice,
             mls_plaintext_bob.as_application_message().unwrap()
         );
+
+        // === Bob updates and commits ===
+        let bob_update_key_package_bundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &bob_credential_bundle,
+            mandatory_extensions.clone(),
+        )
+        .unwrap();
+
+        let update_proposal_bob = group_bob.create_update_proposal(
+            &[],
+            &bob_credential_bundle,
+            bob_update_key_package_bundle.get_key_package().clone(),
+        );
+        let (mls_plaintext_commit, _, kpb_option) = match group_bob.create_commit(
+            &[],
+            &bob_credential_bundle,
+            vec![update_proposal_bob.clone()],
+            false, /* force self update*/
+        ) {
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
+
+        // Check that there is a new KeyPackageBundle
+        assert!(kpb_option.is_some());
+
+        group_alice_1234
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![update_proposal_bob.clone()],
+                &[],
+            )
+            .expect("Error applying commit (Alice)");
+        group_bob
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![update_proposal_bob],
+                &[kpb_option.unwrap()],
+            )
+            .expect("Error applying commit (Bob)");
+
+        // Make sure that both groups have the same public tree
+        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice_1234.tree(), "Alice added Bob");
+            panic!("Different public trees");
+        }
+
+        // === Alice updates and commits ===
+        let alice_update_key_package_bundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &alice_credential_bundle,
+            mandatory_extensions.clone(),
+        )
+        .unwrap();
+
+        let update_proposal_alice = group_alice_1234.create_update_proposal(
+            &[],
+            &alice_credential_bundle,
+            alice_update_key_package_bundle.get_key_package().clone(),
+        );
+        let (mls_plaintext_commit, _, kpb_option) = match group_alice_1234.create_commit(
+            &[],
+            &alice_credential_bundle,
+            vec![update_proposal_alice.clone()],
+            false, /* force self update*/
+        ) {
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
+
+        // Check that there is a new KeyPackageBundle
+        assert!(kpb_option.is_some());
+
+        group_alice_1234
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![update_proposal_alice.clone()],
+                &[kpb_option.unwrap()],
+            )
+            .expect("Error applying commit (Alice)");
+        group_bob
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![update_proposal_alice],
+                &[],
+            )
+            .expect("Error applying commit (Bob)");
+
+        // Make sure that both groups have the same public tree
+        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice_1234.tree(), "Alice added Bob");
+            panic!("Different public trees");
+        }
+
+        // === Bob updates and Alice commits ===
+        let bob_update_key_package_bundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &bob_credential_bundle,
+            mandatory_extensions.clone(),
+        )
+        .unwrap();
+
+        let update_proposal_bob = group_bob.create_update_proposal(
+            &[],
+            &bob_credential_bundle,
+            bob_update_key_package_bundle.get_key_package().clone(),
+        );
+        let (mls_plaintext_commit, _, kpb_option) = match group_alice_1234.create_commit(
+            &[],
+            &alice_credential_bundle,
+            vec![update_proposal_bob.clone()],
+            false, /* force self update*/
+        ) {
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
+
+        // Check that there is a new KeyPackageBundle
+        assert!(kpb_option.is_some());
+
+        group_alice_1234
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![update_proposal_bob.clone()],
+                &[kpb_option.unwrap()],
+            )
+            .expect("Error applying commit (Alice)");
+        group_bob
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![update_proposal_bob],
+                &[bob_update_key_package_bundle],
+            )
+            .expect("Error applying commit (Bob)");
+
+        // Make sure that both groups have the same public tree
+        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice_1234.tree(), "Alice added Bob");
+            panic!("Different public trees");
+        }
+
+        // === Bob adds Charlie ===
+        let charlie_credential_bundle =
+            CredentialBundle::new("Charlie".into(), CredentialType::Basic, ciphersuite.name())
+                .unwrap();
+
+        let charlie_key_package_bundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &charlie_credential_bundle,
+            mandatory_extensions.clone(),
+        )
+        .unwrap();
+        let charlie_key_package = charlie_key_package_bundle.get_key_package().clone();
+
+        let add_charlie_proposal_bob =
+            group_bob.create_add_proposal(&[], &bob_credential_bundle, charlie_key_package);
+
+        let (mls_plaintext_commit, welcome_for_charlie_option, kpb_option) = match group_bob
+            .create_commit(
+                &[],
+                &bob_credential_bundle,
+                vec![add_charlie_proposal_bob.clone()],
+                false, /* force self update*/
+            ) {
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
+
+        // Check there is no KeyPackageBundle since there are only Add Proposals and no forced self-update
+        assert!(kpb_option.is_none());
+        // Make sure the is a Welcome message for Charlie
+        assert!(welcome_for_charlie_option.is_some());
+
+        group_alice_1234
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![add_charlie_proposal_bob.clone()],
+                &[],
+            )
+            .expect("Error applying commit (Alice)");
+        group_bob
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![add_charlie_proposal_bob],
+                &[],
+            )
+            .expect("Error applying commit (Bob)");
+
+        let ratchet_tree = group_alice_1234.tree().public_key_tree_copy();
+        let mut group_charlie = match MlsGroup::new_from_welcome(
+            welcome_for_charlie_option.unwrap(),
+            Some(ratchet_tree),
+            charlie_key_package_bundle,
+        ) {
+            Ok(group) => group,
+            Err(e) => panic!("Error creating group from Welcome: {:?}", e),
+        };
+
+        // Make sure that all groups have the same public tree
+        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice_1234.tree(), "Bob added Charlie");
+            panic!("Different public trees");
+        }
+        if group_alice_1234.tree().public_key_tree() != group_charlie.tree().public_key_tree() {
+            _print_tree(&group_alice_1234.tree(), "Bob added Charlie");
+            panic!("Different public trees");
+        }
+
+        // === Charlie sends a message to the group ===
+        let message_charlie = [1, 2, 3];
+        let mls_ciphertext_charlie = group_charlie.create_application_message(
+            &[],
+            &message_charlie,
+            &charlie_credential_bundle,
+        );
+        let mls_plaintext_alice = match group_alice_1234.decrypt(mls_ciphertext_charlie.clone()) {
+            Ok(mls_plaintext) => mls_plaintext,
+            Err(e) => panic!("Error decrypting MLSCiphertext: {:?}", e),
+        };
+        let mls_plaintext_bob = match group_bob.decrypt(mls_ciphertext_charlie) {
+            Ok(mls_plaintext) => mls_plaintext,
+            Err(e) => panic!("Error decrypting MLSCiphertext: {:?}", e),
+        };
+        assert_eq!(
+            message_charlie,
+            mls_plaintext_alice.as_application_message().unwrap()
+        );
+        assert_eq!(
+            message_charlie,
+            mls_plaintext_bob.as_application_message().unwrap()
+        );
+
+        // === Charlie updates and commits ===
+        let charlie_update_key_package_bundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &charlie_credential_bundle,
+            mandatory_extensions.clone(),
+        )
+        .unwrap();
+
+        let update_proposal_charlie = group_charlie.create_update_proposal(
+            &[],
+            &charlie_credential_bundle,
+            charlie_update_key_package_bundle.get_key_package().clone(),
+        );
+        let (mls_plaintext_commit, _, kpb_option) = match group_charlie.create_commit(
+            &[],
+            &charlie_credential_bundle,
+            vec![update_proposal_charlie.clone()],
+            false, /* force self update*/
+        ) {
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
+
+        // Check that there is a new KeyPackageBundle
+        assert!(kpb_option.is_some());
+
+        group_alice_1234
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![update_proposal_charlie.clone()],
+                &[],
+            )
+            .expect("Error applying commit (Alice)");
+        group_bob
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![update_proposal_charlie.clone()],
+                &[],
+            )
+            .expect("Error applying commit (Bob)");
+        group_charlie
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![update_proposal_charlie],
+                &[kpb_option.unwrap()],
+            )
+            .expect("Error applying commit (Charlie)");
+
+        // Make sure that all groups have the same public tree
+        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice_1234.tree(), "Charlie updated");
+            panic!("Different public trees");
+        }
+        if group_alice_1234.tree().public_key_tree() != group_charlie.tree().public_key_tree() {
+            _print_tree(&group_alice_1234.tree(), "Charlie updated");
+            panic!("Different public trees");
+        }
+
+        // === Charlie removes Bob ===
+        let remove_bob_proposal_charlie = group_charlie.create_remove_proposal(
+            &[],
+            &charlie_credential_bundle,
+            LeafIndex::from(1u32),
+        );
+        let (mls_plaintext_commit, _, kpb_option) = match group_charlie.create_commit(
+            &[],
+            &charlie_credential_bundle,
+            vec![remove_bob_proposal_charlie.clone()],
+            false, /* force self update*/
+        ) {
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
+
+        // Check that there is a new KeyPackageBundle
+        assert!(kpb_option.is_some());
+
+        group_alice_1234
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![remove_bob_proposal_charlie.clone()],
+                &[],
+            )
+            .expect("Error applying commit (Alice)");
+        assert!(
+            group_bob
+                .apply_commit(
+                    mls_plaintext_commit.clone(),
+                    vec![remove_bob_proposal_charlie.clone()],
+                    &[],
+                )
+                .unwrap_err()
+                == ApplyCommitError::SelfRemoved
+        );
+        group_charlie
+            .apply_commit(
+                mls_plaintext_commit.clone(),
+                vec![remove_bob_proposal_charlie],
+                &[kpb_option.unwrap()],
+            )
+            .expect("Error applying commit (Charlie)");
+
+        // Make sure that all groups have the same public tree
+        if group_alice_1234.tree().public_key_tree() == group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice_1234.tree(), "Charlie removed Bob");
+            panic!("Same public trees");
+        }
+        if group_alice_1234.tree().public_key_tree() != group_charlie.tree().public_key_tree() {
+            _print_tree(&group_alice_1234.tree(), "Charlie removed Bob");
+            panic!("Different public trees");
+        }
     }
 }
-/*
-    // Bob updates and commits
-    let update_proposal_bob = group_bob.create_update_proposal(None);
-    let (commit2, ms2, _) = group_bob.create_commit(None);
-
-    group_alice_1234.process_proposal(update_proposal_bob);
-    group_alice_1234.process_commit(commit2.clone());
-    group_bob.process_commit(commit2);
-
-    group_alice_1234.tree.print(&format!("\n{:?}", ms2));
-
-    // Alice updates and commits
-    let update_proposal_alice = group_alice_1234.create_update_proposal(None);
-    let (commit3, ms3, _) = group_alice_1234.create_commit(None);
-
-    group_bob.process_proposal(update_proposal_alice);
-    group_alice_1234.process_commit(commit3.clone());
-    group_bob.process_commit(commit3);
-
-    group_alice_1234.tree.print(&format!("\n{:?}", ms3));
-
-    // Alice updates and Bob commits
-    let update_proposal_alice = group_alice_1234.create_update_proposal(None);
-    group_bob.process_proposal(update_proposal_alice);
-    let (commit4, ms4, _) = group_bob.create_commit(None);
-
-    group_bob.process_commit(commit4.clone());
-    group_alice_1234.process_commit(commit4);
-
-    group_alice_1234.tree.print(&format!("\n{:?}", ms4));
-
-    // Bob updates and Alice commits
-    let update_proposal_bob = group_bob.create_update_proposal(None);
-    group_alice_1234.process_proposal(update_proposal_bob);
-    let (commit5, ms5, _) = group_alice_1234.create_commit(None);
-
-    group_alice_1234.process_commit(commit5.clone());
-    group_bob.process_commit(commit5);
-
-    group_alice_1234.tree.print(&format!("\n{:?}", ms5));
-
-    // Bob adds Charlie
-    let add_proposal = group_bob.create_add_proposal(&charlie_key_package, None);
-    group_alice_1234.process_proposal(add_proposal);
-
-    let (commit6, ms6, welcome_bundle_bob_charlie) = group_bob.create_commit(None);
-
-    group_alice_1234.process_commit(commit6.clone());
-    group_bob.process_commit(commit6);
-
-    let mut group_charlie = Group::new_from_welcome(
-        charlie_identity,
-        welcome_bundle_bob_charlie.unwrap(),
-        charlie_key_package_bundle,
-    );
-
-    group_alice_1234.tree.print(&format!("\n{:?}", ms6));
-
-    // Charlie updates
-    let update_proposal_charlie = group_charlie.create_update_proposal(None);
-
-    group_alice_1234.process_proposal(update_proposal_charlie.clone());
-    group_bob.process_proposal(update_proposal_charlie);
-
-    let (commit7, ms7, _) = group_charlie.create_commit(None);
-
-    group_alice_1234.process_commit(commit7.clone());
-    group_bob.process_commit(commit7.clone());
-    group_charlie.process_commit(commit7);
-
-    group_alice_1234.tree.print(&format!("\n{:?}", ms7));
-
-    // Alice updates
-    let update_proposal_alice = group_alice_1234.create_update_proposal(None);
-
-    group_bob.process_proposal(update_proposal_alice.clone());
-    group_charlie.process_proposal(update_proposal_alice);
-
-    let (commit8, ms8, _) = group_alice_1234.create_commit(None);
-
-    group_alice_1234.process_commit(commit8.clone());
-    group_bob.process_commit(commit8.clone());
-    group_charlie.process_commit(commit8);
-
-    group_alice_1234.tree.print(&format!("\n{:?}", ms8));
-
-    // Charlie removes Bob
-    let remove_proposal_charlie = group_charlie.create_remove_proposal(2, None);
-
-    group_alice_1234.process_proposal(remove_proposal_charlie.clone());
-    group_bob.process_proposal(remove_proposal_charlie);
-
-    let (commit9, ms9, _) = group_charlie.create_commit(None);
-
-    group_alice_1234.process_commit(commit9.clone());
-    group_bob.process_commit(commit9.clone());
-    group_charlie.process_commit(commit9);
-
-    group_alice_1234.tree.print(&format!("\n{:?}", ms9));
-}
-*/

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -43,7 +43,7 @@ fn create_commit_optional_path() {
 
         // Alice creates a group
         let group_id = [1, 2, 3, 4];
-        let mut group_alice_1234 = MlsGroup::new(
+        let mut group_alice = MlsGroup::new(
             &group_id,
             ciphersuite.name(),
             alice_key_package_bundle,
@@ -53,22 +53,22 @@ fn create_commit_optional_path() {
 
         // Alice proposes to add Bob with forced self-update
         // Even though there are only Add Proposals, this should generated a path field on the Commit
-        let bob_add_proposal = group_alice_1234.create_add_proposal(
+        let bob_add_proposal = group_alice.create_add_proposal(
             group_aad,
             &alice_credential_bundle,
             bob_key_package.clone(),
         );
         let epoch_proposals = vec![bob_add_proposal];
-        let (mls_plaintext_commit, _welcome_bundle_alice_bob_option, kpb_option) =
-            match group_alice_1234.create_commit(
+        let (mls_plaintext_commit, _welcome_bundle_alice_bob_option, kpb_option) = match group_alice
+            .create_commit(
                 group_aad,
                 &alice_credential_bundle,
                 epoch_proposals,
                 true, /* force self-update */
             ) {
-                Ok(c) => c,
-                Err(e) => panic!("Error creating commit: {:?}", e),
-            };
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
         let commit = match &mls_plaintext_commit.content {
             MLSPlaintextContentType::Commit((commit, _)) => commit,
             _ => panic!(),
@@ -79,22 +79,22 @@ fn create_commit_optional_path() {
         // Alice adds Bob without forced self-update
         // Since there are only Add Proposals, this does not generate a path field on the Commit
         // Creating a second proposal to add the same member should not fail, only committing that proposal should fail
-        let bob_add_proposal = group_alice_1234.create_add_proposal(
+        let bob_add_proposal = group_alice.create_add_proposal(
             group_aad,
             &alice_credential_bundle,
             bob_key_package.clone(),
         );
         let epoch_proposals = vec![bob_add_proposal];
-        let (mls_plaintext_commit, welcome_bundle_alice_bob_option, kpb_option) =
-            match group_alice_1234.create_commit(
+        let (mls_plaintext_commit, welcome_bundle_alice_bob_option, kpb_option) = match group_alice
+            .create_commit(
                 group_aad,
                 &alice_credential_bundle,
                 epoch_proposals.clone(),
                 false, /* don't force selfupdate */
             ) {
-                Ok(c) => c,
-                Err(e) => panic!("Error creating commit: {:?}", e),
-            };
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
         let commit = match &mls_plaintext_commit.content {
             MLSPlaintextContentType::Commit((commit, _)) => commit,
             _ => panic!(),
@@ -102,14 +102,14 @@ fn create_commit_optional_path() {
         assert!(commit.path.is_none() && kpb_option.is_none());
 
         // Alice applies the Commit without the forced self-update
-        match group_alice_1234.apply_commit(mls_plaintext_commit, epoch_proposals, &[]) {
+        match group_alice.apply_commit(mls_plaintext_commit, epoch_proposals, &[]) {
             Ok(_) => {}
             Err(e) => panic!("Error applying commit: {:?}", e),
         };
-        let ratchet_tree = group_alice_1234.tree().public_key_tree_copy();
+        let ratchet_tree = group_alice.tree().public_key_tree_copy();
 
         // Bob creates group from Welcome
-        let _group_bob_1234 = match MlsGroup::new_from_welcome(
+        let _group_bob = match MlsGroup::new_from_welcome(
             welcome_bundle_alice_bob_option.unwrap(),
             Some(ratchet_tree),
             bob_key_package_bundle,
@@ -119,12 +119,12 @@ fn create_commit_optional_path() {
         };
 
         assert_eq!(
-            group_alice_1234.tree().public_key_tree(),
-            group_alice_1234.tree().public_key_tree()
+            group_alice.tree().public_key_tree(),
+            group_alice.tree().public_key_tree()
         );
 
         // Alice updates
-        let alice_update_proposal = group_alice_1234.create_update_proposal(
+        let alice_update_proposal = group_alice.create_update_proposal(
             group_aad,
             &alice_credential_bundle,
             alice_update_key_package.clone(),
@@ -132,13 +132,12 @@ fn create_commit_optional_path() {
         let proposals = vec![alice_update_proposal];
 
         // Only UpdateProposal
-        let (commit_mls_plaintext, _welcome_option, kpb_option) = match group_alice_1234
-            .create_commit(
-                group_aad,
-                &alice_credential_bundle,
-                proposals.clone(),
-                false, /* force self update */
-            ) {
+        let (commit_mls_plaintext, _welcome_option, kpb_option) = match group_alice.create_commit(
+            group_aad,
+            &alice_credential_bundle,
+            proposals.clone(),
+            false, /* force self update */
+        ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
         };
@@ -151,7 +150,7 @@ fn create_commit_optional_path() {
         assert!(commit.path.is_some() && kpb_option.is_some());
 
         // Apply UpdateProposal
-        group_alice_1234
+        group_alice
             .apply_commit(
                 commit_mls_plaintext.clone(),
                 proposals,
@@ -191,7 +190,7 @@ fn basic_group_setup() {
 
         // Alice creates a group
         let group_id = [1, 2, 3, 4];
-        let group_alice_1234 = MlsGroup::new(
+        let group_alice = MlsGroup::new(
             &group_id,
             ciphersuite.name(),
             alice_key_package_bundle,
@@ -200,12 +199,12 @@ fn basic_group_setup() {
         .unwrap();
 
         // Alice adds Bob
-        let bob_add_proposal = group_alice_1234.create_add_proposal(
+        let bob_add_proposal = group_alice.create_add_proposal(
             group_aad,
             &alice_credential_bundle,
             bob_key_package.clone(),
         );
-        let _commit = match group_alice_1234.create_commit(
+        let _commit = match group_alice.create_commit(
             group_aad,
             &alice_credential_bundle,
             vec![bob_add_proposal],
@@ -264,7 +263,7 @@ fn group_operations() {
 
         // === Alice creates a group ===
         let group_id = [1, 2, 3, 4];
-        let mut group_alice_1234 = MlsGroup::new(
+        let mut group_alice = MlsGroup::new(
             &group_id,
             ciphersuite.name(),
             alice_key_package_bundle,
@@ -273,22 +272,22 @@ fn group_operations() {
         .unwrap();
 
         // === Alice adds Bob ===
-        let bob_add_proposal = group_alice_1234.create_add_proposal(
+        let bob_add_proposal = group_alice.create_add_proposal(
             group_aad,
             &alice_credential_bundle,
             bob_key_package.clone(),
         );
         let epoch_proposals = vec![bob_add_proposal];
-        let (mls_plaintext_commit, welcome_bundle_alice_bob_option, kpb_option) =
-            match group_alice_1234.create_commit(
+        let (mls_plaintext_commit, welcome_bundle_alice_bob_option, kpb_option) = match group_alice
+            .create_commit(
                 group_aad,
                 &alice_credential_bundle,
                 epoch_proposals.clone(),
                 false,
             ) {
-                Ok(c) => c,
-                Err(e) => panic!("Error creating commit: {:?}", e),
-            };
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
         let commit = match &mls_plaintext_commit.content {
             MLSPlaintextContentType::Commit((commit, _)) => commit,
             _ => panic!("Wrong content type"),
@@ -297,10 +296,10 @@ fn group_operations() {
         // Check that the function returned a Welcome message
         assert!(welcome_bundle_alice_bob_option.is_some());
 
-        group_alice_1234
+        group_alice
             .apply_commit(mls_plaintext_commit, epoch_proposals, &[])
             .expect("error applying commit");
-        let ratchet_tree = group_alice_1234.tree().public_key_tree_copy();
+        let ratchet_tree = group_alice.tree().public_key_tree_copy();
 
         let mut group_bob = match MlsGroup::new_from_welcome(
             welcome_bundle_alice_bob_option.unwrap(),
@@ -312,18 +311,15 @@ fn group_operations() {
         };
 
         // Make sure that both groups have the same public tree
-        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
-            _print_tree(&group_alice_1234.tree(), "Alice added Bob");
+        if group_alice.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice.tree(), "Alice added Bob");
             panic!("Different public trees");
         }
 
         // === Alice sends a message to Bob ===
         let message_alice = [1, 2, 3];
-        let mls_ciphertext_alice = group_alice_1234.create_application_message(
-            &[],
-            &message_alice,
-            &alice_credential_bundle,
-        );
+        let mls_ciphertext_alice =
+            group_alice.create_application_message(&[], &message_alice, &alice_credential_bundle);
         let mls_plaintext_bob = match group_bob.decrypt(mls_ciphertext_alice) {
             Ok(mls_plaintext) => mls_plaintext,
             Err(e) => panic!("Error decrypting MLSCiphertext: {:?}", e),
@@ -359,7 +355,7 @@ fn group_operations() {
         // Check that there is a new KeyPackageBundle
         assert!(kpb_option.is_some());
 
-        group_alice_1234
+        group_alice
             .apply_commit(
                 mls_plaintext_commit.clone(),
                 vec![update_proposal_bob.clone()],
@@ -375,8 +371,8 @@ fn group_operations() {
             .expect("Error applying commit (Bob)");
 
         // Make sure that both groups have the same public tree
-        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
-            _print_tree(&group_alice_1234.tree(), "Alice added Bob");
+        if group_alice.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice.tree(), "Alice added Bob");
             panic!("Different public trees");
         }
 
@@ -388,12 +384,12 @@ fn group_operations() {
         )
         .unwrap();
 
-        let update_proposal_alice = group_alice_1234.create_update_proposal(
+        let update_proposal_alice = group_alice.create_update_proposal(
             &[],
             &alice_credential_bundle,
             alice_update_key_package_bundle.get_key_package().clone(),
         );
-        let (mls_plaintext_commit, _, kpb_option) = match group_alice_1234.create_commit(
+        let (mls_plaintext_commit, _, kpb_option) = match group_alice.create_commit(
             &[],
             &alice_credential_bundle,
             vec![update_proposal_alice.clone()],
@@ -406,7 +402,7 @@ fn group_operations() {
         // Check that there is a new KeyPackageBundle
         assert!(kpb_option.is_some());
 
-        group_alice_1234
+        group_alice
             .apply_commit(
                 mls_plaintext_commit.clone(),
                 vec![update_proposal_alice.clone()],
@@ -422,8 +418,8 @@ fn group_operations() {
             .expect("Error applying commit (Bob)");
 
         // Make sure that both groups have the same public tree
-        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
-            _print_tree(&group_alice_1234.tree(), "Alice added Bob");
+        if group_alice.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice.tree(), "Alice added Bob");
             panic!("Different public trees");
         }
 
@@ -440,7 +436,7 @@ fn group_operations() {
             &bob_credential_bundle,
             bob_update_key_package_bundle.get_key_package().clone(),
         );
-        let (mls_plaintext_commit, _, kpb_option) = match group_alice_1234.create_commit(
+        let (mls_plaintext_commit, _, kpb_option) = match group_alice.create_commit(
             &[],
             &alice_credential_bundle,
             vec![update_proposal_bob.clone()],
@@ -453,7 +449,7 @@ fn group_operations() {
         // Check that there is a new KeyPackageBundle
         assert!(kpb_option.is_some());
 
-        group_alice_1234
+        group_alice
             .apply_commit(
                 mls_plaintext_commit.clone(),
                 vec![update_proposal_bob.clone()],
@@ -469,8 +465,8 @@ fn group_operations() {
             .expect("Error applying commit (Bob)");
 
         // Make sure that both groups have the same public tree
-        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
-            _print_tree(&group_alice_1234.tree(), "Alice added Bob");
+        if group_alice.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice.tree(), "Alice added Bob");
             panic!("Different public trees");
         }
 
@@ -506,7 +502,7 @@ fn group_operations() {
         // Make sure the is a Welcome message for Charlie
         assert!(welcome_for_charlie_option.is_some());
 
-        group_alice_1234
+        group_alice
             .apply_commit(
                 mls_plaintext_commit.clone(),
                 vec![add_charlie_proposal_bob.clone()],
@@ -521,7 +517,7 @@ fn group_operations() {
             )
             .expect("Error applying commit (Bob)");
 
-        let ratchet_tree = group_alice_1234.tree().public_key_tree_copy();
+        let ratchet_tree = group_alice.tree().public_key_tree_copy();
         let mut group_charlie = match MlsGroup::new_from_welcome(
             welcome_for_charlie_option.unwrap(),
             Some(ratchet_tree),
@@ -532,12 +528,12 @@ fn group_operations() {
         };
 
         // Make sure that all groups have the same public tree
-        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
-            _print_tree(&group_alice_1234.tree(), "Bob added Charlie");
+        if group_alice.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice.tree(), "Bob added Charlie");
             panic!("Different public trees");
         }
-        if group_alice_1234.tree().public_key_tree() != group_charlie.tree().public_key_tree() {
-            _print_tree(&group_alice_1234.tree(), "Bob added Charlie");
+        if group_alice.tree().public_key_tree() != group_charlie.tree().public_key_tree() {
+            _print_tree(&group_alice.tree(), "Bob added Charlie");
             panic!("Different public trees");
         }
 
@@ -548,7 +544,7 @@ fn group_operations() {
             &message_charlie,
             &charlie_credential_bundle,
         );
-        let mls_plaintext_alice = match group_alice_1234.decrypt(mls_ciphertext_charlie.clone()) {
+        let mls_plaintext_alice = match group_alice.decrypt(mls_ciphertext_charlie.clone()) {
             Ok(mls_plaintext) => mls_plaintext,
             Err(e) => panic!("Error decrypting MLSCiphertext: {:?}", e),
         };
@@ -591,7 +587,7 @@ fn group_operations() {
         // Check that there is a new KeyPackageBundle
         assert!(kpb_option.is_some());
 
-        group_alice_1234
+        group_alice
             .apply_commit(
                 mls_plaintext_commit.clone(),
                 vec![update_proposal_charlie.clone()],
@@ -614,12 +610,12 @@ fn group_operations() {
             .expect("Error applying commit (Charlie)");
 
         // Make sure that all groups have the same public tree
-        if group_alice_1234.tree().public_key_tree() != group_bob.tree().public_key_tree() {
-            _print_tree(&group_alice_1234.tree(), "Charlie updated");
+        if group_alice.tree().public_key_tree() != group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice.tree(), "Charlie updated");
             panic!("Different public trees");
         }
-        if group_alice_1234.tree().public_key_tree() != group_charlie.tree().public_key_tree() {
-            _print_tree(&group_alice_1234.tree(), "Charlie updated");
+        if group_alice.tree().public_key_tree() != group_charlie.tree().public_key_tree() {
+            _print_tree(&group_alice.tree(), "Charlie updated");
             panic!("Different public trees");
         }
 
@@ -642,7 +638,7 @@ fn group_operations() {
         // Check that there is a new KeyPackageBundle
         assert!(kpb_option.is_some());
 
-        group_alice_1234
+        group_alice
             .apply_commit(
                 mls_plaintext_commit.clone(),
                 vec![remove_bob_proposal_charlie.clone()],
@@ -668,12 +664,12 @@ fn group_operations() {
             .expect("Error applying commit (Charlie)");
 
         // Make sure that all groups have the same public tree
-        if group_alice_1234.tree().public_key_tree() == group_bob.tree().public_key_tree() {
-            _print_tree(&group_alice_1234.tree(), "Charlie removed Bob");
+        if group_alice.tree().public_key_tree() == group_bob.tree().public_key_tree() {
+            _print_tree(&group_alice.tree(), "Charlie removed Bob");
             panic!("Same public trees");
         }
-        if group_alice_1234.tree().public_key_tree() != group_charlie.tree().public_key_tree() {
-            _print_tree(&group_alice_1234.tree(), "Charlie removed Bob");
+        if group_alice.tree().public_key_tree() != group_charlie.tree().public_key_tree() {
+            _print_tree(&group_alice.tree(), "Charlie removed Bob");
             panic!("Different public trees");
         }
     }


### PR DESCRIPTION
This is a follow-up PR to #177.

This PR re-enables all remaining group operation tests that were previously commented out and closes #77.

While much more testing will be needed to cover more scenarios, this is not in the scope of this PR. The only goal is to have a baseline for testing.