### PR TITLE
some minor changes to the API that allow using the mls group API

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -147,6 +147,33 @@ impl Codec for u64 {
     }
 }
 
+impl Codec for String {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        let string_bytes = self.as_bytes();
+        (string_bytes.len() as u16).encode(buffer)?;
+        buffer.extend_from_slice(&string_bytes);
+        Ok(())
+    }
+
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let string_length = u16::decode(cursor)?;
+        match std::str::from_utf8(cursor.consume(string_length.into())?) {
+            Ok(s) => Ok(s.to_string()),
+            Err(_) => Err(CodecError::DecodingError),
+        }
+    }
+}
+
+impl<T> Codec for Vec<T> where T: Codec {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        encode_vec(VecSize::VecU32, buffer, self)
+    }
+
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        decode_vec(VecSize::VecU32, cursor)
+    }
+}
+
 impl<T: Codec> Codec for Option<T> {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         match self {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -165,7 +165,7 @@ pub(crate) fn extensions_vec_from_cursor(
 /// # Extension
 ///
 /// This trait defines functions to interact with an extension.
-pub trait Extension: Debug + ExtensionHelper {
+pub trait Extension: Debug + ExtensionHelper + Send {
     /// Build a new extension from a byte slice.
     ///
     /// Note that all implementations of this trait are not public such that

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -18,8 +18,8 @@ mod test_framing;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct MLSPlaintext {
-    pub(crate) group_id: GroupId,
-    pub(crate) epoch: GroupEpoch,
+    pub group_id: GroupId,
+    pub epoch: GroupEpoch,
     pub(crate) sender: Sender,
     pub(crate) authenticated_data: Vec<u8>,
     pub(crate) content_type: ContentType,
@@ -74,10 +74,18 @@ impl MLSPlaintext {
             signature,
         })
     }
+
     /// Returns a reference to the `content` field
     pub fn content(&self) -> &MLSPlaintextContentType {
         &self.content
     }
+
+    /// Get the sender leaf index of this message.
+    pub fn sender(&self) -> LeafIndex {
+        self.sender.to_leaf_index()
+    }
+
+    /// Sign this `MLSPlaintext`.
     pub fn sign(
         &mut self,
         credential_bundle: &CredentialBundle,
@@ -99,6 +107,11 @@ impl MLSPlaintext {
             MLSPlaintextContentType::Application(message) => Ok(message),
             _ => Err(MLSPlaintextError::NotAnApplicationMessage),
         }
+    }
+
+    /// Returns `true` if this is a handshake message and `false` otherwise.
+    pub fn is_handshake_message(&self) -> bool {
+        self.content_type.is_handshake_message()
     }
 }
 
@@ -145,25 +158,6 @@ pub struct MLSCiphertext {
 }
 
 impl MLSCiphertext {
-    // pub fn from_bytes(bytes: &[u8]) -> Result<Self, CodecError> {
-    //     let mut cursor = Cursor::new(bytes);
-    //     let group_id = GroupId::decode(&mut cursor)?;
-    //     let epoch = GroupEpoch::decode(&mut cursor)?;
-    //     let content_type = ContentType::decode(&mut cursor)?;
-    //     let authenticated_data = decode_vec(VecSize::VecU32, &mut cursor)?;
-    //     let sender_data_nonce = decode_vec(VecSize::VecU8, &mut cursor)?;
-    //     let encrypted_sender_data = decode_vec(VecSize::VecU8, &mut cursor)?;
-    //     let ciphertext = decode_vec(VecSize::VecU32, &mut cursor)?;
-    //     Ok(MLSCiphertext {
-    //         group_id,
-    //         epoch,
-    //         content_type,
-    //         authenticated_data,
-    //         sender_data_nonce,
-    //         encrypted_sender_data,
-    //         ciphertext,
-    //     })
-    // }
     pub fn as_slice(&self) -> Vec<u8> {
         self.encode_detached().unwrap()
     }
@@ -319,6 +313,11 @@ impl MLSCiphertext {
         Ok(mls_plaintext)
     }
 
+    /// Returns `true` if this is a handshake message and `false` otherwise.
+    pub fn is_handshake_message(&self) -> bool {
+        self.content_type.is_handshake_message()
+    }
+
     fn encode_padded_ciphertext_content_detached(
         mls_plaintext: &MLSPlaintext,
     ) -> Result<Vec<u8>, CodecError> {
@@ -406,6 +405,12 @@ impl Codec for ContentType {
     }
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
         Ok(ContentType::from(u8::decode(cursor)?))
+    }
+}
+
+impl ContentType {
+    fn is_handshake_message(&self) -> bool {
+        self == &ContentType::Proposal || self == &ContentType::Commit
     }
 }
 

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -36,6 +36,7 @@ fn codec() {
         let enc = orig.encode_detached().unwrap();
         let copy = MLSPlaintext::from_bytes(&enc).unwrap();
         assert_eq!(orig, copy);
+        assert!(!orig.is_handshake_message());
     }
 }
 
@@ -84,5 +85,6 @@ fn context_presence() {
         orig.signature = signature_input.sign(&credential_bundle);
         assert!(!orig.verify(Some(serialized_context), credential_bundle.credential()));
         assert!(orig.verify(None, credential_bundle.credential()));
+        assert!(!orig.is_handshake_message());
     }
 }

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -379,7 +379,7 @@ impl<'a> ManagedGroup<'a> {
                         app_message_received(
                             &self,
                             &aad_option.unwrap(),
-                            &indexed_members[&plaintext.sender.to_leaf_index()],
+                            &indexed_members[&plaintext.sender()],
                             app_message,
                         );
                     }
@@ -640,7 +640,7 @@ impl<'a> ManagedGroup<'a> {
         framed_proposal: &MLSPlaintext,
         indexed_members: HashMap<LeafIndex, Credential>,
     ) -> bool {
-        let sender = &indexed_members[&framed_proposal.sender.to_leaf_index()];
+        let sender = &indexed_members[&framed_proposal.sender()];
         match framed_proposal.content {
             MLSPlaintextContentType::Proposal(ref proposal) => match proposal {
                 // Validate add proposals
@@ -679,7 +679,7 @@ impl<'a> ManagedGroup<'a> {
     /// Send out the corresponding events for the pending proposal list.
     fn send_events(&self, indexed_members: HashMap<LeafIndex, Credential>) {
         for framed_proposal in &self.pending_proposals {
-            let sender = &indexed_members[&framed_proposal.sender.to_leaf_index()];
+            let sender = &indexed_members[&framed_proposal.sender()];
             match framed_proposal.content {
                 MLSPlaintextContentType::Proposal(ref proposal) => match proposal {
                     // Add proposals

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -75,11 +75,14 @@ impl MlsGroup {
             None
         };
         // Set nodes either from the extension or from the `nodes_option`.
-        let nodes = match ratchet_tree_extension {
-            Some(tree) => tree.into_vector(),
+        // If we got a ratchet tree extension in the welcome, we enable it for
+        // this group. Note that this is not strictly necessary. But there's
+        // currently no other mechanism to enable the extension.
+        let (nodes, enable_ratchet_tree_extension) = match ratchet_tree_extension {
+            Some(tree) => (tree.into_vector(), true),
             None => {
                 if let Some(nodes) = nodes_option {
-                    nodes
+                    (nodes, false)
                 } else {
                     return Err(WelcomeError::MissingRatchetTree);
                 }
@@ -173,7 +176,7 @@ impl MlsGroup {
                 secret_tree: RefCell::new(secret_tree),
                 tree: RefCell::new(tree),
                 interim_transcript_hash,
-                add_ratchet_tree_extension: false,
+                add_ratchet_tree_extension: enable_ratchet_tree_extension,
             })
         }
     }

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -211,6 +211,11 @@ impl KeyPackage {
     pub(crate) fn cipher_suite(&self) -> &Ciphersuite {
         self.cipher_suite
     }
+
+    /// Get the `CiphersuiteName`.
+    pub fn ciphersuite(&self) -> CiphersuiteName {
+        self.cipher_suite.name()
+    }
 }
 
 #[derive(Debug)]

--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -35,7 +35,7 @@ impl From<LeafIndex> for NodeIndex {
     }
 }
 
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Copy, Clone)]
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Copy, Clone, Default)]
 pub struct LeafIndex(u32);
 
 impl LeafIndex {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -168,7 +168,7 @@ impl RatchetTree {
             .collect()
     }
 
-    pub(crate) fn leaf_count(&self) -> LeafIndex {
+    pub fn leaf_count(&self) -> LeafIndex {
         self.tree_size().into()
     }
 

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -26,8 +26,8 @@ pub struct Node {
     pub node_type: NodeType,
     // The node only holds public values.
     // The private HPKE keys are stored in the `PrivateTree`.
-    pub key_package: Option<KeyPackage>,
-    pub node: Option<ParentNode>,
+    pub(crate) key_package: Option<KeyPackage>,
+    pub(crate) node: Option<ParentNode>,
 }
 
 impl Node {
@@ -117,7 +117,7 @@ impl Node {
     }
 
     /// Get a reference to the key package in this node.
-    pub(crate) fn key_package(&self) -> Option<&KeyPackage> {
+    pub fn key_package(&self) -> Option<&KeyPackage> {
         self.key_package.as_ref()
     }
 

--- a/tests/test_codec.rs
+++ b/tests/test_codec.rs
@@ -1,0 +1,23 @@
+// Testing some codec functions
+
+use openmls::prelude::*;
+
+#[test]
+fn string_codec() {
+    let s = "Codec Test String".to_string();
+    let encoded_s = s.encode_detached().unwrap();
+    let decoded_s = String::decode(&mut Cursor::new(&encoded_s)).unwrap();
+    assert_eq!(s, decoded_s);
+}
+
+#[test]
+fn vec_codec() {
+    fn test<T: Codec + std::fmt::Debug + PartialEq>(vec: Vec<T>) {
+        let encoded_vec = vec.encode_detached().unwrap();
+        let decoded_vec = Vec::<T>::decode(&mut Cursor::new(&encoded_vec)).unwrap();
+        assert_eq!(vec, decoded_vec);
+    }
+
+    test(vec![0u8, 1, 2, 3, 4]);
+    test(vec![vec![0u8, 1, 2, 3, 4], vec![0u8, 1, 2, 3, 4]]);
+}


### PR DESCRIPTION
This commit changes the visibility of some functions and adds
some convenience functions.

* Codec for Vec<T: Codec> using 32-bit lengths
* Codec for String for lengths up to 16-bit
* Add convenience function MLSPlaintext::is_handshake_message to
  check whether a message is a handshake or application message
* Add MLSPlaintext::sender to get the LeafIndex of the sender of
  the message
* Enable ratchet tree extension in groups that were created from
  a welcome message with one. This isn't really necessary but
  makes life easier for now.