### PR TITLE
Quick fix for handshake message encryption

### DIFF
--- a/src/framing/errors.rs
+++ b/src/framing/errors.rs
@@ -10,7 +10,7 @@ pub enum MLSPlaintextError {
     /// This is not an application message.
     NotAnApplicationMessage = 0,
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[repr(u16)]
 pub enum MLSCiphertextError {
     /// Invalid content type in message.

--- a/src/framing/errors.rs
+++ b/src/framing/errors.rs
@@ -18,6 +18,9 @@ pub enum MLSCiphertextError {
 
     /// Ratcheting secret generation is not found.
     GenerationOutOfBound = 2,
+
+    /// Sender is not part of the group
+    UnknownSender = 3,
 }
 
 implement_enum_display!(MLSPlaintextError);
@@ -40,6 +43,7 @@ impl Error for MLSCiphertextError {
             Self::GenerationOutOfBound => {
                 "Couldn't find a ratcheting secret for the given sender and generation."
             }
+            Self::UnknownSender => "The sender of the MLSCiphertext is not part of the group.",
         }
     }
 }

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -517,7 +517,7 @@ impl<'a> ManagedGroup<'a> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction);
         }
-        
+
         // If a KeyPackageBundle was provided, create an UpdateProposal
         let mut plaintext_messages = if let Some(key_package_bundle) = key_package_bundle_option {
             let update_proposal = self.group.create_update_proposal(

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -543,7 +543,7 @@ impl<'a> ManagedGroup<'a> {
             &self.aad,
             &self.credential_bundle,
             &messages_to_commit,
-            true,
+            true, /* force_self_update */
         )?;
 
         // Add the Commit message to the other pending messages

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -16,6 +16,7 @@ use crate::schedule::*;
 use crate::tree::{index::*, node::*, secret_tree::*, *};
 
 use std::cell::{Ref, RefCell};
+use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use super::errors::ExporterError;
@@ -225,21 +226,19 @@ impl MlsGroup {
     }
 
     pub fn decrypt(&mut self, mls_ciphertext: &MLSCiphertext) -> Result<MLSPlaintext, GroupError> {
-        let tree = self.tree.borrow();
-        let mut roster = Vec::new();
+        let tree = self.tree();
+        let mut indexed_members = HashMap::new();
         for i in 0..tree.leaf_count().as_usize() {
-            let node = &tree.nodes[LeafIndex::from(i)];
-            let credential = if let Some(kp) = &node.key_package {
-                kp.credential()
-            } else {
-                panic!("Missing key package");
-            };
-            roster.push(credential);
+            let leaf_index = LeafIndex::from(i);
+            let node = &tree.nodes[leaf_index];
+            if let Some(kp) = node.key_package.as_ref() {
+                indexed_members.insert(leaf_index, kp.credential());
+            }
         }
 
         Ok(mls_ciphertext.to_plaintext(
             self.ciphersuite(),
-            &roster,
+            indexed_members,
             &self.epoch_secrets,
             &mut self.secret_tree.borrow_mut(),
             &self.group_context,
@@ -260,14 +259,10 @@ impl MlsGroup {
             key_length,
         ))
     }
-}
 
-impl MlsGroup {
+    /// Returns the ratchet tree
     pub fn tree(&self) -> Ref<RatchetTree> {
         self.tree.borrow()
-    }
-    fn sender_index(&self) -> LeafIndex {
-        self.tree.borrow().own_node_index().into()
     }
 
     /// Get the ciphersuite implementation used in this group.
@@ -275,12 +270,21 @@ impl MlsGroup {
         self.ciphersuite
     }
 
+    /// Get the group context
     pub fn context(&self) -> &GroupContext {
         &self.group_context
     }
 
+    /// Get the group ID
     pub fn group_id(&self) -> &GroupId {
         &self.group_context.group_id
+    }
+}
+
+// Private and crate functions
+impl MlsGroup {
+    fn sender_index(&self) -> LeafIndex {
+        self.tree.borrow().own_node_index().into()
     }
 
     pub(crate) fn epoch_secrets(&self) -> &EpochSecrets {

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -435,4 +435,9 @@ impl KeyPackageBundle {
     ) -> Secret {
         leaf_secret.derive_secret(ciphersuite, "node")
     }
+
+    /// Sign the KeyPackageBundle
+    pub(crate) fn sign(&mut self, credential_bundle: &CredentialBundle) {
+        self.key_package_mut().sign(credential_bundle);
+    }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,7 +18,7 @@ pub use crate::codec::*;
 pub use crate::config::*;
 pub use crate::creds::*;
 pub use crate::extensions::*;
-pub use crate::framing::{sender::Sender, *};
+pub use crate::framing::{errors::*, sender::Sender, *};
 pub use crate::group::GroupId;
 pub use crate::key_packages::*;
 pub use crate::messages::{

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -451,6 +451,7 @@ impl RatchetTree {
 
         // Update own leaf node with the new values
         self.nodes[own_index.as_usize()] = Node::new_leaf(Some(key_package.clone()));
+        self.compute_parent_hash(self.own_node_index());
         if with_update_path {
             let update_path_nodes = self
                 .encrypt_to_copath(new_public_keys, group_context)

--- a/src/tree/sender_ratchet.rs
+++ b/src/tree/sender_ratchet.rs
@@ -63,10 +63,16 @@ impl SenderRatchet {
     }
     /// Gets a secret from the SenderRatchet and ratchets forward
     pub fn secret_for_encryption(&mut self, ciphersuite: &Ciphersuite) -> (u32, RatchetSecrets) {
-        let current_path_secret = self.past_secrets[0].clone();
+        let current_path_secret = self.past_secrets.last().unwrap().clone();
         let next_path_secret = self.ratchet_secret(ciphersuite, &current_path_secret);
-        let generation = self.generation();
-        self.past_secrets = vec![next_path_secret];
+        let generation = self.generation;
+        // Check if we have too many secrets in `past_secrets`
+        if self.past_secrets.len() >= OUT_OF_ORDER_TOLERANCE as usize {
+            //Drain older secrets
+            let surplus = self.past_secrets.len() - OUT_OF_ORDER_TOLERANCE as usize + 1;
+            self.past_secrets.drain(0..surplus);
+        }
+        self.past_secrets.push(next_path_secret);
         self.generation += 1;
         (
             generation,
@@ -113,6 +119,7 @@ impl SenderRatchet {
         )
     }
     /// Gets the current generation
+    #[cfg(test)]
     pub(crate) fn generation(&self) -> u32 {
         self.generation
     }

--- a/src/tree/sender_ratchet.rs
+++ b/src/tree/sender_ratchet.rs
@@ -63,7 +63,12 @@ impl SenderRatchet {
     }
     /// Gets a secret from the SenderRatchet and ratchets forward
     pub fn secret_for_encryption(&mut self, ciphersuite: &Ciphersuite) -> (u32, RatchetSecrets) {
-        let current_path_secret = self.past_secrets.last().unwrap().clone();
+        let current_path_secret = match self.past_secrets.last() {
+            Some(secret) => secret.clone(),
+            None => {
+                panic!("Library error. PastSecrets should never be depleted in SenderRatchet.")
+            }
+        };
         let next_path_secret = self.ratchet_secret(ciphersuite, &current_path_secret);
         let generation = self.generation;
         // Check if we have too many secrets in `past_secrets`

--- a/tests/test_managed_group.rs
+++ b/tests/test_managed_group.rs
@@ -175,7 +175,7 @@ fn managed_group_operations() {
             .with_invalid_message_received(invalid_message_received)
             .with_error_occured(error_occured);
         let managed_group_config =
-            ManagedGroupConfig::new(HandshakeMessageFormat::Plaintext, update_policy, callbacks);
+            ManagedGroupConfig::new(HandshakeMessageFormat::Ciphertext, update_policy, callbacks);
 
         // === Alice creates a group ===
         let mut alice_group = ManagedGroup::new(
@@ -233,7 +233,6 @@ fn managed_group_operations() {
         alice_group
             .process_messages(queued_messages.clone())
             .expect("The group is no longer active");
-        println!("Alice processed messages");
         bob_group
             .process_messages(queued_messages.clone())
             .expect("The group is no longer active");

--- a/tests/test_managed_group.rs
+++ b/tests/test_managed_group.rs
@@ -145,402 +145,414 @@ fn error_occured(managed_group: &ManagedGroup, error: ManagedGroupError) {
 #[test]
 fn managed_group_operations() {
     for ciphersuite in Config::supported_ciphersuites() {
-        let group_id = GroupId::from_slice(b"Test Group");
+        for handshake_message_format in vec![
+            HandshakeMessageFormat::Plaintext,
+            HandshakeMessageFormat::Ciphertext,
+        ]
+        .into_iter()
+        {
+            let group_id = GroupId::from_slice(b"Test Group");
 
-        // Define credential bundles
-        let alice_credential_bundle =
-            CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite.name())
-                .unwrap();
-        let bob_credential_bundle =
-            CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite.name()).unwrap();
+            // Define credential bundles
+            let alice_credential_bundle =
+                CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite.name())
+                    .unwrap();
+            let bob_credential_bundle =
+                CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite.name())
+                    .unwrap();
 
-        // Generate KeyPackages
-        let alice_key_package_bundle =
-            KeyPackageBundle::new(&[ciphersuite.name()], &alice_credential_bundle, vec![]).unwrap();
+            // Generate KeyPackages
+            let alice_key_package_bundle =
+                KeyPackageBundle::new(&[ciphersuite.name()], &alice_credential_bundle, vec![])
+                    .unwrap();
 
-        let bob_key_package_bundle =
-            KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle, vec![]).unwrap();
-        let bob_key_package = bob_key_package_bundle.key_package().clone();
+            let bob_key_package_bundle =
+                KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle, vec![])
+                    .unwrap();
+            let bob_key_package = bob_key_package_bundle.key_package().clone();
 
-        // Define the managed group configuration
+            // Define the managed group configuration
 
-        let update_policy = UpdatePolicy::default();
-        let callbacks = ManagedGroupCallbacks::new()
-            .with_validate_add(validate_add)
-            .with_validate_remove(validate_remove)
-            .with_member_added(member_added)
-            .with_member_removed(member_removed)
-            .with_member_updated(member_updated)
-            .with_app_message_received(app_message_received)
-            .with_invalid_message_received(invalid_message_received)
-            .with_error_occured(error_occured);
-        let managed_group_config =
-            ManagedGroupConfig::new(HandshakeMessageFormat::Ciphertext, update_policy, callbacks);
+            let update_policy = UpdatePolicy::default();
+            let callbacks = ManagedGroupCallbacks::new()
+                .with_validate_add(validate_add)
+                .with_validate_remove(validate_remove)
+                .with_member_added(member_added)
+                .with_member_removed(member_removed)
+                .with_member_updated(member_updated)
+                .with_app_message_received(app_message_received)
+                .with_invalid_message_received(invalid_message_received)
+                .with_error_occured(error_occured);
+            let managed_group_config =
+                ManagedGroupConfig::new(handshake_message_format, update_policy, callbacks);
 
-        // === Alice creates a group ===
-        let mut alice_group = ManagedGroup::new(
-            &alice_credential_bundle,
-            &managed_group_config,
-            group_id,
-            alice_key_package_bundle,
-        )
-        .unwrap();
+            // === Alice creates a group ===
+            let mut alice_group = ManagedGroup::new(
+                &alice_credential_bundle,
+                &managed_group_config,
+                group_id,
+                alice_key_package_bundle,
+            )
+            .unwrap();
 
-        // === Alice adds Bob ===
-        let (queued_messages, welcome) = match alice_group.add_members(&[bob_key_package.clone()]) {
-            Ok((qm, welcome)) => (qm, welcome),
-            Err(e) => panic!("Could not add member to group: {:?}", e),
-        };
+            // === Alice adds Bob ===
+            let (queued_messages, welcome) =
+                match alice_group.add_members(&[bob_key_package.clone()]) {
+                    Ok((qm, welcome)) => (qm, welcome),
+                    Err(e) => panic!("Could not add member to group: {:?}", e),
+                };
 
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        // Check that the group now has two members
-        assert_eq!(alice_group.members().len(), 2);
+            // Check that the group now has two members
+            assert_eq!(alice_group.members().len(), 2);
 
-        // Check that Alice & Bob are the members of the group
-        let members = alice_group.members();
-        assert_eq!(members[0].identity(), b"Alice");
-        assert_eq!(members[1].identity(), b"Bob");
+            // Check that Alice & Bob are the members of the group
+            let members = alice_group.members();
+            assert_eq!(members[0].identity(), b"Alice");
+            assert_eq!(members[1].identity(), b"Bob");
 
-        let mut bob_group = ManagedGroup::new_from_welcome(
-            &bob_credential_bundle,
-            &managed_group_config,
-            welcome,
-            Some(alice_group.export_ratchet_tree()),
-            bob_key_package_bundle,
-        )
-        .expect("Error creating group from Welcome");
+            let mut bob_group = ManagedGroup::new_from_welcome(
+                &bob_credential_bundle,
+                &managed_group_config,
+                welcome,
+                Some(alice_group.export_ratchet_tree()),
+                bob_key_package_bundle,
+            )
+            .expect("Error creating group from Welcome");
 
-        // Make sure that both groups have the same members
-        assert_eq!(alice_group.members(), bob_group.members());
+            // Make sure that both groups have the same members
+            assert_eq!(alice_group.members(), bob_group.members());
 
-        // === Alice sends a message to Bob ===
-        let message_alice = b"Hi, I'm Alice!";
-        let queued_message = alice_group
-            .create_message(message_alice)
-            .expect("Error creating application message");
-        bob_group
-            .process_messages(vec![queued_message])
-            .expect("The group is no longer active");
+            // === Alice sends a message to Bob ===
+            let message_alice = b"Hi, I'm Alice!";
+            let queued_message = alice_group
+                .create_message(message_alice)
+                .expect("Error creating application message");
+            bob_group
+                .process_messages(vec![queued_message])
+                .expect("The group is no longer active");
 
-        // === Bob updates and commits ===
-        let queued_messages = match bob_group.self_update(None) {
-            Ok(qm) => qm,
-            Err(e) => panic!("Error performing self-update: {:?}", e),
-        };
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        bob_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            // === Bob updates and commits ===
+            let queued_messages = match bob_group.self_update(None) {
+                Ok(qm) => qm,
+                Err(e) => panic!("Error performing self-update: {:?}", e),
+            };
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            bob_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        // Check that both groups have the same state
-        assert_eq!(
-            alice_group.export_secret("", 32),
-            bob_group.export_secret("", 32)
-        );
+            // Check that both groups have the same state
+            assert_eq!(
+                alice_group.export_secret("", 32),
+                bob_group.export_secret("", 32)
+            );
 
-        // Make sure that both groups have the same public tree
-        assert_eq!(
-            alice_group.export_ratchet_tree(),
-            bob_group.export_ratchet_tree()
-        );
+            // Make sure that both groups have the same public tree
+            assert_eq!(
+                alice_group.export_ratchet_tree(),
+                bob_group.export_ratchet_tree()
+            );
 
-        // === Alice updates and commits ===
-        let queued_messages = match alice_group.propose_self_update(None) {
-            Ok(qm) => qm,
-            Err(e) => panic!("Error performing self-update: {:?}", e),
-        };
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        bob_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            // === Alice updates and commits ===
+            let queued_messages = match alice_group.propose_self_update(None) {
+                Ok(qm) => qm,
+                Err(e) => panic!("Error performing self-update: {:?}", e),
+            };
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            bob_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        let (queued_messages, _welcome_option) = match alice_group.process_pending_proposals() {
-            Ok(qm) => qm,
-            Err(e) => panic!("Error performing self-update: {:?}", e),
-        };
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        bob_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            let (queued_messages, _welcome_option) = match alice_group.process_pending_proposals() {
+                Ok(qm) => qm,
+                Err(e) => panic!("Error performing self-update: {:?}", e),
+            };
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            bob_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        // Check that both groups have the same state
-        assert_eq!(
-            alice_group.export_secret("", 32),
-            bob_group.export_secret("", 32)
-        );
+            // Check that both groups have the same state
+            assert_eq!(
+                alice_group.export_secret("", 32),
+                bob_group.export_secret("", 32)
+            );
 
-        // Make sure that both groups have the same public tree
-        assert_eq!(
-            alice_group.export_ratchet_tree(),
-            bob_group.export_ratchet_tree()
-        );
+            // Make sure that both groups have the same public tree
+            assert_eq!(
+                alice_group.export_ratchet_tree(),
+                bob_group.export_ratchet_tree()
+            );
 
-        // === Bob adds Charlie ===
-        let charlie_credential_bundle =
-            CredentialBundle::new("Charlie".into(), CredentialType::Basic, ciphersuite.name())
-                .unwrap();
+            // === Bob adds Charlie ===
+            let charlie_credential_bundle =
+                CredentialBundle::new("Charlie".into(), CredentialType::Basic, ciphersuite.name())
+                    .unwrap();
 
-        let charlie_key_package_bundle =
-            KeyPackageBundle::new(&[ciphersuite.name()], &charlie_credential_bundle, vec![])
-                .unwrap();
-        let charlie_key_package = charlie_key_package_bundle.key_package().clone();
+            let charlie_key_package_bundle =
+                KeyPackageBundle::new(&[ciphersuite.name()], &charlie_credential_bundle, vec![])
+                    .unwrap();
+            let charlie_key_package = charlie_key_package_bundle.key_package().clone();
 
-        let (queued_messages, welcome) = match bob_group.add_members(&[charlie_key_package]) {
-            Ok((qm, welcome)) => (qm, welcome),
-            Err(e) => panic!("Could not add member to group: {:?}", e),
-        };
+            let (queued_messages, welcome) = match bob_group.add_members(&[charlie_key_package]) {
+                Ok((qm, welcome)) => (qm, welcome),
+                Err(e) => panic!("Could not add member to group: {:?}", e),
+            };
 
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        bob_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            bob_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        let mut charlie_group = ManagedGroup::new_from_welcome(
-            &charlie_credential_bundle,
-            &managed_group_config,
-            welcome,
-            Some(bob_group.export_ratchet_tree()),
-            charlie_key_package_bundle,
-        )
-        .expect("Error creating group from Welcome");
+            let mut charlie_group = ManagedGroup::new_from_welcome(
+                &charlie_credential_bundle,
+                &managed_group_config,
+                welcome,
+                Some(bob_group.export_ratchet_tree()),
+                charlie_key_package_bundle,
+            )
+            .expect("Error creating group from Welcome");
 
-        // Make sure that all groups have the same public tree
-        assert_eq!(
-            alice_group.export_ratchet_tree(),
-            bob_group.export_ratchet_tree(),
-        );
-        assert_eq!(
-            alice_group.export_ratchet_tree(),
-            charlie_group.export_ratchet_tree()
-        );
+            // Make sure that all groups have the same public tree
+            assert_eq!(
+                alice_group.export_ratchet_tree(),
+                bob_group.export_ratchet_tree(),
+            );
+            assert_eq!(
+                alice_group.export_ratchet_tree(),
+                charlie_group.export_ratchet_tree()
+            );
 
-        // Check that Alice, Bob & Charlie are the members of the group
-        let members = alice_group.members();
-        assert_eq!(members[0].identity(), b"Alice");
-        assert_eq!(members[1].identity(), b"Bob");
-        assert_eq!(members[2].identity(), b"Charlie");
+            // Check that Alice, Bob & Charlie are the members of the group
+            let members = alice_group.members();
+            assert_eq!(members[0].identity(), b"Alice");
+            assert_eq!(members[1].identity(), b"Bob");
+            assert_eq!(members[2].identity(), b"Charlie");
 
-        // === Charlie sends a message to the group ===
-        let message_charlie = b"Hi, I'm Charlie!";
-        let queued_message = charlie_group
-            .create_message(message_charlie)
-            .expect("Error creating application message");
-        alice_group
-            .process_messages(vec![queued_message.clone()])
-            .expect("The group is no longer active");
-        bob_group
-            .process_messages(vec![queued_message])
-            .expect("The group is no longer active");
+            // === Charlie sends a message to the group ===
+            let message_charlie = b"Hi, I'm Charlie!";
+            let queued_message = charlie_group
+                .create_message(message_charlie)
+                .expect("Error creating application message");
+            alice_group
+                .process_messages(vec![queued_message.clone()])
+                .expect("The group is no longer active");
+            bob_group
+                .process_messages(vec![queued_message])
+                .expect("The group is no longer active");
 
-        // === Charlie updates and commits ===
-        let queued_messages = match charlie_group.self_update(None) {
-            Ok(qm) => qm,
-            Err(e) => panic!("Error performing self-update: {:?}", e),
-        };
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        bob_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        charlie_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            // === Charlie updates and commits ===
+            let queued_messages = match charlie_group.self_update(None) {
+                Ok(qm) => qm,
+                Err(e) => panic!("Error performing self-update: {:?}", e),
+            };
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            bob_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            charlie_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        // Check that all groups have the same state
-        assert_eq!(
-            alice_group.export_secret("", 32),
-            bob_group.export_secret("", 32)
-        );
-        assert_eq!(
-            alice_group.export_secret("", 32),
-            charlie_group.export_secret("", 32)
-        );
+            // Check that all groups have the same state
+            assert_eq!(
+                alice_group.export_secret("", 32),
+                bob_group.export_secret("", 32)
+            );
+            assert_eq!(
+                alice_group.export_secret("", 32),
+                charlie_group.export_secret("", 32)
+            );
 
-        // Make sure that all groups have the same public tree
-        assert_eq!(
-            alice_group.export_ratchet_tree(),
-            bob_group.export_ratchet_tree(),
-        );
-        assert_eq!(
-            alice_group.export_ratchet_tree(),
-            charlie_group.export_ratchet_tree()
-        );
+            // Make sure that all groups have the same public tree
+            assert_eq!(
+                alice_group.export_ratchet_tree(),
+                bob_group.export_ratchet_tree(),
+            );
+            assert_eq!(
+                alice_group.export_ratchet_tree(),
+                charlie_group.export_ratchet_tree()
+            );
 
-        // === Charlie removes Bob ===
-        let queued_messages = match charlie_group.remove_members(&[1]) {
-            Ok(qm) => qm,
-            Err(e) => panic!("Could not remove member from group: {:?}", e),
-        };
+            // === Charlie removes Bob ===
+            let queued_messages = match charlie_group.remove_members(&[1]) {
+                Ok(qm) => qm,
+                Err(e) => panic!("Could not remove member from group: {:?}", e),
+            };
 
-        // Check that Bob's group is still active
-        assert!(bob_group.is_active());
+            // Check that Bob's group is still active
+            assert!(bob_group.is_active());
 
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        bob_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        charlie_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            bob_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            charlie_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        // Check that Bob's group is no longer active
-        assert!(!bob_group.is_active());
+            // Check that Bob's group is no longer active
+            assert!(!bob_group.is_active());
 
-        // Make sure that all groups have the same public tree
-        assert_eq!(
-            alice_group.export_ratchet_tree(),
-            charlie_group.export_ratchet_tree()
-        );
+            // Make sure that all groups have the same public tree
+            assert_eq!(
+                alice_group.export_ratchet_tree(),
+                charlie_group.export_ratchet_tree()
+            );
 
-        // Make sure the group only contains two members
-        assert_eq!(alice_group.members().len(), 2);
+            // Make sure the group only contains two members
+            assert_eq!(alice_group.members().len(), 2);
 
-        // Check that Alice & Charlie are the members of the group
-        let members = alice_group.members();
-        assert_eq!(members[0].identity(), b"Alice");
-        assert_eq!(members[1].identity(), b"Charlie");
+            // Check that Alice & Charlie are the members of the group
+            let members = alice_group.members();
+            assert_eq!(members[0].identity(), b"Alice");
+            assert_eq!(members[1].identity(), b"Charlie");
 
-        // Check that Bob can no longer send messages
-        assert!(bob_group.create_message(b"Should not go through").is_err());
+            // Check that Bob can no longer send messages
+            assert!(bob_group.create_message(b"Should not go through").is_err());
 
-        // === Alice removes Charlie and re-adds Bob ===
+            // === Alice removes Charlie and re-adds Bob ===
 
-        // Create a new KeyPackageBundle for Bob
-        let bob_key_package_bundle =
-            KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle, vec![]).unwrap();
-        let bob_key_package = bob_key_package_bundle.key_package().clone();
+            // Create a new KeyPackageBundle for Bob
+            let bob_key_package_bundle =
+                KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle, vec![])
+                    .unwrap();
+            let bob_key_package = bob_key_package_bundle.key_package().clone();
 
-        // Create RemoveProposal and process it
-        let queued_messages = alice_group
-            .propose_remove_members(&[2])
-            .expect("Could not create proposal to remove Charlie");
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        charlie_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            // Create RemoveProposal and process it
+            let queued_messages = alice_group
+                .propose_remove_members(&[2])
+                .expect("Could not create proposal to remove Charlie");
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            charlie_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        // Create AddProposal and process it
-        let queued_messages = alice_group
-            .propose_add_members(&[bob_key_package])
-            .expect("Could not create proposal to add Bob");
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        charlie_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            // Create AddProposal and process it
+            let queued_messages = alice_group
+                .propose_add_members(&[bob_key_package])
+                .expect("Could not create proposal to add Bob");
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            charlie_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        // Commit to the proposals and process it
-        let (queued_messages, welcome_option) = alice_group
-            .process_pending_proposals()
-            .expect("Could not flush proposals");
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        charlie_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            // Commit to the proposals and process it
+            let (queued_messages, welcome_option) = alice_group
+                .process_pending_proposals()
+                .expect("Could not flush proposals");
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            charlie_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        // Make sure the group contains two members
-        assert_eq!(alice_group.members().len(), 2);
+            // Make sure the group contains two members
+            assert_eq!(alice_group.members().len(), 2);
 
-        // Check that Alice & Bob are the members of the group
-        let members = alice_group.members();
-        assert_eq!(members[0].identity(), b"Alice");
-        assert_eq!(members[1].identity(), b"Bob");
+            // Check that Alice & Bob are the members of the group
+            let members = alice_group.members();
+            assert_eq!(members[0].identity(), b"Alice");
+            assert_eq!(members[1].identity(), b"Bob");
 
-        // Bob creates a new group
-        let mut bob_group = ManagedGroup::new_from_welcome(
-            &bob_credential_bundle,
-            &managed_group_config,
-            welcome_option.expect("Welcome was not returned"),
-            Some(alice_group.export_ratchet_tree()),
-            bob_key_package_bundle,
-        )
-        .expect("Error creating group from Welcome");
+            // Bob creates a new group
+            let mut bob_group = ManagedGroup::new_from_welcome(
+                &bob_credential_bundle,
+                &managed_group_config,
+                welcome_option.expect("Welcome was not returned"),
+                Some(alice_group.export_ratchet_tree()),
+                bob_key_package_bundle,
+            )
+            .expect("Error creating group from Welcome");
 
-        // Make sure the group contains two members
-        assert_eq!(alice_group.members().len(), 2);
+            // Make sure the group contains two members
+            assert_eq!(alice_group.members().len(), 2);
 
-        // Check that Alice & Bob are the members of the group
-        let members = alice_group.members();
-        assert_eq!(members[0].identity(), b"Alice");
-        assert_eq!(members[1].identity(), b"Bob");
+            // Check that Alice & Bob are the members of the group
+            let members = alice_group.members();
+            assert_eq!(members[0].identity(), b"Alice");
+            assert_eq!(members[1].identity(), b"Bob");
 
-        // Make sure the group contains two members
-        assert_eq!(bob_group.members().len(), 2);
+            // Make sure the group contains two members
+            assert_eq!(bob_group.members().len(), 2);
 
-        // Check that Alice & Bob are the members of the group
-        let members = bob_group.members();
-        assert_eq!(members[0].identity(), b"Alice");
-        assert_eq!(members[1].identity(), b"Bob");
+            // Check that Alice & Bob are the members of the group
+            let members = bob_group.members();
+            assert_eq!(members[0].identity(), b"Alice");
+            assert_eq!(members[1].identity(), b"Bob");
 
-        // === lice sends a message to the group ===
-        let message_alice = b"Hi, I'm Alice!";
-        let queued_message = alice_group
-            .create_message(message_alice)
-            .expect("Error creating application message");
-        bob_group
-            .process_messages(vec![queued_message.clone()])
-            .expect("The group is no longer active");
+            // === lice sends a message to the group ===
+            let message_alice = b"Hi, I'm Alice!";
+            let queued_message = alice_group
+                .create_message(message_alice)
+                .expect("Error creating application message");
+            bob_group
+                .process_messages(vec![queued_message.clone()])
+                .expect("The group is no longer active");
 
-        // === Bob leaves the group ===
+            // === Bob leaves the group ===
 
-        let queued_messages = bob_group.leave_group().expect("Could not leave group");
+            let queued_messages = bob_group.leave_group().expect("Could not leave group");
 
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        bob_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            bob_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        // Should fail because you cannot remove yourself from a group
-        assert_eq!(
-            bob_group.process_pending_proposals(),
-            Err(ManagedGroupError::CreateCommit(
-                CreateCommitError::CannotRemoveSelf
-            ))
-        );
+            // Should fail because you cannot remove yourself from a group
+            assert_eq!(
+                bob_group.process_pending_proposals(),
+                Err(ManagedGroupError::CreateCommit(
+                    CreateCommitError::CannotRemoveSelf
+                ))
+            );
 
-        let (queued_messages, _welcome_option) = alice_group
-            .process_pending_proposals()
-            .expect("Could not commit to proposals");
+            let (queued_messages, _welcome_option) = alice_group
+                .process_pending_proposals()
+                .expect("Could not commit to proposals");
 
-        // Check that Bob's group is still active
-        assert!(bob_group.is_active());
+            // Check that Bob's group is still active
+            assert!(bob_group.is_active());
 
-        alice_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
-        bob_group
-            .process_messages(queued_messages.clone())
-            .expect("The group is no longer active");
+            alice_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
+            bob_group
+                .process_messages(queued_messages.clone())
+                .expect("The group is no longer active");
 
-        // Check that Bob's group is no longer active
-        assert!(!bob_group.is_active());
+            // Check that Bob's group is no longer active
+            assert!(!bob_group.is_active());
 
-        // Make sure the group contains one member
-        assert_eq!(alice_group.members().len(), 1);
+            // Make sure the group contains one member
+            assert_eq!(alice_group.members().len(), 1);
 
-        // Check that Alice is the only member of the group
-        let members = alice_group.members();
-        assert_eq!(members[0].identity(), b"Alice");
+            // Check that Alice is the only member of the group
+            let members = alice_group.members();
+            assert_eq!(members[0].identity(), b"Alice");
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a quick fix for handshake message encryption. It also fixes a missing `KeyPackageBundle` signature in Managed Groups.

Note that this fix just enables HS encryption for now, it does not address #243.


