### PR TITLE
Use static ciphersuite references from the config.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ rust-crypto = ["evercrypt/rust-crypto-aes"]
 evercrypt = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt", branch = "0.0.3", features = ["serialization"] }
 evercrypt-sys = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt-sys", branch = "0.0.3" }
 
-[patch."https://github.com/franziskuskiefer/hpke-rs"]
-hpke = { path = "../hpke-rs" }
-
 [dev-dependencies]
 criterion = "^0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,18 @@ lazy_static = "1.4"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 hpke = {git = "https://github.com/franziskuskiefer/hpke-rs", version = "0.0.2", branch = "0.0.2", features = ["hazmat", "serialization"] }
-evercrypt = { version = "0.0.3" }
+evercrypt = { version = "0.0.3", features = ["serialization"] }
 
 [features]
 default = ["rust-crypto"]
 rust-crypto = ["evercrypt/rust-crypto-aes"]
 
 [patch.crates-io]
-evercrypt = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt", branch = "0.0.3" }
+evercrypt = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt", branch = "0.0.3", features = ["serialization"] }
 evercrypt-sys = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt-sys", branch = "0.0.3" }
+
+[patch."https://github.com/franziskuskiefer/hpke-rs"]
+hpke = { path = "../hpke-rs" }
 
 [dev-dependencies]
 criterion = "^0.2"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -16,7 +16,7 @@ fn criterion_kp_bundle(c: &mut Criterion) {
                     .unwrap()
             },
             |credential_bundle: CredentialBundle| {
-                KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new());
+                KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new()).unwrap();
             },
         );
     });

--- a/src/ciphersuite/codec.rs
+++ b/src/ciphersuite/codec.rs
@@ -16,18 +16,6 @@ impl Codec for CiphersuiteName {
     }
 }
 
