### PR TITLE
Proc macro to test all ciphersuites

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "delivery-service/ds-lib",
     "delivery-service/ds",
     "cli",
+    "test_macros",
 ]
 default-members = [ "." ]
 
@@ -40,6 +41,7 @@ criterion = "^0.3"
 flexi_logger = "0.17"
 pretty_env_logger = "0.4.0"
 itertools = "0.10"
+test_macros = { path = "test_macros" }
 
 
 [[bench]]

--- a/test_macros/Cargo.toml
+++ b/test_macros/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test_macros"
+version = "0.1.0"
+authors = ["Franziskus Kiefer <franziskuskiefer@gmail.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+openmls = { path = "../" }
+syn = "1.0"
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/test_macros/src/lib.rs
+++ b/test_macros/src/lib.rs
@@ -1,0 +1,53 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Ident, Span};
+use quote::quote;
+use syn::{
+    parse::Result,
+    parse::{Parse, ParseStream},
+    parse_macro_input, Block,
+};
+
+struct TestInput {
+    test_name: Ident,
+    body: Block,
+}
+
+impl Parse for TestInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            test_name: input.parse()?,
+            body: input.parse()?,
+        })
+    }
+}
+
+#[proc_macro]
+pub fn ctest(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as TestInput);
+    impl_ciphersuite_tests(input).unwrap()
+}
+
+fn impl_ciphersuite_tests(input: TestInput) -> Result<TokenStream> {
+    let ast = input.body;
+    let test_name = input.test_name;
+    let tests = openmls::config::Config::supported_ciphersuite_names()
+        .into_iter()
+        .map(|&ciphersuite_name| {
+            let ciphersuite_code = ciphersuite_name as u16;
+            let test_name = Ident::new(
+                &format!("{}_{}", test_name.to_string(), ciphersuite_name),
+                Span::call_site(),
+            );
+            quote! {
+                #[test]
+                fn #test_name () {
+                    let _ciphersuite_code = #ciphersuite_code;
+                    #ast
+                }
+            }
+        });
+    let gen = quote! {
+        #(#tests)*
+    };
+    Ok(gen.into())
+}

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -1,117 +1,76 @@
 //! # Key package tests
 
 use openmls::prelude::*;
+use std::convert::TryFrom;
+use test_macros::ctest;
 
