### PR TITLE
Enforce correct order of proposals in ProposalQueue

### DIFF
--- a/cli/src/backend.rs
+++ b/cli/src/backend.rs
@@ -24,7 +24,8 @@ impl Backend {
         Ok(String::from_utf8(response).unwrap())
     }
 
-    /// Get a list of all clients with name, ID, and key packages from the server.
+    /// Get a list of all clients with name, ID, and key packages from the
+    /// server.
     pub fn list_clients(&self) -> Result<Vec<ClientInfo>, String> {
         let mut url = self.ds_url.clone();
         url.set_path(&"/clients/list");

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -5,6 +5,7 @@
 
 use crate::config::ConfigError;
 use crate::framing::errors::MLSCiphertextError;
+use crate::messages::errors::ProposalQueueError;
 use crate::tree::{secret_tree::SecretTypeError, TreeError};
 
 implement_error! {
@@ -23,6 +24,8 @@ implement_error! {
             "See [`ExporterError`](`ExporterError`) for details",
         SecretTypeError(SecretTypeError) =
             "See [`SecretTypeError`](`crate::tree::secret_tree::SecretTypeError`) for details",
+            ProposalQueueError(ProposalQueueError) =
+        "See [`ProposalQueueError`](`crate::messages::errors::ProposalQueueError`) for details",
     }
 }
 

--- a/src/group/managed_group/errors.rs
+++ b/src/group/managed_group/errors.rs
@@ -26,6 +26,8 @@ implement_error! {
             "See [`PendingProposalsError`](`PendingProposalsError`) for details",
         Exporter(ExporterError) =
             "See [`ExporterError`](`crate::group::ExporterError`) for details",
+        EmptyInput(EmptyInputError) =
+            "Empty input. Additional detail is provided.",
     }
 }
 
