### PR TITLE
messages refactoring

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -19,6 +19,7 @@ impl From<ConfigError> for CodecError {
 
 impl From<CodecError> for ConfigError {
     // TODO: tbd in #83, also this direction shouldn't be necessary.
+    #[allow(clippy::match_single_binding)]
     fn from(e: CodecError) -> Self {
         match e {
             _ => ConfigError::InvalidConfig,

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -778,7 +778,7 @@ impl From<&MLSPlaintext> for MLSPlaintextCommitAuthData {
 impl From<&ConfirmationTag> for MLSPlaintextCommitAuthData {
     fn from(confirmation_tag: &ConfirmationTag) -> Self {
         MLSPlaintextCommitAuthData {
-            confirmation_tag: confirmation_tag.as_slice(),
+            confirmation_tag: confirmation_tag.to_vec(),
         }
     }
 }

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -76,9 +76,7 @@ impl MlsGroup {
                     Some(kpb) => kpb,
                     None => return Err(ApplyCommitError::MissingOwnKeyPackage),
                 };
-                provisional_tree
-                    .replace_private_tree(ciphersuite, own_kpb, &serialized_context)
-                    .unwrap()
+                provisional_tree.replace_private_tree(ciphersuite, own_kpb, &serialized_context)
             } else {
                 provisional_tree
                     .update_path(sender, &path, &serialized_context)

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -122,7 +122,7 @@ impl MlsGroup {
                 tree_hash,
                 confirmed_transcript_hash,
                 extensions,
-                confirmation_tag.as_slice(),
+                confirmation_tag.to_vec(),
                 sender_index,
             );
             group_info.set_signature(group_info.sign(credential_bundle));
@@ -157,10 +157,7 @@ impl MlsGroup {
                 } else {
                     None
                 };
-                let group_secrets = GroupSecrets {
-                    joiner_secret: epoch_secret.clone(),
-                    path_secret,
-                };
+                let group_secrets = GroupSecrets::new(epoch_secret.clone(), path_secret);
                 let group_secrets_bytes = group_secrets.encode_detached().unwrap();
                 plaintext_secrets.push((
                     key_package.hpke_init_key().clone(),

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -20,7 +20,7 @@ impl MlsGroup {
         // Find key_package in welcome secrets
         let egs = if let Some(egs) = Self::find_key_package_from_welcome_secrets(
             key_package_bundle.get_key_package(),
-            welcome.get_secrets_ref(),
+            welcome.secrets(),
         ) {
             egs
         } else {
@@ -37,7 +37,7 @@ impl MlsGroup {
             &ciphersuite,
             &egs,
             key_package_bundle.get_private_key_ref(),
-            welcome.get_encrypted_group_info_ref(),
+            welcome.encrypted_group_info(),
         )?;
 
         // Build the ratchet tree

--- a/src/messages/codec.rs
+++ b/src/messages/codec.rs
@@ -1,0 +1,97 @@
+//! Codec implementations for message structs.
+
+use super::*;
+
+impl Codec for GroupInfo {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        buffer.append(&mut self.unsigned_payload()?);
+        self.signature.encode(buffer)?;
+        Ok(())
+    }
+}
+
+impl Codec for Commit {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        encode_vec(VecSize::VecU32, buffer, &self.proposals)?;
+        self.path.encode(buffer)?;
+        Ok(())
+    }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let proposals = decode_vec(VecSize::VecU32, cursor)?;
+        let path = Option::<UpdatePath>::decode(cursor)?;
+        Ok(Commit { proposals, path })
+    }
+}
+
+impl Codec for ConfirmationTag {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        encode_vec(VecSize::VecU8, buffer, &self.0)?;
+        Ok(())
+    }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let inner = decode_vec(VecSize::VecU8, cursor)?;
+        Ok(ConfirmationTag(inner))
+    }
+}
+
+impl Codec for PathSecret {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.path_secret.encode(buffer)?;
+        Ok(())
+    }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let path_secret = Secret::decode(cursor)?;
+        Ok(PathSecret { path_secret })
+    }
+}
+
+impl Codec for EncryptedGroupSecrets {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        encode_vec(VecSize::VecU8, buffer, &self.key_package_hash)?;
+        self.encrypted_group_secrets.encode(buffer)?;
+        Ok(())
+    }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let key_package_hash = decode_vec(VecSize::VecU8, cursor)?;
+        let encrypted_group_secrets = HpkeCiphertext::decode(cursor)?;
+        Ok(EncryptedGroupSecrets {
+            key_package_hash,
+            encrypted_group_secrets,
+        })
+    }
+}
+
+impl Codec for Welcome {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.version.encode(buffer)?;
+        self.cipher_suite.name().encode(buffer)?;
+        encode_vec(VecSize::VecU32, buffer, &self.secrets)?;
+        encode_vec(VecSize::VecU32, buffer, &self.encrypted_group_info)?;
+        Ok(())
+    }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let version = ProtocolVersion::decode(cursor)?;
+        let cipher_suite = CiphersuiteName::decode(cursor)?;
+        let secrets = decode_vec(VecSize::VecU32, cursor)?;
+        let encrypted_group_info = decode_vec(VecSize::VecU32, cursor)?;
+        Ok(Welcome {
+            version,
+            cipher_suite: Config::ciphersuite(cipher_suite)?,
+            secrets,
+            encrypted_group_info,
+        })
+    }
+}
+
+impl Codec for GroupSecrets {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.joiner_secret.encode(buffer)?;
+        self.path_secret.encode(buffer)?;
+        Ok(())
+    }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let joiner_secret = Secret::decode(cursor)?;
+        let path_secret = Option::<PathSecret>::decode(cursor)?;
+        Ok(GroupSecrets::new(joiner_secret, path_secret))
+    }
+}

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -76,13 +76,13 @@ impl Welcome {
         self.cipher_suite
     }
 
