### PR TITLE
Bump HPKE and evercrypt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 log = { version = "0.4", features = ["std"] }
 typetag = "0.1"
-hpke = { version = "0.0.2", package = "hpke-rs", features = ["hazmat", "serialization"] }
-evercrypt = { version = "0.0.3", features = ["serialization"] }
+hpke = { version = "0.0.3", package = "hpke-rs", features = ["hazmat", "serialization"] }
+evercrypt = { version = "0.0.5", features = ["serialization"] }
 
 [features]
 default = ["rust-crypto"]


### PR DESCRIPTION
There are a couple fixes in HPKE and evercrypt.
This should also build on Windows (it's not under CI yet, so no guarantees).

replacing #260