### PR TITLE
Improve FS by dropping the encryption_secret after use

### DIFF
--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -198,7 +198,7 @@ impl MLSCiphertext {
         let sender_data_key = AeadKey::from_secret(
             hkdf_expand_label(
                 ciphersuite,
-                &epoch_secrets.sender_data_secret,
+                &epoch_secrets.sender_data_secret(),
                 "sd key",
                 &ciphertext,
                 ciphersuite.aead_key_length(),
@@ -208,7 +208,7 @@ impl MLSCiphertext {
         // Derive initial nonce from the key schedule using the ciphertext.
         let sender_data_nonce = AeadNonce::from_secret(hkdf_expand_label(
             ciphersuite,
-            &epoch_secrets.sender_data_secret,
+            &epoch_secrets.sender_data_secret(),
             "sd nonce",
             &ciphertext,
             ciphersuite.aead_nonce_length(),
@@ -252,7 +252,7 @@ impl MLSCiphertext {
         let sender_data_key = AeadKey::from_secret(
             hkdf_expand_label(
                 ciphersuite,
-                &epoch_secrets.sender_data_secret,
+                &epoch_secrets.sender_data_secret(),
                 "sd key",
                 &self.ciphertext,
                 ciphersuite.aead_key_length(),
@@ -262,7 +262,7 @@ impl MLSCiphertext {
         // Derive initial nonce from the key schedule using the ciphertext.
         let sender_data_nonce = AeadNonce::from_secret(hkdf_expand_label(
             ciphersuite,
-            &epoch_secrets.sender_data_secret,
+            &epoch_secrets.sender_data_secret(),
             "sd nonce",
             &self.ciphertext,
             ciphersuite.aead_nonce_length(),

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -154,8 +154,8 @@ impl MlsGroup {
         self.group_context = provisional_group_context;
         self.epoch_secrets = provisional_epoch_secrets;
         self.interim_transcript_hash = interim_transcript_hash;
-        // Pass ownership of the `encryption_secret` to the `SecretTree`
-        // constructor, so that the `encryption_secret` is dropped afterwards.
+        // Create a secret_tree, dropping the `encryption_secret` in the
+        // process.
         self.secret_tree = RefCell::new(
             self.epoch_secrets
                 .create_secret_tree(provisional_tree.leaf_count())

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -154,8 +154,10 @@ impl MlsGroup {
         self.group_context = provisional_group_context;
         self.epoch_secrets = provisional_epoch_secrets;
         self.interim_transcript_hash = interim_transcript_hash;
+        // Pass ownership of the `encryption_secret` to the `SecretTree`
+        // constructor, so that the `encryption_secret` is dropped afterwards.
         self.secret_tree = RefCell::new(SecretTree::new(
-            &self.epoch_secrets.encryption_secret,
+            self.epoch_secrets.remove_encryption_secret().unwrap(),
             provisional_tree.leaf_count(),
         ));
         Ok(())

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -125,7 +125,7 @@ impl MlsGroup {
         // Verify confirmation tag
         let own_confirmation_tag = ConfirmationTag::new(
             &ciphersuite,
-            &provisional_epoch_secrets.confirmation_key,
+            &provisional_epoch_secrets.confirmation_key(),
             &confirmed_transcript_hash,
         );
         if &own_confirmation_tag != received_confirmation_tag {

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -156,10 +156,11 @@ impl MlsGroup {
         self.interim_transcript_hash = interim_transcript_hash;
         // Pass ownership of the `encryption_secret` to the `SecretTree`
         // constructor, so that the `encryption_secret` is dropped afterwards.
-        self.secret_tree = RefCell::new(SecretTree::new(
-            self.epoch_secrets.consume_encryption_secret().unwrap(),
-            provisional_tree.leaf_count(),
-        ));
+        self.secret_tree = RefCell::new(
+            self.epoch_secrets
+                .create_secret_tree(provisional_tree.leaf_count())
+                .unwrap(),
+        );
         Ok(())
     }
 }

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -157,7 +157,7 @@ impl MlsGroup {
         // Pass ownership of the `encryption_secret` to the `SecretTree`
         // constructor, so that the `encryption_secret` is dropped afterwards.
         self.secret_tree = RefCell::new(SecretTree::new(
-            self.epoch_secrets.remove_encryption_secret().unwrap(),
+            self.epoch_secrets.consume_encryption_secret().unwrap(),
             provisional_tree.leaf_count(),
         ));
         Ok(())

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -94,7 +94,7 @@ impl MlsGroup {
         // Compute confirmation tag
         let confirmation_tag = ConfirmationTag::new(
             &ciphersuite,
-            &provisional_epoch_secrets.confirmation_key,
+            &provisional_epoch_secrets.confirmation_key(),
             &confirmed_transcript_hash,
         );
         // Create MLSPlaintext

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -47,7 +47,14 @@ impl MlsGroup {
         let group_id = GroupId { value: id.to_vec() };
         let epoch_secrets = EpochSecrets::default();
         let ciphersuite = Config::ciphersuite(ciphersuite_name)?;
-        let secret_tree = SecretTree::new(&epoch_secrets.encryption_secret, LeafIndex::from(1u32));
+        // Pass ownership of the `encryption_secret` to the `SecretTree`
+        // constructor, so that the `encryption_secret` is dropped afterwards.
+        // TODO: We're currently creating a secret tree from an empty secret
+        // here. This should be solved by #60.
+        let secret_tree = SecretTree::new(
+            epoch_secrets.remove_encryption_secret().unwrap(),
+            LeafIndex::from(1u32),
+        );
         let tree = RatchetTree::new(ciphersuite, key_package_bundle);
         let group_context = GroupContext {
             group_id,

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -45,7 +45,7 @@ impl MlsGroup {
         info!("Created group {:x?}", id);
         debug!(" >>> with {:?}, {:?}", ciphersuite_name, config);
         let group_id = GroupId { value: id.to_vec() };
-        let epoch_secrets = EpochSecrets::default();
+        let mut epoch_secrets = EpochSecrets::default();
         let ciphersuite = Config::ciphersuite(ciphersuite_name)?;
         // Pass ownership of the `encryption_secret` to the `SecretTree`
         // constructor, so that the `encryption_secret` is dropped afterwards.

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -52,7 +52,7 @@ impl MlsGroup {
         // TODO: We're currently creating a secret tree from an empty secret
         // here. This should be solved by #60.
         let secret_tree = SecretTree::new(
-            epoch_secrets.remove_encryption_secret().unwrap(),
+            epoch_secrets.consume_encryption_secret().unwrap(),
             LeafIndex::from(1u32),
         );
         let tree = RatchetTree::new(ciphersuite, key_package_bundle);

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -51,10 +51,9 @@ impl MlsGroup {
         // constructor, so that the `encryption_secret` is dropped afterwards.
         // TODO: We're currently creating a secret tree from an empty secret
         // here. This should be solved by #60.
-        let secret_tree = SecretTree::new(
-            epoch_secrets.consume_encryption_secret().unwrap(),
-            LeafIndex::from(1u32),
-        );
+        let secret_tree = epoch_secrets
+            .create_secret_tree(LeafIndex::from(1u32))
+            .unwrap();
         let tree = RatchetTree::new(ciphersuite, key_package_bundle);
         let group_context = GroupContext {
             group_id,

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -47,8 +47,6 @@ impl MlsGroup {
         let group_id = GroupId { value: id.to_vec() };
         let mut epoch_secrets = EpochSecrets::default();
         let ciphersuite = Config::ciphersuite(ciphersuite_name)?;
-        // Pass ownership of the `encryption_secret` to the `SecretTree`
-        // constructor, so that the `encryption_secret` is dropped afterwards.
         // TODO: We're currently creating a secret tree from an empty secret
         // here. This should be solved by #60.
         let secret_tree = epoch_secrets

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -152,7 +152,7 @@ impl MlsGroup {
             Secret::new_empty_secret(),
         );
         let secret_tree = SecretTree::new(
-            epoch_secrets.remove_encryption_secret().unwrap(),
+            epoch_secrets.consume_encryption_secret().unwrap(),
             tree.leaf_count(),
         );
 

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -7,7 +7,7 @@ use crate::group::{mls_group::*, *};
 use crate::key_packages::*;
 use crate::messages::*;
 use crate::schedule::*;
-use crate::tree::{index::*, node::*, secret_tree::*, treemath, *};
+use crate::tree::{index::*, node::*, treemath, *};
 
 impl MlsGroup {
     pub(crate) fn new_from_welcome_internal(
@@ -151,10 +151,7 @@ impl MlsGroup {
             &group_secrets.joiner_secret,
             Secret::new_empty_secret(),
         );
-        let secret_tree = SecretTree::new(
-            epoch_secrets.consume_encryption_secret().unwrap(),
-            tree.leaf_count(),
-        );
+        let secret_tree = epoch_secrets.create_secret_tree(tree.leaf_count()).unwrap();
 
         let confirmation_tag = ConfirmationTag::new(
             &ciphersuite,

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -158,7 +158,7 @@ impl MlsGroup {
 
         let confirmation_tag = ConfirmationTag::new(
             &ciphersuite,
-            &epoch_secrets.confirmation_key,
+            &epoch_secrets.confirmation_key(),
             &group_context.confirmed_transcript_hash,
         );
         let interim_transcript_hash = update_interim_transcript_hash(

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -146,7 +146,7 @@ impl MlsGroup {
             tree_hash: tree.compute_tree_hash(),
             confirmed_transcript_hash: group_info.confirmed_transcript_hash().to_vec(),
         };
-        let epoch_secrets = EpochSecrets::derive_epoch_secrets(
+        let mut epoch_secrets = EpochSecrets::derive_epoch_secrets(
             &ciphersuite,
             &group_secrets.joiner_secret,
             Secret::new_empty_secret(),

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -151,7 +151,10 @@ impl MlsGroup {
             &group_secrets.joiner_secret,
             Secret::new_empty_secret(),
         );
-        let secret_tree = SecretTree::new(&epoch_secrets.encryption_secret, tree.leaf_count());
+        let secret_tree = SecretTree::new(
+            epoch_secrets.remove_encryption_secret().unwrap(),
+            tree.leaf_count(),
+        );
 
         let confirmation_tag = ConfirmationTag::new(
             &ciphersuite,

--- a/src/schedule/errors.rs
+++ b/src/schedule/errors.rs
@@ -1,0 +1,19 @@
+use std::error::Error;
+
+#[repr(u16)]
+#[derive(Debug)]
+pub enum KeyScheduleError {
+    SecretReuseError = 0,
+}
+
+implement_enum_display!(KeyScheduleError);
+
+impl Error for KeyScheduleError {
+    fn description(&self) -> &str {
+        match self {
+            KeyScheduleError::SecretReuseError => {
+                "The Secret was already used and deleted to achieve forward secrecy."
+            }
+        }
+    }
+}

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -71,12 +71,12 @@ impl HkdfLabel {
 
 #[derive(Clone, Debug)]
 pub struct EpochSecrets {
-    pub welcome_secret: Secret,
-    pub sender_data_secret: Secret,
+    welcome_secret: Secret,
+    sender_data_secret: Secret,
     encryption_secret: Option<Secret>,
-    pub exporter_secret: Secret,
-    pub confirmation_key: Secret,
-    pub init_secret: Secret,
+    exporter_secret: Secret,
+    confirmation_key: Secret,
+    init_secret: Secret,
 }
 
 impl Default for EpochSecrets {
@@ -158,5 +158,15 @@ impl EpochSecrets {
         // Pass ownership to the `SecretTree` constructor, so that the
         // `encryption_secret` is dropped afterwards.
         Ok(encryption_secret)
+    }
+
+    /// Get the sender_data secret.
+    pub(crate) fn sender_data_secret(&self) -> &Secret {
+        &self.sender_data_secret
+    }
+
+    /// Get the confirmation key.
+    pub(crate) fn confirmation_key(&self) -> &Secret {
+        &self.confirmation_key
     }
 }

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 use crate::ciphersuite::*;
 use crate::codec::*;
 use crate::group::*;
@@ -75,7 +73,7 @@ impl HkdfLabel {
 pub struct EpochSecrets {
     pub welcome_secret: Secret,
     pub sender_data_secret: Secret,
-    encryption_secret: RefCell<Option<Secret>>,
+    encryption_secret: Option<Secret>,
     pub exporter_secret: Secret,
     pub confirmation_key: Secret,
     pub init_secret: Secret,
@@ -85,7 +83,7 @@ impl Default for EpochSecrets {
     fn default() -> Self {
         let welcome_secret = Secret::new_empty_secret();
         let sender_data_secret = Secret::new_empty_secret();
-        let encryption_secret = RefCell::new(Some(Secret::new_empty_secret()));
+        let encryption_secret = Some(Secret::new_empty_secret());
         let exporter_secret = Secret::new_empty_secret();
         let confirmation_key = Secret::new_empty_secret();
         let init_secret = Secret::new_empty_secret();
@@ -135,8 +133,7 @@ impl EpochSecrets {
         welcome_secret: Secret,
     ) -> EpochSecrets {
         let sender_data_secret = derive_secret(ciphersuite, epoch_secret, "sender data");
-        let encryption_secret =
-            RefCell::new(Some(derive_secret(ciphersuite, epoch_secret, "encryption")));
+        let encryption_secret = Some(derive_secret(ciphersuite, epoch_secret, "encryption"));
         let exporter_secret = derive_secret(ciphersuite, epoch_secret, "exporter");
         let confirmation_key = derive_secret(ciphersuite, epoch_secret, "confirm");
         let init_secret = derive_secret(ciphersuite, epoch_secret, "init");
@@ -152,26 +149,14 @@ impl EpochSecrets {
 
     /// Remove the `encryption_secret` from the `EpochSecrets`, replacing it
     /// with `None` and return it.
-    pub fn remove_encryption_secret(&self) -> Result<Secret, KeyScheduleError> {
+    pub fn remove_encryption_secret(&mut self) -> Result<Secret, KeyScheduleError> {
         // Remove the encryption secret by replacing it with `None`.
-        let encryption_secret = match self.encryption_secret.replace(None) {
+        let encryption_secret = match self.encryption_secret.take() {
             Some(es) => es,
             None => return Err(KeyScheduleError::SecretReuseError),
         };
         // Pass ownership to the `SecretTree` constructor, so that the
         // `encryption_secret` is dropped afterwards.
         Ok(encryption_secret)
-    }
-}
-
-impl Codec for EpochSecrets {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.welcome_secret.encode(buffer)?;
-        self.sender_data_secret.encode(buffer)?;
-        self.encryption_secret.borrow().encode(buffer)?;
-        self.exporter_secret.encode(buffer)?;
-        self.confirmation_key.encode(buffer)?;
-        self.init_secret.encode(buffer)?;
-        Ok(())
     }
 }

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -162,13 +162,10 @@ impl EpochSecrets {
     /// Consume the `encryption_secret` from the `EpochSecrets`, replacing it
     /// with `None` and return it.
     fn consume_encryption_secret(&mut self) -> Result<Secret, KeyScheduleError> {
-        // Remove the encryption secret by replacing it with `None`.
         let encryption_secret = match self.encryption_secret.take() {
             Some(es) => es,
             None => return Err(KeyScheduleError::SecretReuseError),
         };
-        // Pass ownership to the `SecretTree` constructor, so that the
-        // `encryption_secret` is dropped afterwards.
         Ok(encryption_secret)
     }
 

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -147,9 +147,9 @@ impl EpochSecrets {
         }
     }
 
-    /// Remove the `encryption_secret` from the `EpochSecrets`, replacing it
+    /// Consume the `encryption_secret` from the `EpochSecrets`, replacing it
     /// with `None` and return it.
-    pub fn remove_encryption_secret(&mut self) -> Result<Secret, KeyScheduleError> {
+    pub fn consume_encryption_secret(&mut self) -> Result<Secret, KeyScheduleError> {
         // Remove the encryption secret by replacing it with `None`.
         let encryption_secret = match self.encryption_secret.take() {
             Some(es) => es,

--- a/src/schedule/test_schedule.rs
+++ b/src/schedule/test_schedule.rs
@@ -1,0 +1,21 @@
+use crate::ciphersuite::*;
+use crate::config::*;
+use evercrypt::prelude::get_random_vec;
+
+use super::EpochSecrets;
+
+#[test]
+fn test_encryption_secret_removal() {
+    for ciphersuite in Config::supported_ciphersuites() {
+        let epoch_secret = Secret::from(get_random_vec(ciphersuite.hash_length()));
+        let welcome_secret = Secret::from(get_random_vec(ciphersuite.hash_length()));
+        let epoch_secrets =
+            EpochSecrets::derive_epoch_secrets(ciphersuite, &epoch_secret, welcome_secret);
+        // Getting the encryption secret once should not be a problem.
+        let encryption_secret = epoch_secrets.remove_encryption_secret();
+        assert!(encryption_secret.is_ok());
+        // Getting it for a second time should yield an error.
+        let encryption_secret = epoch_secrets.remove_encryption_secret();
+        assert!(encryption_secret.is_err());
+    }
+}

--- a/src/schedule/test_schedule.rs
+++ b/src/schedule/test_schedule.rs
@@ -9,7 +9,7 @@ fn test_encryption_secret_removal() {
     for ciphersuite in Config::supported_ciphersuites() {
         let epoch_secret = Secret::from(get_random_vec(ciphersuite.hash_length()));
         let welcome_secret = Secret::from(get_random_vec(ciphersuite.hash_length()));
-        let epoch_secrets =
+        let mut epoch_secrets =
             EpochSecrets::derive_epoch_secrets(ciphersuite, &epoch_secret, welcome_secret);
         // Getting the encryption secret once should not be a problem.
         let encryption_secret = epoch_secrets.remove_encryption_secret();

--- a/src/schedule/test_schedule.rs
+++ b/src/schedule/test_schedule.rs
@@ -12,10 +12,10 @@ fn test_encryption_secret_removal() {
         let mut epoch_secrets =
             EpochSecrets::derive_epoch_secrets(ciphersuite, &epoch_secret, welcome_secret);
         // Getting the encryption secret once should not be a problem.
-        let encryption_secret = epoch_secrets.remove_encryption_secret();
+        let encryption_secret = epoch_secrets.consume_encryption_secret();
         assert!(encryption_secret.is_ok());
         // Getting it for a second time should yield an error.
-        let encryption_secret = epoch_secrets.remove_encryption_secret();
+        let encryption_secret = epoch_secrets.consume_encryption_secret();
         assert!(encryption_secret.is_err());
     }
 }

--- a/src/tree/secret_tree.rs
+++ b/src/tree/secret_tree.rs
@@ -93,7 +93,7 @@ impl SecretTree {
         let num_indices = NodeIndex::from(size).as_usize() - 1;
         let mut nodes = vec![None; num_indices];
         nodes[root.as_usize()] = Some(SecretTreeNode {
-            secret: encryption_secret.clone(),
+            secret: encryption_secret,
         });
 
         SecretTree {

--- a/src/tree/secret_tree.rs
+++ b/src/tree/secret_tree.rs
@@ -88,7 +88,7 @@ impl SecretTree {
     /// `size`. The inner nodes of the tree and the SenderRatchets only get
     /// initialized when secrets are requested either through `get_secret()`
     /// or `next_secret()`.
-    pub fn new(encryption_secret: &Secret, size: LeafIndex) -> Self {
+    pub fn new(encryption_secret: Secret, size: LeafIndex) -> Self {
         let root = root(size);
         let num_indices = NodeIndex::from(size).as_usize() - 1;
         let mut nodes = vec![None; num_indices];

--- a/src/tree/test_secret_tree.rs
+++ b/src/tree/test_secret_tree.rs
@@ -8,7 +8,7 @@ fn test_boundaries() {
 
     for ciphersuite in Config::supported_ciphersuites() {
         let mut secret_tree =
-            SecretTree::new(&Secret::from([0u8; 32].to_vec()), LeafIndex::from(2u32));
+            SecretTree::new(Secret::from([0u8; 32].to_vec()), LeafIndex::from(2u32));
         let secret_type = SecretType::ApplicationSecret;
         assert!(secret_tree
             .get_secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 0)
@@ -53,7 +53,7 @@ fn test_boundaries() {
             Err(SecretTreeError::IndexOutOfBounds)
         );
         let mut largetree = SecretTree::new(
-            &Secret::from([0u8; 32].to_vec()),
+            Secret::from([0u8; 32].to_vec()),
             LeafIndex::from(100_000u32),
         );
         assert!(largetree
@@ -91,7 +91,7 @@ fn increment_generation() {
     for ciphersuite in Config::supported_ciphersuites() {
         let mut unique_values: HashMap<Vec<u8>, bool> = HashMap::new();
         let mut secret_tree = SecretTree::new(
-            &Secret::from([1, 2, 3].to_vec()),
+            Secret::from([1, 2, 3].to_vec()),
             LeafIndex::from(SIZE as u32),
         );
         for i in 0..SIZE {


### PR DESCRIPTION
Fixes #91 by introducing a dedicated function to retrieve the `encryption_secret` from an `EpochSecrets` object. The function removes the `Secret` such that ownership can be passed to the `SecretTree` constructor, at the end of which the Secret is dropped. 