-    /// Get a reference to the ciphersuite in this Welcome message.
-    pub fn get_secrets_ref(&self) -> &[EncryptedGroupSecrets] {
+    /// Get a reference to the encrypted group secrets in this Welcome message.
+    pub fn secrets(&self) -> &[EncryptedGroupSecrets] {
         &self.secrets
     }
 
     /// Get a reference to the encrypted group info.
-    pub(crate) fn get_encrypted_group_info_ref(&self) -> &[u8] {
+    pub(crate) fn encrypted_group_info(&self) -> &[u8] {
         &self.encrypted_group_info
     }
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -4,9 +4,12 @@ use crate::config::Config;
 use crate::config::ProtocolVersion;
 use crate::extensions::*;
 use crate::group::*;
+use crate::schedule::psk::PreSharedKeys;
 use crate::tree::{index::*, *};
 
+mod codec;
 pub(crate) mod proposals;
+pub use codec::*;
 use proposals::*;
 
 #[cfg(test)]
@@ -15,29 +18,100 @@ mod test_proposals;
 #[cfg(test)]
 mod test_welcome;
 
+/// Welcome Messages
+///
+/// > 11.2.2. Welcoming New Members
+///
+/// ```text
+/// struct {
+///   ProtocolVersion version = mls10;
+///   CipherSuite cipher_suite;
+///   EncryptedGroupSecrets secrets<0..2^32-1>;
+///   opaque encrypted_group_info<1..2^32-1>;
+/// } Welcome;
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct Welcome {
+    version: ProtocolVersion,
+    cipher_suite: &'static Ciphersuite,
+    secrets: Vec<EncryptedGroupSecrets>,
+    encrypted_group_info: Vec<u8>,
+}
+
+/// EncryptedGroupSecrets
+///
+/// > 11.2.2. Welcoming New Members
+///
+/// ```text
+/// struct {
+///   opaque key_package_hash<1..255>;
+///   HPKECiphertext encrypted_group_secrets;
+/// } EncryptedGroupSecrets;
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct EncryptedGroupSecrets {
+    pub key_package_hash: Vec<u8>,
+    pub encrypted_group_secrets: HpkeCiphertext,
+}
+
+impl Welcome {
+    /// Create a new welcome message from the provided data.
+    /// Note that secrets and the encrypted group info are consumed.
+    pub(crate) fn new(
+        version: ProtocolVersion,
+        cipher_suite: &'static Ciphersuite,
+        secrets: Vec<EncryptedGroupSecrets>,
+        encrypted_group_info: Vec<u8>,
+    ) -> Self {
+        Self {
+            version,
+            cipher_suite,
+            secrets,
+            encrypted_group_info,
+        }
+    }
+
+    /// Get a reference to the ciphersuite in this Welcome message.
+    pub(crate) fn ciphersuite(&self) -> &'static Ciphersuite {
+        self.cipher_suite
+    }
+
+    /// Get a reference to the ciphersuite in this Welcome message.
+    pub fn get_secrets_ref(&self) -> &[EncryptedGroupSecrets] {
+        &self.secrets
+    }
+
+    /// Get a reference to the encrypted group info.
+    pub(crate) fn get_encrypted_group_info_ref(&self) -> &[u8] {
+        &self.encrypted_group_info
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct Commit {
-    pub proposals: Vec<ProposalID>,
-    pub path: Option<UpdatePath>,
+    pub(crate) proposals: Vec<ProposalID>,
+    pub(crate) path: Option<UpdatePath>,
 }
 
-impl Codec for Commit {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU32, buffer, &self.proposals)?;
-        self.path.encode(buffer)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let proposals = decode_vec(VecSize::VecU32, cursor)?;
-        let path = Option::<UpdatePath>::decode(cursor)?;
-        Ok(Commit { proposals, path })
+impl Commit {
+    /// Returns `true` if the commit contains an update path. `false` otherwise.
+    pub fn has_path(&self) -> bool {
+        self.path.is_some()
     }
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct ConfirmationTag(pub Vec<u8>);
+pub struct ConfirmationTag(pub(crate) Vec<u8>);
 
 impl ConfirmationTag {
+    /// Create a new confirmation tag.
+    ///
+    /// >  11.2. Commit
+    ///
+    /// ```text
+    /// MLSPlaintext.confirmation_tag =
+    ///     MAC(confirmation_key, GroupContext.confirmed_transcript_hash)
+    /// ```
     pub fn new(
         ciphersuite: &Ciphersuite,
         confirmation_key: &Secret,
@@ -52,26 +126,30 @@ impl ConfirmationTag {
                 .to_vec(),
         )
     }
-    pub fn new_empty() -> Self {
-        ConfirmationTag(vec![])
-    }
-    pub fn as_slice(&self) -> Vec<u8> {
+
+    /// Get a copy of the raw byte vector.
+    pub(crate) fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
     }
 }
 
-impl Codec for ConfirmationTag {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU8, buffer, &self.0)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let inner = decode_vec(VecSize::VecU8, cursor)?;
-        Ok(ConfirmationTag(inner))
-    }
-}
-
-pub struct GroupInfo {
+/// GroupInfo
+///
+/// > 11.2.2. Welcoming New Members
+///
+/// ```text
+/// struct {
+///   opaque group_id<0..255>;
+///   uint64 epoch;
+///   opaque tree_hash<0..255>;
+///   opaque confirmed_transcript_hash<0..255>;
+///   Extension extensions<0..2^32-1>;
+///   MAC confirmation_tag;
+///   uint32 signer_index;
+///   opaque signature<0..2^16-1>;
+/// } GroupInfo;
+/// ```
+pub(crate) struct GroupInfo {
     group_id: GroupId,
     epoch: GroupEpoch,
     tree_hash: Vec<u8>,
@@ -179,14 +257,6 @@ impl GroupInfo {
     }
 }
 
-impl Codec for GroupInfo {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        buffer.append(&mut self.unsigned_payload()?);
-        self.signature.encode(buffer)?;
-        Ok(())
-    }
-}
-
 impl Signable for GroupInfo {
     fn unsigned_payload(&self) -> Result<Vec<u8>, CodecError> {
         let buffer = &mut vec![];
@@ -207,123 +277,44 @@ impl Signable for GroupInfo {
     }
 }
 
-pub struct PathSecret {
+/// PathSecret
+///
+/// > 11.2.2. Welcoming New Members
+///
+/// ```text
+/// struct {
+///   opaque path_secret<1..255>;
+/// } PathSecret;
+/// ```
+pub(crate) struct PathSecret {
     pub path_secret: Secret,
 }
 
-impl Codec for PathSecret {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.path_secret.encode(buffer)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let path_secret = Secret::decode(cursor)?;
-        Ok(PathSecret { path_secret })
-    }
+/// GroupSecrets
+///
+/// > 11.2.2. Welcoming New Members
+///
+/// ```text
+/// struct {
+///   opaque joiner_secret<1..255>;
+///   optional<PathSecret> path_secret;
+///   optional<PreSharedKeys> psks;
+/// } GroupSecrets;
+/// ```
+#[allow(dead_code)]
+pub(crate) struct GroupSecrets {
+    pub(crate) joiner_secret: Secret,
+    pub(crate) path_secret: Option<PathSecret>,
+    pub(crate) psks: Option<PreSharedKeys>,
 }
 
-pub struct GroupSecrets {
-    pub joiner_secret: Secret,
-    pub path_secret: Option<PathSecret>,
-}
-
-impl Codec for GroupSecrets {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.joiner_secret.encode(buffer)?;
-        self.path_secret.encode(buffer)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let joiner_secret = Secret::decode(cursor)?;
-        let path_secret = Option::<PathSecret>::decode(cursor)?;
-        Ok(GroupSecrets {
+impl GroupSecrets {
+    /// Create a new group secret.
+    pub(crate) fn new(joiner_secret: Secret, path_secret: Option<PathSecret>) -> Self {
+        Self {
             joiner_secret,
             path_secret,
-        })
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct EncryptedGroupSecrets {
-    pub key_package_hash: Vec<u8>,
-    pub encrypted_group_secrets: HpkeCiphertext,
-}
-
-impl Codec for EncryptedGroupSecrets {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU8, buffer, &self.key_package_hash)?;
-        self.encrypted_group_secrets.encode(buffer)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let key_package_hash = decode_vec(VecSize::VecU8, cursor)?;
-        let encrypted_group_secrets = HpkeCiphertext::decode(cursor)?;
-        Ok(EncryptedGroupSecrets {
-            key_package_hash,
-            encrypted_group_secrets,
-        })
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct Welcome {
-    version: ProtocolVersion,
-    cipher_suite: &'static Ciphersuite,
-    secrets: Vec<EncryptedGroupSecrets>,
-    encrypted_group_info: Vec<u8>,
-}
-
-impl Welcome {
-    /// Create a new welcome message from the provided data.
-    /// Note that secrets and the encrypted group info are consumed.
-    pub(crate) fn new(
-        version: ProtocolVersion,
-        cipher_suite: &'static Ciphersuite,
-        secrets: Vec<EncryptedGroupSecrets>,
-        encrypted_group_info: Vec<u8>,
-    ) -> Self {
-        Self {
-            version,
-            cipher_suite,
-            secrets,
-            encrypted_group_info,
+            psks: None,
         }
-    }
-
-    /// Get a reference to the ciphersuite in this Welcome message.
-    pub(crate) fn ciphersuite(&self) -> &'static Ciphersuite {
-        self.cipher_suite
-    }
-
-    /// Get a reference to the ciphersuite in this Welcome message.
-    pub fn get_secrets_ref(&self) -> &[EncryptedGroupSecrets] {
-        &self.secrets
-    }
-
-    /// Get a reference to the encrypted group info.
-    pub(crate) fn get_encrypted_group_info_ref(&self) -> &[u8] {
-        &self.encrypted_group_info
-    }
-}
-
-impl Codec for Welcome {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.version.encode(buffer)?;
-        self.cipher_suite.name().encode(buffer)?;
-        encode_vec(VecSize::VecU32, buffer, &self.secrets)?;
-        encode_vec(VecSize::VecU32, buffer, &self.encrypted_group_info)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let version = ProtocolVersion::decode(cursor)?;
-        let cipher_suite = CiphersuiteName::decode(cursor)?;
-        let secrets = decode_vec(VecSize::VecU32, cursor)?;
-        let encrypted_group_info = decode_vec(VecSize::VecU32, cursor)?;
-        Ok(Welcome {
-            version,
-            cipher_suite: Config::ciphersuite(cipher_suite)?,
-            secrets,
-            encrypted_group_info,
-        })
     }
 }

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -7,6 +7,7 @@ use crate::tree::secret_tree::SecretTree;
 use self::errors::KeyScheduleError;
 
 pub mod errors;
+pub(crate) mod psk;
 
 #[cfg(test)]
 mod test_schedule;

--- a/src/schedule/psk.rs
+++ b/src/schedule/psk.rs
@@ -1,0 +1,65 @@
+#![allow(dead_code)]
+//! # Pre shared keys.
+
+/// enum {
+///   reserved(0),
+///   external(1),
+///   reinit(2),
+///   branch(3),
+///   (255)
+/// } PSKType;
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(u8)]
+pub(crate) enum PSKType {
+    Reserved = 0,
+    External = 1,
+    Reinit = 2,
+    Branch = 3,
+}
+
+struct ExternalPsk {
+    psk_id: Vec<u8>,
+}
+struct ReinitPsk {
+    psk_group_id: Vec<u8>,
+    psk_epoch: u64,
+}
+struct BranchPsk {
+    psk_group_id: Vec<u8>,
+    psk_epoch: u64,
+}
+
+enum Psk {
+    External(ExternalPsk),
+    Reinit(ReinitPsk),
+    Branch(BranchPsk),
+}
+
+/// ```text
+/// struct {
+///   PSKType psktype;
+///   select (PreSharedKeyID.psktype) {
+///     case external:
+///       opaque psk_id<0..255>;
+///
+///     case reinit:
+///       opaque psk_group_id<0..255>;
+///       uint64 psk_epoch;
+///
+///     case branch:
+///       opaque psk_group_id<0..255>;
+///       uint64 psk_epoch;
+///   }
+///   opaque psk_nonce<0..255>;
+/// } PreSharedKeyID;
+/// ```
+struct PreSharedKeyID {
+    psktype: PSKType,
+}
+
+/// struct {
+///     PreSharedKeyID psks<0..2^16-1>;
+/// } PreSharedKeys;
+pub(crate) struct PreSharedKeys {
+    psks: Vec<PreSharedKeyID>,
+}

--- a/src/schedule/psk.rs
+++ b/src/schedule/psk.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 //! # Pre shared keys.
 
+// TODO: Implement PSK support #141.
+
 /// enum {
 ///   reserved(0),
 ///   external(1),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -377,14 +377,14 @@ impl RatchetTree {
         ciphersuite: &Ciphersuite,
         key_package_bundle: &KeyPackageBundle,
         group_context: &[u8],
-    ) -> Result<Secret, TreeError> {
+    ) -> Secret {
         let _path_option = self.replace_private_tree_(
             ciphersuite,
             key_package_bundle,
             group_context,
             false, /* without update path */
         );
-        Ok(self.private_tree.get_commit_secret())
+        self.private_tree.get_commit_secret()
     }
 
     /// Update the private tree.

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -80,8 +80,8 @@ fn create_commit_optional_path() {
             MLSPlaintextContentType::Commit((commit, _)) => commit,
             _ => panic!(),
         };
-        assert!(commit.path.is_some());
-        assert!(commit.path.is_some() && kpb_option.is_some());
+        assert!(commit.has_path());
+        assert!(commit.has_path() && kpb_option.is_some());
 
         // Alice adds Bob without forced self-update
         // Since there are only Add Proposals, this does not generate a path field on
@@ -107,7 +107,7 @@ fn create_commit_optional_path() {
             MLSPlaintextContentType::Commit((commit, _)) => commit,
             _ => panic!(),
         };
-        assert!(commit.path.is_none() && kpb_option.is_none());
+        assert!(!commit.has_path() && kpb_option.is_none());
 
         // Alice applies the Commit without the forced self-update
         match group_alice.apply_commit(mls_plaintext_commit, epoch_proposals, &[]) {
@@ -155,7 +155,7 @@ fn create_commit_optional_path() {
             }
             _ => panic!(),
         };
-        assert!(commit.path.is_some() && kpb_option.is_some());
+        assert!(commit.has_path() && kpb_option.is_some());
 
         // Apply UpdateProposal
         group_alice
@@ -299,7 +299,7 @@ fn group_operations() {
             MLSPlaintextContentType::Commit((commit, _)) => commit,
             _ => panic!("Wrong content type"),
         };
-        assert!(commit.path.is_none() && kpb_option.is_none());
+        assert!(!commit.has_path() && kpb_option.is_none());
         // Check that the function returned a Welcome message
         assert!(welcome_bundle_alice_bob_option.is_some());
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -206,7 +206,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                 // Figure out which key package bundle we should use. This is
                 // a bit ugly and inefficient.
                 let member_secret = welcome
-                    .get_secrets_ref()
+                    .secrets()
                     .iter()
                     .find(|x| {
                         new_group_member


### PR DESCRIPTION
As part of #83 (error handling) I did a little cleanup of the messages module.

This PR
* adds PSK dummy structs to the schedule and adds them to the `GroupSecrets` .
* moves codec implementations out of the main messages module file.
* messages only return `CodecErrors`.