### PR TITLE
Detach the binary tree structure from the RatchetTree

### DIFF
--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -46,6 +46,7 @@ pub enum ApplyCommitError {
     MissingOwnKeyPackage = 209,
     MissingProposal = 210,
     OwnKeyNotFound = 211,
+    SenderOutsideOfTree = 212,
 }
 
 #[derive(PartialEq, Debug)]
@@ -90,6 +91,12 @@ impl From<ConfigError> for ApplyCommitError {
 impl From<ExtensionError> for ApplyCommitError {
     fn from(_e: ExtensionError) -> ApplyCommitError {
         ApplyCommitError::NoParentHashExtension
+    }
+}
+
+impl From<TreeError> for ApplyCommitError {
+    fn from(_e: TreeError) -> ApplyCommitError {
+        ApplyCommitError::SenderOutsideOfTree
     }
 }
 

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -3,10 +3,10 @@
 //! `WelcomeError`, `ApplyCommitError`, `DecryptionError`, and
 //! `CreateCommitError`.
 
-use crate::config::ConfigError;
 use crate::extensions::ExtensionError;
 use crate::framing::errors::MLSCiphertextError;
 use crate::tree::TreeError;
+use crate::{config::ConfigError, tree::binary_tree::errors::BinaryTreeError};
 
 #[derive(PartialEq, Debug)]
 #[repr(u16)]
@@ -76,6 +76,12 @@ impl From<TreeError> for WelcomeError {
             TreeError::InvalidUpdatePath => WelcomeError::InvalidRatchetTree,
             TreeError::UnknownError => WelcomeError::UnknownError,
         }
+    }
+}
+
+impl From<BinaryTreeError> for WelcomeError {
+    fn from(_: BinaryTreeError) -> Self {
+        WelcomeError::InvalidRatchetTree
     }
 }
 

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -286,7 +286,7 @@ impl<'a> ManagedGroup<'a> {
         let tree = self.group.tree();
         let leaf_count = self.group.tree().leaf_count();
         for index in 0..leaf_count.as_usize() {
-            let leaf = &tree.nodes[LeafIndex::from(index)];
+            let leaf = &tree.public_tree[LeafIndex::from(index)];
             if let Some(leaf_node) = leaf.key_package() {
                 members.push(leaf_node.credential().clone());
             }
@@ -391,7 +391,7 @@ impl<'a> ManagedGroup<'a> {
 
     // === Application messages ===
 
-    /// Creates an application message.  
+    /// Creates an application message.
     /// Returns `ManagedGroupError::UseAfterEviction` if the member is no longer
     /// part of the group. Returns `ManagedGroupError::
     /// PendingProposalsExist` if pending proposals exist. In that case
@@ -745,7 +745,7 @@ impl<'a> ManagedGroup<'a> {
         let leaf_count = self.group.tree().leaf_count();
         for index in 0..leaf_count.as_usize() {
             let leaf_index = LeafIndex::from(index);
-            let leaf = &tree.nodes[leaf_index];
+            let leaf = &tree.public_tree[leaf_index];
             if let Some(leaf_node) = leaf.key_package() {
                 indexed_members.insert(leaf_index, leaf_node.credential().clone());
             }

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -286,7 +286,9 @@ impl<'a> ManagedGroup<'a> {
         let tree = self.group.tree();
         let leaf_count = self.group.tree().leaf_count();
         for index in 0..leaf_count.as_usize() {
-            let leaf = &tree.public_tree[LeafIndex::from(index)];
+            // We can unwrap here, because the index is scoped by the leaf
+            // count.
+            let leaf = &tree.public_tree.leaf(&LeafIndex::from(index)).unwrap();
             if let Some(leaf_node) = leaf.key_package() {
                 members.push(leaf_node.credential().clone());
             }
@@ -745,7 +747,9 @@ impl<'a> ManagedGroup<'a> {
         let leaf_count = self.group.tree().leaf_count();
         for index in 0..leaf_count.as_usize() {
             let leaf_index = LeafIndex::from(index);
-            let leaf = &tree.public_tree[leaf_index];
+            // We can unwrap here, because `leaf_index` is scoped by
+            // `leaf_count`.
+            let leaf = &tree.public_tree.leaf(&leaf_index).unwrap();
             if let Some(leaf_node) = leaf.key_package() {
                 indexed_members.insert(leaf_index, leaf_node.credential().clone());
             }

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -137,7 +137,7 @@ impl MlsGroup {
         // Verify KeyPackage extensions
         if let Some(path) = &commit.path {
             if !is_own_commit {
-                let parent_hash = provisional_tree.compute_parent_hash(NodeIndex::from(sender));
+                let parent_hash = provisional_tree.compute_parent_hash(NodeIndex::from(sender))?;
                 if let Some(received_parent_hash) = path
                     .leaf_key_package
                     .extension_with_type(ExtensionType::ParentHash)

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -76,10 +76,9 @@ impl MlsGroup {
                 };
                 provisional_tree.replace_private_tree(own_kpb, &serialized_context)
             } else {
-                match provisional_tree.update_path(sender, &path, &serialized_context) {
-                    Ok(cs) => cs,
-                    Err(e) => panic!("Error while retrieving update_path: {:?}", e),
-                }
+                provisional_tree
+                    .update_path(sender, &path, &serialized_context)
+                    .unwrap()
             }
         } else {
             if path_required_by_commit {

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -76,9 +76,10 @@ impl MlsGroup {
                 };
                 provisional_tree.replace_private_tree(own_kpb, &serialized_context)
             } else {
-                provisional_tree
-                    .update_path(sender, &path, &serialized_context)
-                    .unwrap()
+                match provisional_tree.update_path(sender, &path, &serialized_context) {
+                    Ok(cs) => cs,
+                    Err(e) => panic!("Error while retrieving update_path: {:?}", e),
+                }
             }
         } else {
             if path_required_by_commit {

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -228,7 +228,8 @@ impl MlsGroup {
         let tree = self.tree.borrow();
         let mut roster = Vec::new();
         for i in 0..tree.leaf_count().as_usize() {
-            let node = &tree.public_tree[LeafIndex::from(i)];
+            // We can unwrap here, because `i` is scoped by `leaf_count()`.
+            let node = &tree.public_tree.leaf(&LeafIndex::from(i)).unwrap();
             let credential = if let Some(kp) = &node.key_package {
                 kp.credential()
             } else {

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -228,7 +228,7 @@ impl MlsGroup {
         let tree = self.tree.borrow();
         let mut roster = Vec::new();
         for i in 0..tree.leaf_count().as_usize() {
-            let node = &tree.nodes[LeafIndex::from(i)];
+            let node = &tree.public_tree[LeafIndex::from(i)];
             let credential = if let Some(kp) = &node.key_package {
                 kp.credential()
             } else {

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -94,7 +94,7 @@ impl MlsGroup {
         }
 
         // Verify GroupInfo signature
-        let signer_node = tree.public_tree[group_info.signer_index()].clone();
+        let signer_node = tree.public_tree.leaf(&group_info.signer_index())?.clone();
         let signer_key_package = signer_node.key_package.unwrap();
         let payload = group_info.unsigned_payload().unwrap();
         if !signer_key_package

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -121,8 +121,7 @@ impl MlsGroup {
                 tree.own_node_index(),
                 NodeIndex::from(group_info.signer_index()),
             );
-            let common_path = treemath::direct_path_root(common_ancestor_index, tree.leaf_count())
-                .expect("new_from_welcome_internal: TreeMath error when computing direct path.");
+            let common_path = treemath::direct_path_root(common_ancestor_index, tree.leaf_count());
 
             // Update the private tree.
             let private_tree = tree.private_tree_mut();

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -94,7 +94,7 @@ impl MlsGroup {
         }
 
         // Verify GroupInfo signature
-        let signer_node = tree.nodes[group_info.signer_index()].clone();
+        let signer_node = tree.public_tree[group_info.signer_index()].clone();
         let signer_key_package = signer_node.key_package.unwrap();
         let payload = group_info.unsigned_payload().unwrap();
         if !signer_key_package

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -128,8 +128,7 @@ impl JoinerSecret {
         let dirpath = treemath::direct_path_root(
             provisional_tree.own_node_index(),
             provisional_tree.leaf_count(),
-        )
-        .expect("create_commit_internal: TreeMath error when computing direct path.");
+        );
 
         let mut plaintext_secrets = vec![];
         for (index, add_proposal) in invited_members {

--- a/src/tree/binary_tree.rs
+++ b/src/tree/binary_tree.rs
@@ -6,7 +6,7 @@ use super::TreeError;
 /// Note, that this is not a full implementation of a binary tree, but rather
 /// only enables the operations needed by MLS.
 #[derive(Debug, Clone)]
-pub(crate) struct BinaryTree<T> {
+pub struct BinaryTree<T> {
     pub(crate) nodes: Vec<T>,
 }
 
@@ -18,44 +18,20 @@ impl<T> From<Vec<T>> for BinaryTree<T> {
 
 impl<T> BinaryTree<T> {
     fn check_if_within_bounds(&self, node_index: &NodeIndex) -> Result<(), TreeError> {
-        if node_index < &self.size() {
+        if node_index >= &self.size() {
             return Err(TreeError::InvalidArguments);
         };
         Ok(())
     }
 
-    /// Create a new, empty binary tree.
-    pub(crate) fn new() -> Self {
-        BinaryTree { nodes: Vec::new() }
+    /// Extend the tree by the given nodes on the right.
+    pub(crate) fn add(&mut self, nodes: Vec<T>) {
+        self.nodes.extend(nodes)
     }
 
-    pub(crate) fn leaf_count(&self) -> LeafIndex {
-        self.size().into()
-    }
-
-    /// Extend the tree by the given leaves on the right.
-    pub(crate) fn add(&mut self, nodes: &[T]) {
-        let num_new_nodes = nodes.len();
-        let mut added_nodes: Vec<T> = Vec::with_capacity(num_new_nodes);
-
-        if num_new_nodes > (2 * self.leaf_count().as_usize()) {
-            self.nodes
-                .reserve_exact(2 * ((num_new_nodes) - (self.leaf_count().as_usize())));
-        }
-
-        let mut leaf_index = self.size().as_usize() + 1;
-        for node in nodes.iter() {
-            added_nodes.extend(vec![
-                Node::new_blank_parent_node(),
-                Node::new_leaf(Some((*add_proposal).clone())),
-            ]);
-            let node_index = NodeIndex::from(leaf_index);
-            added_members.push((node_index, add_proposal.credential().clone()));
-            leaf_index += 2;
-        }
-        self.public_tree.extend(new_nodes);
-        self.trim_tree();
-        added_members
+    /// Extend the tree by the given nodes on the right.
+    pub(crate) fn truncate(&mut self, new_length: usize) {
+        self.nodes.truncate(new_length)
     }
 
     /// Replace the node at index `index`, consuming the new node and returning
@@ -64,11 +40,6 @@ impl<T> BinaryTree<T> {
         self.check_if_within_bounds(&node_index)?;
         self.nodes.push(node);
         Ok(self.nodes.swap_remove(node_index.as_usize()))
-    }
-
-    /// Remove the rightmost leaf.
-    pub(crate) fn pop_leaf(&mut self) -> T {
-        unimplemented!()
     }
 
     /// Get the size of the tree.
@@ -84,10 +55,7 @@ impl<T> BinaryTree<T> {
 
     /// Get a mutable reference to a node of the tree by index.
     pub(crate) fn node_mut(&mut self, node_index: &NodeIndex) -> Result<&mut T, TreeError> {
-        // Check if index is within bounds.
-        if node_index < &self.size() {
-            return Err(TreeError::InvalidArguments);
-        }
+        self.check_if_within_bounds(node_index)?;
         Ok(&mut self.nodes[node_index])
     }
 

--- a/src/tree/binary_tree.rs
+++ b/src/tree/binary_tree.rs
@@ -200,4 +200,9 @@ impl<T> BinaryTree<T> {
     pub(crate) fn nodes(&self) -> &Vec<T> {
         &self.nodes
     }
+
+    /// Return the index of the root node.
+    pub(crate) fn root(&self) -> NodeIndex {
+        treemath::root(self.leaf_count())
+    }
 }

--- a/src/tree/binary_tree.rs
+++ b/src/tree/binary_tree.rs
@@ -7,7 +7,7 @@ use super::{treemath, TreeError};
 /// only enables the operations needed by MLS.
 #[derive(Debug, Clone)]
 pub struct BinaryTree<T> {
-    pub(crate) nodes: Vec<T>,
+    nodes: Vec<T>,
 }
 
 impl<T> From<Vec<T>> for BinaryTree<T> {
@@ -194,5 +194,10 @@ impl<T> BinaryTree<T> {
             let right_result = self.fold_tree(&right_node, f)?;
             Ok(f(node, node_index, &left_result, &right_result))
         }
+    }
+
+    /// Return a reference to the nodes of the tree.
+    pub(crate) fn nodes(&self) -> &Vec<T> {
+        &self.nodes
     }
 }

--- a/src/tree/binary_tree.rs
+++ b/src/tree/binary_tree.rs
@@ -107,26 +107,6 @@ impl<T> BinaryTree<T> {
         }
     }
 
-    pub(crate) fn copath_resolution<F>(
-        &self,
-        node_index: &NodeIndex,
-        predicate: &F,
-    ) -> Result<Vec<NodeIndex>, TreeError>
-    where
-        F: Fn(NodeIndex, &T) -> Vec<NodeIndex>,
-    {
-        self.check_if_within_bounds(node_index)?;
-        let leaf_count = LeafIndex::from(self.size());
-        let copath = treemath::copath(*node_index, leaf_count)
-            .expect("Treemath error when retrieving copath nodes.");
-        let mut resolution = Vec::new();
-        for copath_index in copath {
-            let copath_index_resolution = self.resolve(&copath_index, predicate)?;
-            resolution.extend(copath_index_resolution);
-        }
-        Ok(resolution)
-    }
-
     /// Apply the given function `f` to each node in the direct path of the node
     /// with index `node_index`, the result of the function applied to the
     /// parent is used as input to the functinon applied to the child.
@@ -152,24 +132,6 @@ impl<T> BinaryTree<T> {
         //    f(self.node_mut(&i)?);
         //}
         //Ok(())
-    }
-
-    /// Given two leaves, apply the function `f` to the direct path of the
-    /// closest common ancestor.
-    pub(crate) fn shared_direct_path_map<F, U: Default>(
-        &mut self,
-        leaf1: &LeafIndex,
-        leaf2: &LeafIndex,
-        f: &F,
-    ) -> Result<U, TreeError>
-    where
-        F: Fn(&mut T, U) -> Result<U, TreeError>,
-    {
-        self.check_if_within_bounds(&NodeIndex::from(leaf1))?;
-        self.check_if_within_bounds(&NodeIndex::from(leaf2))?;
-        let common_ancestor_index =
-            treemath::common_ancestor_index(NodeIndex::from(leaf1), NodeIndex::from(leaf2));
-        self.direct_path_map(&common_ancestor_index, f)
     }
 
     /// Get given two nodes, get the node in the copath of the first node, such

--- a/src/tree/binary_tree.rs
+++ b/src/tree/binary_tree.rs
@@ -1,6 +1,6 @@
 use crate::{prelude::LeafIndex, tree::index::NodeIndex};
 
-use super::TreeError;
+use super::{treemath, TreeError};
 
 /// A binary tree in the array (vector) representation used in the MLS spec.
 /// Note, that this is not a full implementation of a binary tree, but rather
@@ -61,6 +61,69 @@ impl<T> BinaryTree<T> {
 
     pub(crate) fn leaf(&self, leaf_index: &LeafIndex) -> Result<&T, TreeError> {
         self.node(&NodeIndex::from(leaf_index.clone()))
+    }
+
+    /// Return the nodes in the CoPath of a given node.
+    pub(crate) fn copath(&self, node_index: &NodeIndex) -> Result<Vec<&T>, TreeError> {
+        let leaf_count = LeafIndex::from(self.size());
+        let copath = treemath::copath(*node_index, leaf_count)
+            .expect("Treemath error when retrieving copath nodes.");
+        let mut copath_nodes = Vec::new();
+        for i in copath {
+            copath_nodes.push(self.node(&i)?);
+        }
+        Ok(copath_nodes)
+    }
+
+    /// Given a node index, check if the given predicate evaluates to a
+    /// non-empty vector or T-references. If that is the case, return that
+    /// vector. If it returns an empty vector, recursively traverse up the left
+    /// and right subtree of the node and return the gathered vectors of
+    /// T-references.
+    pub(crate) fn resolve<F>(
+        &self,
+        node_index: &NodeIndex,
+        predicate: &F,
+    ) -> Result<Vec<NodeIndex>, TreeError>
+    where
+        F: Fn(NodeIndex, &T) -> Vec<NodeIndex>,
+    {
+        self.check_if_within_bounds(node_index)?;
+        let node = self.node(node_index)?;
+        let predicate_result = predicate(*node_index, node);
+        if !predicate_result.is_empty() {
+            return Ok(predicate_result);
+        } else if node_index.is_leaf() {
+            return Ok(vec![]);
+        } else {
+            let mut left_resolution =
+                self.resolve(&treemath::left(*node_index).unwrap(), predicate)?;
+            let right_resolution = self.resolve(
+                &treemath::right(*node_index, LeafIndex::from(self.size())).unwrap(),
+                predicate,
+            )?;
+            left_resolution.extend(right_resolution);
+            return Ok(left_resolution);
+        }
+    }
+
+    pub(crate) fn copath_resolution<F>(
+        &self,
+        node_index: &NodeIndex,
+        predicate: &F,
+    ) -> Result<Vec<NodeIndex>, TreeError>
+    where
+        F: Fn(NodeIndex, &T) -> Vec<NodeIndex>,
+    {
+        let leaf_count = LeafIndex::from(self.size());
+        let copath = treemath::copath(*node_index, leaf_count)
+            .expect("Treemath error when retrieving copath nodes.");
+        let mut resolution = Vec::new();
+        for copath_index in copath {
+            let copath_index_resolution = self.resolve(&copath_index, predicate)?;
+            resolution.extend(copath_index_resolution);
+        }
+        Ok(resolution)
     }
 
     // Probably a few more functions to manipulate the `BinaryTree`.

--- a/src/tree/binary_tree.rs
+++ b/src/tree/binary_tree.rs
@@ -1,0 +1,99 @@
+use crate::{prelude::LeafIndex, tree::index::NodeIndex};
+
+use super::TreeError;
+
+/// A binary tree in the array (vector) representation used in the MLS spec.
+/// Note, that this is not a full implementation of a binary tree, but rather
+/// only enables the operations needed by MLS.
+#[derive(Debug, Clone)]
+pub(crate) struct BinaryTree<T> {
+    pub(crate) nodes: Vec<T>,
+}
+
+impl<T> From<Vec<T>> for BinaryTree<T> {
+    fn from(nodes: Vec<T>) -> Self {
+        BinaryTree { nodes }
+    }
+}
+
+impl<T> BinaryTree<T> {
+    fn check_if_within_bounds(&self, node_index: &NodeIndex) -> Result<(), TreeError> {
+        if node_index < &self.size() {
+            return Err(TreeError::InvalidArguments);
+        };
+        Ok(())
+    }
+
+    /// Create a new, empty binary tree.
+    pub(crate) fn new() -> Self {
+        BinaryTree { nodes: Vec::new() }
+    }
+
+    pub(crate) fn leaf_count(&self) -> LeafIndex {
+        self.size().into()
+    }
+
+    /// Extend the tree by the given leaves on the right.
+    pub(crate) fn add(&mut self, nodes: &[T]) {
+        let num_new_nodes = nodes.len();
+        let mut added_nodes: Vec<T> = Vec::with_capacity(num_new_nodes);
+
+        if num_new_nodes > (2 * self.leaf_count().as_usize()) {
+            self.nodes
+                .reserve_exact(2 * ((num_new_nodes) - (self.leaf_count().as_usize())));
+        }
+
+        let mut leaf_index = self.size().as_usize() + 1;
+        for node in nodes.iter() {
+            added_nodes.extend(vec![
+                Node::new_blank_parent_node(),
+                Node::new_leaf(Some((*add_proposal).clone())),
+            ]);
+            let node_index = NodeIndex::from(leaf_index);
+            added_members.push((node_index, add_proposal.credential().clone()));
+            leaf_index += 2;
+        }
+        self.public_tree.extend(new_nodes);
+        self.trim_tree();
+        added_members
+    }
+
+    /// Replace the node at index `index`, consuming the new node and returning
+    /// the old one.
+    pub(crate) fn replace(&mut self, node_index: NodeIndex, node: T) -> Result<T, TreeError> {
+        self.check_if_within_bounds(&node_index)?;
+        self.nodes.push(node);
+        Ok(self.nodes.swap_remove(node_index.as_usize()))
+    }
+
+    /// Remove the rightmost leaf.
+    pub(crate) fn pop_leaf(&mut self) -> T {
+        unimplemented!()
+    }
+
+    /// Get the size of the tree.
+    pub(crate) fn size(&self) -> NodeIndex {
+        NodeIndex::from(self.nodes.len())
+    }
+
+    /// Get a reference to a node of the tree by index.
+    pub(crate) fn node(&self, node_index: &NodeIndex) -> Result<&T, TreeError> {
+        self.check_if_within_bounds(node_index)?;
+        Ok(&self.nodes[node_index])
+    }
+
+    /// Get a mutable reference to a node of the tree by index.
+    pub(crate) fn node_mut(&mut self, node_index: &NodeIndex) -> Result<&mut T, TreeError> {
+        // Check if index is within bounds.
+        if node_index < &self.size() {
+            return Err(TreeError::InvalidArguments);
+        }
+        Ok(&mut self.nodes[node_index])
+    }
+
+    pub(crate) fn leaf(&self, leaf_index: &LeafIndex) -> Result<&T, TreeError> {
+        self.node(&NodeIndex::from(leaf_index.clone()))
+    }
+
+    // Probably a few more functions to manipulate the `BinaryTree`.
+}

--- a/src/tree/binary_tree/errors.rs
+++ b/src/tree/binary_tree/errors.rs
@@ -1,0 +1,25 @@
+use std::error::Error;
+
+use crate::tree::treemath::TreeMathError;
+
+#[derive(Debug)]
+pub enum BinaryTreeError {
+    /// This is not an application message.
+    IndexOutOfBounds,
+}
+
+implement_enum_display!(BinaryTreeError);
+
+impl Error for BinaryTreeError {
+    fn description(&self) -> &str {
+        match self {
+            Self::IndexOutOfBounds => "This index does not point to a node within the tree.",
+        }
+    }
+}
+
+impl From<TreeMathError> for BinaryTreeError {
+    fn from(_: TreeMathError) -> Self {
+        BinaryTreeError::IndexOutOfBounds
+    }
+}

--- a/src/tree/binary_tree/mod.rs
+++ b/src/tree/binary_tree/mod.rs
@@ -160,8 +160,8 @@ impl<T> BinaryTree<T> {
 
         let target_direct_path = self.direct_path(copath_target).unwrap();
         let copath_node_index = match target_direct_path.iter().find(|x| copath.contains(x)) {
-            Some(index) => index.clone(),
-            None => copath_target.clone(),
+            Some(index) => index.to_owned(),
+            None => copath_target.to_owned(),
         };
         copath_node_index
     }

--- a/src/tree/binary_tree/mod.rs
+++ b/src/tree/binary_tree/mod.rs
@@ -181,9 +181,9 @@ impl<T> BinaryTree<T> {
     }
 
     /// Compute a function f based on the node itself, as well as the result of
-    /// the same function computed on the left and right child. Leafs return the
-    /// result of the function with their node, as well as the default values
-    /// for `U`.
+    /// the same function computed on the left and right child. Leaves return
+    /// the result of the function with their node, as well as the default
+    /// values for `U`.
     pub(crate) fn fold_tree<F, U: Default>(
         &self,
         node_index: &NodeIndex,
@@ -204,7 +204,7 @@ impl<T> BinaryTree<T> {
         }
     }
 
-    /// Return a reference to the nodes of the tree.
+    /// Return a reference to the nodes of the tree as a Vector.
     pub(crate) fn nodes(&self) -> &Vec<T> {
         &self.nodes
     }

--- a/src/tree/binary_tree/mod.rs
+++ b/src/tree/binary_tree/mod.rs
@@ -5,6 +5,8 @@ use self::errors::BinaryTreeError;
 use super::treemath;
 
 pub(crate) mod errors;
+#[cfg(test)]
+pub(crate) mod test_binary_tree;
 
 /// A binary tree in the array (vector) representation used in the MLS spec.
 /// Note, that this is not a full implementation of a binary tree, but rather

--- a/src/tree/binary_tree/test_binary_tree.rs
+++ b/src/tree/binary_tree/test_binary_tree.rs
@@ -1,0 +1,80 @@
+use super::BinaryTree;
+use crate::{prelude::random_u8, tree::index::NodeIndex};
+use evercrypt::prelude::get_random_vec;
+
+fn create_random_tree() -> BinaryTree<u8> {
+    let size = random_u8();
+    let nodes = get_random_vec(size as usize);
+    BinaryTree::from(nodes)
+}
+
+#[test]
+fn test_basic_operations() {
+    let tree = create_random_tree();
+    // Get current tree size.
+    let tree_size = tree.size().as_usize();
+    // Create nodes to add.
+    let new_nodes = get_random_vec(10);
+    // Clone so we can compare later.
+    let mut new_tree = tree.clone();
+    // Add new nodes to the tree.
+    new_tree.add(new_nodes.clone());
+    let new_tree_size = new_tree.size().as_usize();
+
+    // Compare sizes of old and new tree.
+    assert_eq!(tree_size + 10, new_tree_size);
+
+    // Check that nodes were added properly.
+    assert_eq!(
+        &new_tree.nodes().as_slice()[tree_size..new_tree_size],
+        new_nodes.as_slice()
+    );
+
+    // Remove newly added nodes.
+    new_tree.truncate(tree_size);
+
+    // Check that trees are now the same again.
+    assert_eq!(new_tree.nodes(), tree.nodes());
+
+    // Replace first node with zero.
+    let old_first = new_tree.nodes().first().unwrap().clone();
+    let old_removed_first = new_tree.replace(&NodeIndex::from(0u32), 0u8);
+    // Check that it worked.
+    assert_eq!(new_tree.nodes().first().unwrap(), &0u8);
+    assert_eq!(old_first, old_removed_first.unwrap());
+}
+
+#[test]
+fn test_out_of_bounds() {
+    let mut tree = create_random_tree();
+
+    let node = tree.node(&NodeIndex::from(tree.size().as_usize() + 1));
+
+    assert!(node.is_err());
+
+    let node = tree.node_mut(&NodeIndex::from(tree.size().as_usize() + 1));
+
+    assert!(node.is_err());
+}
+
+#[test]
+fn test_resolution() {
+    // Create simple tree.
+    let nodes = vec![0, 1, 2, 3, 4, 5, 6];
+    let tree = BinaryTree::from(nodes);
+    // A simple predicate. Return true if the node equals 1 or if it's a leaf
+    // node.
+    let predicate = |index: NodeIndex, node: &u8| -> Vec<NodeIndex> {
+        if node == &1u8 || index.is_leaf() {
+            vec![index.to_owned()]
+        } else {
+            vec![]
+        }
+    };
+
+    let resolution = tree.resolve(&NodeIndex::from(3u32), &predicate).unwrap();
+    println!("Resolution: {:?}", resolution);
+    let mut result = vec![1u32, 4u32, 6u32];
+    let result_indices: Vec<NodeIndex> = result.drain(..).map(|i| NodeIndex::from(i)).collect();
+    assert_eq!(resolution, result_indices)
+}

--- a/src/tree/binary_tree/test_binary_tree.rs
+++ b/src/tree/binary_tree/test_binary_tree.rs
@@ -42,6 +42,10 @@ fn test_basic_operations() {
     // Check that it worked.
     assert_eq!(new_tree.nodes().first().unwrap(), &0u8);
     assert_eq!(old_first, old_removed_first.unwrap());
+
+    // Finally, let's try to replace something with an out-of-bounds index.
+    let error = new_tree.replace(&NodeIndex::from(new_tree_size), 0u8);
+    assert!(error.is_err());
 }
 
 #[test]

--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -140,3 +140,19 @@ impl Codec for LeafIndex {
         self.0.encode(buffer)
     }
 }
+
+#[test]
+fn test_indices() {
+    let vector = vec![1, 2, 3];
+    let index = NodeIndex::from(0u32);
+    assert_eq!(vector[index], 1);
+    assert_eq!(vector[&index], 1);
+
+    let mut element = vector[index];
+    element = element + 1;
+    assert_eq!(element, 2);
+
+    let mut element = vector[&index];
+    element = element + 1;
+    assert_eq!(element, 2);
+}

--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -143,16 +143,20 @@ impl Codec for LeafIndex {
 
 #[test]
 fn test_indices() {
-    let vector = vec![1, 2, 3];
+    let mut vector = vec![1, 2, 3];
     let index = NodeIndex::from(0u32);
     assert_eq!(vector[index], 1);
     assert_eq!(vector[&index], 1);
 
-    let mut element = vector[index];
-    element = element + 1;
-    assert_eq!(element, 2);
+    vector[index] = 2;
+    assert_eq!(vector[index], 2);
 
-    let mut element = vector[&index];
-    element = element + 1;
-    assert_eq!(element, 2);
+    vector[&index] = 2;
+    assert_eq!(vector[&index], 2);
+
+    let leaf_index = LeafIndex::from(1u32);
+    assert_eq!(vector[leaf_index], 3);
+
+    vector[leaf_index] = 4;
+    assert_eq!(vector[leaf_index], 4);
 }

--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -33,6 +33,12 @@ impl From<LeafIndex> for NodeIndex {
     }
 }
 
+impl From<&LeafIndex> for NodeIndex {
+    fn from(node_index: &LeafIndex) -> NodeIndex {
+        NodeIndex(node_index.as_u32() * 2)
+    }
+}
+
 impl<T> Index<NodeIndex> for Vec<T> {
     type Output = T;
 

--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -3,8 +3,6 @@ use std::ops::IndexMut;
 
 use crate::codec::*;
 
-use super::node::Node;
-
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash, Default)]
 pub struct NodeIndex(u32);
 
@@ -32,6 +30,42 @@ impl From<usize> for NodeIndex {
 impl From<LeafIndex> for NodeIndex {
     fn from(node_index: LeafIndex) -> NodeIndex {
         NodeIndex(node_index.as_u32() * 2)
+    }
+}
+
+impl<T> Index<NodeIndex> for Vec<T> {
+    type Output = T;
+
+    fn index(&self, node_index: NodeIndex) -> &Self::Output {
+        &self[node_index.as_usize()]
+    }
+}
+
+impl<T> IndexMut<NodeIndex> for Vec<T> {
+    fn index_mut(&mut self, node_index: NodeIndex) -> &mut Self::Output {
+        &mut self[node_index.as_usize()]
+    }
+}
+
+impl<T> Index<&NodeIndex> for Vec<T> {
+    type Output = T;
+
+    fn index(&self, node_index: &NodeIndex) -> &Self::Output {
+        &self[node_index.as_usize()]
+    }
+}
+
+impl<T> IndexMut<&NodeIndex> for Vec<T> {
+    fn index_mut(&mut self, node_index: &NodeIndex) -> &mut Self::Output {
+        &mut self[node_index.as_usize()]
+    }
+}
+
+impl NodeIndex {
+    /// Returns `true` if the `NodeIndex` corresponds to a leaf and `false`
+    /// otherwise.
+    pub(crate) fn is_leaf(&self) -> bool {
+        self.as_usize() % 2 == 0
     }
 }
 
@@ -77,21 +111,21 @@ impl From<NodeIndex> for LeafIndex {
     }
 }
 
-impl Index<LeafIndex> for Vec<Node> {
-    type Output = Node;
+impl<T> Index<LeafIndex> for Vec<T> {
+    type Output = T;
 
     /// This converts a `LeafIndex`, which points to a particular leaf in the
     /// vector of leaves in a tree, to a `NodeIndex`, i.e. it makes it point the
     /// same leaf, but in the array representing the tree as opposed to the one
     /// only containing the leaves.
     fn index(&self, leaf_index: LeafIndex) -> &Self::Output {
-        &self[NodeIndex::from(leaf_index).as_usize()]
+        &self[NodeIndex::from(leaf_index)]
     }
 }
 
-impl IndexMut<LeafIndex> for Vec<Node> {
+impl<T> IndexMut<LeafIndex> for Vec<T> {
     fn index_mut(&mut self, leaf_index: LeafIndex) -> &mut Self::Output {
-        &mut self[NodeIndex::from(leaf_index).as_usize()]
+        &mut self[NodeIndex::from(leaf_index)]
     }
 }
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -352,7 +352,7 @@ impl RatchetTree {
         self.merge_direct_path_keys(update_path, sender_direct_path)?;
         self.merge_public_keys(&new_path_public_keys, &common_path)?;
         self.public_tree.replace(
-            NodeIndex::from(sender),
+            &NodeIndex::from(sender),
             Node::new_leaf(Some(update_path.leaf_key_package.clone())),
         )?;
         self.compute_parent_hash(NodeIndex::from(sender))?;
@@ -447,7 +447,7 @@ impl RatchetTree {
         // Update own leaf node with the new values. We can unwrap here, because
         // `own_index` is always within the tree.
         self.public_tree
-            .replace(own_index, Node::new_leaf(Some(key_package.clone())))
+            .replace(&own_index, Node::new_leaf(Some(key_package.clone())))
             .unwrap();
         if with_update_path {
             let update_path_nodes = self
@@ -589,7 +589,7 @@ impl RatchetTree {
             // `free_leaves`, which in turn only contains indices that are
             // within the tree.
             self.public_tree
-                .replace(leaf_node_index, Node::new_leaf(Some((*new_kp).clone())))
+                .replace(&leaf_node_index, Node::new_leaf(Some((*new_kp).clone())))
                 .unwrap();
             let dirpath = self.public_tree.direct_path(&leaf_node_index).unwrap();
             for d in dirpath.iter() {
@@ -657,7 +657,7 @@ impl RatchetTree {
             // Blank the direct path of that leaf node
             self.blank_member(sender_index)?;
             // Replace the leaf node
-            self.public_tree.replace(sender_index, leaf_node)?;
+            self.public_tree.replace(&sender_index, leaf_node)?;
             // Check if it is a self-update
             if sender_index == self.own_node_index() {
                 let own_kpb = match updates_key_package_bundles

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -758,7 +758,7 @@ impl RatchetTree {
                 NodeType::Default => panic!("Default node type not supported in tree hash."),
             }
         };
-        let root = treemath::root(self.leaf_count());
+        let root = self.public_tree.root();
 
         // We can unwrap here, as the root is always within the tree.
         self.public_tree.fold_tree(&root, &node_hash).unwrap()
@@ -766,7 +766,7 @@ impl RatchetTree {
     /// Computes the parent hash. Throws a `TreeError` if the given `index` is
     /// outside of the tree.
     pub fn compute_parent_hash(&mut self, index: NodeIndex) -> Result<Vec<u8>, TreeError> {
-        let root = treemath::root(self.leaf_count());
+        let root = self.public_tree.root();
         // This should only happen when the group only contains one member
         if index == root {
             return Ok(vec![]);

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -6,7 +6,7 @@ use crate::key_packages::*;
 use crate::messages::proposals::*;
 
 // Tree modules
-mod binary_tree;
+pub(crate) mod binary_tree;
 pub(crate) mod codec;
 pub(crate) mod hash_input;
 pub mod index;
@@ -23,7 +23,10 @@ use node::*;
 use private_tree::{PathSecrets, PrivateTree};
 use treemath::TreeMathError;
 
-use self::{binary_tree::BinaryTree, private_tree::CommitSecret};
+use self::{
+    binary_tree::{errors::BinaryTreeError, BinaryTree},
+    private_tree::CommitSecret,
+};
 
 // Internal tree tests
 #[cfg(test)]
@@ -200,7 +203,7 @@ impl RatchetTree {
             }
         };
 
-        self.public_tree.resolve(&index, &predicate)
+        Ok(self.public_tree.resolve(&index, &predicate)?)
     }
 
     /// Get the index of the own node.
@@ -269,7 +272,7 @@ impl RatchetTree {
 
         let common_ancestor_copath_index = self
             .public_tree
-            .copath_node(&sender_node_index, &own_node_index)?;
+            .copath_node(&sender_node_index, &own_node_index);
 
         // Resolve the node of that co-path index
         let resolution = self.resolve(common_ancestor_copath_index)?;
@@ -797,7 +800,7 @@ impl RatchetTree {
                 }
             }
         };
-        self.public_tree.direct_path_map(&index, &f)
+        Ok(self.public_tree.direct_path_map(&index, &f)?)
     }
     /// Verifies the integrity of a public tree
     pub fn verify_integrity(ciphersuite: &Ciphersuite, nodes: &[Option<Node>]) -> bool {
@@ -909,6 +912,12 @@ pub enum TreeError {
 
 impl From<TreeMathError> for TreeError {
     fn from(_: TreeMathError) -> Self {
+        TreeError::InvalidArguments
+    }
+}
+
+impl From<BinaryTreeError> for TreeError {
+    fn from(_: BinaryTreeError) -> Self {
         TreeError::InvalidArguments
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -150,7 +150,7 @@ impl RatchetTree {
     /// nodes.
     pub fn public_key_tree(&self) -> Vec<Option<&Node>> {
         let mut tree = vec![];
-        for node in self.public_tree.nodes.iter() {
+        for node in self.public_tree.nodes().iter() {
             if node.is_blank() {
                 tree.push(None)
             } else {
@@ -236,7 +236,7 @@ impl RatchetTree {
 
     fn free_leaves(&self) -> Vec<NodeIndex> {
         let mut free_leaves = vec![];
-        for (index, node) in self.public_tree.nodes.iter().enumerate() {
+        for (index, node) in self.public_tree.nodes().iter().enumerate() {
             let node_index = NodeIndex::from(index);
             if NodeIndex::from(index).is_leaf() && node.is_blank() {
                 free_leaves.push(node_index);

--- a/src/tree/secret_tree.rs
+++ b/src/tree/secret_tree.rs
@@ -136,10 +136,7 @@ impl SecretTree {
         // Calculate direct path
         let index_in_tree = NodeIndex::from(index);
         let mut dir_path = vec![index_in_tree];
-        dir_path.extend(
-            dirpath(index_in_tree, self.size)
-                .expect("initialize_sender_rathets: Error while computing direct path."),
-        );
+        dir_path.extend(dirpath(index_in_tree, self.size));
         dir_path.push(root(self.size));
         let mut empty_nodes: Vec<NodeIndex> = vec![];
         for n in dir_path {

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -1,5 +1,3 @@
-use super::treemath::TreeMathError;
-
 /// The following test uses an old test vector that assumes an outdated version
 /// of the treemath defined in the spec. In a few select cases, we should now
 /// expect errors based on the new treemath.
@@ -87,12 +85,6 @@ fn test_dir_path() {
             assert_eq!(
                 dir_path_test,
                 direct_path_root(index, LeafIndex::from(size)).unwrap()
-            );
-            let mut dirpath_long_test = vec![index];
-            dirpath_long_test.extend(dir_path_test);
-            assert_eq!(
-                dirpath_long_test,
-                dirpath_long(index, LeafIndex::from(size)).unwrap()
             );
         }
     }

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -79,12 +79,12 @@ fn test_dir_path() {
     for size in 0..SIZE {
         for i in 0..size / 2 {
             let index = NodeIndex::from(i);
-            let mut dir_path_test = dirpath(index, LeafIndex::from(size)).unwrap();
+            let mut dir_path_test = dirpath(index, LeafIndex::from(size));
             let root = root(LeafIndex::from(size));
             dir_path_test.extend_from_slice(&[root]);
             assert_eq!(
                 dir_path_test,
-                direct_path_root(index, LeafIndex::from(size)).unwrap()
+                direct_path_root(index, LeafIndex::from(size))
             );
         }
     }

--- a/src/tree/treemath.rs
+++ b/src/tree/treemath.rs
@@ -123,7 +123,7 @@ pub(crate) fn direct_path_root(index: NodeIndex, size: LeafIndex) -> Vec<NodeInd
     }
 
     let mut d = vec![];
-    let mut x = index.to_owned();
+    let mut x = index;
     while x != r {
         // We can unwrap here, because we know that `index` is not the root node.
         x = parent(x, size).unwrap();
@@ -148,9 +148,9 @@ pub(crate) fn copath(index: NodeIndex, size: LeafIndex) -> Vec<NodeIndex> {
 pub(crate) fn common_ancestor_index(x: NodeIndex, y: NodeIndex) -> NodeIndex {
     let (lx, ly) = (level(x) + 1, level(y) + 1);
     if (lx <= ly) && (x.as_usize() >> ly == y.as_usize() >> ly) {
-        return y.to_owned();
+        return y;
     } else if (ly <= lx) && (x.as_usize() >> lx == y.as_usize() >> lx) {
-        return x.to_owned();
+        return x;
     }
 
     let (mut xn, mut yn) = (x.as_usize(), y.as_usize());

--- a/src/tree/treemath.rs
+++ b/src/tree/treemath.rs
@@ -113,26 +113,6 @@ pub(crate) fn dirpath(index: NodeIndex, size: LeafIndex) -> Result<Vec<NodeIndex
 }
 
 // Ordered from leaf to root
-// Includes leaf and root
-pub(crate) fn dirpath_long(
-    index: NodeIndex,
-    size: LeafIndex,
-) -> Result<Vec<NodeIndex>, TreeMathError> {
-    let r = root(size);
-    if index == r {
-        return Ok(vec![r]);
-    }
-
-    let mut x = index;
-    let mut d = vec![index];
-    while x != r {
-        x = parent(x, size)?;
-        d.push(x);
-    }
-    Ok(d)
-}
-
-// Ordered from leaf to root
 // Includes root but not leaf
 pub(crate) fn direct_path_root(
     index: NodeIndex,

--- a/src/tree/treemath.rs
+++ b/src/tree/treemath.rs
@@ -97,57 +97,60 @@ pub(crate) fn sibling(index: NodeIndex, size: LeafIndex) -> Result<NodeIndex, Tr
 
 // Ordered from leaf to root
 // Includes neither leaf nor root
-pub(crate) fn dirpath(index: NodeIndex, size: LeafIndex) -> Result<Vec<NodeIndex>, TreeMathError> {
+pub(crate) fn dirpath(index: NodeIndex, size: LeafIndex) -> Vec<NodeIndex> {
     let r = root(size);
     if index == r {
-        return Ok(vec![]);
+        return vec![];
     }
 
     let mut d = vec![];
-    let mut x = parent(index, size)?;
+    // We can unwrap here, because we know that `index` is not the root node.
+    let mut x = parent(index, size).unwrap();
     while x != r {
         d.push(x);
-        x = parent(x, size)?;
+        // We can unwrap here, because we know that `index` is not the root node.
+        x = parent(x, size).unwrap();
     }
-    Ok(d)
+    d
 }
 
 // Ordered from leaf to root
 // Includes root but not leaf
-pub(crate) fn direct_path_root(
-    index: NodeIndex,
-    size: LeafIndex,
-) -> Result<Vec<NodeIndex>, TreeMathError> {
+pub(crate) fn direct_path_root(index: NodeIndex, size: LeafIndex) -> Vec<NodeIndex> {
     let r = root(size);
     if index == r {
-        return Ok(vec![r]);
+        return vec![r];
     }
 
     let mut d = vec![];
-    let mut x = index;
+    let mut x = index.to_owned();
     while x != r {
-        x = parent(x, size)?;
+        // We can unwrap here, because we know that `index` is not the root node.
+        x = parent(x, size).unwrap();
         d.push(x);
     }
-    Ok(d)
+    d
 }
 
 // Ordered from leaf to root
-pub(crate) fn copath(index: NodeIndex, size: LeafIndex) -> Result<Vec<NodeIndex>, TreeMathError> {
+pub(crate) fn copath(index: NodeIndex, size: LeafIndex) -> Vec<NodeIndex> {
     if index == root(size) {
-        return Ok(vec![]);
+        return vec![];
     }
     let mut d = vec![index];
-    d.append(&mut dirpath(index, size)?);
-    d.iter().map(|&index| sibling(index, size)).collect()
+    d.append(&mut dirpath(index, size));
+    // Since dirpath doesn't include the root, we can unwrap here.
+    d.iter()
+        .map(|&index| sibling(index, size).unwrap())
+        .collect()
 }
 
 pub(crate) fn common_ancestor_index(x: NodeIndex, y: NodeIndex) -> NodeIndex {
     let (lx, ly) = (level(x) + 1, level(y) + 1);
     if (lx <= ly) && (x.as_usize() >> ly == y.as_usize() >> ly) {
-        return y;
+        return y.to_owned();
     } else if (ly <= lx) && (x.as_usize() >> lx == y.as_usize() >> lx) {
-        return x;
+        return x.to_owned();
     }
 
     let (mut xn, mut yn) = (x.as_usize(), y.as_usize());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,7 +45,7 @@ macro_rules! implement_enum_display {
 pub fn _print_tree(tree: &RatchetTree, message: &str) {
     let factor = 3;
     println!("{}", message);
-    for (i, node) in tree.public_tree.iter().enumerate() {
+    for (i, node) in tree.public_tree.nodes.iter().enumerate() {
         let level = treemath::level(NodeIndex::from(i));
         print!("{:04}", i);
         if !node.is_blank() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,7 +45,7 @@ macro_rules! implement_enum_display {
 pub fn _print_tree(tree: &RatchetTree, message: &str) {
     let factor = 3;
     println!("{}", message);
-    for (i, node) in tree.public_tree.nodes.iter().enumerate() {
+    for (i, node) in tree.public_tree.nodes().iter().enumerate() {
         let level = treemath::level(NodeIndex::from(i));
         print!("{:04}", i);
         if !node.is_blank() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,7 +45,7 @@ macro_rules! implement_enum_display {
 pub fn _print_tree(tree: &RatchetTree, message: &str) {
     let factor = 3;
     println!("{}", message);
-    for (i, node) in tree.nodes.iter().enumerate() {
+    for (i, node) in tree.public_tree.iter().enumerate() {
         let level = treemath::level(NodeIndex::from(i));
         print!("{:04}", i);
         if !node.is_blank() {


### PR DESCRIPTION
This PR introduces the `BinaryTree` as data structure, which is then used to represent the `RatchetTree`. With the exception of `verify_integrity`, which operates on a slice of nodes, all functions of `tree/mod.rs` have been refactored to use the `BinaryTree`. The functions provided by `BinaryTree` are somewhat tailored to what is needed by `RatchetTree`, so they're not meant to be particularly general or even useful in many other cases.

Additionally (sorry about the scope creep):
- Indexing has been improved: More (and more general) `Index` implementations, allowing us to get rid of a lot of index conversions.
- Removed the `dirpath_long` function, as it's not used anymore.
- Added some unwraps in `treemath` in places where we know that no errors will be thrown, simplifying some functions downstream.

Note, that the `BinaryTree` is not yet incorporated into the `SecretTree` (which also uses some `treemath`).

Test coverage is nothing to be excited about, especially in `tree/mod.rs`, but that should improve with the planned uptick in managed-API testing.

(Please don't look at the commit messages, they're pretty worthless. I'll squash in the end and write a proper one.)