### PR TITLE
Don't cache on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --verbose
     - name: Build Release
@@ -39,13 +32,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Stable with rustfmt and clippy
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,6 @@
 name: Build & Test
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,11 @@ edition = "2018"
 
 [dependencies]
 uuid = { version = "0.8", features = ["v4"] }
-rand = "0.7"
-byteorder = "1.3"
+rand = "^0.7"
+byteorder = "^1.3"
 lazy_static = "1.4"
-serde = "1.0"
-serde_json = "1.0"
-serde_derive = "1.0"
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
 hpke = {git = "https://github.com/franziskuskiefer/hpke-rs", version = "0.0.2", branch = "0.0.2", features = ["hazmat", "serialization"] }
 evercrypt = { version = "0.0.3", features = ["serialization"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2018"
 
 [dependencies]
 uuid = { version = "0.8", features = ["v4"] }
-rand = "^0.7"
-byteorder = "^1.3"
+rand = "0.7"
+byteorder = "1.3"
 lazy_static = "1.4"
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
 hpke = {git = "https://github.com/franziskuskiefer/hpke-rs", version = "0.0.2", branch = "0.0.2", features = ["hazmat", "serialization"] }
 evercrypt = { version = "0.0.3", features = ["serialization"] }
 


### PR DESCRIPTION
Looks like the CI cache is broken (probably because of the way the dependencies work right now). Let's disable for now until we move to more stable dependencies.