### PR TITLE
Only keep ARM on linux for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: rust
 rust:
   - stable
-  - beta
-  - nightly
 os:
   - linux
-  - osx
 arch:
-  - amd64
   - arm64
 
 matrix:


### PR DESCRIPTION
Since Travis Ci became so slow and unreliable and we only need it for ARM, I removed all other targets. Maybe this helps staying within the 1000 minutes they allow fro OS projects as of now (see #189).