-impl Codec for Ciphersuite {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        (self.name as u16).encode(buffer)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        Ok(Ciphersuite::new(CiphersuiteName::try_from(u16::decode(
-            cursor,
-        )?)?))
-    }
-}
-
 impl Codec for SignaturePublicKey {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         encode_vec(VecSize::VecU16, buffer, &self.value)?;

--- a/src/ciphersuite/test_ciphersuite.rs
+++ b/src/ciphersuite/test_ciphersuite.rs
@@ -7,9 +7,8 @@ use crate::config::Config;
 #[test]
 fn test_hpke_seal_open() {
     // Test through ciphersuites.
-    for &suite in Config::supported_ciphersuites() {
-        println!("Test {:?}", suite);
-        let ciphersuite = Ciphersuite::new(suite);
+    for ciphersuite in Config::supported_ciphersuites() {
+        println!("Test {:?}", ciphersuite.name());
         println!("Ciphersuite {:?}", ciphersuite);
         let plaintext = &[1, 2, 3];
         let kp = ciphersuite.derive_hpke_keypair(&[1, 2, 3]);
@@ -22,7 +21,8 @@ fn test_hpke_seal_open() {
 #[test]
 fn test_sign_verify() {
     let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
+        Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+            .unwrap();
     let keypair = ciphersuite.new_signature_keypair();
     let payload = &[1, 2, 3];
     let signature = keypair.sign(payload).unwrap();

--- a/src/extensions/capabilities_extension.rs
+++ b/src/extensions/capabilities_extension.rs
@@ -32,7 +32,7 @@ impl Default for CapabilitiesExtension {
     fn default() -> Self {
         CapabilitiesExtension {
             versions: Config::supported_versions().to_vec(),
-            ciphersuites: Config::supported_ciphersuites().to_vec(),
+            ciphersuites: Config::supported_ciphersuite_names().to_vec(),
             extensions: Config::supported_extensions().to_vec(),
         }
     }
@@ -54,7 +54,7 @@ impl CapabilitiesExtension {
             },
             ciphersuites: match ciphersuites {
                 Some(c) => c.to_vec(),
-                None => Config::supported_ciphersuites().to_vec(),
+                None => Config::supported_ciphersuite_names().to_vec(),
             },
             extensions: match extensions {
                 Some(e) => e.to_vec(),

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::framing::*;
 
 /// This tests serializing/deserializing MLSPlaintext
@@ -6,7 +7,8 @@ fn codec() {
     use crate::ciphersuite::*;
 
     let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
+        Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+            .unwrap();
     let credential_bundle =
         CredentialBundle::new(vec![7, 8, 9], CredentialType::Basic, ciphersuite.name()).unwrap();
     let sender = Sender {

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -15,6 +15,8 @@ pub enum WelcomeError {
     InvalidGroupInfoSignature = 107,
     GroupInfoDecryptionFailure = 108,
     DuplicateRatchetTreeExtension = 109,
+    UnsupportedMlsVersion = 110,
+    UnknownError = 111,
 }
 
 #[derive(PartialEq, Debug)]
@@ -56,7 +58,7 @@ impl From<TreeError> for WelcomeError {
             TreeError::DuplicateIndex => WelcomeError::InvalidRatchetTree,
             TreeError::InvalidArguments => WelcomeError::InvalidRatchetTree,
             TreeError::InvalidUpdatePath => WelcomeError::InvalidRatchetTree,
-            TreeError::NoneError => WelcomeError::InvalidRatchetTree,
+            TreeError::UnknownError => WelcomeError::UnknownError,
         }
     }
 }
@@ -73,5 +75,16 @@ impl From<ConfigError> for ApplyCommitError {
 impl From<ExtensionError> for ApplyCommitError {
     fn from(_e: ExtensionError) -> ApplyCommitError {
         ApplyCommitError::NoParentHashExtension
+    }
+}
+
+// TODO: Should get fixed in #83
+impl From<ConfigError> for WelcomeError {
+    fn from(e: ConfigError) -> WelcomeError {
+        match e {
+            ConfigError::UnsupportedMlsVersion => WelcomeError::UnsupportedMlsVersion,
+            ConfigError::UnsupportedCiphersuite => WelcomeError::CiphersuiteMismatch,
+            _ => WelcomeError::UnknownError,
+        }
     }
 }

--- a/src/group/managed_group.rs
+++ b/src/group/managed_group.rs
@@ -1,6 +1,7 @@
 use crate::ciphersuite::*;
 use crate::codec::*;
 use crate::creds::*;
+use crate::errors::ConfigError;
 use crate::framing::*;
 use crate::group::*;
 use crate::key_packages::*;
@@ -21,22 +22,22 @@ impl ManagedGroup {
         group_id: GroupId,
         ciphersuite_name: CiphersuiteName,
         key_package_bundle: KeyPackageBundle,
-    ) -> Self {
+    ) -> Result<Self, ConfigError> {
         let group = MlsGroup::new(
             &group_id.as_slice(),
             ciphersuite_name,
             key_package_bundle,
             GroupConfig::default(),
-        );
+        )?;
 
-        ManagedGroup {
+        Ok(ManagedGroup {
             group,
             generation: 0,
             plaintext_queue: vec![],
             public_queue: ProposalQueue::new(),
             own_queue: ProposalQueue::new(),
             pending_kpbs: vec![],
-        }
+        })
     }
     pub fn new_from_welcome(
         welcome: Welcome,

--- a/src/group/mls_group/api.rs
+++ b/src/group/mls_group/api.rs
@@ -1,4 +1,5 @@
 use crate::creds::CredentialBundle;
+use crate::errors::ConfigError;
 use crate::framing::*;
 use crate::group::*;
 use crate::key_packages::*;
@@ -12,7 +13,7 @@ pub trait Api: Sized {
         ciphersuite_name: CiphersuiteName,
         key_package_bundle: KeyPackageBundle,
         config: GroupConfig,
-    ) -> Self;
+    ) -> Result<Self, ConfigError>;
     /// Join a group from a Welcome message
     fn new_from_welcome(
         welcome: Welcome,

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -188,7 +188,7 @@ impl MlsGroup {
             // Create welcome message
             let welcome = Welcome::new(
                 Config::supported_versions()[0],
-                self.ciphersuite.name(),
+                self.ciphersuite,
                 secrets,
                 encrypted_group_info,
             );

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -5,7 +5,9 @@ mod new_from_welcome;
 
 use crate::ciphersuite::*;
 use crate::codec::*;
+use crate::config::Config;
 use crate::creds::CredentialBundle;
+use crate::errors::ConfigError;
 use crate::framing::*;
 use crate::group::*;
 use crate::key_packages::*;
@@ -19,7 +21,7 @@ use std::cell::{Ref, RefCell};
 use std::convert::TryFrom;
 
 pub struct MlsGroup {
-    ciphersuite: Ciphersuite,
+    ciphersuite: &'static Ciphersuite,
     group_context: GroupContext,
     generation: u32,
     epoch_secrets: EpochSecrets,
@@ -38,11 +40,12 @@ impl Api for MlsGroup {
         ciphersuite_name: CiphersuiteName,
         key_package_bundle: KeyPackageBundle,
         config: GroupConfig,
-    ) -> MlsGroup {
+    ) -> Result<Self, ConfigError> {
         let group_id = GroupId { value: id.to_vec() };
         let epoch_secrets = EpochSecrets::new();
+        let ciphersuite = Config::ciphersuite(ciphersuite_name)?;
         let secret_tree = SecretTree::new(&epoch_secrets.encryption_secret, LeafIndex::from(1u32));
-        let tree = RatchetTree::new(ciphersuite_name, key_package_bundle);
+        let tree = RatchetTree::new(ciphersuite, key_package_bundle);
         let group_context = GroupContext {
             group_id,
             epoch: GroupEpoch(0),
@@ -50,8 +53,8 @@ impl Api for MlsGroup {
             confirmed_transcript_hash: vec![],
         };
         let interim_transcript_hash = vec![];
-        MlsGroup {
-            ciphersuite: Ciphersuite::new(ciphersuite_name),
+        Ok(MlsGroup {
+            ciphersuite,
             group_context,
             generation: 0,
             epoch_secrets,
@@ -59,8 +62,9 @@ impl Api for MlsGroup {
             tree: RefCell::new(tree),
             interim_transcript_hash,
             add_ratchet_tree_extension: config.add_ratchet_tree_extension,
-        }
+        })
     }
+
     // Join a group from a welcome message
     fn new_from_welcome(
         welcome: Welcome,
@@ -195,7 +199,7 @@ impl Api for MlsGroup {
         let mut secret_tree = self.secret_tree.borrow_mut();
         let secret_type = SecretType::try_from(&mls_plaintext).unwrap();
         let (generation, (ratchet_key, ratchet_nonce)) = secret_tree.get_secret_for_encryption(
-            &self.ciphersuite,
+            self.ciphersuite(),
             mls_plaintext.sender.sender,
             secret_type,
         );
@@ -222,7 +226,7 @@ impl Api for MlsGroup {
         }
 
         Ok(mls_ciphertext.to_plaintext(
-            &self.ciphersuite,
+            self.ciphersuite(),
             &roster,
             &self.epoch_secrets,
             &mut self.secret_tree.borrow_mut(),
@@ -244,7 +248,7 @@ impl Api for MlsGroup {
 
 impl Codec for MlsGroup {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.ciphersuite.encode(buffer)?;
+        self.ciphersuite.name().encode(buffer)?;
         self.group_context.encode(buffer)?;
         self.generation.encode(buffer)?;
         self.epoch_secrets.encode(buffer)?;
@@ -254,7 +258,7 @@ impl Codec for MlsGroup {
         Ok(())
     }
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let ciphersuite = Ciphersuite::decode(cursor)?;
+        let ciphersuite = CiphersuiteName::decode(cursor)?;
         let group_context = GroupContext::decode(cursor)?;
         let generation = u32::decode(cursor)?;
         let epoch_secrets = EpochSecrets::decode(cursor)?;
@@ -262,7 +266,7 @@ impl Codec for MlsGroup {
         let tree = RatchetTree::decode(cursor)?;
         let interim_transcript_hash = decode_vec(VecSize::VecU8, cursor)?;
         let group = MlsGroup {
-            ciphersuite,
+            ciphersuite: Config::ciphersuite(ciphersuite)?,
             group_context,
             generation,
             epoch_secrets,
@@ -282,8 +286,10 @@ impl MlsGroup {
     fn sender_index(&self) -> LeafIndex {
         self.tree.borrow().get_own_node_index().into()
     }
+
+    /// Get the ciphersuite implementation used in this group.
     pub(crate) fn ciphersuite(&self) -> &Ciphersuite {
-        &self.ciphersuite
+        self.ciphersuite
     }
 
     pub(crate) fn context(&self) -> &GroupContext {

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -13,8 +13,7 @@ impl MlsGroup {
         nodes_option: Option<Vec<Option<Node>>>,
         key_package_bundle: KeyPackageBundle,
     ) -> Result<Self, WelcomeError> {
-        let ciphersuite_name = welcome.get_ciphersuite();
-        let ciphersuite = Ciphersuite::new(ciphersuite_name);
+        let ciphersuite = welcome.ciphersuite();
 
         // Find key_package in welcome secrets
         let egs = if let Some(egs) = Self::find_key_package_from_welcome_secrets(
@@ -25,7 +24,7 @@ impl MlsGroup {
         } else {
             return Err(WelcomeError::JoinerSecretNotFound);
         };
-        if ciphersuite_name != key_package_bundle.get_key_package().cipher_suite() {
+        if ciphersuite.name() != key_package_bundle.get_key_package().cipher_suite().name() {
             return Err(WelcomeError::CiphersuiteMismatch);
         }
 
@@ -77,7 +76,7 @@ impl MlsGroup {
             }
         };
 
-        let mut tree = RatchetTree::new_from_nodes(ciphersuite_name, key_package_bundle, &nodes)?;
+        let mut tree = RatchetTree::new_from_nodes(ciphersuite, key_package_bundle, &nodes)?;
 
         // Verify tree hash
         if tree.compute_tree_hash() != group_info.tree_hash() {

--- a/src/key_packages/codec.rs
+++ b/src/key_packages/codec.rs
@@ -1,4 +1,4 @@
-use crate::config::ProtocolVersion;
+use crate::config::{Config, ProtocolVersion};
 use crate::extensions::*;
 use crate::key_packages::*;
 
@@ -18,7 +18,7 @@ impl Codec for KeyPackage {
         let signature = Signature::decode(cursor)?;
         let kp = KeyPackage {
             protocol_version,
-            cipher_suite: cipher_suite_name,
+            cipher_suite: Config::ciphersuite(cipher_suite_name)?,
             hpke_init_key,
             credential,
             extensions,

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -1,12 +1,15 @@
 use crate::ciphersuite::*;
 use crate::codec::*;
+use crate::config::Config;
 use crate::config::ProtocolVersion;
 use crate::creds::*;
+use crate::errors::ConfigError;
 use crate::extensions::{
     CapabilitiesExtension, Extension, ExtensionError, ExtensionStruct, ExtensionType,
     ParentHashExtension,
 };
 use crate::schedule::*;
+
 use evercrypt::rand_util::*;
 
 mod codec;
@@ -35,7 +38,7 @@ impl From<ExtensionError> for KeyPackageError {
 #[derive(Debug, Clone, PartialEq)]
 pub struct KeyPackage {
     protocol_version: ProtocolVersion,
-    cipher_suite: CiphersuiteName,
+    cipher_suite: &'static Ciphersuite,
     hpke_init_key: HPKEPublicKey,
     credential: Credential,
     extensions: Vec<Box<dyn Extension>>,
@@ -54,18 +57,18 @@ impl KeyPackage {
         hpke_init_key: HPKEPublicKey,
         credential_bundle: &CredentialBundle,
         extensions: Vec<Box<dyn Extension>>,
-    ) -> Self {
+    ) -> Result<Self, ConfigError> {
         let mut key_package = Self {
             // TODO: #85 Take from global config.
             protocol_version: ProtocolVersion::default(),
-            cipher_suite: ciphersuite_name,
+            cipher_suite: Config::ciphersuite(ciphersuite_name)?,
             hpke_init_key,
             credential: credential_bundle.credential().clone(),
             extensions,
             signature: Signature::new_empty(),
         };
         key_package.sign(&credential_bundle);
-        key_package
+        Ok(key_package)
     }
 
     /// Verify that this key package is valid:
@@ -118,7 +121,7 @@ impl KeyPackage {
     /// Compute the hash of the encoding of this key package.
     pub(crate) fn hash(&self) -> Vec<u8> {
         let bytes = self.encode_detached().unwrap();
-        Ciphersuite::new(self.cipher_suite).hash(&bytes)
+        self.cipher_suite.hash(&bytes)
     }
 
     /// Get a reference to the extension of `extension_type`.
@@ -182,8 +185,8 @@ impl KeyPackage {
         self.hpke_init_key = hpke_init_key;
     }
 
-    /// Get the `CiphersuiteName`.
-    pub(crate) fn cipher_suite(&self) -> CiphersuiteName {
+    /// Get the `Ciphersuite`.
+    pub(crate) fn cipher_suite(&self) -> &Ciphersuite {
         self.cipher_suite
     }
 
@@ -197,7 +200,7 @@ impl KeyPackage {
     fn unsigned_payload(&self) -> Result<Vec<u8>, CodecError> {
         let buffer = &mut Vec::new();
         self.protocol_version.encode(buffer)?;
-        self.cipher_suite.encode(buffer)?;
+        self.cipher_suite.name().encode(buffer)?;
         self.hpke_init_key.encode(buffer)?;
         self.credential.encode(buffer)?;
         // Get extensions encoded. We need to build a Vec::<ExtensionStruct> first.
@@ -233,9 +236,9 @@ impl KeyPackageBundle {
         ciphersuites: &[CiphersuiteName],
         credential_bundle: &CredentialBundle,
         extensions: Vec<Box<dyn Extension>>,
-    ) -> Self {
+    ) -> Result<Self, ConfigError> {
         debug_assert!(!ciphersuites.is_empty());
-        let ciphersuite = Ciphersuite::new(ciphersuites[0]);
+        let ciphersuite = Config::ciphersuite(ciphersuites[0]).unwrap();
         let leaf_secret = get_random_vec(ciphersuite.hash_length());
         Self::new_from_leaf_secret(ciphersuites, credential_bundle, extensions, leaf_secret)
     }
@@ -245,9 +248,9 @@ impl KeyPackageBundle {
         credential_bundle: &CredentialBundle,
         extensions: Vec<Box<dyn Extension>>,
         leaf_secret: Vec<u8>,
-    ) -> Self {
+    ) -> Result<Self, ConfigError> {
         debug_assert!(!ciphersuites.is_empty());
-        let ciphersuite = &Ciphersuite::new(ciphersuites[0]);
+        let ciphersuite = Config::ciphersuite(ciphersuites[0]).unwrap();
         let leaf_node_secret = Self::derive_leaf_node_secret(ciphersuite, &leaf_secret);
         let keypair = ciphersuite.derive_hpke_keypair(&leaf_node_secret);
         Self::new_with_keypair(
@@ -274,7 +277,7 @@ impl KeyPackageBundle {
         extensions: Vec<Box<dyn Extension>>,
         key_pair: HPKEKeyPair,
         leaf_secret: Vec<u8>,
-    ) -> Self {
+    ) -> Result<Self, ConfigError> {
         debug_assert!(!ciphersuites.is_empty());
         let capabilities_extension = CapabilitiesExtension::new(None, Some(ciphersuites), None);
         let mut final_extensions: Vec<Box<dyn Extension>> = vec![Box::new(capabilities_extension)];
@@ -286,12 +289,12 @@ impl KeyPackageBundle {
             public_key,
             credential_bundle,
             final_extensions,
-        );
-        KeyPackageBundle {
+        )?;
+        Ok(KeyPackageBundle {
             key_package,
             private_key,
             leaf_secret,
-        }
+        })
     }
 
     /// Assembles a new KeyPackageBundle from a KeyPackage, a HPKEPrivateKey, and a leaf secret

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -6,7 +6,7 @@ fn generate_key_package() {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let credential_bundle =
         CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, ciphersuite_name).unwrap();
-    let kpb = KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new());
+    let kpb = KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new()).unwrap();
     // This is invalid because the lifetime extension is missing.
     assert!(kpb.get_key_package().verify().is_err());
 
@@ -16,7 +16,8 @@ fn generate_key_package() {
         &[ciphersuite_name],
         &credential_bundle,
         vec![lifetime_extension],
-    );
+    )
+    .unwrap();
     std::thread::sleep(std::time::Duration::from_secs(1));
     assert!(kpb.get_key_package().verify().is_ok());
 
@@ -26,7 +27,8 @@ fn generate_key_package() {
         &[ciphersuite_name],
         &credential_bundle,
         vec![lifetime_extension],
-    );
+    )
+    .unwrap();
     std::thread::sleep(std::time::Duration::from_secs(1));
     assert!(kpb.get_key_package().verify().is_err());
 }
@@ -37,7 +39,8 @@ fn test_codec() {
     let id = vec![1, 2, 3];
     let credential_bundle =
         CredentialBundle::new(id, CredentialType::Basic, ciphersuite_name).unwrap();
-    let mut kpb = KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new());
+    let mut kpb =
+        KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new()).unwrap();
 
     // Encode and decode the key package.
     let enc = kpb.get_key_package().encode_detached().unwrap();
@@ -67,7 +70,8 @@ fn key_package_id_extension() {
         &[ciphersuite_name],
         &credential_bundle,
         vec![Box::new(LifetimeExtension::new(60))],
-    );
+    )
+    .unwrap();
     assert!(kpb.get_key_package().verify().is_ok());
 
     // Add an ID to the key package.

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1,5 +1,6 @@
 use crate::ciphersuite::{signable::*, *};
 use crate::codec::*;
+use crate::config::Config;
 use crate::config::ProtocolVersion;
 use crate::extensions::*;
 use crate::group::*;
@@ -302,7 +303,7 @@ impl Codec for EncryptedGroupSecrets {
 #[derive(Clone, Debug)]
 pub struct Welcome {
     version: ProtocolVersion,
-    cipher_suite: CiphersuiteName,
+    cipher_suite: &'static Ciphersuite,
     secrets: Vec<EncryptedGroupSecrets>,
     encrypted_group_info: Vec<u8>,
 }
@@ -312,7 +313,7 @@ impl Welcome {
     /// Note that secrets and the encrypted group info are consumed.
     pub(crate) fn new(
         version: ProtocolVersion,
-        cipher_suite: CiphersuiteName,
+        cipher_suite: &'static Ciphersuite,
         secrets: Vec<EncryptedGroupSecrets>,
         encrypted_group_info: Vec<u8>,
     ) -> Self {
@@ -325,7 +326,7 @@ impl Welcome {
     }
 
     /// Get a reference to the ciphersuite in this Welcome message.
-    pub(crate) fn get_ciphersuite(&self) -> CiphersuiteName {
+    pub(crate) fn ciphersuite(&self) -> &'static Ciphersuite {
         self.cipher_suite
     }
 
@@ -343,7 +344,7 @@ impl Welcome {
 impl Codec for Welcome {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.version.encode(buffer)?;
-        self.cipher_suite.encode(buffer)?;
+        self.cipher_suite.name().encode(buffer)?;
         encode_vec(VecSize::VecU32, buffer, &self.secrets)?;
         encode_vec(VecSize::VecU32, buffer, &self.encrypted_group_info)?;
         Ok(())
@@ -355,7 +356,7 @@ impl Codec for Welcome {
         let encrypted_group_info = decode_vec(VecSize::VecU32, cursor)?;
         Ok(Welcome {
             version,
-            cipher_suite,
+            cipher_suite: Config::ciphersuite(cipher_suite)?,
             secrets,
             encrypted_group_info,
         })

--- a/src/messages/test_proposals.rs
+++ b/src/messages/test_proposals.rs
@@ -1,4 +1,3 @@
-use crate::ciphersuite::*;
 use crate::config::*;
 use crate::creds::*;
 use crate::extensions::*;
@@ -13,15 +12,13 @@ use crate::tree::index::*;
 /// `get_filtered_proposals` returns only proposals of a certain type
 #[test]
 fn proposal_queue_functions() {
-    for ciphersuite_name in Config::supported_ciphersuites() {
-        let ciphersuite = Ciphersuite::new(*ciphersuite_name);
-
+    for ciphersuite in Config::supported_ciphersuites() {
         // Define identities
         let alice_credential_bundle =
-            CredentialBundle::new("Alice".into(), CredentialType::Basic, *ciphersuite_name)
+            CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite.name())
                 .unwrap();
         let bob_credential_bundle =
-            CredentialBundle::new("Bob".into(), CredentialType::Basic, *ciphersuite_name).unwrap();
+            CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite.name()).unwrap();
 
         // Mandatory extensions, will be fixed in #164
         let lifetime_extension = Box::new(LifetimeExtension::new(60));
@@ -29,21 +26,24 @@ fn proposal_queue_functions() {
 
         // Generate KeyPackages
         let alice_key_package_bundle = KeyPackageBundle::new(
-            &[*ciphersuite_name],
+            &[ciphersuite.name()],
             &alice_credential_bundle,
             mandatory_extensions.clone(),
-        );
+        )
+        .unwrap();
         let bob_key_package_bundle = KeyPackageBundle::new(
-            &[*ciphersuite_name],
+            &[ciphersuite.name()],
             &bob_credential_bundle,
             mandatory_extensions.clone(),
-        );
+        )
+        .unwrap();
         let bob_key_package = bob_key_package_bundle.get_key_package();
         let alice_update_key_package_bundle = KeyPackageBundle::new(
-            &[*ciphersuite_name],
+            &[ciphersuite.name()],
             &alice_credential_bundle,
             mandatory_extensions,
-        );
+        )
+        .unwrap();
         let alice_update_key_package = alice_update_key_package_bundle.get_key_package();
         assert!(alice_update_key_package.verify().is_ok());
 
@@ -66,11 +66,11 @@ fn proposal_queue_functions() {
         };
 
         let proposal_add_alice1 = Proposal::Add(add_proposal_alice1);
-        let proposal_id_add_alice1 = ProposalID::from_proposal(&ciphersuite, &proposal_add_alice1);
+        let proposal_id_add_alice1 = ProposalID::from_proposal(ciphersuite, &proposal_add_alice1);
         let proposal_add_alice2 = Proposal::Add(add_proposal_alice2);
-        let proposal_id_add_alice2 = ProposalID::from_proposal(&ciphersuite, &proposal_add_alice2);
+        let proposal_id_add_alice2 = ProposalID::from_proposal(ciphersuite, &proposal_add_alice2);
         let proposal_add_bob1 = Proposal::Add(add_proposal_bob1);
-        let proposal_id_add_bob1 = ProposalID::from_proposal(&ciphersuite, &proposal_add_bob1);
+        let proposal_id_add_bob1 = ProposalID::from_proposal(ciphersuite, &proposal_add_bob1);
 
         // Test proposal types
         assert!(proposal_add_alice1.is_type(ProposalType::Add));

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,6 +1,7 @@
 use crate::ciphersuite::*;
 use crate::codec::*;
 use crate::creds::*;
+use crate::errors::ConfigError;
 use crate::key_packages::*;
 use crate::messages::{proposals::*, *};
 
@@ -36,7 +37,7 @@ mod test_util;
 /// The ratchet tree.
 pub struct RatchetTree {
     /// The ciphersuite used in this tree.
-    ciphersuite: Ciphersuite,
+    ciphersuite: &'static Ciphersuite,
 
     /// All nodes in the tree.
     /// Note that these only hold public values.
@@ -50,7 +51,7 @@ pub struct RatchetTree {
 
 impl RatchetTree {
     /// Create a new empty `RatchetTree`.
-    pub(crate) fn new(ciphersuite_name: CiphersuiteName, kpb: KeyPackageBundle) -> RatchetTree {
+    pub(crate) fn new(ciphersuite: &'static Ciphersuite, kpb: KeyPackageBundle) -> RatchetTree {
         let nodes = vec![Node {
             node_type: NodeType::Leaf,
             key_package: Some(kpb.get_key_package().clone()),
@@ -59,7 +60,7 @@ impl RatchetTree {
         let private_tree = PrivateTree::from_key_package_bundle(NodeIndex::from(0u32), &kpb);
 
         RatchetTree {
-            ciphersuite: Ciphersuite::new(ciphersuite_name),
+            ciphersuite,
             nodes,
             private_tree,
         }
@@ -69,7 +70,7 @@ impl RatchetTree {
     /// and an empty `PrivateTree`
     pub(crate) fn new_from_public_tree(ratchet_tree: &RatchetTree) -> Self {
         RatchetTree {
-            ciphersuite: ratchet_tree.ciphersuite.clone(),
+            ciphersuite: ratchet_tree.ciphersuite,
             nodes: ratchet_tree.nodes.clone(),
             private_tree: PrivateTree::new(ratchet_tree.private_tree.get_node_index()),
         }
@@ -78,7 +79,7 @@ impl RatchetTree {
     /// Generate a new `RatchetTree` from `Node`s with the client's key package
     /// bundle `kpb`.
     pub(crate) fn new_from_nodes(
-        ciphersuite_name: CiphersuiteName,
+        ciphersuite: &'static Ciphersuite,
         kpb: KeyPackageBundle,
         node_options: &[Option<Node>],
     ) -> Result<RatchetTree, TreeError> {
@@ -114,7 +115,6 @@ impl RatchetTree {
             }
         }
 
-        let ciphersuite = Ciphersuite::new(ciphersuite_name);
         // Build private tree
         let private_tree = PrivateTree::from_key_package_bundle(own_node_index, &kpb);
 
@@ -888,7 +888,18 @@ impl UpdatePath {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum TreeError {
     InvalidArguments,
-    NoneError,
     DuplicateIndex,
     InvalidUpdatePath,
+    UnknownError,
+}
+
+// TODO: Should get fixed in #83
+impl From<ConfigError> for TreeError {
+    fn from(e: ConfigError) -> TreeError {
+        match e {
+            ConfigError::UnsupportedMlsVersion => TreeError::InvalidArguments,
+            ConfigError::UnsupportedCiphersuite => TreeError::InvalidArguments,
+            _ => TreeError::UnknownError,
+        }
+    }
 }

--- a/src/tree/private_tree.rs
+++ b/src/tree/private_tree.rs
@@ -52,9 +52,8 @@ impl PrivateTree {
         key_package_bundle: &KeyPackageBundle,
     ) -> Self {
         let leaf_secret = key_package_bundle.leaf_secret();
-        let ciphersuite = Ciphersuite::new(key_package_bundle.key_package.cipher_suite());
-        let leaf_node_secret =
-            KeyPackageBundle::derive_leaf_node_secret(&ciphersuite, &leaf_secret);
+        let ciphersuite = key_package_bundle.key_package.cipher_suite();
+        let leaf_node_secret = KeyPackageBundle::derive_leaf_node_secret(ciphersuite, &leaf_secret);
         let keypair = ciphersuite.derive_hpke_keypair(&leaf_node_secret);
         let (private_key, _) = keypair.into_keys();
 

--- a/src/tree/secret_tree.rs
+++ b/src/tree/secret_tree.rs
@@ -211,7 +211,7 @@ impl SecretTree {
 
     /// Return RatchetSecrets for a given index and generation. This should be called when decrypting
     /// an MLSCiphertext received fromanother member. Returns an error if index or genartion are out of bound.
-    pub fn get_secret_for_decryption(
+    pub(crate) fn get_secret_for_decryption(
         &mut self,
         ciphersuite: &Ciphersuite,
         index: LeafIndex,
@@ -230,7 +230,7 @@ impl SecretTree {
     }
 
     /// Return the next RatchetSecrets that should be used for encryption and then increments the generation.
-    pub fn get_secret_for_encryption(
+    pub(crate) fn get_secret_for_encryption(
         &mut self,
         ciphersuite: &Ciphersuite,
         index: LeafIndex,

--- a/src/tree/sender_ratchet.rs
+++ b/src/tree/sender_ratchet.rs
@@ -55,7 +55,7 @@ impl SenderRatchet {
         }
     }
     /// Gets a secret from the SenderRatchet. Returns an error if the generation is out of bound.
-    pub fn get_secret_for_decryption(
+    pub(crate) fn get_secret_for_decryption(
         &mut self,
         ciphersuite: &Ciphersuite,
         generation: u32,

--- a/src/tree/test_private_tree.rs
+++ b/src/tree/test_private_tree.rs
@@ -3,16 +3,24 @@
 #[cfg(test)]
 use super::{index::NodeIndex, private_tree::*, test_util::*};
 #[cfg(test)]
-use crate::{ciphersuite::*, creds::*, key_packages::*, utils::*};
+use crate::{ciphersuite::*, config::Config, creds::*, key_packages::*, utils::*};
 
 #[cfg(test)]
 // Common setup for tests.
-fn setup(len: usize) -> (Ciphersuite, KeyPackageBundle, NodeIndex, Vec<NodeIndex>) {
+fn setup(
+    len: usize,
+) -> (
+    &'static Ciphersuite,
+    KeyPackageBundle,
+    NodeIndex,
+    Vec<NodeIndex>,
+) {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let ciphersuite = Ciphersuite::new(ciphersuite_name);
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
     let credential_bundle =
         CredentialBundle::new("username".into(), CredentialType::Basic, ciphersuite_name).unwrap();
-    let key_package_bundle = KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, vec![]);
+    let key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, vec![]).unwrap();
     let own_index = NodeIndex::from(0u32);
     let direct_path = generate_path_u8(len);
 

--- a/src/tree/test_secret_tree.rs
+++ b/src/tree/test_secret_tree.rs
@@ -2,27 +2,29 @@
 #[test]
 fn test_boundaries() {
     use crate::ciphersuite::*;
+    use crate::config::Config;
     use crate::tree::{index::*, secret_tree::*};
 
     let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519);
+        Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519)
+            .unwrap();
     let mut secret_tree = SecretTree::new(&[0u8; 32], LeafIndex::from(2u32));
     let secret_type = SecretType::ApplicationSecret;
     assert!(secret_tree
-        .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 0)
+        .get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 0)
         .is_ok());
     assert!(secret_tree
-        .get_secret_for_decryption(&ciphersuite, LeafIndex::from(1u32), secret_type, 0)
+        .get_secret_for_decryption(ciphersuite, LeafIndex::from(1u32), secret_type, 0)
         .is_ok());
     assert!(secret_tree
-        .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 1)
+        .get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 1)
         .is_ok());
     assert!(secret_tree
-        .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 1_000)
+        .get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 1_000)
         .is_ok());
     assert_eq!(
         secret_tree.get_secret_for_decryption(
-            &ciphersuite,
+            ciphersuite,
             LeafIndex::from(1u32),
             secret_type,
             1001
@@ -30,34 +32,29 @@ fn test_boundaries() {
         Err(SecretTreeError::TooDistantInTheFuture)
     );
     assert!(secret_tree
-        .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 996)
+        .get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 996)
         .is_ok());
     assert_eq!(
-        secret_tree.get_secret_for_decryption(
-            &ciphersuite,
-            LeafIndex::from(0u32),
-            secret_type,
-            995
-        ),
+        secret_tree.get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 995),
         Err(SecretTreeError::TooDistantInThePast)
     );
     assert_eq!(
-        secret_tree.get_secret_for_decryption(&ciphersuite, LeafIndex::from(2u32), secret_type, 0),
+        secret_tree.get_secret_for_decryption(ciphersuite, LeafIndex::from(2u32), secret_type, 0),
         Err(SecretTreeError::IndexOutOfBounds)
     );
     let mut largetree = SecretTree::new(&[0u8; 32], LeafIndex::from(100_000u32));
     assert!(largetree
-        .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 0)
+        .get_secret_for_decryption(ciphersuite, LeafIndex::from(0u32), secret_type, 0)
         .is_ok());
     assert!(largetree
-        .get_secret_for_decryption(&ciphersuite, LeafIndex::from(99_999u32), secret_type, 0)
+        .get_secret_for_decryption(ciphersuite, LeafIndex::from(99_999u32), secret_type, 0)
         .is_ok());
     assert!(largetree
-        .get_secret_for_decryption(&ciphersuite, LeafIndex::from(99_999u32), secret_type, 1_000)
+        .get_secret_for_decryption(ciphersuite, LeafIndex::from(99_999u32), secret_type, 1_000)
         .is_ok());
     assert_eq!(
         largetree.get_secret_for_decryption(
-            &ciphersuite,
+            ciphersuite,
             LeafIndex::from(100_000u32),
             secret_type,
             0
@@ -69,14 +66,16 @@ fn test_boundaries() {
 // This tests if the generation gets incremented correctly and that the returned values are unique.
 #[test]
 fn increment_generation() {
-    use crate::ciphersuite::*;
+    use crate::ciphersuite::CiphersuiteName;
+    use crate::config::Config;
     use crate::tree::{secret_tree::*, *};
     use std::collections::HashMap;
 
     const SIZE: usize = 100;
     const MAX_GENERATIONS: usize = 10;
     let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
+        Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+            .unwrap();
     let mut unique_values: HashMap<Vec<u8>, bool> = HashMap::new();
     let mut secret_tree = SecretTree::new(&[1, 2, 3], LeafIndex::from(SIZE as u32));
     for i in 0..SIZE {
@@ -93,7 +92,7 @@ fn increment_generation() {
         for j in 0..SIZE {
             let (next_gen, (handshake_key, handshake_nonce)) = secret_tree
                 .get_secret_for_encryption(
-                    &ciphersuite,
+                    ciphersuite,
                     LeafIndex::from(j as u32),
                     SecretType::HandshakeSecret,
                 );
@@ -106,7 +105,7 @@ fn increment_generation() {
                 .is_none());
             let (next_gen, (application_key, application_nonce)) = secret_tree
                 .get_secret_for_encryption(
-                    &ciphersuite,
+                    ciphersuite,
                     LeafIndex::from(j as u32),
                     SecretType::ApplicationSecret,
                 );

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -1,4 +1,5 @@
 use super::treemath::TreeMathError;
+use crate::config::Config;
 
 /// The following test uses an old test vector that assumes an outdated version
 /// of the treemath defined in the spec. In a few select cases, we should now
@@ -107,14 +108,15 @@ fn test_tree_hash() {
     fn create_identity(id: &[u8], ciphersuite_name: CiphersuiteName) -> KeyPackageBundle {
         let credential_bundle =
             CredentialBundle::new(id.to_vec(), CredentialType::Basic, ciphersuite_name).unwrap();
-        KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new())
+        KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new()).unwrap()
     }
 
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
     let kbp = create_identity(b"Tree creator", ciphersuite_name);
 
     // Initialise tree
-    let mut tree = RatchetTree::new(ciphersuite_name, kbp);
+    let mut tree = RatchetTree::new(ciphersuite, kbp);
     let tree_hash = tree.compute_tree_hash();
     println!("Tree hash: {:?}", tree_hash);
 

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -48,7 +48,7 @@ fn default_extensions() {
 #[test]
 fn default_ciphersuites() {
     // Make sure the supported ciphersuites are what we expect them to be.
-    let supported_ciphersuites = Config::supported_ciphersuites();
+    let supported_ciphersuites = Config::supported_ciphersuite_names();
     assert_eq!(
         vec![
             CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,

--- a/tests/test_framing.rs
+++ b/tests/test_framing.rs
@@ -9,9 +9,10 @@ fn padding() {
     let id = vec![1, 2, 3];
     let credential_bundle =
         CredentialBundle::new(id.clone(), CredentialType::Basic, ciphersuite_name).unwrap();
-    let kpb = KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new());
+    let kpb = KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new()).unwrap();
 
-    let mut group_alice = MlsGroup::new(&id, ciphersuite_name, kpb, GroupConfig::default());
+    let mut group_alice =
+        MlsGroup::new(&id, ciphersuite_name, kpb, GroupConfig::default()).unwrap();
     const PADDING_SIZE: usize = 10;
 
     for _ in 0..100 {

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -20,20 +20,23 @@ fn create_commit_optional_path() {
         &[ciphersuite_name],
         &alice_credential_bundle,
         mandatory_extensions.clone(),
-    );
+    )
+    .unwrap();
 
     let bob_key_package_bundle = KeyPackageBundle::new(
         &[ciphersuite_name],
         &bob_credential_bundle,
         mandatory_extensions.clone(),
-    );
+    )
+    .unwrap();
     let bob_key_package = bob_key_package_bundle.get_key_package();
 
     let alice_update_key_package_bundle = KeyPackageBundle::new(
         &[ciphersuite_name],
         &alice_credential_bundle,
         mandatory_extensions,
-    );
+    )
+    .unwrap();
     let alice_update_key_package = alice_update_key_package_bundle.get_key_package();
     assert!(alice_update_key_package.verify().is_ok());
 
@@ -44,7 +47,8 @@ fn create_commit_optional_path() {
         ciphersuite_name,
         alice_key_package_bundle,
         GroupConfig::default(),
-    );
+    )
+    .unwrap();
 
     // Alice proposes to add Bob with forced self-update
     // Even though there are only Add Proposals, this should generated a path field on the Commit
@@ -168,14 +172,16 @@ fn basic_group_setup() {
         &[ciphersuite_name],
         &bob_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Vec::new(),
-    );
+    )
+    .unwrap();
     let bob_key_package = bob_key_package_bundle.get_key_package();
 
     let alice_key_package_bundle = KeyPackageBundle::new(
         &[ciphersuite_name],
         &alice_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Vec::new(),
-    );
+    )
+    .unwrap();
 
     // Alice creates a group
     let group_id = [1, 2, 3, 4];
@@ -184,7 +190,8 @@ fn basic_group_setup() {
         ciphersuite_name,
         alice_key_package_bundle,
         GroupConfig::default(),
-    );
+    )
+    .unwrap();
 
     // Alice adds Bob
     let bob_add_proposal = group_alice_1234.create_add_proposal(
@@ -234,13 +241,15 @@ fn group_operations() {
             &[ciphersuite_name],
             &alice_credential_bundle,
             mandatory_extensions.clone(),
-        );
+        )
+        .unwrap();
 
         let bob_key_package_bundle = KeyPackageBundle::new(
             &[ciphersuite_name],
             &bob_credential_bundle,
             mandatory_extensions,
-        );
+        )
+        .unwrap();
         let bob_key_package = bob_key_package_bundle.get_key_package();
 
         // Alice creates a group
@@ -250,7 +259,8 @@ fn group_operations() {
             ciphersuite_name,
             alice_key_package_bundle,
             GroupConfig::default(),
-        );
+        )
+        .unwrap();
 
         // Alice adds Bob
         let bob_add_proposal = group_alice_1234.create_add_proposal(

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -11,14 +11,15 @@ macro_rules! key_package_generation {
                 // TODO: enable more testing for unsupported ciphersuites when they return errors.
                 return;
             }
-            let ciphersuite = Ciphersuite::new($ciphersuite);
-            let supported_ciphersuites = Config::supported_ciphersuites();
+            let ciphersuite = Config::ciphersuite($ciphersuite).unwrap();
+            let supported_ciphersuites = Config::supported_ciphersuite_names();
             assert_eq!($supported, supported_ciphersuites.contains(&$ciphersuite));
             let id = vec![1, 2, 3];
             let credential_bundle =
                 CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name()).unwrap();
             let mut kpb =
-                KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new());
+                KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new())
+                    .unwrap();
 
             // This key package is not valid because the lifetime extension is missing.
             assert!(kpb.get_key_package().verify().is_err());


### PR DESCRIPTION
This moves the ciphersuite to config and only pulls it of there, in particular, Ciphersuite::new is forbidden outside of the config.
Instead Config::ciphersuite(name) is used to get a static reference to a ciphersuite object.
* public APIs: use CiphersuiteName
* internally use &'static Ciphersuite for members and args.
* convert CiphersuiteName to Ciphersuite in first public function
* functions using a CiphersuiteName return errors when the ciphersuite is not supported

cc #114 #85 