@@ -38,6 +40,13 @@ implement_error! {
 implement_error! {
     pub enum PendingProposalsError {
         Exists = "Can't create message because a pending proposal exists.",
+    }
+}
+
+implement_error! {
+    pub enum EmptyInputError {
+        AddMembers = "An empty list of KeyPackages was provided.",
+        RemoveMembers = "An empty list of indexes was provided.",
     }
 }
 

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -397,7 +397,7 @@ impl<'a> ManagedGroup<'a> {
 
     // === Application messages ===
 
-    /// Creates an application message.  
+    /// Creates an application message.
     /// Returns `ManagedGroupError::UseAfterEviction` if the member is no longer
     /// part of the group. Returns `ManagedGroupError::
     /// PendingProposalsExist` if pending proposals exist. In that case
@@ -783,5 +783,15 @@ impl From<MLSPlaintext> for MLSMessage {
 impl From<MLSCiphertext> for MLSMessage {
     fn from(mls_ciphertext: MLSCiphertext) -> Self {
         MLSMessage::Ciphertext(mls_ciphertext)
+    }
+}
+
+impl MLSMessage {
+    /// Get the `GroupId` from an MLSMessage.
+    pub fn group_id(&self) -> &GroupId {
+        match self {
+            MLSMessage::Plaintext(pt) => pt.group_id(),
+            MLSMessage::Ciphertext(ct) => &ct.group_id,
+        }
     }
 }

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -28,16 +28,12 @@ impl MlsGroup {
             _ => return Err(ApplyCommitError::WrongPlaintextContentType),
         };
 
-        // Convert proposals by reference into a queue
-        let proposals_by_ref_queue =
-            ProposalQueue::from_proposals_by_reference(ciphersuite, proposals_by_reference);
-
         // Build a queue with all proposals from the Commit and check that we have all
         // of the proposals by reference locally
         let proposal_queue = match ProposalQueue::from_committed_proposals(
             ciphersuite,
             &commit.proposals,
-            &proposals_by_ref_queue,
+            proposals_by_reference,
             mls_plaintext.sender,
         ) {
             Ok(proposal_queue) => proposal_queue,

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -25,9 +25,9 @@ impl MlsGroup {
             proposals_by_value,
             LeafIndex::from(self.tree().own_node_index()),
             self.tree().leaf_count(),
-        );
+        )?;
 
-        let proposal_id_list = proposal_queue.commit_list();
+        let proposal_reference_list = proposal_queue.commit_list();
 
         let sender_index = self.sender_index();
         // Make a copy of the current tree to apply proposals safely
@@ -61,7 +61,7 @@ impl MlsGroup {
         };
         // Create commit message
         let commit = Commit {
-            proposals: proposal_id_list,
+            proposals: proposal_reference_list,
             path,
         };
         // Create provisional group state

--- a/src/messages/errors.rs
+++ b/src/messages/errors.rs
@@ -2,18 +2,10 @@ use crate::codec::*;
 
 use std::error::Error;
 
-#[derive(Debug)]
-pub enum ProposalQueueError {
-    ProposalNotFound,
-}
-
-implement_enum_display!(ProposalQueueError);
-
-impl Error for ProposalQueueError {
-    fn description(&self) -> &str {
-        match self {
-            Self::ProposalNotFound => "Not all proposals in the Commit were found locally.",
-        }
+implement_error! {
+    pub enum ProposalQueueError {
+        ProposalNotFound =
+            "Not all proposals in the Commit were found locally.",
     }
 }
 

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -73,7 +73,7 @@ impl Welcome {
     }
 
     /// Get a reference to the ciphersuite in this Welcome message.
-    pub(crate) fn ciphersuite(&self) -> &'static Ciphersuite {
+    pub fn ciphersuite(&self) -> &'static Ciphersuite {
         self.cipher_suite
     }
 

--- a/src/messages/proposals.rs
+++ b/src/messages/proposals.rs
@@ -146,7 +146,7 @@ impl ProposalReference {
 #[derive(Clone)]
 pub(crate) struct QueuedProposal<'a> {
     proposal: &'a Proposal,
-    proposal_id: ProposalReference,
+    proposal_reference: ProposalReference,
     sender: Sender,
     proposal_or_ref_type: ProposalOrRefType,
 }
@@ -162,10 +162,10 @@ impl<'a> QueuedProposal<'a> {
             MLSPlaintextContentType::Proposal(p) => p,
             _ => return Err(QueuedProposalError::WrongContentType),
         };
-        let proposal_id = ProposalReference::from_proposal(ciphersuite, &proposal);
+        let proposal_reference = ProposalReference::from_proposal(ciphersuite, &proposal);
         Ok(Self {
             proposal,
-            proposal_id,
+            proposal_reference,
             sender: mls_plaintext.sender,
             proposal_or_ref_type: ProposalOrRefType::Reference,
         })
@@ -176,10 +176,10 @@ impl<'a> QueuedProposal<'a> {
         proposal: &'a Proposal,
         sender: Sender,
     ) -> Self {
-        let proposal_id = ProposalReference::from_proposal(ciphersuite, &proposal);
+        let proposal_reference = ProposalReference::from_proposal(ciphersuite, &proposal);
         Self {
             proposal,
-            proposal_id,
+            proposal_reference,
             sender,
             proposal_or_ref_type: ProposalOrRefType::Proposal,
         }
@@ -189,8 +189,8 @@ impl<'a> QueuedProposal<'a> {
         &self.proposal
     }
     /// Returns the `ProposalReference` as a reference
-    pub(crate) fn proposal_id(&self) -> &ProposalReference {
-        &self.proposal_id
+    pub(crate) fn proposal_reference(&self) -> &ProposalReference {
+        &self.proposal_reference
     }
     /// Returns the `Sender` as a reference
     pub(crate) fn sender(&self) -> &Sender {
@@ -202,6 +202,8 @@ impl<'a> QueuedProposal<'a> {
 /// epoch.
 #[derive(Default)]
 pub struct ProposalQueue<'a> {
+    // We keep the references in a separate `Vec` to enforce the correct order
+    proposal_references: Vec<ProposalReference>,
     queued_proposals: HashMap<ProposalReference, QueuedProposal<'a>>,
 }
 
@@ -209,6 +211,7 @@ impl<'a> ProposalQueue<'a> {
     // Returns a new empty `ProposalQueue`
     pub(crate) fn new() -> Self {
         ProposalQueue {
+            proposal_references: Vec::new(),
             queued_proposals: HashMap::new(),
         }
     }
@@ -221,7 +224,7 @@ impl<'a> ProposalQueue<'a> {
         let mut proposal_queue = ProposalQueue::new();
         for mls_plaintext in proposals {
             // It is safe to unwrap here, because we checked that only proposals can end up
-            // here
+            // here.
             let queued_proposal =
                 QueuedProposal::from_mls_plaintext(ciphersuite, &mls_plaintext).unwrap();
             proposal_queue.add(queued_proposal);
@@ -233,17 +236,33 @@ impl<'a> ProposalQueue<'a> {
     pub(crate) fn from_committed_proposals(
         ciphersuite: &Ciphersuite,
         committed_proposals: &'a [ProposalOrRef],
-        proposals_by_reference: &'a ProposalQueue<'a>,
+        proposals_by_reference: &[&'a MLSPlaintext],
         sender: Sender,
     ) -> Result<Self, ProposalQueueError> {
+        // Feed the `proposals_by_reference` in a `HashMap` so that we can easily
+        // extract then by reference later
+        let mut proposals_by_reference_queue: HashMap<ProposalReference, QueuedProposal> =
+            HashMap::new();
+        for mls_plaintext in proposals_by_reference {
+            let queued_proposal =
+                QueuedProposal::from_mls_plaintext(ciphersuite, mls_plaintext).unwrap();
+            proposals_by_reference_queue.insert(
+                queued_proposal.proposal_reference().clone(),
+                queued_proposal,
+            );
+        }
+
+        // Build the actual queue
         let mut proposal_queue = ProposalQueue::new();
+
+        // Iterate over the committed proposals and insert the proposals in the queue
         for proposal_or_ref in committed_proposals.iter() {
             let queued_proposal = match proposal_or_ref {
                 ProposalOrRef::Proposal(proposal) => {
                     QueuedProposal::from_proposal_and_sender(ciphersuite, proposal, sender)
                 }
-                ProposalOrRef::Reference(proposal_id) => {
-                    match proposals_by_reference.get(proposal_id) {
+                ProposalOrRef::Reference(proposal_reference) => {
+                    match proposals_by_reference_queue.get(proposal_reference) {
                         Some(queued_proposal) => queued_proposal.clone(),
                         None => return Err(ProposalQueueError::ProposalNotFound),
                     }
@@ -280,7 +299,7 @@ impl<'a> ProposalQueue<'a> {
         proposals_by_value: &'a [&Proposal],
         own_index: LeafIndex,
         tree_size: LeafIndex,
-    ) -> (Self, bool) {
+    ) -> Result<(Self, bool), ProposalQueueError> {
         #[derive(Clone)]
         struct Member<'a> {
             updates: Vec<QueuedProposal<'a>>,
@@ -295,7 +314,7 @@ impl<'a> ProposalQueue<'a> {
         ];
         let mut adds: HashSet<ProposalReference> = HashSet::new();
         let mut valid_proposals: HashSet<ProposalReference> = HashSet::new();
-        let mut proposal_queue = ProposalQueue::new();
+        let mut proposal_pool: HashMap<ProposalReference, QueuedProposal> = HashMap::new();
         let mut contains_own_updates = false;
 
         let sender = Sender {
@@ -325,8 +344,9 @@ impl<'a> ProposalQueue<'a> {
         for queued_proposal in queued_proposal_list {
             match queued_proposal.proposal.proposal_type() {
                 ProposalType::Add => {
-                    adds.insert(queued_proposal.proposal_id().clone());
-                    proposal_queue.add(queued_proposal);
+                    let proposal_reference = queued_proposal.proposal_reference().clone();
+                    adds.insert(proposal_reference.clone());
+                    proposal_pool.insert(proposal_reference, queued_proposal);
                 }
                 ProposalType::Update => {
                     let sender_index = queued_proposal.sender.sender.as_usize();
@@ -335,7 +355,8 @@ impl<'a> ProposalQueue<'a> {
                     } else {
                         contains_own_updates = true;
                     }
-                    proposal_queue.add(queued_proposal);
+                    let proposal_reference = queued_proposal.proposal_reference().clone();
+                    proposal_pool.insert(proposal_reference, queued_proposal);
                 }
                 ProposalType::Remove => {
                     let removed_index =
@@ -343,7 +364,8 @@ impl<'a> ProposalQueue<'a> {
                     if removed_index < tree_size.as_usize() {
                         members[removed_index].updates.push(queued_proposal.clone());
                     }
-                    proposal_queue.add(queued_proposal);
+                    let proposal_reference = queued_proposal.proposal_reference().clone();
+                    proposal_pool.insert(proposal_reference, queued_proposal);
                 }
                 _ => {}
             }
@@ -355,57 +377,68 @@ impl<'a> ProposalQueue<'a> {
                 // Delete all Updates when a Remove is found
                 member.updates = Vec::new();
                 // Only keep the last Remove
-                valid_proposals.insert(member.removes.last().unwrap().proposal_id().clone());
+                valid_proposals.insert(member.removes.last().unwrap().proposal_reference().clone());
             }
             if !member.updates.is_empty() {
                 // Only keep the last Update
-                valid_proposals.insert(member.updates.last().unwrap().proposal_id().clone());
+                valid_proposals.insert(member.updates.last().unwrap().proposal_reference().clone());
             }
         }
-        // Only retain valid proposals
-        proposal_queue.retain(|k, _| valid_proposals.get(k).is_some() || adds.get(k).is_some());
-        (proposal_queue, contains_own_updates)
+        // Only retain `adds` and `valid_proposals`
+        let mut proposal_queue = ProposalQueue::new();
+        for proposal_reference in adds.iter().chain(valid_proposals.iter()) {
+            proposal_queue.add(match proposal_pool.get(proposal_reference) {
+                Some(queued_proposal) => queued_proposal.clone(),
+                None => return Err(ProposalQueueError::ProposalNotFound),
+            });
+        }
+        Ok((proposal_queue, contains_own_updates))
     }
     /// Returns `true` if all `ProposalReference` values from the list are
     /// contained in the queue
     #[cfg(test)]
-    pub(crate) fn contains(&self, proposal_id_list: &[ProposalReference]) -> bool {
-        for proposal_id in proposal_id_list {
-            if !self.queued_proposals.contains_key(proposal_id) {
+    pub(crate) fn contains(&self, proposal_reference_list: &[ProposalReference]) -> bool {
+        for proposal_reference in proposal_reference_list {
+            if !self.queued_proposals.contains_key(proposal_reference) {
                 return false;
             }
         }
         true
     }
     /// Returns proposal for a given proposal ID
-    pub(crate) fn get(&self, proposal_id: &ProposalReference) -> Option<&QueuedProposal> {
-        self.queued_proposals.get(proposal_id)
+    pub(crate) fn get(&self, proposal_reference: &ProposalReference) -> Option<&QueuedProposal> {
+        self.queued_proposals.get(proposal_reference)
     }
     /// Add a new `QueuedProposal` to the queue
     pub(crate) fn add(&mut self, queued_proposal: QueuedProposal<'a>) {
-        self.queued_proposals
-            .entry(queued_proposal.proposal_id.clone())
-            .or_insert(queued_proposal);
+        let proposal_reference = queued_proposal.proposal_reference();
+        // Only add the proposal if it's not already there
+        if !self.queued_proposals.contains_key(proposal_reference) {
+            // Add the proposal reference to ensure the correct order
+            self.proposal_references.push(proposal_reference.clone());
+            // Add the proposal to the queue
+            self.queued_proposals
+                .insert(proposal_reference.clone(), queued_proposal);
+        }
     }
-    /// Retains only the elements specified by the predicate
-    pub(crate) fn retain<F>(&mut self, f: F)
-    where
-        F: FnMut(&ProposalReference, &mut QueuedProposal<'a>) -> bool,
-    {
-        self.queued_proposals.retain(f);
-    }
-    /// Gets the list of all `ProposalReference`
+    /// Returns the list of all proposals that are covered by a Commit
     pub(crate) fn commit_list(&self) -> Vec<ProposalOrRef> {
-        self.queued_proposals
+        // Iterate over the reference to extract the proposals in the right order
+        self.proposal_references
             .iter()
-            .map(
-                |(proposal_id, queued_proposal)| match queued_proposal.proposal_or_ref_type {
+            .map(|proposal_reference| {
+                // Extract the proposal from the queue
+                let queued_proposal = self.queued_proposals.get(proposal_reference).unwrap();
+                // Differentiate the type of proposal
+                match queued_proposal.proposal_or_ref_type {
                     ProposalOrRefType::Proposal => {
                         ProposalOrRef::Proposal(queued_proposal.proposal.clone())
                     }
-                    ProposalOrRefType::Reference => ProposalOrRef::Reference(proposal_id.clone()),
-                },
-            )
+                    ProposalOrRefType::Reference => {
+                        ProposalOrRef::Reference(proposal_reference.clone())
+                    }
+                }
+            })
             .collect::<Vec<ProposalOrRef>>()
     }
     /// Returns an iterator over a list of `QueuedProposal` filtered by proposal
@@ -414,9 +447,14 @@ impl<'a> ProposalQueue<'a> {
         &self,
         proposal_type: ProposalType,
     ) -> impl Iterator<Item = &QueuedProposal> {
-        self.queued_proposals
-            .values()
-            .filter(move |p| p.proposal.is_type(proposal_type))
+        // Iterate over the reference to extract the proposals in the right order
+        self.proposal_references
+            .iter()
+            .filter(move |&pr| match self.queued_proposals.get(pr) {
+                Some(p) => p.proposal.is_type(proposal_type),
+                None => false,
+            })
+            .map(move |reference| self.get(reference).unwrap())
     }
 }
 

--- a/src/messages/test_proposals.rs
+++ b/src/messages/test_proposals.rs
@@ -66,13 +66,13 @@ fn proposal_queue_functions() {
         };
 
         let proposal_add_alice1 = Proposal::Add(add_proposal_alice1);
-        let proposal_id_add_alice1 =
+        let proposal_reference_add_alice1 =
             ProposalReference::from_proposal(ciphersuite, &proposal_add_alice1);
         let proposal_add_alice2 = Proposal::Add(add_proposal_alice2);
-        let proposal_id_add_alice2 =
+        let proposal_reference_add_alice2 =
             ProposalReference::from_proposal(ciphersuite, &proposal_add_alice2);
         let proposal_add_bob1 = Proposal::Add(add_proposal_bob1);
-        let proposal_id_add_bob1 =
+        let proposal_reference_add_bob1 =
             ProposalReference::from_proposal(ciphersuite, &proposal_add_bob1);
 
         // Test proposal types
@@ -108,18 +108,18 @@ fn proposal_queue_functions() {
         let proposal_queue = ProposalQueue::from_proposals_by_reference(&ciphersuite, proposals);
 
         // Test if proposals are all covered
-        let valid_proposal_id_list = &[
-            proposal_id_add_alice1.clone(),
-            proposal_id_add_alice2.clone(),
+        let valid_proposal_reference_list = &[
+            proposal_reference_add_alice1.clone(),
+            proposal_reference_add_alice2.clone(),
         ];
-        assert!(proposal_queue.contains(valid_proposal_id_list));
+        assert!(proposal_queue.contains(valid_proposal_reference_list));
 
-        let invalid_proposal_id_list = &[
-            proposal_id_add_alice1,
-            proposal_id_add_alice2,
-            proposal_id_add_bob1,
+        let invalid_proposal_reference_list = &[
+            proposal_reference_add_alice1,
+            proposal_reference_add_alice2,
+            proposal_reference_add_bob1,
         ];
-        assert!(!proposal_queue.contains(invalid_proposal_id_list));
+        assert!(!proposal_queue.contains(invalid_proposal_reference_list));
 
         // Get filtered proposals
         for filtered_proposal in proposal_queue.filtered_by_type(ProposalType::Add) {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,7 +20,6 @@ pub use crate::creds::*;
 pub use crate::extensions::*;
 pub use crate::framing::{errors::*, sender::Sender, *};
 pub use crate::group::GroupId;
-pub use crate::group::MLSMessage;
 pub use crate::key_packages::*;
 pub use crate::messages::{
     proposals::{AddProposal, RemoveProposal, UpdateProposal},

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,6 +20,7 @@ pub use crate::creds::*;
 pub use crate::extensions::*;
 pub use crate::framing::{errors::*, sender::Sender, *};
 pub use crate::group::GroupId;
+pub use crate::group::MLSMessage;
 pub use crate::key_packages::*;
 pub use crate::messages::{
     proposals::{AddProposal, RemoveProposal, UpdateProposal},

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,4 +25,5 @@ pub use crate::messages::{
     proposals::{AddProposal, RemoveProposal, UpdateProposal},
     Welcome,
 };
+pub use crate::tree::node;
 pub use crate::utils::*;

--- a/tests/test_managed_api.rs
+++ b/tests/test_managed_api.rs
@@ -9,8 +9,9 @@ pub enum ClientError {
     NoMatchingCredential,
     NoMatchingGroup,
     FailedToJoinGroup(WelcomeError),
-    InvalidMessage,
-    GroupError(ManagedGroupError),
+    InvalidMessage(GroupError),
+    ManagedGroupError(ManagedGroupError),
+    GroupError(GroupError),
 }
 
 impl From<WelcomeError> for ClientError {
@@ -21,6 +22,12 @@ impl From<WelcomeError> for ClientError {
 
 impl From<ManagedGroupError> for ClientError {
     fn from(e: ManagedGroupError) -> Self {
+        ClientError::ManagedGroupError(e)
+    }
+}
+
+impl From<GroupError> for ClientError {
+    fn from(e: GroupError) -> Self {
         ClientError::GroupError(e)
     }
 }
@@ -307,11 +314,17 @@ fn test_randomized_setup() {
                     aad
                 );
             }
-            InvalidMessageError::CommitWithInvalidProposals => {
-                println!("A Commit message with one ore more invalid proposals was received");
-            }
             InvalidMessageError::CommitError(e) => {
                 println!("An error occured when applying a Commit message: {:?}", e);
+            }
+            InvalidMessageError::CommitWithInvalidProposals(e) => {
+                println!(
+                    "A Commit message with one ore more invalid proposals was received: {:?}",
+                    e
+                );
+            }
+            InvalidMessageError::GroupError(e) => {
+                println!("An error in the managed group occurred: {:?}", e);
             }
         }
     }

--- a/tests/test_managed_api.rs
+++ b/tests/test_managed_api.rs
@@ -1,17 +1,27 @@
 use openmls::prelude::{node::Node, *};
 use rand::{rngs::OsRng, RngCore};
-use std::{collections::HashMap, convert::TryInto};
+use std::{cell::RefCell, collections::HashMap};
 
 /// Errors that can occur when processing messages with the client.
+#[derive(Debug)]
 pub enum ClientError {
     NoMatchingKeyPackage,
     NoMatchingCredential,
-    FailedToJoinGroup,
+    NoMatchingGroup,
+    FailedToJoinGroup(WelcomeError),
+    InvalidMessage,
+    GroupError(ManagedGroupError),
 }
 
 impl From<WelcomeError> for ClientError {
-    fn from(_: WelcomeError) -> Self {
-        ClientError::FailedToJoinGroup
+    fn from(e: WelcomeError) -> Self {
+        ClientError::FailedToJoinGroup(e)
+    }
+}
+
+impl From<ManagedGroupError> for ClientError {
+    fn from(e: ManagedGroupError) -> Self {
+        ClientError::GroupError(e)
     }
 }
 
@@ -19,16 +29,16 @@ struct Client<'a> {
     /// Name of the client.
     pub(crate) identity: Vec<u8>,
     /// Ciphersuites supported by the client.
-    pub(crate) ciphersuites: Vec<CiphersuiteName>,
+    pub(crate) _ciphersuites: Vec<CiphersuiteName>,
     credential_bundles: HashMap<CiphersuiteName, CredentialBundle>,
     // Map from key package hash to the corresponding bundle.
-    pub(crate) key_package_bundles: HashMap<Vec<u8>, KeyPackageBundle>,
-    pub(crate) key_packages: HashMap<CiphersuiteName, KeyPackage>,
-    pub(crate) group_states: HashMap<GroupId, ManagedGroup<'a>>,
+    pub(crate) key_package_bundles: RefCell<HashMap<Vec<u8>, KeyPackageBundle>>,
+    //pub(crate) key_packages: HashMap<CiphersuiteName, KeyPackage>,
+    pub(crate) group_states: RefCell<HashMap<GroupId, ManagedGroup<'a>>>,
 }
 
 impl<'a> Client<'a> {
-    pub fn get_fresh_key_package(&mut self, ciphersuite: &Ciphersuite) -> KeyPackage {
+    pub fn get_fresh_key_package(&self, ciphersuite: &Ciphersuite) -> KeyPackage {
         // We unwrap here for now, because all ciphersuites are supported by all
         // clients.
         let credential_bundle = self.credential_bundles.get(&ciphersuite.name()).unwrap();
@@ -41,12 +51,13 @@ impl<'a> Client<'a> {
         .unwrap();
         let key_package = key_package_bundle.key_package().clone();
         self.key_package_bundles
+            .borrow_mut()
             .insert(key_package_bundle.key_package().hash(), key_package_bundle);
         key_package
     }
 
     pub fn create_group(
-        &mut self,
+        &'a self,
         group_id: GroupId,
         managed_group_config: ManagedGroupConfig,
         ciphersuite: &Ciphersuite,
@@ -55,19 +66,21 @@ impl<'a> Client<'a> {
         let key_package = self.get_fresh_key_package(ciphersuite);
         let key_package_bundle = self
             .key_package_bundles
+            .borrow_mut()
             .remove(&key_package.hash())
             .unwrap();
         let group_state = ManagedGroup::new(
             credential_bundle,
             &managed_group_config,
-            group_id,
+            group_id.clone(),
             key_package_bundle,
         )
         .unwrap();
+        self.group_states.borrow_mut().insert(group_id, group_state);
     }
 
     pub fn join_group(
-        &mut self,
+        &'a self,
         managed_group_config: ManagedGroupConfig,
         welcome: Welcome,
         ratchet_tree: Option<Vec<Option<Node>>>,
@@ -77,16 +90,17 @@ impl<'a> Client<'a> {
             .credential_bundles
             .get(&ciphersuite.name())
             .ok_or(ClientError::NoMatchingCredential)?;
-        let key_package_bundle = match welcome
-            .secrets()
-            .iter()
-            .find(|egs| self.key_package_bundles.contains_key(&egs.key_package_hash))
-        {
+        let key_package_bundle = match welcome.secrets().iter().find(|egs| {
+            self.key_package_bundles
+                .borrow()
+                .contains_key(&egs.key_package_hash)
+        }) {
             // We can unwrap here, because we just checked that this kpb exists.
             // Also, we should be fine just removing the KeyPackageBundle here,
             // because it shouldn't be used again anyway.
             Some(egs) => Ok(self
                 .key_package_bundles
+                .borrow_mut()
                 .remove(&egs.key_package_hash)
                 .unwrap()),
             None => Err(ClientError::NoMatchingKeyPackage),
@@ -99,11 +113,23 @@ impl<'a> Client<'a> {
             key_package_bundle,
         )?;
         self.group_states
+            .borrow_mut()
             .insert(new_group.group_id().to_owned(), new_group);
         Ok(())
     }
 
-    // TODO: Write a function that allows a member to simply process a message.
+    pub fn receive_messages_for_group(
+        &self,
+        group_id: &GroupId,
+        messages: Vec<MLSMessage>,
+    ) -> Result<(), ClientError> {
+        let mut group_states = self.group_states.borrow_mut();
+        let group_state = match group_states.get_mut(group_id) {
+            Some(group_state) => group_state,
+            None => return Err(ClientError::NoMatchingGroup),
+        };
+        Ok(group_state.process_messages(messages)?)
+    }
 }
 
 struct ManagedTestSetup<'a> {
@@ -118,10 +144,9 @@ impl<'a> ManagedTestSetup<'a> {
         for i in 0..number_of_clients {
             let identity = i.to_be_bytes().to_vec();
             // For now, everyone supports all ciphersuites.
-            let ciphersuites = Config::supported_ciphersuite_names();
+            let _ciphersuites = Config::supported_ciphersuite_names();
             let mut credential_bundles = HashMap::new();
-            let mut key_packages = HashMap::new();
-            for ciphersuite in &ciphersuites {
+            for ciphersuite in &_ciphersuites {
                 let credential_bundle = CredentialBundle::new(
                     identity.clone(),
                     CredentialType::Basic,
@@ -130,14 +155,13 @@ impl<'a> ManagedTestSetup<'a> {
                 .unwrap();
                 credential_bundles.insert(ciphersuite.clone(), credential_bundle);
             }
-            let key_package_bundles = HashMap::new();
+            let key_package_bundles = RefCell::new(HashMap::new());
             let client = Client {
                 identity,
-                ciphersuites,
+                _ciphersuites,
                 credential_bundles,
                 key_package_bundles,
-                key_packages,
-                group_states: HashMap::new(),
+                group_states: RefCell::new(HashMap::new()),
             };
             clients.push(client)
         }
@@ -147,7 +171,7 @@ impl<'a> ManagedTestSetup<'a> {
 
     /// Create a random group of size `group_size` and return the `GroupId`
     pub fn create_random_group(
-        &mut self,
+        &'a self,
         group_size: usize,
         ciphersuite: &Ciphersuite,
         managed_group_config: ManagedGroupConfig,
@@ -158,24 +182,86 @@ impl<'a> ManagedTestSetup<'a> {
 
         // Pick a random group creator.
         let group_creator_id = (OsRng.next_u32() as usize) % self.clients.len();
-        let group_creator = self.clients[group_creator_id];
+        let group_creator = &self.clients[group_creator_id];
         let group_id = GroupId {
             value: self.groups.len().to_be_bytes().to_vec(),
         };
-        group_creator.create_group(group_id, managed_group_config, ciphersuite);
-        let members = vec![group_creator_id];
-        for i in 0..group_size {
+        group_creator.create_group(group_id.clone(), managed_group_config.clone(), ciphersuite);
+        //let creator_group_states = group_creator.group_states.borrow();
+        //let creator_group_state = creator_group_states.get(&group_id).unwrap();
+        let mut members = Vec::new();
+        members.push(group_creator);
+        while members.len() < group_size {
             // Get a random group member.
             let adder_id = (OsRng.next_u32() as usize) % members.len();
-            let adder = self.clients[group_creator_id];
-            let adder_group_state = adder.group_states.get(&group_id).unwrap();
-            // Pick a client that's not already a member.
-            let new_member = self.clients.iter().find(|client| {
-                !members
-                    .contains(&(u32::from_be_bytes(client.identity.try_into().unwrap()) as usize))
-            });
-            let key_package = new_member.unwrap().get_fresh_key_package(ciphersuite);
-            adder_group_state.add_members(&[key_package]);
+            println!("adder_id: {:?}", adder_id);
+            let adder = members[adder_id];
+            let mut adder_group_states = adder.group_states.borrow_mut();
+            let adder_group_state = adder_group_states.get_mut(&group_id).unwrap();
+
+            // How many members to add at once?
+            let members_to_add = (OsRng.next_u32() as usize) % (group_size - members.len());
+
+            // Pick a number of clients that are not already members.
+            let mut new_members: Vec<&Client<'a>> = Vec::new();
+            let mut new_member_key_packages = Vec::new();
+            for _ in 0..members_to_add {
+                let new_member = self
+                    .clients
+                    .iter()
+                    .find(|client| {
+                        let identity = client.identity.clone();
+                        (!members
+                            .iter()
+                            .find(|member| member.identity == identity)
+                            .is_some())
+                            & (!new_members
+                                .iter()
+                                .find(|member| member.identity == identity)
+                                .is_some())
+                    })
+                    .unwrap();
+                // Get a fresh key package from each of them.
+                let key_package = new_member.get_fresh_key_package(ciphersuite);
+                new_members.push(new_member);
+                new_member_key_packages.push(key_package);
+            }
+            println!("KPs: {:?}", new_member_key_packages.len());
+            // Have the adder add them to the group.
+            let (mls_messages, welcome) = adder_group_state
+                .add_members(new_member_key_packages.as_slice())
+                .unwrap();
+            drop(adder_group_state);
+            drop(adder_group_states);
+            let _ = members
+                .iter()
+                .map(|member| {
+                    member
+                        .receive_messages_for_group(&group_id, mls_messages.clone())
+                        .unwrap();
+                })
+                .collect::<Vec<_>>();
+            let group_states = members[0].group_states.borrow_mut();
+            let group_state = group_states.get(&group_id).unwrap();
+            let ratchet_tree = group_state.export_ratchet_tree();
+            //let mut adder_group_states = adder.group_states.borrow_mut();
+            //let adder_group_state = adder_group_states.get_mut(&group_id).unwrap();
+            //let ratchet_tree = adder_group_state.export_ratchet_tree();
+            //drop(adder_group_state);
+            //drop(adder_group_states);
+            let _ = new_members
+                .iter()
+                .map(|nm| {
+                    println!("Ratchet Tree: {:?}", ratchet_tree);
+                    nm.join_group(
+                        managed_group_config.clone(),
+                        welcome.clone(),
+                        Some(ratchet_tree.clone()),
+                    )
+                    .unwrap();
+                    println!("A member just joined.")
+                })
+                .collect::<Vec<_>>();
         }
         group_id
     }
@@ -184,4 +270,12 @@ impl<'a> ManagedTestSetup<'a> {
 #[test]
 fn test_randomized_setup() {
     let setup = ManagedTestSetup::new(2000);
+    for ciphersuite in Config::supported_ciphersuites() {
+        let handshake_message_format = HandshakeMessageFormat::Ciphertext;
+        let update_policy = UpdatePolicy::default();
+        let callbacks = ManagedGroupCallbacks::default();
+        let managed_group_config =
+            ManagedGroupConfig::new(handshake_message_format, update_policy, callbacks);
+        setup.create_random_group(100, ciphersuite, managed_group_config);
+    }
 }

--- a/tests/test_managed_api.rs
+++ b/tests/test_managed_api.rs
@@ -1,0 +1,132 @@
+use openmls::prelude::*;
+use rand::{rngs::OsRng, RngCore};
+use std::collections::HashMap;
+
+struct Client<'a> {
+    /// Name of the client.
+    pub(crate) identity: Vec<u8>,
+    /// Ciphersuites supported by the client.
+    pub(crate) ciphersuites: Vec<CiphersuiteName>,
+    pub(crate) credential_bundles: HashMap<CiphersuiteName, CredentialBundle>,
+    // Map from key package hash to the corresponding bundle.
+    pub(crate) key_package_bundles: HashMap<Vec<u8>, KeyPackageBundle>,
+    pub(crate) key_packages: HashMap<CiphersuiteName, KeyPackage>,
+    pub(crate) group_states: HashMap<GroupId, ManagedGroup<'a>>,
+}
+
+impl<'a> Client<'a> {
+    pub fn get_fresh_key_package(&mut self, ciphersuite: &Ciphersuite) -> KeyPackage {
+        // We unwrap here for now, because all ciphersuites are supported by all
+        // clients.
+        let credential_bundle = self.credential_bundles.get(&ciphersuite.name()).unwrap();
+        let mandatory_extensions = Vec::new();
+        let key_package_bundle: KeyPackageBundle = KeyPackageBundle::new(
+            &[ciphersuite.name()],
+            &credential_bundle,
+            mandatory_extensions,
+        )
+        .unwrap();
+        let key_package = key_package_bundle.key_package().clone();
+        self.key_package_bundles
+            .insert(key_package_bundle.key_package().hash(), key_package_bundle);
+        key_package
+    }
+
+    pub fn create_group(
+        &mut self,
+        group_id: GroupId,
+        managed_group_config: ManagedGroupConfig,
+        ciphersuite: &Ciphersuite,
+    ) {
+        let credential_bundle = self.credential_bundles.get(&ciphersuite.name()).unwrap();
+        let key_package = self.get_fresh_key_package(ciphersuite);
+        let key_package_bundle = self
+            .key_package_bundles
+            .remove(&key_package.hash())
+            .unwrap();
+        let group_state = ManagedGroup::new(
+            credential_bundle,
+            &managed_group_config,
+            group_id,
+            key_package_bundle,
+        )
+        .unwrap();
+    }
+}
+
+// For now, everyone generates 20 KeyPackages.
+const KEY_PACKAGE_COUNT: usize = 20;
+
+struct ManagedTestSetup<'a> {
+    // The clients identity is its position in the vector in be_bytes.
+    clients: Vec<Client<'a>>,
+    groups: Vec<GroupId>,
+}
+
+impl<'a> ManagedTestSetup<'a> {
+    pub fn new(number_of_clients: usize) -> Self {
+        let mut clients = Vec::new();
+        for i in 0..number_of_clients {
+            let identity = i.to_be_bytes().to_vec();
+            // For now, everyone supports all ciphersuites.
+            let ciphersuites = Config::supported_ciphersuite_names();
+            let mut credential_bundles = HashMap::new();
+            let mut key_packages = HashMap::new();
+            for ciphersuite in &ciphersuites {
+                let credential_bundle = CredentialBundle::new(
+                    identity.clone(),
+                    CredentialType::Basic,
+                    ciphersuite.clone(),
+                )
+                .unwrap();
+                credential_bundles.insert(ciphersuite.clone(), credential_bundle);
+            }
+            let key_package_bundles = HashMap::new();
+            let client = Client {
+                identity,
+                ciphersuites,
+                credential_bundles,
+                key_package_bundles,
+                key_packages,
+                group_states: HashMap::new(),
+            };
+            clients.push(client)
+        }
+        let groups = Vec::new();
+        ManagedTestSetup { clients, groups }
+    }
+
+    /// Create a random group of size `group_size` and return the `GroupId`
+    pub fn create_random_group(
+        &mut self,
+        group_size: usize,
+        ciphersuite: &Ciphersuite,
+        managed_group_config: ManagedGroupConfig,
+    ) -> GroupId {
+        if group_size > self.clients.len() {
+            panic!("Not enough members to create a group this large.");
+        }
+
+        // Pick a random group creator.
+        let group_creator_id = (OsRng.next_u32() as usize) % self.clients.len();
+        let group_creator = self.clients[group_creator_id];
+        let group_id = GroupId {
+            value: self.groups.len().to_be_bytes().to_vec(),
+        };
+        let group_id = group_creator.create_group(group_id, managed_group_config, ciphersuite);
+        let members = vec![group_creator_id];
+        let potential_members =
+        for i in 0..group_size {
+            // Get a random group member.
+            let adder_id = (OsRng.next_u32() as usize) % members.len();
+            let adder = self.clients[group_creator_id];
+
+        }
+        group_id
+    }
+}
+
+#[test]
+fn test_randomized_setup() {
+    let setup = ManagedTestSetup::new(2000);
+}


### PR DESCRIPTION
This PR fixes #251.

 - `ProposalQueue` now has an internal list of `ReferenceProposal` to track the right order of insertion
 - An error in managed API was fixed, where `add_member` and `remove_member` would throw the wrong error when provided with empty input
 - `ProposalID` is now renamed everywhere to `ProposalReference`
 - The is a stub test for group fuzzing