### PR TITLE
Throw an error when trying to add or remove members with an empty input

### DIFF
--- a/src/group/managed_group/errors.rs
+++ b/src/group/managed_group/errors.rs
@@ -26,6 +26,15 @@ implement_error! {
             "See [`PendingProposalsError`](`PendingProposalsError`) for details",
         Exporter(ExporterError) =
             "See [`ExporterError`](`crate::group::ExporterError`) for details",
+        EmptyInput(EmptyInputError) =
+            "Empty input. Additional detail is provided.",
+    }
+}
+
+implement_error! {
+    pub enum EmptyInputError {
+        AddMembers = "An empty list of KeyPackages was provided.",
+        RemoveMembers = "An empty list of indexes was provided.",
     }
 }
 

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -18,7 +18,10 @@ use std::io::{Error, Read, Write};
 
 pub use callbacks::*;
 pub use config::*;
-pub use errors::{InvalidMessageError, ManagedGroupError, PendingProposalsError, UseAfterEviction};
+pub use errors::{
+    EmptyInputError, InvalidMessageError, ManagedGroupError, PendingProposalsError,
+    UseAfterEviction,
+};
 use ser::*;
 
 /// A `ManagedGroup` represents an [MlsGroup] with
@@ -150,6 +153,10 @@ impl<'a> ManagedGroup<'a> {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
+        if key_packages.is_empty() {
+            return Err(ManagedGroupError::EmptyInput(EmptyInputError::AddMembers));
+        }
+
         // Create add proposals by value from key packages
         let proposals = key_packages
             .iter()
@@ -213,6 +220,12 @@ impl<'a> ManagedGroup<'a> {
     ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+        }
+
+        if members.is_empty() {
+            return Err(ManagedGroupError::EmptyInput(
+                EmptyInputError::RemoveMembers,
+            ));
         }
 
         // Create add proposals by value

--- a/src/group/managed_group/test_managed_group.rs
+++ b/src/group/managed_group/test_managed_group.rs
@@ -1,7 +1,5 @@
 use crate::prelude::*;
 
-use super::errors::EmptyInputError;
-
 #[test]
 fn test_managed_group_persistence() {
     use std::fs::File;
@@ -49,47 +47,4 @@ fn test_managed_group_persistence() {
     .expect("Could not deserialize managed group");
 
     assert_eq!(alice_group, alice_group_deserialized);
-}
-
-#[test]
-fn test_empty_input_errors() {
-    let ciphersuite = &Config::supported_ciphersuites()[0];
-    let group_id = GroupId::from_slice(b"Test Group");
-
-    // Define credential bundles
-    let alice_credential_bundle =
-        CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite.name()).unwrap();
-
-    // Generate KeyPackages
-    let alice_key_package_bundle =
-        KeyPackageBundle::new(&[ciphersuite.name()], &alice_credential_bundle, vec![]).unwrap();
-
-    // Define the managed group configuration
-
-    let update_policy = UpdatePolicy::default();
-    let callbacks = ManagedGroupCallbacks::default();
-    let managed_group_config =
-        ManagedGroupConfig::new(HandshakeMessageFormat::Plaintext, update_policy, callbacks);
-
-    // === Alice creates a group ===
-    let mut alice_group = ManagedGroup::new(
-        &alice_credential_bundle,
-        &managed_group_config,
-        group_id,
-        alice_key_package_bundle,
-    )
-    .unwrap();
-
-    assert_eq!(
-        alice_group
-            .add_members(&[])
-            .expect_err("No EmptyInputError when trying to pass an empty slice to `add_members`."),
-        ManagedGroupError::EmptyInput(EmptyInputError::AddMembers)
-    );
-    assert_eq!(
-        alice_group.remove_members(&[]).expect_err(
-            "No EmptyInputError when trying to pass an empty slice to `remove_members`."
-        ),
-        ManagedGroupError::EmptyInput(EmptyInputError::RemoveMembers)
-    );
 }

--- a/tests/test_managed_group.rs
+++ b/tests/test_managed_group.rs
@@ -1,4 +1,4 @@
-use openmls::prelude::*;
+use openmls::{group::EmptyInputError, prelude::*};
 
 use std::fs::File;
 use std::path::Path;
@@ -633,4 +633,47 @@ fn managed_group_operations() {
             );
         }
     }
+}
+
+#[test]
+fn test_empty_input_errors() {
+    let ciphersuite = &Config::supported_ciphersuites()[0];
+    let group_id = GroupId::from_slice(b"Test Group");
+
+    // Define credential bundles
+    let alice_credential_bundle =
+        CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite.name()).unwrap();
+
+    // Generate KeyPackages
+    let alice_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite.name()], &alice_credential_bundle, vec![]).unwrap();
+
+    // Define the managed group configuration
+
+    let update_policy = UpdatePolicy::default();
+    let callbacks = ManagedGroupCallbacks::default();
+    let managed_group_config =
+        ManagedGroupConfig::new(HandshakeMessageFormat::Plaintext, update_policy, callbacks);
+
+    // === Alice creates a group ===
+    let mut alice_group = ManagedGroup::new(
+        &alice_credential_bundle,
+        &managed_group_config,
+        group_id,
+        alice_key_package_bundle,
+    )
+    .unwrap();
+
+    assert_eq!(
+        alice_group
+            .add_members(&[])
+            .expect_err("No EmptyInputError when trying to pass an empty slice to `add_members`."),
+        ManagedGroupError::EmptyInput(EmptyInputError::AddMembers)
+    );
+    assert_eq!(
+        alice_group.remove_members(&[]).expect_err(
+            "No EmptyInputError when trying to pass an empty slice to `remove_members`."
+        ),
+        ManagedGroupError::EmptyInput(EmptyInputError::RemoveMembers)
+    );
 }


### PR DESCRIPTION
What it says on the title, plus a test.

This was originally committed as part of
280a81eab31608de537683a9aa7370d06945e5a4 by @raphaelrobert.