### PR TITLE
finish error rewrite

### DIFF
--- a/src/ciphersuite/errors.rs
+++ b/src/ciphersuite/errors.rs
@@ -2,33 +2,14 @@
 //!
 //! This file defines a set of errors thrown by crypto operations.
 
-use std::error::Error;
-
-#[derive(Debug)]
-pub(crate) enum HKDFError {
-    InvalidLength,
-}
-
-#[derive(Debug)]
-pub(crate) enum CryptoError {
-    CryptoLibraryError,
-}
-
-implement_enum_display!(HKDFError);
-implement_enum_display!(CryptoError);
-
-impl Error for HKDFError {
-    fn description(&self) -> &str {
-        match self {
-            Self::InvalidLength => "The HKDF output is empty.",
-        }
+implement_error! {
+    pub(crate) enum HKDFError {
+        InvalidLength = "The HKDF output is empty.",
     }
 }
 
-impl Error for CryptoError {
-    fn description(&self) -> &str {
-        match self {
-            Self::CryptoLibraryError => "Unrecoverable error in the crypto library.",
-        }
+implement_error! {
+    pub enum CryptoError {
+        CryptoLibraryError = "Unrecoverable error in the crypto library.",
     }
 }

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -658,16 +658,6 @@ impl SignaturePrivateKey {
     }
 }
 
-impl From<ConfigError> for SignatureError {
-    fn from(e: ConfigError) -> SignatureError {
-        // TODO: #83
-        match e {
-            ConfigError::UnsupportedCiphersuite => SignatureError::UnkownAlgorithm,
-            _ => SignatureError::UnkownAlgorithm,
-        }
-    }
-}
-
 /// Make sure that xoring works by xoring a nonce with a reuse guard, testing if
 /// it has changed, xoring it again and testing that it's back in its original
 /// state.

--- a/src/ciphersuite/signable.rs
+++ b/src/ciphersuite/signable.rs
@@ -1,5 +1,5 @@
 use crate::ciphersuite::*;
-use crate::creds::*;
+use crate::credentials::*;
 
 /// The `Signable` trait is implemented by all struct that are being signed.
 /// The implementation has to provide the `unsigned_payload` function.

--- a/src/codec/errors.rs
+++ b/src/codec/errors.rs
@@ -1,0 +1,18 @@
+use crate::config::ConfigError;
+
+// There should only be simple codec errors.
+// Each module should wrap the `CodecError` for more information.
+implement_error! {
+    pub enum CodecError {
+        EncodingError = "Error encoding.",
+        DecodingError = "Error decoding.",
+        Other = "Some other error occurred.",
+    }
+}
+
+impl From<ConfigError> for CodecError {
+    // This happens only when decoding a value that's unsupported by the config.
+    fn from(_e: ConfigError) -> CodecError {
+        CodecError::DecodingError
+    }
+}

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,6 +1,6 @@
 mod errors;
 
-pub(crate) use errors::*;
+pub use errors::*;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::HashMap;

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,32 +1,10 @@
-use crate::config::ConfigError;
+mod errors;
+
+pub(crate) use errors::*;
+
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::HashMap;
 use std::convert::*;
-
-implement_error! {
-    pub enum CodecError {
-        EncodingError = "Error encoding.",
-        DecodingError = "Error decoding.",
-        Other = "Some other error occurred.",
-    }
-}
-
-impl From<ConfigError> for CodecError {
-    // TODO: tbd in #83
-    fn from(_e: ConfigError) -> CodecError {
-        CodecError::DecodingError
-    }
-}
-
-impl From<CodecError> for ConfigError {
-    // TODO: tbd in #83, also this direction shouldn't be necessary.
-    #[allow(clippy::match_single_binding)]
-    fn from(e: CodecError) -> Self {
-        match e {
-            _ => ConfigError::InvalidConfig,
-        }
-    }
-}
 
 pub enum VecSize {
     VecU8,

--- a/src/config/errors.rs
+++ b/src/config/errors.rs
@@ -5,10 +5,10 @@
 //! supported.
 
 implement_error! {
-pub enum ConfigError {
-    InvalidConfig = "Invalid configuration.",
-    UnsupportedMlsVersion = "MLS version is not supported by this configuration.",
-    UnsupportedCiphersuite = "Ciphersuite is not supported by this configuration.",
-    UnsupportedSignatureScheme = "Signature scheme is not supported by this configuration.",
-}
+    pub enum ConfigError {
+        InvalidConfig = "Invalid configuration.",
+        UnsupportedMlsVersion = "MLS version is not supported by this configuration.",
+        UnsupportedCiphersuite = "Ciphersuite is not supported by this configuration.",
+        UnsupportedSignatureScheme = "Signature scheme is not supported by this configuration.",
+    }
 }

--- a/src/credentials/errors.rs
+++ b/src/credentials/errors.rs
@@ -1,0 +1,14 @@
+use crate::ciphersuite::*;
+use crate::config::ConfigError;
+
+implement_error! {
+    pub enum CredentialError {
+        Simple {
+            UnsupportedCredentialType = "Unsupported credential type",
+        }
+        Complex {
+            ConfigError(ConfigError) = "See `ConfigError` for details.",
+            CryptoError(CryptoError) = "See `CryptoError` for details.",
+        }
+    }
+}

--- a/src/extensions/errors.rs
+++ b/src/extensions/errors.rs
@@ -10,142 +10,67 @@
 //! * `ParentHashError`
 //! * `RatchetTreeError`
 
+use crate::error::ErrorString;
 use crate::{codec::CodecError, config::ConfigError};
-use std::error::Error;
 
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[repr(u16)]
-pub enum ExtensionError {
-    /// Invalid extension type error.
-    InvalidExtensionType,
-
-    /// Error when decoding an extension.
-    DecodingError,
-
-    /// Capabilities extension error.
-    /// See `CapabilitiesExtensionError` for details.
-    Capabilities(CapabilitiesExtensionError),
-
-    /// Lifetime extension error.
-    /// See `LifetimeExtensionError` for details.
-    Lifetime(LifetimeExtensionError),
-
-    /// Key package ID extension error.
-    /// See `KeyPackageIdError` for details.
-    KeyPackageId(KeyPackageIdError),
-
-    /// Parent hash extension error.
-    /// See `ParentHashError` for details.
-    ParentHash(ParentHashError),
-
-    /// Ratchet tree extension error.
-    /// See `RatchetTreeError` for details.
-    RatchetTree(RatchetTreeError),
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[repr(u16)]
-pub enum LifetimeExtensionError {
-    /// Invalid lifetime extensions.
-    Invalid = 0,
-
-    /// Lifetime extension is expired.
-    Expired = 1,
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[repr(u16)]
-pub enum CapabilitiesExtensionError {
-    /// Invalid capabilities extensions.
-    Invalid = 0,
-
-    /// Capabilities extension is missing a version field.
-    EmptyVersionsField = 1,
-
-    /// Capabilities contains only unsupported ciphersuites.
-    UnsupportedCiphersuite = 2,
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[repr(u16)]
-pub enum KeyPackageIdError {
-    /// Invalid key package ID extensions.
-    Invalid = 0,
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[repr(u16)]
-pub enum ParentHashError {
-    /// Invalid parent hash extensions.
-    Invalid = 0,
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[repr(u16)]
-pub enum RatchetTreeError {
-    /// Invalid ratchet tree extensions.
-    Invalid = 0,
-}
-
-implement_enum_display!(ExtensionError);
-implement_enum_display!(LifetimeExtensionError);
-implement_enum_display!(CapabilitiesExtensionError);
-implement_enum_display!(KeyPackageIdError);
-implement_enum_display!(ParentHashError);
-implement_enum_display!(RatchetTreeError);
-
-impl Error for ExtensionError {
-    fn description(&self) -> &str {
-        match self {
-            Self::DecodingError => "Error decoding an extension.",
-            Self::InvalidExtensionType => {
-                "The requested extension type is not supported by OpenMLS."
-            }
-            Self::Capabilities(e) => match e {
-                CapabilitiesExtensionError::Invalid => "Error decoding a capabilities extensions.",
-                CapabilitiesExtensionError::EmptyVersionsField => {
-                    "The versions field in the extension is empty."
-                }
-                CapabilitiesExtensionError::UnsupportedCiphersuite => {
-                    "No supported ciphersuite in the extension."
-                }
-            },
-            Self::KeyPackageId(e) => match e {
-                KeyPackageIdError::Invalid => "Error decoding a key package id extension.",
-            },
-            Self::ParentHash(e) => match e {
-                ParentHashError::Invalid => "Error decoding a parent hash extension.",
-            },
-            Self::RatchetTree(e) => match e {
-                RatchetTreeError::Invalid => "Error decoding a ratchet tree extension.",
-            },
-            Self::Lifetime(e) => match e {
-                LifetimeExtensionError::Invalid => "Invalid lifetime extension.",
-                LifetimeExtensionError::Expired => "Lifetime extension is expired.",
-            },
-        }
+implement_error! {
+    pub enum ExtensionError {
+        InvalidExtensionType(ErrorString) =
+            "Invalid extension type error.",
+        Capabilities(CapabilitiesExtensionError) =
+            "Capabilities extension error. See `CapabilitiesExtensionError` for details.",
+        Lifetime(LifetimeExtensionError) =
+            "Lifetime extension error. See `LifetimeExtensionError` for details.",
+        KeyPackageId(KeyPackageIdError) =
+            "Key package ID extension error. See `KeyPackageIdError` for details.",
+        ParentHash(ParentHashError) =
+            "Parent hash extension error. See `ParentHashError` for details.",
+        RatchetTree(RatchetTreeError) =
+            "Ratchet tree extension error. See `RatchetTreeError` for details.",
+        CodecError(CodecError) =
+            "Error decoding or encoding an extension.",
+        ConfigError(ConfigError) =
+            "Configuration error. See `ConfigError` for details.",
+        InvalidExtension(InvalidExtensionError) =
+            "The extension is malformed. See [`InvalidExtensionError`](`InvalidExtensionError`) for details.",
     }
 }
 
-impl From<ConfigError> for ExtensionError {
-    fn from(_e: ConfigError) -> Self {
-        ExtensionError::InvalidExtensionType
+implement_error! {
+    pub enum LifetimeExtensionError {
+        Invalid = "Invalid lifetime extensions.",
+        Expired = "Lifetime extension is expired.",
     }
 }
 
-impl From<CodecError> for ExtensionError {
-    fn from(e: CodecError) -> Self {
-        match e {
-            CodecError::DecodingError => ExtensionError::DecodingError,
-            CodecError::EncodingError | CodecError::Other => {
-                panic!("Extension errors can't result from encoding errors.")
-            }
-        }
+implement_error! {
+    pub enum CapabilitiesExtensionError {
+        Invalid = "Invalid capabilities extensions.",
+        EmptyVersionsField = "Capabilities extension is missing a version field.",
+        UnsupportedCiphersuite = "Capabilities contains only unsupported ciphersuites.",
     }
 }
 
-impl From<ExtensionError> for CodecError {
-    fn from(_e: ExtensionError) -> Self {
-        CodecError::DecodingError
+implement_error! {
+    pub enum KeyPackageIdError {
+        Invalid = "Invalid key package ID extensions.",
+    }
+}
+
+implement_error! {
+    pub enum ParentHashError {
+        Invalid = "Invalid parent hash extensions.",
+    }
+}
+
+implement_error! {
+    pub enum RatchetTreeError {
+        Invalid = "Invalid ratchet tree extensions.",
+    }
+}
+
+implement_error! {
+    pub enum InvalidExtensionError {
+        Duplicate = "The provided extension list contains duplicate extensions.",
     }
 }

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -1,6 +1,6 @@
 use crate::ciphersuite::*;
 use crate::codec::*;
-use crate::creds::*;
+use crate::credentials::*;
 use crate::group::*;
 use crate::messages::{proposals::*, *};
 use crate::schedule::*;

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -92,7 +92,7 @@ fn context_presence() {
 #[test]
 fn unknown_sender() {
     use crate::config::*;
-    use crate::creds::*;
+    use crate::credentials::*;
     use crate::key_packages::*;
     use crate::utils::*;
 

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -28,28 +28,32 @@ implement_error! {
 
 implement_error! {
     pub enum WelcomeError {
-        CiphersuiteMismatch =
-            "Ciphersuites in the Welcome message and the corresponding key package bundle don't match.",
-        JoinerSecretNotFound =
-            "No joiner secret found in the Welcome message.",
-        MissingRatchetTree =
-            "No ratchet tree available to build initial tree after receiving a Welcome message",
-        TreeHashMismatch =
-            "The tree hash computed does not match the one in the GroupInfo.",
-        ConfirmationTagMismatch =
-             "The computed confirmation tag does not match the expected one.",
-        InvalidRatchetTree =
-            "Invalid ratchet tree in Welcome message.",
-        InvalidGroupInfoSignature =
-            "The signature on the GroupInfo is not valid.",
-        GroupInfoDecryptionFailure =
-            "Unable to decrypt the GroupInfo",
-        DuplicateRatchetTreeExtension =
-            "Found more than one ratchet tree extension in the Welcome message.",
-        UnsupportedMlsVersion =
-            "The Welcome message uses an unsupported MLS version",
-        UnknownError =
-            "An unknown error occurred.",
+        Simple {
+            CiphersuiteMismatch =
+                "Ciphersuites in the Welcome message and the corresponding key package bundle don't match.",
+            JoinerSecretNotFound =
+                "No joiner secret found in the Welcome message.",
+            MissingRatchetTree =
+                "No ratchet tree available to build initial tree after receiving a Welcome message",
+            TreeHashMismatch =
+                "The tree hash computed does not match the one in the GroupInfo.",
+            ConfirmationTagMismatch =
+                "The computed confirmation tag does not match the expected one.",
+            InvalidGroupInfoSignature =
+                "The signature on the GroupInfo is not valid.",
+            GroupInfoDecryptionFailure =
+                "Unable to decrypt the GroupInfo",
+            DuplicateRatchetTreeExtension =
+                "Found more than one ratchet tree extension in the Welcome message.",
+            UnsupportedMlsVersion =
+                "The Welcome message uses an unsupported MLS version",
+            UnknownError =
+                "An unknown error occurred.",
+        }
+        Complex {
+            InvalidRatchetTree(TreeError) =
+                "Invalid ratchet tree in Welcome message.",
+        }
     }
 }
 
@@ -95,16 +99,5 @@ implement_error! {
     pub enum ExporterError {
         KeyLengthTooLong =
             "The requested key length is not supported (too large).",
-    }
-}
-
-impl From<TreeError> for WelcomeError {
-    fn from(e: TreeError) -> WelcomeError {
-        match e {
-            TreeError::DuplicateIndex
-            | TreeError::InvalidArguments
-            | TreeError::InvalidUpdatePath => WelcomeError::InvalidRatchetTree,
-            TreeError::UnknownError => WelcomeError::UnknownError,
-        }
     }
 }

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -36,7 +36,7 @@ implement_error! {
             MissingRatchetTree =
                 "No ratchet tree available to build initial tree after receiving a Welcome message",
             TreeHashMismatch =
-                "The tree hash computed does not match the one in the GroupInfo.",
+                "The computed tree hash does not match the one in the GroupInfo.",
             ConfirmationTagMismatch =
                 "The computed confirmation tag does not match the expected one.",
             InvalidGroupInfoSignature =
@@ -44,7 +44,7 @@ implement_error! {
             GroupInfoDecryptionFailure =
                 "Unable to decrypt the GroupInfo",
             DuplicateRatchetTreeExtension =
-                "Found more than one ratchet tree extension in the Welcome message.",
+                "Found a duplicate ratchet tree extension in the Welcome message.",
             UnsupportedMlsVersion =
                 "The Welcome message uses an unsupported MLS version",
             UnknownError =

--- a/src/group/managed_group/callbacks.rs
+++ b/src/group/managed_group/callbacks.rs
@@ -1,4 +1,4 @@
-use crate::creds::*;
+use crate::credentials::*;
 use crate::group::*;
 
 /// Collection of callback functions that are passed to a `ManagedGroup` as part

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -5,7 +5,7 @@ mod ser;
 #[cfg(test)]
 mod test_managed_group;
 
-use crate::creds::{Credential, CredentialBundle};
+use crate::credentials::{Credential, CredentialBundle};
 use crate::framing::*;
 use crate::group::*;
 use crate::key_packages::{KeyPackage, KeyPackageBundle};

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -1,7 +1,7 @@
 use crate::ciphersuite::signable::Signable;
 use crate::codec::*;
 use crate::config::Config;
-use crate::creds::CredentialBundle;
+use crate::credentials::CredentialBundle;
 use crate::extensions::*;
 use crate::framing::*;
 use crate::group::mls_group::*;

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -9,7 +9,7 @@ mod test_mls_group;
 use crate::ciphersuite::*;
 use crate::codec::*;
 use crate::config::Config;
-use crate::creds::CredentialBundle;
+use crate::credentials::CredentialBundle;
 use crate::framing::*;
 use crate::group::*;
 use crate::key_packages::*;

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -111,7 +111,7 @@ impl MlsGroup {
         // TODO: #35 Why does this get the nodes? Shouldn't `new_from_nodes` consume the
         // nodes?
         if !RatchetTree::verify_integrity(&ciphersuite, &nodes) {
-            return Err(WelcomeError::InvalidRatchetTree);
+            return Err(WelcomeError::InvalidRatchetTree(TreeError::InvalidTree));
         }
 
         // Compute path secrets
@@ -138,7 +138,7 @@ impl MlsGroup {
                 .validate_public_keys(&new_public_keys, &common_path)
                 .is_err()
             {
-                return Err(WelcomeError::InvalidRatchetTree);
+                return Err(WelcomeError::InvalidRatchetTree(TreeError::InvalidTree));
             }
         }
 

--- a/src/key_packages/errors.rs
+++ b/src/key_packages/errors.rs
@@ -49,7 +49,7 @@ implement_enum_display!(KeyPackageError);
 impl From<ExtensionError> for KeyPackageError {
     fn from(e: ExtensionError) -> Self {
         match e {
-            ExtensionError::InvalidExtensionType => KeyPackageError::ExtensionNotPresent,
+            ExtensionError::InvalidExtensionType(_) => KeyPackageError::ExtensionNotPresent,
             _ => KeyPackageError::UnknownExtensionError,
         }
     }

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -5,7 +5,7 @@ use evercrypt::rand_util::*;
 use crate::ciphersuite::*;
 use crate::codec::*;
 use crate::config::{Config, ProtocolVersion};
-use crate::creds::*;
+use crate::credentials::*;
 use crate::extensions::{
     CapabilitiesExtension, Extension, ExtensionStruct, ExtensionType, LifetimeExtension,
     ParentHashExtension,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub mod error;
 mod ciphersuite;
 mod codec;
 pub mod config;
-mod creds;
+mod credentials;
 mod extensions;
 pub mod framing;
 pub mod group;

--- a/src/messages/errors.rs
+++ b/src/messages/errors.rs
@@ -1,25 +1,15 @@
 use crate::codec::*;
 
-use std::error::Error;
-
-#[derive(Debug)]
-pub enum ProposalQueueError {
-    ProposalNotFound,
-}
-
-implement_enum_display!(ProposalQueueError);
-
-impl Error for ProposalQueueError {
-    fn description(&self) -> &str {
-        match self {
-            Self::ProposalNotFound => "Not all proposals in the Commit were found locally.",
-        }
+implement_error! {
+    pub enum ProposalQueueError {
+        ProposalNotFound = "Not all proposals in the Commit were found locally.",
     }
 }
 
-#[derive(Debug)]
-pub enum ProposalOrRefTypeError {
-    UnknownValue,
+implement_error! {
+    pub enum ProposalOrRefTypeError {
+        UnknownValue = "Invalid value for ProposalOrRefType was found.",
+    }
 }
 
 impl From<ProposalOrRefTypeError> for CodecError {
@@ -28,27 +18,8 @@ impl From<ProposalOrRefTypeError> for CodecError {
     }
 }
 
-implement_enum_display!(ProposalOrRefTypeError);
-
-impl Error for ProposalOrRefTypeError {
-    fn description(&self) -> &str {
-        match self {
-            Self::UnknownValue => "Invalid value for ProposalOrRefType was found.",
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum QueuedProposalError {
-    WrongContentType,
-}
-
-implement_enum_display!(QueuedProposalError);
-
-impl Error for QueuedProposalError {
-    fn description(&self) -> &str {
-        match self {
-            Self::WrongContentType => "API misuse. Only proposals can end up in the proposal queue",
-        }
+implement_error! {
+    pub enum QueuedProposalError {
+        WrongContentType = "API misuse. Only proposals can end up in the proposal queue",
     }
 }

--- a/src/messages/test_proposals.rs
+++ b/src/messages/test_proposals.rs
@@ -1,5 +1,5 @@
 use crate::config::*;
-use crate::creds::*;
+use crate::credentials::*;
 use crate::extensions::*;
 use crate::framing::*;
 use crate::group::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,7 +16,7 @@ pub use crate::tree::index::LeafIndex;
 pub use crate::ciphersuite::*;
 pub use crate::codec::*;
 pub use crate::config::*;
-pub use crate::creds::*;
+pub use crate::credentials::*;
 pub use crate::extensions::*;
 pub use crate::framing::{errors::*, sender::Sender, *};
 pub use crate::group::GroupId;

--- a/src/tree/errors.rs
+++ b/src/tree/errors.rs
@@ -1,0 +1,15 @@
+use crate::config::ConfigError;
+
+implement_error! {
+    pub enum TreeError {
+        Simple {
+            InvalidArguments = "Invalid arguments.",
+            InvalidUpdatePath = "The computed update path is invalid.",
+            InvalidTree = "The tree is not valid.",
+        }
+        Complex {
+            ConfigError(ConfigError) =
+                "See [`ConfigError`](`crate::config::ConfigError`) for details.",
+        }
+    }
+}

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,12 +1,13 @@
 use crate::ciphersuite::*;
 use crate::codec::*;
-use crate::config::{Config, ConfigError};
-use crate::creds::*;
+use crate::config::Config;
+use crate::credentials::*;
 use crate::key_packages::*;
 use crate::messages::proposals::*;
 
 // Tree modules
 pub(crate) mod codec;
+pub(crate) mod errors;
 pub(crate) mod hash_input;
 pub mod index;
 pub mod node;
@@ -16,6 +17,7 @@ pub(crate) mod secret_tree;
 pub(crate) mod sender_ratchet;
 pub(crate) mod treemath;
 
+pub(crate) use errors::*;
 use hash_input::*;
 use index::*;
 use node::*;
@@ -908,26 +910,6 @@ impl UpdatePath {
         Self {
             leaf_key_package,
             nodes,
-        }
-    }
-}
-
-implement_error! {
-    pub enum TreeError {
-        InvalidArguments = "",
-        DuplicateIndex = "",
-        InvalidUpdatePath = "",
-        UnknownError = "",
-    }
-}
-
-// TODO: Should get fixed in #83
-impl From<ConfigError> for TreeError {
-    fn from(e: ConfigError) -> TreeError {
-        match e {
-            ConfigError::UnsupportedMlsVersion => TreeError::InvalidArguments,
-            ConfigError::UnsupportedCiphersuite => TreeError::InvalidArguments,
-            _ => TreeError::UnknownError,
         }
     }
 }

--- a/src/tree/test_private_tree.rs
+++ b/src/tree/test_private_tree.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 use super::{index::NodeIndex, private_tree::*, test_util::*};
 #[cfg(test)]
-use crate::{ciphersuite::*, creds::*, key_packages::*, utils::*};
+use crate::{ciphersuite::*, credentials::*, key_packages::*, utils::*};
 
 #[cfg(test)]
 // Common setup for tests.

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -102,7 +102,7 @@ fn test_dir_path() {
 fn test_tree_hash() {
     use crate::ciphersuite::*;
     use crate::config::*;
-    use crate::creds::*;
+    use crate::credentials::*;
     use crate::tree::*;
 
     fn create_identity(id: &[u8], ciphersuite_name: CiphersuiteName) -> KeyPackageBundle {


### PR DESCRIPTION
This PR finishes the error rewrite. It also introduces a new type of errors.
Now the following is allowed as well.
```Rust
implement_error! {
    pub enum CredentialError {
        Simple {
            UnsupportedCredentialType = "Unsupported credential type",
        }
        Complex {
            ConfigError(ConfigError) = "See `ConfigError` for details.",
            CryptoError(CryptoError) = "See `CryptoError` for details.",
        }
    }
}
```

fixes #83 