### PR TITLE
Redundant ciphertexts

### DIFF
--- a/cli/src/backend.rs
+++ b/cli/src/backend.rs
@@ -24,7 +24,8 @@ impl Backend {
         Ok(String::from_utf8(response).unwrap())
     }
 
-    /// Get a list of all clients with name, ID, and key packages from the server.
+    /// Get a list of all clients with name, ID, and key packages from the
+    /// server.
     pub fn list_clients(&self) -> Result<Vec<ClientInfo>, String> {
         let mut url = self.ds_url.clone();
         url.set_path(&"/clients/list");

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -46,14 +46,14 @@ impl MlsGroup {
 
         // Create provisional tree and apply proposals
         let mut provisional_tree = self.tree.borrow_mut();
-        let (path_required_by_commit, group_removed, _invited_members, new_leaves_indexes) =
+        let apply_proposals_values =
             match provisional_tree.apply_proposals(proposal_queue, own_key_packages) {
                 Ok(res) => res,
                 Err(_) => return Err(ApplyCommitError::OwnKeyNotFound),
             };
 
         // Check if we were removed from the group
-        if group_removed {
+        if apply_proposals_values.self_removed {
             return Err(ApplyCommitError::SelfRemoved);
         }
 
@@ -85,11 +85,16 @@ impl MlsGroup {
             } else {
                 // Collect the new leaves indexes so we can filter them out in the resolution later
                 provisional_tree
-                    .update_path(sender, &path, &serialized_context, new_leaves_indexes)
+                    .update_path(
+                        sender,
+                        &path,
+                        &serialized_context,
+                        apply_proposals_values.exclusion_list(),
+                    )
                     .unwrap()
             }
         } else {
-            if path_required_by_commit {
+            if apply_proposals_values.path_required {
                 return Err(ApplyCommitError::RequiredPathNotFound);
             }
             &zero_commit_secret

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -83,7 +83,7 @@ impl MlsGroup {
                 };
                 provisional_tree.replace_private_tree(own_kpb, &serialized_context)
             } else {
-                // Collect the new leaves indexes so we can filter them out in the resolution later
+                // Collect the new leaves' indexes so we can filter them out in the resolution later.
                 provisional_tree
                     .update_path(
                         sender,

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -46,7 +46,7 @@ impl MlsGroup {
 
         // Create provisional tree and apply proposals
         let mut provisional_tree = self.tree.borrow_mut();
-        let (path_required_by_commit, group_removed, _invited_members) =
+        let (path_required_by_commit, group_removed, _invited_members, new_leaves_indexes) =
             match provisional_tree.apply_proposals(proposal_queue, own_key_packages) {
                 Ok(res) => res,
                 Err(_) => return Err(ApplyCommitError::OwnKeyNotFound),
@@ -83,8 +83,9 @@ impl MlsGroup {
                 };
                 provisional_tree.replace_private_tree(own_kpb, &serialized_context)
             } else {
+                // Collect the new leaves indexes so we can filter them out in the resolution later
                 provisional_tree
-                    .update_path(sender, &path, &serialized_context)
+                    .update_path(sender, &path, &serialized_context, new_leaves_indexes)
                     .unwrap()
             }
         } else {

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -83,7 +83,8 @@ impl MlsGroup {
                 };
                 provisional_tree.replace_private_tree(own_kpb, &serialized_context)
             } else {
-                // Collect the new leaves' indexes so we can filter them out in the resolution later.
+                // Collect the new leaves' indexes so we can filter them out in the resolution
+                // later.
                 provisional_tree
                     .update_path(
                         sender,

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -34,7 +34,7 @@ impl MlsGroup {
         let mut provisional_tree = RatchetTree::new_from_public_tree(&self.tree());
 
         // Apply proposals to tree
-        let (path_required_by_commit, self_removed, invited_members) =
+        let (path_required_by_commit, self_removed, invited_members, new_leaves_indexes) =
             match provisional_tree.apply_proposals(proposal_queue, &[]) {
                 Ok(res) => res,
                 Err(_) => return Err(CreateCommitError::OwnKeyNotFound.into()),
@@ -48,7 +48,11 @@ impl MlsGroup {
         let (commit_secret, path, path_secrets_option, kpb_option) = if path_required {
             // If path is needed, compute path values
             let (commit_secret, path, path_secrets, key_package_bundle) = provisional_tree
-                .refresh_private_tree(credential_bundle, &self.group_context.serialize());
+                .refresh_private_tree(
+                    credential_bundle,
+                    &self.group_context.serialize(),
+                    new_leaves_indexes,
+                );
             (
                 Some(commit_secret),
                 Some(path),

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -34,16 +34,16 @@ impl MlsGroup {
         let mut provisional_tree = RatchetTree::new_from_public_tree(&self.tree());
 
         // Apply proposals to tree
-        let (path_required_by_commit, self_removed, invited_members, new_leaves_indexes) =
-            match provisional_tree.apply_proposals(proposal_queue, &[]) {
-                Ok(res) => res,
-                Err(_) => return Err(CreateCommitError::OwnKeyNotFound.into()),
-            };
-        if self_removed {
+        let apply_proposals_values = match provisional_tree.apply_proposals(proposal_queue, &[]) {
+            Ok(res) => res,
+            Err(_) => return Err(CreateCommitError::OwnKeyNotFound.into()),
+        };
+        if apply_proposals_values.self_removed {
             return Err(CreateCommitError::CannotRemoveSelf.into());
         }
         // Determine if Commit needs path field
-        let path_required = path_required_by_commit || contains_own_updates || force_self_update;
+        let path_required =
+            apply_proposals_values.path_required || contains_own_updates || force_self_update;
 
         let (commit_secret, path, path_secrets_option, kpb_option) = if path_required {
             // If path is needed, compute path values
@@ -51,7 +51,7 @@ impl MlsGroup {
                 .refresh_private_tree(
                     credential_bundle,
                     &self.group_context.serialize(),
-                    new_leaves_indexes,
+                    apply_proposals_values.exclusion_list(),
                 );
             (
                 Some(commit_secret),
@@ -85,8 +85,11 @@ impl MlsGroup {
         );
         // Create group secrets for later use, so we can afterwards consume the
         // `joiner_secret`.
-        let plaintext_secrets =
-            joiner_secret.group_secrets(invited_members, &provisional_tree, path_secrets_option);
+        let plaintext_secrets = joiner_secret.group_secrets(
+            apply_proposals_values.invitation_list,
+            &provisional_tree,
+            path_secrets_option,
+        );
         let member_secret =
             MemberSecret::from_joiner_secret_and_psk(ciphersuite, joiner_secret, None);
         // Derive the welcome key material before consuming the `MemberSecret`

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -29,11 +29,16 @@ pub(crate) use serde::{
     Deserialize, Deserializer, Serialize,
 };
 
+use std::collections::HashSet;
+use std::iter::FromIterator;
+
 // Internal tree tests
 #[cfg(test)]
 mod test_path_keys;
 #[cfg(test)]
 mod test_private_tree;
+#[cfg(test)]
+mod test_resolution;
 #[cfg(test)]
 mod test_secret_tree;
 #[cfg(test)]
@@ -181,11 +186,11 @@ impl RatchetTree {
         self.tree_size().into()
     }
 
-    fn resolve(&self, index: NodeIndex) -> Vec<NodeIndex> {
+    fn resolve(&self, index: NodeIndex, exclusion_list: &HashSet<NodeIndex>) -> Vec<NodeIndex> {
         let size = self.leaf_count();
 
         if self.nodes[index.as_usize()].node_type == NodeType::Leaf {
-            if self.nodes[index.as_usize()].is_blank() {
+            if self.nodes[index.as_usize()].is_blank() || exclusion_list.contains(&index) {
                 return vec![];
             } else {
                 return vec![index];
@@ -206,10 +211,12 @@ impl RatchetTree {
 
         let mut left = self.resolve(
             treemath::left(index).expect("resolve: TreeMath error when computing left child."),
+            exclusion_list,
         );
         let right = self.resolve(
             treemath::right(index, size)
                 .expect("resolve: TreeMath error when computing right child."),
+            exclusion_list,
         );
         left.extend(right);
         left
@@ -271,6 +278,7 @@ impl RatchetTree {
         sender: LeafIndex,
         update_path: &UpdatePath,
         group_context: &[u8],
+        new_leaves_indexes: HashSet<NodeIndex>,
     ) -> Result<&CommitSecret, TreeError> {
         let own_index = self.own_node_index();
 
@@ -297,7 +305,7 @@ impl RatchetTree {
             };
 
         // Resolve the node of that co-path index
-        let resolution = self.resolve(common_ancestor_copath_index);
+        let resolution = self.resolve(common_ancestor_copath_index, &new_leaves_indexes);
         let position_in_resolution = resolution.iter().position(|&x| x == own_index).unwrap_or(0);
 
         // Decrypt the ciphertext of that node
@@ -385,7 +393,7 @@ impl RatchetTree {
         let _path_option = self.replace_private_tree_(
             key_package_bundle,
             group_context,
-            false, /* without update path */
+            None, /* without update path */
         );
         self.private_tree.commit_secret()
     }
@@ -395,6 +403,7 @@ impl RatchetTree {
         &mut self,
         credential_bundle: &CredentialBundle,
         group_context: &[u8],
+        new_leaves_indexes: HashSet<NodeIndex>,
     ) -> (&CommitSecret, UpdatePath, PathSecrets, KeyPackageBundle) {
         // Generate new keypair
         let own_index = self.own_node_index();
@@ -409,7 +418,7 @@ impl RatchetTree {
             .replace_private_tree_(
                 &key_package_bundle,
                 group_context,
-                true, /* with update path */
+                Some(new_leaves_indexes), /* with update path */
             )
             .unwrap();
 
@@ -438,7 +447,7 @@ impl RatchetTree {
         &mut self,
         key_package_bundle: &KeyPackageBundle,
         group_context: &[u8],
-        with_update_path: bool,
+        new_leaves_indexes_option: Option<HashSet<NodeIndex>>,
     ) -> Option<UpdatePath> {
         let key_package = key_package_bundle.key_package().clone();
         let ciphersuite = key_package.ciphersuite();
@@ -461,9 +470,9 @@ impl RatchetTree {
         // Update own leaf node with the new values
         self.nodes[own_index.as_usize()] = Node::new_leaf(Some(key_package.clone()));
         self.compute_parent_hash(self.own_node_index());
-        if with_update_path {
+        if let Some(new_leaves_indexes) = new_leaves_indexes_option {
             let update_path_nodes = self
-                .encrypt_to_copath(new_public_keys, group_context)
+                .encrypt_to_copath(new_public_keys, group_context, new_leaves_indexes)
                 .unwrap();
             let update_path = UpdatePath::new(key_package, update_path_nodes);
             Some(update_path)
@@ -477,6 +486,7 @@ impl RatchetTree {
         &self,
         public_keys: Vec<HPKEPublicKey>,
         group_context: &[u8],
+        new_leaves_indexes: HashSet<NodeIndex>,
     ) -> Result<Vec<UpdatePathNode>, TreeError> {
         let copath = treemath::copath(self.private_tree.node_index(), self.leaf_count())
             .expect("encrypt_to_copath: Error when computing copath.");
@@ -499,10 +509,10 @@ impl RatchetTree {
         let mut ciphertexts = vec![];
         for (path_secret, copath_node) in path_secrets.iter().zip(copath.iter()) {
             let node_ciphertexts: Vec<HpkeCiphertext> = self
-                .resolve(*copath_node)
+                .resolve(*copath_node, &new_leaves_indexes)
                 .iter()
-                .map(|&x| {
-                    let pk = self.nodes[x.as_usize()].public_hpke_key().unwrap();
+                .map(|&index| {
+                    let pk = self.nodes[index.as_usize()].public_hpke_key().unwrap();
                     self.ciphersuite
                         .hpke_seal_secret(&pk, group_context, &[], &path_secret)
                 })
@@ -639,8 +649,8 @@ impl RatchetTree {
         &mut self,
         proposal_queue: ProposalQueue,
         updates_key_package_bundles: &[KeyPackageBundle],
-        // (path_required, self_removed, invitation_list)
-    ) -> Result<(bool, bool, InvitationList), TreeError> {
+        // (path_required, self_removed, invitation_list, new_leaves_indexes)
+    ) -> Result<(bool, bool, InvitationList, HashSet<NodeIndex>), TreeError> {
         let mut has_updates = false;
         let mut has_removes = false;
         let mut invitation_list = Vec::new();
@@ -706,7 +716,20 @@ impl RatchetTree {
         // Determine if Commit needs a path field
         let path_required = has_updates || has_removes || !has_adds;
 
-        Ok((path_required, self_removed, invitation_list))
+        // Collect the new leaves indexes so we can filter them out in the resolution later
+        let new_leaves_indexes: HashSet<NodeIndex> = HashSet::from_iter(
+            invitation_list
+                .iter()
+                .map(|(index, _)| *index)
+                .collect::<Vec<NodeIndex>>(),
+        );
+
+        Ok((
+            path_required,
+            self_removed,
+            invitation_list,
+            new_leaves_indexes,
+        ))
     }
     /// Trims the tree from the right when there are empty leaf nodes
     fn trim_tree(&mut self) {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -862,7 +862,7 @@ pub struct ApplyProposalsValues {
 
 impl ApplyProposalsValues {
     pub fn exclusion_list(&self) -> HashSet<&NodeIndex> {
-        // Collect the new leaves indexes so we can filter them out in the resolution later
+        // Collect the new leaves' indexes so we can filter them out in the resolution later
         let new_leaves_indexes: HashSet<&NodeIndex> =
             HashSet::from_iter(self.invitation_list.iter().map(|(index, _)| index));
         new_leaves_indexes

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -863,12 +863,8 @@ pub struct ApplyProposalsValues {
 impl ApplyProposalsValues {
     pub fn exclusion_list(&self) -> HashSet<&NodeIndex> {
         // Collect the new leaves indexes so we can filter them out in the resolution later
-        let new_leaves_indexes: HashSet<&NodeIndex> = HashSet::from_iter(
-            self.invitation_list
-                .iter()
-                .map(|(index, _)| index)
-                .collect::<Vec<&NodeIndex>>(),
-        );
+        let new_leaves_indexes: HashSet<&NodeIndex> =
+            HashSet::from_iter(self.invitation_list.iter().map(|(index, _)| index));
         new_leaves_indexes
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -854,6 +854,7 @@ impl RatchetTree {
     }
 }
 
+/// This struct contain the return vallues of the `apply_proposals()` function
 pub struct ApplyProposalsValues {
     pub path_required: bool,
     pub self_removed: bool,
@@ -861,8 +862,12 @@ pub struct ApplyProposalsValues {
 }
 
 impl ApplyProposalsValues {
+    /// This function creates a `HashSet` of node indexes of the new nodes that
+    /// were added to the tree. The `HashSet` will be querried by the
+    /// `resolve()` function to filter out those nodes from the resolution.
     pub fn exclusion_list(&self) -> HashSet<&NodeIndex> {
-        // Collect the new leaves' indexes so we can filter them out in the resolution later
+        // Collect the new leaves' indexes so we can filter them out in the resolution
+        // later
         let new_leaves_indexes: HashSet<&NodeIndex> =
             HashSet::from_iter(self.invitation_list.iter().map(|(index, _)| index));
         new_leaves_indexes

--- a/src/tree/test_resolution.rs
+++ b/src/tree/test_resolution.rs
@@ -1,15 +1,21 @@
 use super::*;
 
+/// This test makes sure the filtering of the exclusion list during resolution works as intended.
 #[test]
 
 fn test_exclusion_list() {
     for ciphersuite in Config::supported_ciphersuites() {
+        // Number of nodes in the tree
         const NODES: usize = 31;
+        // Resolution for the root node of that tree
         const FULL_RESOLUTION: &[usize] =
             &[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30];
+        // Arbitrary exclusion list
         const EXCLUSION_LIST: &[usize] = &[10, 12, 14, 16, 18, 20, 22];
+        // Expected filtered resolution (the nodes from the exclusion list should be stripped from the full resolution)
         const FILTERED_RESOLUTION: &[usize] = &[0, 2, 4, 6, 8, 24, 26, 28, 30];
 
+        // Build a list of nodes, for which we need credentials and key package bundles
         let mut nodes = vec![];
         let mut key_package_bundles = vec![];
         for i in 0..NODES {
@@ -19,6 +25,7 @@ fn test_exclusion_list() {
             let key_package_bundle =
                 KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, vec![]).unwrap();
 
+            // We build a leaf node from the key packages
             let leaf_node = Node {
                 node_type: NodeType::Leaf,
                 key_package: Some(key_package_bundle.key_package().clone()),
@@ -26,13 +33,15 @@ fn test_exclusion_list() {
             };
             key_package_bundles.push(key_package_bundle);
             nodes.push(Some(leaf_node));
+            // We skip the last parent node (trees should always end with a leaf node)
             if i != NODES - 1 {
+                // We insert blank parent nodes to get a longer resolution list
                 nodes.push(None);
             }
         }
 
+        // The first key package bundle is used for the tree holder
         let key_package_bundle = key_package_bundles.remove(0);
-        drop(key_package_bundles);
 
         let tree = RatchetTree::new_from_nodes(&ciphersuite, key_package_bundle, &nodes).unwrap();
 
@@ -46,14 +55,18 @@ fn test_exclusion_list() {
             .map(|node_index| node_index.as_usize())
             .collect::<Vec<usize>>();
 
+        // We expect to have all resolved nodes
         assert_eq!(FULL_RESOLUTION, full_resolution);
 
         // Test resolution with exclusion list
+        let exclusion_list_node_indexes = EXCLUSION_LIST
+            .iter()
+            .map(|index| NodeIndex::from(*index))
+            .collect::<Vec<NodeIndex>>();
         let exclusion_list = HashSet::from_iter(
-            EXCLUSION_LIST
+            exclusion_list_node_indexes
                 .iter()
-                .map(|index| NodeIndex::from(*index))
-                .collect::<Vec<NodeIndex>>(),
+                .collect::<Vec<&NodeIndex>>(),
         );
         let filtered_resultion = tree
             .resolve(root, &exclusion_list)
@@ -61,6 +74,7 @@ fn test_exclusion_list() {
             .map(|node_index| node_index.as_usize())
             .collect::<Vec<usize>>();
 
+        // We expect to only see the nodes that were not removed by the filtering
         assert_eq!(FILTERED_RESOLUTION, filtered_resultion);
     }
 }

--- a/src/tree/test_resolution.rs
+++ b/src/tree/test_resolution.rs
@@ -63,11 +63,7 @@ fn test_exclusion_list() {
             .iter()
             .map(|index| NodeIndex::from(*index))
             .collect::<Vec<NodeIndex>>();
-        let exclusion_list = HashSet::from_iter(
-            exclusion_list_node_indexes
-                .iter()
-                .collect::<Vec<&NodeIndex>>(),
-        );
+        let exclusion_list = HashSet::from_iter(exclusion_list_node_indexes.iter());
         let filtered_resultion = tree
             .resolve(root, &exclusion_list)
             .iter()

--- a/src/tree/test_resolution.rs
+++ b/src/tree/test_resolution.rs
@@ -1,0 +1,66 @@
+use super::*;
+
+#[test]
+
+fn test_exclusion_list() {
+    for ciphersuite in Config::supported_ciphersuites() {
+        const NODES: usize = 31;
+        const FULL_RESOLUTION: &[usize] =
+            &[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30];
+        const EXCLUSION_LIST: &[usize] = &[10, 12, 14, 16, 18, 20, 22];
+        const FILTERED_RESOLUTION: &[usize] = &[0, 2, 4, 6, 8, 24, 26, 28, 30];
+
+        let mut nodes = vec![];
+        let mut key_package_bundles = vec![];
+        for i in 0..NODES {
+            let credential_bundle =
+                CredentialBundle::new(vec![i as u8], CredentialType::Basic, ciphersuite.name())
+                    .unwrap();
+            let key_package_bundle =
+                KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, vec![]).unwrap();
+
+            let leaf_node = Node {
+                node_type: NodeType::Leaf,
+                key_package: Some(key_package_bundle.key_package().clone()),
+                node: None,
+            };
+            key_package_bundles.push(key_package_bundle);
+            nodes.push(Some(leaf_node));
+            if i != NODES - 1 {
+                nodes.push(None);
+            }
+        }
+
+        let key_package_bundle = key_package_bundles.remove(0);
+        drop(key_package_bundles);
+
+        let tree = RatchetTree::new_from_nodes(&ciphersuite, key_package_bundle, &nodes).unwrap();
+
+        let root = treemath::root(NodeIndex::from(NODES).into());
+
+        // Test full resolution
+        let exclusion_list = HashSet::new();
+        let full_resolution = tree
+            .resolve(root, &exclusion_list)
+            .iter()
+            .map(|node_index| node_index.as_usize())
+            .collect::<Vec<usize>>();
+
+        assert_eq!(FULL_RESOLUTION, full_resolution);
+
+        // Test resolution with exclusion list
+        let exclusion_list = HashSet::from_iter(
+            EXCLUSION_LIST
+                .iter()
+                .map(|index| NodeIndex::from(*index))
+                .collect::<Vec<NodeIndex>>(),
+        );
+        let filtered_resultion = tree
+            .resolve(root, &exclusion_list)
+            .iter()
+            .map(|node_index| node_index.as_usize())
+            .collect::<Vec<usize>>();
+
+        assert_eq!(FILTERED_RESOLUTION, filtered_resultion);
+    }
+}

--- a/src/tree/test_resolution.rs
+++ b/src/tree/test_resolution.rs
@@ -1,6 +1,7 @@
 use super::*;
 
-/// This test makes sure the filtering of the exclusion list during resolution works as intended.
+/// This test makes sure the filtering of the exclusion list during resolution
+/// works as intended.
 #[test]
 
 fn test_exclusion_list() {
@@ -12,7 +13,8 @@ fn test_exclusion_list() {
             &[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30];
         // Arbitrary exclusion list
         const EXCLUSION_LIST: &[usize] = &[10, 12, 14, 16, 18, 20, 22];
-        // Expected filtered resolution (the nodes from the exclusion list should be stripped from the full resolution)
+        // Expected filtered resolution (the nodes from the exclusion list should be
+        // stripped from the full resolution)
         const FILTERED_RESOLUTION: &[usize] = &[0, 2, 4, 6, 8, 24, 26, 28, 30];
 
         // Build a list of nodes, for which we need credentials and key package bundles


### PR DESCRIPTION
This PR fixes #148.

The `resolve()` function is modified so that it accepts an exclusion list of `NodeIndex`es to filter out from the resolution.
The exclusion list is created in `apply_proposal()` when new members are added to a provisional tree and passed to the `resolve()` function.
There is a test to verify that the filtering works.