-macro_rules! key_package_generation {
-    ($name:ident, $ciphersuite:expr, $supported:literal) => {
-        #[test]
-        fn $name() {
-            if !$supported {
-                // TODO: enable more testing for unsupported ciphersuites when they return
-                // errors.
-                return;
-            }
-            let ciphersuite = Config::ciphersuite($ciphersuite).unwrap();
-            let supported_ciphersuites = Config::supported_ciphersuite_names();
-            assert_eq!($supported, supported_ciphersuites.contains(&$ciphersuite));
-            let id = vec![1, 2, 3];
-            let credential_bundle =
-                CredentialBundle::new(id, CredentialType::Basic, ciphersuite.signature_scheme())
-                    .unwrap();
-            let mut kpb =
-                KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new())
-                    .unwrap();
+ctest!(key_package_generation {
+    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+    println!("Testing ciphersuite {:?}", ciphersuite_name);
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
-            // After creation, the signature should be ok.
-            assert!(kpb.key_package().verify().is_ok());
+    let id = vec![1, 2, 3];
+    let credential_bundle =
+        CredentialBundle::new(id, CredentialType::Basic, ciphersuite.signature_scheme()).unwrap();
+    let mut kpb =
+        KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new()).unwrap();
 
-            {
-                let extensions = kpb.key_package().extensions();
+    // After creation, the signature should be ok.
+    assert!(kpb.key_package().verify().is_ok());
 
-                // The capabilities extension must be present and valid.
-                // It's added automatically.
-                let capabilities_extension = extensions
-                    .iter()
-                    .find(|e| e.extension_type() == ExtensionType::Capabilities)
-                    .expect("Capabilities extension is missing in key package");
-                let capabilities_extension =
-                    capabilities_extension.to_capabilities_extension().unwrap();
+    {
+        let extensions = kpb.key_package().extensions();
 
-                // Only the single ciphersuite is set.
-                assert_eq!(1, capabilities_extension.ciphersuites().len());
-                assert_eq!($ciphersuite, capabilities_extension.ciphersuites()[0]);
+        // The capabilities extension must be present and valid.
+        // It's added automatically.
+        let capabilities_extension = extensions
+            .iter()
+            .find(|e| e.extension_type() == ExtensionType::Capabilities)
+            .expect("Capabilities extension is missing in key package");
+        let capabilities_extension = capabilities_extension.to_capabilities_extension().unwrap();
 
-                // Check supported versions.
-                assert_eq!(
-                    Config::supported_versions(),
-                    capabilities_extension.versions()
-                );
+        // Only the single ciphersuite is set.
+        assert_eq!(1, capabilities_extension.ciphersuites().len());
+        assert_eq!(ciphersuite_name, capabilities_extension.ciphersuites()[0]);
 
-                // Check supported extensions.
-                assert_eq!(
-                    Config::supported_extensions(),
-                    capabilities_extension.extensions()
-                );
+        // Check supported versions.
+        assert_eq!(
+            Config::supported_versions(),
+            capabilities_extension.versions()
+        );
 
-                // Get the lifetime extension. It's added automatically.
-                let lifetime_extension = extensions
-                    .iter()
-                    .find(|e| e.extension_type() == ExtensionType::Lifetime)
-                    .expect("Lifetime extension is missing in key package");
-                let _lifetime_extension = lifetime_extension.to_lifetime_extension().unwrap();
-            }
+        // Check supported extensions.
+        assert_eq!(
+            Config::supported_extensions(),
+            capabilities_extension.extensions()
+        );
 
-            // Add and retrieve a key package ID.
-            let key_id = [1, 2, 3, 4, 5, 6, 7];
-            kpb.key_package_mut()
-                .add_extension(Box::new(KeyIDExtension::new(&key_id)));
+        // Get the lifetime extension. It's added automatically.
+        let lifetime_extension = extensions
+            .iter()
+            .find(|e| e.extension_type() == ExtensionType::Lifetime)
+            .expect("Lifetime extension is missing in key package");
+        let _lifetime_extension = lifetime_extension.to_lifetime_extension().unwrap();
+    }
 
-            // The key package is invalid because the signature is invalid now.
-            assert!(kpb.key_package().verify().is_err());
+    // Add and retrieve a key package ID.
+    let key_id = [1, 2, 3, 4, 5, 6, 7];
+    kpb.key_package_mut()
+        .add_extension(Box::new(KeyIDExtension::new(&key_id)));
 
-            // After re-signing the package it is valid.
-            kpb.key_package_mut().sign(&credential_bundle);
-            assert!(kpb.key_package().verify().is_ok());
+    // The key package is invalid because the signature is invalid now.
+    assert!(kpb.key_package().verify().is_err());
 
-            // Get the key ID extension.
-            let extensions = kpb.key_package().extensions();
-            let key_id_extension = extensions
-                .iter()
-                .find(|e| e.extension_type() == ExtensionType::KeyID)
-                .expect("Key ID extension is missing in key package");
-            let key_id_extension = key_id_extension.to_key_id_extension().unwrap();
-            assert_eq!(&key_id, key_id_extension.as_slice());
-        }
-    };
-}
+    // After re-signing the package it is valid.
+    kpb.key_package_mut().sign(&credential_bundle);
+    assert!(kpb.key_package().verify().is_ok());
 
-key_package_generation!(
-    key_package_0x0001,
-    CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
-    true
-);
-key_package_generation!(
-    key_package_0x0002,
-    CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256,
-    true
-);
-key_package_generation!(
-    key_package_0x0003,
-    CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
-    true
-);
-key_package_generation!(
-    key_package_0x0004,
-    CiphersuiteName::MLS10_256_DHKEMX448_AES256GCM_SHA512_Ed448,
-    false
-);
-key_package_generation!(
-    key_package_0x0005,
-    CiphersuiteName::MLS10_256_DHKEMP521_AES256GCM_SHA512_P521,
-    false
-);
-key_package_generation!(
-    key_package_0x0006,
-    CiphersuiteName::MLS10_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448,
-    false
-);
+    // Get the key ID extension.
+    let extensions = kpb.key_package().extensions();
+    let key_id_extension = extensions
+        .iter()
+        .find(|e| e.extension_type() == ExtensionType::KeyID)
+        .expect("Key ID extension is missing in key package");
+    let key_id_extension = key_id_extension.to_key_id_extension().unwrap();
+    assert_eq!(&key_id, key_id_extension.as_slice());
+});


### PR DESCRIPTION
This PR adds a new crate `test_macros` that exposes a proc-macro
`ctest` that allows defining tests for all supported ciphersuites
as follows

```
ctest!(test_name {
  // test body
})
```

This is used to replace the existing tests in tests/test-key_packages.rs