### PR TITLE
Return optional Welcome messages

### DIFF
--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -617,7 +617,7 @@ impl<'a> ManagedGroup<'a> {
     /// be provided. If not, a new one will be created on the fly.
     ///
     /// If successful, it returns a `Vec` of
-    /// [`MLSMessage`](crate::prelude::MLSMessage) and a n optional
+    /// [`MLSMessage`](crate::prelude::MLSMessage) and an optional
     /// [`Welcome`](crate::prelude::Welcome) message if there were add proposals
     /// in the queue of pending proposals.
     pub fn self_update(

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -204,7 +204,7 @@ impl<'a> ManagedGroup<'a> {
     /// Members are removed by providing the index of their leaf in the tree.
     ///
     /// If successful, it returns a `Vec` of
-    /// [`MLSMessage`](crate::prelude::MLSMessage) and a n optional
+    /// [`MLSMessage`](crate::prelude::MLSMessage) and an optional
     /// [`Welcome`](crate::prelude::Welcome) message if there were add proposals
     /// in the queue of pending proposals.
     pub fn remove_members(

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -136,6 +136,12 @@ impl<'a> ManagedGroup<'a> {
     // === Membership management ===
 
     /// Adds members to the group
+    ///
+    /// New members are added by providing a `KeyPackage` for each member.
+    ///
+    /// If successful, it returns a `Vec` of
+    /// [`MLSMessage`](crate::prelude::MLSMessage) and a
+    /// [`Welcome`](crate::prelude::Welcome) message.
     pub fn add_members(
         &mut self,
         key_packages: &[KeyPackage],
@@ -194,10 +200,17 @@ impl<'a> ManagedGroup<'a> {
     }
 
     /// Removes members from the group
+    ///
+    /// Members are removed by providing the index of their leaf in the tree.
+    ///
+    /// If successful, it returns a `Vec` of
+    /// [`MLSMessage`](crate::prelude::MLSMessage) and a n optional
+    /// [`Welcome`](crate::prelude::Welcome) message if there were add proposals
+    /// in the queue of pending proposals.
     pub fn remove_members(
         &mut self,
         members: &[usize],
-    ) -> Result<Vec<MLSMessage>, ManagedGroupError> {
+    ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
@@ -220,7 +233,7 @@ impl<'a> ManagedGroup<'a> {
             .collect::<Vec<&MLSPlaintext>>();
 
         // Create Commit over all proposals
-        let (commit, _welcome_option, kpb_option) = self.group.create_commit(
+        let (commit, welcome_option, kpb_option) = self.group.create_commit(
             &self.aad,
             &self.credential_bundle,
             proposals_by_reference,
@@ -244,7 +257,7 @@ impl<'a> ManagedGroup<'a> {
         // Since the state of the group was changed, call the auto-save function
         self.auto_save();
 
-        Ok(mls_messages)
+        Ok((mls_messages, welcome_option))
     }
 
     /// Creates proposals to add members to the group
@@ -599,10 +612,18 @@ impl<'a> ManagedGroup<'a> {
     }
 
     /// Updates the own leaf node
+    ///
+    /// A [`KeyPackageBundle`](crate::prelude::KeyPackageBundle) can optionally
+    /// be provided. If not, a new one will be created on the fly.
+    ///
+    /// If successful, it returns a `Vec` of
+    /// [`MLSMessage`](crate::prelude::MLSMessage) and a n optional
+    /// [`Welcome`](crate::prelude::Welcome) message if there were add proposals
+    /// in the queue of pending proposals.
     pub fn self_update(
         &mut self,
         key_package_bundle_option: Option<KeyPackageBundle>,
-    ) -> Result<Vec<MLSMessage>, ManagedGroupError> {
+    ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
@@ -628,7 +649,7 @@ impl<'a> ManagedGroup<'a> {
             .collect();
 
         // Create Commit over all proposals
-        let (commit, _welcome_option, kpb_option) = self.group.create_commit(
+        let (commit, welcome_option, kpb_option) = self.group.create_commit(
             &self.aad,
             &self.credential_bundle,
             &messages_to_commit,
@@ -657,7 +678,7 @@ impl<'a> ManagedGroup<'a> {
         // Since the state of the group was changed, call the auto-save function
         self.auto_save();
 
-        Ok(mls_messages)
+        Ok((mls_messages, welcome_option))
     }
 
     /// Creates a proposal to update the own leaf node

--- a/tests/test_managed_group.rs
+++ b/tests/test_managed_group.rs
@@ -258,7 +258,7 @@ fn managed_group_operations() {
                 .expect("The group is no longer active");
 
             // === Bob updates and commits ===
-            let queued_messages = match bob_group.self_update(None) {
+            let (queued_messages, welcome_option) = match bob_group.self_update(None) {
                 Ok(qm) => qm,
                 Err(e) => panic!("Error performing self-update: {:?}", e),
             };
@@ -268,6 +268,9 @@ fn managed_group_operations() {
             bob_group
                 .process_messages(queued_messages.clone())
                 .expect("The group is no longer active");
+
+            // Check we didn't receive a Welcome message
+            assert!(welcome_option.is_none());
 
             // Check that both groups have the same state
             assert_eq!(
@@ -376,7 +379,7 @@ fn managed_group_operations() {
                 .expect("The group is no longer active");
 
             // === Charlie updates and commits ===
-            let queued_messages = match charlie_group.self_update(None) {
+            let (queued_messages, welcome_option) = match charlie_group.self_update(None) {
                 Ok(qm) => qm,
                 Err(e) => panic!("Error performing self-update: {:?}", e),
             };
@@ -389,6 +392,9 @@ fn managed_group_operations() {
             charlie_group
                 .process_messages(queued_messages.clone())
                 .expect("The group is no longer active");
+
+            // Check we didn't receive a Welcome message
+            assert!(welcome_option.is_none());
 
             // Check that all groups have the same state
             assert_eq!(
@@ -411,7 +417,7 @@ fn managed_group_operations() {
             );
 
             // === Charlie removes Bob ===
-            let queued_messages = match charlie_group.remove_members(&[1]) {
+            let (queued_messages, welcome_option) = match charlie_group.remove_members(&[1]) {
                 Ok(qm) => qm,
                 Err(e) => panic!("Could not remove member from group: {:?}", e),
             };
@@ -428,6 +434,9 @@ fn managed_group_operations() {
             charlie_group
                 .process_messages(queued_messages.clone())
                 .expect("The group is no longer active");
+
+            // Check we didn't receive a Welcome message
+            assert!(welcome_option.is_none());
 
             // Check that Bob's group is no longer active
             assert!(!bob_group.is_active());


### PR DESCRIPTION
This PR fixes #263.

There was a bug in the managed API where potential add proposals in the pending proposals queue could be applied without the API returning a corresponding `Welcome` message for the new joiners to consume. This has been fixed.

This is mostly covered by existing tests for creating `Commit` messages, but a negative was added to the integration test for the managed API.