### PR TITLE
TLS codec crate & derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,14 @@ members = [
     "delivery-service/ds-lib",
     "delivery-service/ds",
     "cli",
+    "tls-codec",
+    "tls-codec-derive",
 ]
-default-members = [ "." ]
+default-members = [
+    ".",
+    "tls-codec",
+    "tls-codec-derive",
+]
 
 [dependencies]
 uuid = { version = "0.8", features = ["v4"] }
@@ -25,6 +31,7 @@ byteorder = "^1.3"
 lazy_static = "1.4"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
+tls-codec = { version = "0.1", path = "tls-codec", features = ["derive", "hpke"] }
 log = { version = "0.4", features = ["std"] }
 typetag = "0.1"
 hpke = { version = "0.0.4", package = "hpke-rs", features = ["hazmat", "serialization"] }

--- a/tls-codec-derive/Cargo.toml
+++ b/tls-codec-derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tls-codec-derive"
+version = "0.1.0"
+authors = ["Franziskus Kiefer <franziskuskiefer@gmail.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0", features = ["parsing"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[dev-dependencies]
+tls-codec = { version = "0.1", path = "../tls-codec" }

--- a/tls-codec-derive/src/lib.rs
+++ b/tls-codec-derive/src/lib.rs
@@ -1,0 +1,178 @@
+extern crate proc_macro;
+extern crate proc_macro2;
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{quote, ToTokens};
+use syn::{
+    self, parenthesized,
+    parse::{ParseStream, Parser, Result},
+    parse_macro_input, Data, DeriveInput, Fields, FieldsNamed, Ident,
+};
+
+#[proc_macro_derive(TlsSerialize)]
+pub fn serialize_macro_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    impl_serialize(ast).unwrap()
+}
+
+fn impl_serialize(ast: DeriveInput) -> Result<TokenStream> {
+    let call_site = Span::call_site();
+    let ident = &ast.ident;
+    match ast.data {
+        Data::Struct(st) => match st.fields {
+            Fields::Named(FieldsNamed { named, .. }) => {
+                let idents = named.iter().map(|f| &f.ident);
+
+                let gen = quote! {
+                    impl tls_codec::Serialize for #ident {
+                        fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), tls_codec::Error> {
+                            #(self.#idents.tls_serialize(buffer)?;)*
+                            Ok(())
+                        }
+                    }
+                };
+                Ok(gen.into())
+            }
+            _ => unimplemented!(),
+        },
+        // Enums.
+        // Note that they require a repr attribute.
+        Data::Enum(syn::DataEnum { variants, .. }) => {
+            let mut repr = None;
+            for attr in ast.attrs {
+                if attr.path.is_ident("repr") {
+                    fn repr_arg(input: ParseStream) -> Result<Ident> {
+                        let content;
+                        parenthesized!(content in input);
+                        content.parse()
+                    }
+                    let ty = repr_arg.parse2(attr.tokens)?;
+                    repr = Some(ty);
+                    break;
+                }
+            }
+            let repr = repr.ok_or(syn::Error::new(call_site, "missing #[repr(...)] attribute"))?;
+            let variants = variants.iter().map(|variant| {
+                let variant = &variant.ident;
+                quote! {
+                    #ident::#variant => #ident::#variant as #repr,
+                }
+            });
+
+            let gen = quote! {
+                impl tls_codec::Serialize for #ident {
+                    fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), tls_codec::Error> {
+                        let enum_value: #repr = match self {
+                            #(#variants)*
+                        };
+                        enum_value.tls_serialize(buffer)
+                    }
+                }
+            };
+            Ok(gen.into())
+        }
+        Data::Union(_) => unimplemented!(),
+    }
+}
+
+#[proc_macro_derive(TlsDeserialize)]
+pub fn deserialize_macro_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    impl_deserialize(ast).unwrap()
+}
+
+fn impl_deserialize(ast: DeriveInput) -> Result<TokenStream> {
+    let call_site = Span::call_site();
+    let ident = &ast.ident;
+    match ast.data {
+        Data::Struct(st) => match st.fields {
+            Fields::Named(FieldsNamed { named, .. }) => {
+                let idents = named.iter().map(|f| &f.ident);
+                let paths = named.iter().map(|f| match f.ty.clone() {
+                    syn::Type::Path(mut p) => {
+                        let path = &mut p.path;
+                        // Convert generic arguments in the path to const arguments.
+                        path.segments
+                            .iter_mut()
+                            .for_each(|mut p| match &mut p.arguments {
+                                syn::PathArguments::AngleBracketed(ab) => {
+                                    let mut ab = ab.clone();
+                                    ab.colon2_token = Some(syn::token::Colon2::default());
+                                    p.arguments = syn::PathArguments::AngleBracketed(ab);
+                                }
+                                _ => (),
+                            });
+                        syn::Type::Path(p).to_token_stream()
+                    }
+                    syn::Type::Array(a) => {
+                        quote! { <#a> }
+                    }
+                    _ => panic!(format!("Invalid field type for {:?}", f.ident)),
+                });
+
+                let gen = quote! {
+                    impl tls_codec::Deserialize for #ident {
+                        fn tls_deserialize(cursor: &tls_codec::Cursor) -> Result<Self, tls_codec::Error> {
+                            Ok(Self {
+                                #(#idents: #paths::tls_deserialize(cursor)?,)*
+                            })
+                        }
+                    }
+                };
+                Ok(gen.into())
+            }
+            _ => unimplemented!(),
+        },
+        // Enums.
+        // Note that they require a repr attribute.
+        Data::Enum(syn::DataEnum { variants, .. }) => {
+            let mut repr = None;
+            for attr in ast.attrs {
+                if attr.path.is_ident("repr") {
+                    fn repr_arg(input: ParseStream) -> Result<Ident> {
+                        let content;
+                        parenthesized!(content in input);
+                        content.parse()
+                    }
+                    let ty = repr_arg.parse2(attr.tokens)?;
+                    repr = Some(ty);
+                    break;
+                }
+            }
+            let repr = repr.ok_or(syn::Error::new(call_site, "missing #[repr(...)] attribute"))?;
+
+            let discriminants = variants.iter().map(|variant| {
+                let variant = &variant.ident;
+                quote! {
+                    const #variant: #repr = #ident::#variant as #repr;
+                }
+            });
+
+            let matched = variants.iter().map(|variant| {
+                let variant = &variant.ident;
+                quote! {
+                    #variant => core::result::Result::Ok(#ident::#variant),
+                }
+            });
+
+            let gen = quote! {
+                impl tls_codec::Deserialize for #ident {
+                    #[allow(non_upper_case_globals)]
+                    fn tls_deserialize(cursor: &tls_codec::Cursor) -> Result<Self, tls_codec::Error> {
+                        #(#discriminants)*
+
+                        let value = #repr::tls_deserialize(cursor)?;
+                        match value {
+                            #(#matched)*
+                            // XXX: This assumes non-exhaustive matches only.
+                            _ => Err(tls_codec::Error::DecodingError),
+                        }
+                    }
+                }
+            };
+            Ok(gen.into())
+        }
+        Data::Union(_) => unimplemented!(),
+    }
+}

--- a/tls-codec-derive/src/lib.rs
+++ b/tls-codec-derive/src/lib.rs
@@ -52,7 +52,8 @@ fn impl_serialize(ast: DeriveInput) -> Result<TokenStream> {
                     break;
                 }
             }
-            let repr = repr.ok_or(syn::Error::new(call_site, "missing #[repr(...)] attribute"))?;
+            let repr =
+                repr.ok_or_else(|| syn::Error::new(call_site, "missing #[repr(...)] attribute"))?;
             let variants = variants.iter().map(|variant| {
                 let variant = &variant.ident;
                 quote! {
@@ -93,16 +94,13 @@ fn impl_deserialize(ast: DeriveInput) -> Result<TokenStream> {
                     syn::Type::Path(mut p) => {
                         let path = &mut p.path;
                         // Convert generic arguments in the path to const arguments.
-                        path.segments
-                            .iter_mut()
-                            .for_each(|mut p| match &mut p.arguments {
-                                syn::PathArguments::AngleBracketed(ab) => {
-                                    let mut ab = ab.clone();
-                                    ab.colon2_token = Some(syn::token::Colon2::default());
-                                    p.arguments = syn::PathArguments::AngleBracketed(ab);
-                                }
-                                _ => (),
-                            });
+                        path.segments.iter_mut().for_each(|mut p| {
+                            if let syn::PathArguments::AngleBracketed(ab) = &mut p.arguments {
+                                let mut ab = ab.clone();
+                                ab.colon2_token = Some(syn::token::Colon2::default());
+                                p.arguments = syn::PathArguments::AngleBracketed(ab);
+                            }
+                        });
                         syn::Type::Path(p).to_token_stream()
                     }
                     syn::Type::Array(a) => {
@@ -140,7 +138,8 @@ fn impl_deserialize(ast: DeriveInput) -> Result<TokenStream> {
                     break;
                 }
             }
-            let repr = repr.ok_or(syn::Error::new(call_site, "missing #[repr(...)] attribute"))?;
+            let repr =
+                repr.ok_or_else(|| syn::Error::new(call_site, "missing #[repr(...)] attribute"))?;
 
             let discriminants = variants.iter().map(|variant| {
                 let variant = &variant.ident;

--- a/tls-codec-derive/tests/decode.rs
+++ b/tls-codec-derive/tests/decode.rs
@@ -33,7 +33,7 @@ pub struct ArrayWrap {
 #[test]
 fn simple_enum() {
     let b = [0, 5];
-    let deserialized = ExtensionType::deserialize_detached(&b).unwrap();
+    let deserialized = ExtensionType::tls_deserialize_detached(&b).unwrap();
     assert_eq!(ExtensionType::RatchetTree, deserialized);
 
     let b = [0, 5, 1, 244, 0, 1];
@@ -56,7 +56,7 @@ fn simple_struct() {
         extension_type: ExtensionType::KeyID,
         extension_data: TlsVecU16::from_slice(&[1, 2, 3, 4, 5]),
     };
-    let deserialized = ExtensionStruct::deserialize_detached(&b).unwrap();
+    let deserialized = ExtensionStruct::tls_deserialize_detached(&b).unwrap();
     assert_eq!(extension, deserialized);
 
     let b = [8, 0, 1, 0, 2, 0, 3, 1, 244];
@@ -68,24 +68,24 @@ fn simple_struct() {
             ExtensionType::SomethingElse,
         ]),
     };
-    let deserialized = ExtensionTypeVec::deserialize_detached(&b).unwrap();
+    let deserialized = ExtensionTypeVec::tls_deserialize_detached(&b).unwrap();
     assert_eq!(extension, deserialized);
 }
 
 #[test]
 fn byte_arrays() {
     let x = [0u8, 1, 2, 3];
-    let serialized = x.serialize_detached().unwrap();
+    let serialized = x.tls_serialize_detached().unwrap();
     assert_eq!(x.to_vec(), serialized);
 
-    let y = <[u8; 4]>::deserialize_detached(&serialized).unwrap();
+    let y = <[u8; 4]>::tls_deserialize_detached(&serialized).unwrap();
     assert_eq!(y, x);
 
     let x = [0u8, 1, 2, 3, 7, 6, 5, 4];
     let w = ArrayWrap { data: x.clone() };
-    let serialized = x.serialize_detached().unwrap();
+    let serialized = x.tls_serialize_detached().unwrap();
     assert_eq!(x.to_vec(), serialized);
 
-    let y = ArrayWrap::deserialize_detached(&serialized).unwrap();
+    let y = ArrayWrap::tls_deserialize_detached(&serialized).unwrap();
     assert_eq!(y, w);
 }

--- a/tls-codec-derive/tests/decode.rs
+++ b/tls-codec-derive/tests/decode.rs
@@ -1,0 +1,91 @@
+use tls_codec::{Cursor, Deserialize, Serialize, TlsVecU16, TlsVecU8};
+use tls_codec_derive::{TlsDeserialize, TlsSerialize};
+
+#[derive(TlsDeserialize, Debug, PartialEq, Clone, Copy, TlsSerialize)]
+#[allow(dead_code)]
+#[repr(u16)]
+pub enum ExtensionType {
+    Reserved = 0,
+    Capabilities = 1,
+    Lifetime = 2,
+    KeyID = 3,
+    ParentHash = 4,
+    RatchetTree = 5,
+    SomethingElse = 500,
+}
+
+#[derive(TlsDeserialize, Debug, PartialEq, TlsSerialize)]
+pub struct ExtensionStruct {
+    extension_type: ExtensionType,
+    extension_data: TlsVecU16<u8>,
+}
+
+#[derive(TlsDeserialize, Debug, PartialEq, TlsSerialize)]
+pub struct ExtensionTypeVec {
+    data: TlsVecU8<ExtensionType>,
+}
+
+#[derive(TlsDeserialize, Debug, PartialEq, TlsSerialize)]
+pub struct ArrayWrap {
+    data: [u8; 8],
+}
+
+#[test]
+fn simple_enum() {
+    let b = [0, 5, 1, 99];
+    let deserialized = ExtensionType::deserialize_detached(&b).unwrap();
+    assert_eq!(ExtensionType::RatchetTree, deserialized);
+
+    let b = [0, 5, 1, 244, 0, 1];
+    let variants = [
+        ExtensionType::RatchetTree,
+        ExtensionType::SomethingElse,
+        ExtensionType::Capabilities,
+    ];
+    let c = Cursor::new(&b);
+    for variant in variants.iter() {
+        let deserialized = ExtensionType::tls_deserialize(&c).unwrap();
+        assert_eq!(variant, &deserialized);
+    }
+}
+
+#[test]
+fn simple_struct() {
+    let b = [0, 3, 0, 5, 1, 2, 3, 4, 5];
+    let extension = ExtensionStruct {
+        extension_type: ExtensionType::KeyID,
+        extension_data: TlsVecU16::from_slice(&[1, 2, 3, 4, 5]),
+    };
+    let deserialized = ExtensionStruct::deserialize_detached(&b).unwrap();
+    assert_eq!(extension, deserialized);
+
+    let b = [8, 0, 1, 0, 2, 0, 3, 1, 244];
+    let extension = ExtensionTypeVec {
+        data: TlsVecU8::from_slice(&[
+            ExtensionType::Capabilities,
+            ExtensionType::Lifetime,
+            ExtensionType::KeyID,
+            ExtensionType::SomethingElse,
+        ]),
+    };
+    let deserialized = ExtensionTypeVec::deserialize_detached(&b).unwrap();
+    assert_eq!(extension, deserialized);
+}
+
+#[test]
+fn byte_arrays() {
+    let x = [0u8, 1, 2, 3];
+    let serialized = x.serialize_detached().unwrap();
+    assert_eq!(x.to_vec(), serialized);
+
+    let y = <[u8; 4]>::deserialize_detached(&serialized).unwrap();
+    assert_eq!(y, x);
+
+    let x = [0u8, 1, 2, 3, 7, 6, 5, 4];
+    let w = ArrayWrap { data: x.clone() };
+    let serialized = x.serialize_detached().unwrap();
+    assert_eq!(x.to_vec(), serialized);
+
+    let y = ArrayWrap::deserialize_detached(&serialized).unwrap();
+    assert_eq!(y, w);
+}

--- a/tls-codec-derive/tests/decode.rs
+++ b/tls-codec-derive/tests/decode.rs
@@ -32,7 +32,7 @@ pub struct ArrayWrap {
 
 #[test]
 fn simple_enum() {
-    let b = [0, 5, 1, 99];
+    let b = [0, 5];
     let deserialized = ExtensionType::deserialize_detached(&b).unwrap();
     assert_eq!(ExtensionType::RatchetTree, deserialized);
 

--- a/tls-codec-derive/tests/encode.rs
+++ b/tls-codec-derive/tests/encode.rs
@@ -24,7 +24,9 @@ pub struct ExtensionStruct {
 fn simple_enum() {
     let serialized = ExtensionType::KeyID.tls_serialize_detached().unwrap();
     assert_eq!(vec![0, 3], serialized);
-    let serialized = ExtensionType::SomethingElse.tls_serialize_detached().unwrap();
+    let serialized = ExtensionType::SomethingElse
+        .tls_serialize_detached()
+        .unwrap();
     assert_eq!(vec![1, 244], serialized);
 }
 

--- a/tls-codec-derive/tests/encode.rs
+++ b/tls-codec-derive/tests/encode.rs
@@ -22,9 +22,9 @@ pub struct ExtensionStruct {
 
 #[test]
 fn simple_enum() {
-    let serialized = ExtensionType::KeyID.serialize_detached().unwrap();
+    let serialized = ExtensionType::KeyID.tls_serialize_detached().unwrap();
     assert_eq!(vec![0, 3], serialized);
-    let serialized = ExtensionType::SomethingElse.serialize_detached().unwrap();
+    let serialized = ExtensionType::SomethingElse.tls_serialize_detached().unwrap();
     assert_eq!(vec![1, 244], serialized);
 }
 
@@ -34,13 +34,13 @@ fn simple_struct() {
         extension_type: ExtensionType::KeyID,
         extension_data: TlsVecU16::from_slice(&[1, 2, 3, 4, 5]),
     };
-    let serialized = extension.serialize_detached().unwrap();
+    let serialized = extension.tls_serialize_detached().unwrap();
     assert_eq!(vec![0, 3, 0, 5, 1, 2, 3, 4, 5], serialized);
 }
 
 #[test]
 fn byte_arrays() {
     let x = [0u8, 1, 2, 3];
-    let serialized = x.serialize_detached().unwrap();
+    let serialized = x.tls_serialize_detached().unwrap();
     assert_eq!(vec![0, 1, 2, 3], serialized);
 }

--- a/tls-codec-derive/tests/encode.rs
+++ b/tls-codec-derive/tests/encode.rs
@@ -1,0 +1,46 @@
+use tls_codec::{Serialize, TlsVecU16};
+use tls_codec_derive::TlsSerialize;
+
+#[derive(TlsSerialize, Debug)]
+#[allow(dead_code)]
+#[repr(u16)]
+pub enum ExtensionType {
+    Reserved = 0,
+    Capabilities = 1,
+    Lifetime = 2,
+    KeyID = 3,
+    ParentHash = 4,
+    RatchetTree = 5,
+    SomethingElse = 500,
+}
+
+#[derive(TlsSerialize, Debug)]
+pub struct ExtensionStruct {
+    extension_type: ExtensionType,
+    extension_data: TlsVecU16<u8>,
+}
+
+#[test]
+fn simple_enum() {
+    let serialized = ExtensionType::KeyID.serialize_detached().unwrap();
+    assert_eq!(vec![0, 3], serialized);
+    let serialized = ExtensionType::SomethingElse.serialize_detached().unwrap();
+    assert_eq!(vec![1, 244], serialized);
+}
+
+#[test]
+fn simple_struct() {
+    let extension = ExtensionStruct {
+        extension_type: ExtensionType::KeyID,
+        extension_data: TlsVecU16::from_slice(&[1, 2, 3, 4, 5]),
+    };
+    let serialized = extension.serialize_detached().unwrap();
+    assert_eq!(vec![0, 3, 0, 5, 1, 2, 3, 4, 5], serialized);
+}
+
+#[test]
+fn byte_arrays() {
+    let x = [0u8, 1, 2, 3];
+    let serialized = x.serialize_detached().unwrap();
+    assert_eq!(vec![0, 1, 2, 3], serialized);
+}

--- a/tls-codec/Cargo.toml
+++ b/tls-codec/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tls-codec"
+version = "0.1.0"
+authors = ["Franziskus Kiefer <franziskuskiefer@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tls-codec-derive = { version = "0.1", path = "../tls-codec-derive", optional = true }
+hpke-rs = { version = "0.0.4", package = "hpke-rs", features = ["hazmat", "serialization"], optional = true }
+
+[features]
+derive = [ "tls-codec-derive" ]
+hpke = [ "hpke-rs" ]

--- a/tls-codec/src/arrays.rs
+++ b/tls-codec/src/arrays.rs
@@ -1,0 +1,30 @@
+//! Implement the TLS codec for some byte arrays.
+
+use super::{Cursor, Deserialize, Error, Serialize};
+use std::convert::TryInto;
+
+macro_rules! impl_array {
+    ($len:literal) => {
+        impl Serialize for [u8; $len] {
+            fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error> {
+                for b in self {
+                    buffer.push(*b);
+                }
+                Ok(())
+            }
+        }
+
+        impl Deserialize for [u8; $len] {
+            fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error> {
+                Ok(cursor.read($len)?.try_into()?)
+            }
+        }
+    };
+}
+
+impl_array!(2);
+impl_array!(4);
+impl_array!(8);
+impl_array!(16);
+impl_array!(32);
+impl_array!(64);

--- a/tls-codec/src/hpke.rs
+++ b/tls-codec/src/hpke.rs
@@ -1,0 +1,18 @@
+//! TLS Codec for HPKE primitives
+
+use super::*;
+use hpke_rs::HPKEPublicKey;
+
+impl Serialize for HPKEPublicKey {
+    fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error> {
+        let value = TlsVecU16::from(self.as_slice());
+        value.tls_serialize(buffer)
+    }
+}
+
+impl Deserialize for HPKEPublicKey {
+    fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error> {
+        let value = TlsVecU16::<u8>::tls_deserialize(&cursor)?;
+        Ok(Self::new(value.as_slice().to_vec()))
+    }
+}

--- a/tls-codec/src/lib.rs
+++ b/tls-codec/src/lib.rs
@@ -1,0 +1,80 @@
+use std::cell::Cell;
+
+mod arrays;
+#[cfg(feature = "hpke")]
+mod hpke;
+mod primitives;
+mod tls_vec;
+pub use tls_vec::{TlsVecU16, TlsVecU32, TlsVecU64, TlsVecU8};
+
+#[cfg(feature = "derive")]
+pub use tls_codec_derive::{TlsDeserialize, TlsSerialize};
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Error {
+    EncodingError,
+    InvalidVectorLength,
+    InvalidInput,
+    DecodingError,
+}
+
+pub trait Serialize {
+    fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error>;
+
+    fn serialize_detached(&self) -> Result<Vec<u8>, Error> {
+        let mut buffer = Vec::new();
+        self.tls_serialize(&mut buffer)?;
+        Ok(buffer)
+    }
+}
+
+pub trait Deserialize {
+    fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error>
+    where
+        Self: Sized;
+
+    fn deserialize_detached(bytes: &[u8]) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Self::tls_deserialize(&mut Cursor::new(bytes))
+    }
+}
+
+#[derive(Debug)]
+pub struct Cursor {
+    bytes: Vec<u8>,
+    position: Cell<usize>,
+}
+
+impl Cursor {
+    pub fn new(bytes: &[u8]) -> Cursor {
+        Cursor {
+            bytes: bytes.to_vec(),
+            position: Cell::new(0),
+        }
+    }
+
+    pub(crate) fn read(&self, length: usize) -> Result<&[u8], Error> {
+        let unread_bytes = self.bytes.len() - self.position.get();
+        if unread_bytes < length {
+            return Err(Error::InvalidInput);
+        }
+
+        let position = self.position.get();
+        self.position.replace(self.position.get() + length);
+        Ok(&self.bytes[position..position + length])
+    }
+
+    pub(crate) fn sub_cursor(&self, length: usize) -> Result<Cursor, Error> {
+        self.read(length).map(|buffer| Cursor::new(buffer))
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.position.get() >= self.bytes.len()
+    }
+
+    pub(crate) fn has_more(&self) -> bool {
+        !self.is_empty()
+    }
+}

--- a/tls-codec/src/lib.rs
+++ b/tls-codec/src/lib.rs
@@ -5,11 +5,11 @@
 //!
 //! With the feature `derive` `TlsSerialize` and `TlsDeserialize` can be derived.
 //!
-//! Tis crate provides the following data structures that implement TLS serialization
+//! This crate provides the following data structures that implement TLS serialization
 //! * `u8`, `u16`, `u32`, `u64`
 //! * `TlsVecU8`, `TlsVecU16`, `TlsVecU32`
 //! * `[u8; 2]`, `[u8; 4]`, `[u8; 8]`, `[u8; 16]`, `[u8; 32]`, `[u8; 64]`
-//! * If the `hpke` features is enabled, the TLS codec is implemented for
+//! * If the `hpke` feature is enabled, the TLS codec is implemented for
 //!  `HPKEPublicKeys` from [hpke-rs](https://github.com/franziskuskiefer/hpke-rs).
 
 use std::cell::Cell;

--- a/tls-codec/src/lib.rs
+++ b/tls-codec/src/lib.rs
@@ -1,3 +1,17 @@
+//! # TLS Codec
+//!
+//! This crate implements the TLS codec as defined in [RFC 8446](https://tools.ietf.org/html/rfc8446)
+//! as well as some extensions required by MLS.
+//!
+//! With the feature `derive` `TlsSerialize` and `TlsDeserialize` can be derived.
+//!
+//! Tis crate provides the following data structures that implement TLS serialization
+//! * `u8`, `u16`, `u32`, `u64`
+//! * `TlsVecU8`, `TlsVecU16`, `TlsVecU32`
+//! * `[u8; 2]`, `[u8; 4]`, `[u8; 8]`, `[u8; 16]`, `[u8; 32]`, `[u8; 64]`
+//! * If the `hpke` features is enabled, the TLS codec is implemented for
+//!  `HPKEPublicKeys` from [hpke-rs](https://github.com/franziskuskiefer/hpke-rs).
+
 use std::cell::Cell;
 
 mod arrays;
@@ -10,30 +24,49 @@ pub use tls_vec::{TlsVecU16, TlsVecU32, TlsVecU8};
 #[cfg(feature = "derive")]
 pub use tls_codec_derive::{TlsDeserialize, TlsSerialize};
 
+/// Errors that are thrown by this crate.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Error {
+    /// An error occurred during encoding.
     EncodingError,
+
+    /// The length of a vector is invalid.
     InvalidVectorLength,
+
+    /// Invalid input when trying to decode a primitive integer.
     InvalidInput,
+
+    /// An error occurred during decoding.
     DecodingError,
 }
 
+/// The `Serialize` trait provides functions to serialize a struct or enum.
+///
+/// The trait provides two functions:
+/// * `tls_serialize` that takes a buffer to write the serialization to
+/// * `tls_serialize_detached` that returns a byte vector
 pub trait Serialize {
     fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error>;
 
-    fn serialize_detached(&self) -> Result<Vec<u8>, Error> {
+    fn tls_serialize_detached(&self) -> Result<Vec<u8>, Error> {
         let mut buffer = Vec::new();
         self.tls_serialize(&mut buffer)?;
         Ok(buffer)
     }
 }
 
+/// The `Deserialize` trait provides functions to deserialize a byte slice to a
+/// struct or enum.
+///
+/// The trait provides two functions:
+/// * `tls_deserialize` that takes a [`Cursor`] to read from
+/// * `tls_deserialize_detached` that takes a byte slice
 pub trait Deserialize {
     fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error>
     where
         Self: Sized;
 
-    fn deserialize_detached(bytes: &[u8]) -> Result<Self, Error>
+    fn tls_deserialize_detached(bytes: &[u8]) -> Result<Self, Error>
     where
         Self: Sized,
     {
@@ -41,6 +74,9 @@ pub trait Deserialize {
     }
 }
 
+/// The `Cursor` is a helper used to read byte slices when deserializing.
+/// Note that this shouldn't be needed in most cases and `tls_deserialize_detached`
+/// can be used instead.
 #[derive(Debug)]
 pub struct Cursor {
     bytes: Vec<u8>,
@@ -48,6 +84,8 @@ pub struct Cursor {
 }
 
 impl Cursor {
+    /// Create a new `Cursor` from a byte slice.
+    /// This function copies the content of `bytes`.
     pub fn new(bytes: &[u8]) -> Cursor {
         Cursor {
             bytes: bytes.to_vec(),
@@ -55,6 +93,7 @@ impl Cursor {
         }
     }
 
+    // Read `length` bytes from the cursor and return the slice.
     pub(crate) fn read(&self, length: usize) -> Result<&[u8], Error> {
         let unread_bytes = self.bytes.len() - self.position.get();
         if unread_bytes < length {
@@ -66,14 +105,17 @@ impl Cursor {
         Ok(&self.bytes[position..position + length])
     }
 
+    // Create a new cursor with the given `length`.
     pub(crate) fn sub_cursor(&self, length: usize) -> Result<Cursor, Error> {
         self.read(length).map(|buffer| Cursor::new(buffer))
     }
 
+    // Check if the cursor is empty/fully read.
     pub(crate) fn is_empty(&self) -> bool {
         self.position.get() >= self.bytes.len()
     }
 
+    // Check if there are more bytes that can be read.
     pub(crate) fn has_more(&self) -> bool {
         !self.is_empty()
     }

--- a/tls-codec/src/lib.rs
+++ b/tls-codec/src/lib.rs
@@ -5,7 +5,7 @@ mod arrays;
 mod hpke;
 mod primitives;
 mod tls_vec;
-pub use tls_vec::{TlsVecU16, TlsVecU32, TlsVecU64, TlsVecU8};
+pub use tls_vec::{TlsVecU16, TlsVecU32, TlsVecU8};
 
 #[cfg(feature = "derive")]
 pub use tls_codec_derive::{TlsDeserialize, TlsSerialize};
@@ -37,7 +37,7 @@ pub trait Deserialize {
     where
         Self: Sized,
     {
-        Self::tls_deserialize(&mut Cursor::new(bytes))
+        Self::tls_deserialize(&Cursor::new(bytes))
     }
 }
 

--- a/tls-codec/src/primitives.rs
+++ b/tls-codec/src/primitives.rs
@@ -32,10 +32,7 @@ impl Serialize for u64 {
 
 impl Deserialize for u8 {
     fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error> {
-        match cursor.read(1) {
-            Ok(bytes) => Ok(bytes[0]),
-            Err(e) => Err(e),
-        }
+        cursor.read(1).map(|b| b[0])
     }
 }
 

--- a/tls-codec/src/primitives.rs
+++ b/tls-codec/src/primitives.rs
@@ -1,0 +1,73 @@
+use super::{Cursor, Deserialize, Error, Serialize};
+
+use std::convert::TryInto;
+
+impl Serialize for u8 {
+    fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error> {
+        buffer.push(*self);
+        Ok(())
+    }
+}
+
+impl Serialize for u16 {
+    fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error> {
+        buffer.extend_from_slice(&self.to_be_bytes());
+        Ok(())
+    }
+}
+
+impl Serialize for u32 {
+    fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error> {
+        buffer.extend_from_slice(&self.to_be_bytes());
+        Ok(())
+    }
+}
+
+impl Serialize for u64 {
+    fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error> {
+        buffer.extend_from_slice(&self.to_be_bytes());
+        Ok(())
+    }
+}
+
+impl Deserialize for u8 {
+    fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error> {
+        match cursor.read(1) {
+            Ok(bytes) => Ok(bytes[0]),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl Deserialize for u16 {
+    fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error> {
+        match cursor.read(2) {
+            Ok(bytes) => Ok(u16::from_be_bytes(bytes.try_into()?)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl Deserialize for u32 {
+    fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error> {
+        match cursor.read(4) {
+            Ok(bytes) => Ok(u32::from_be_bytes(bytes.try_into()?)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl Deserialize for u64 {
+    fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error> {
+        match cursor.read(8) {
+            Ok(bytes) => Ok(u64::from_be_bytes(bytes.try_into()?)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl From<std::array::TryFromSliceError> for Error {
+    fn from(_e: std::array::TryFromSliceError) -> Self {
+        Self::InvalidInput
+    }
+}

--- a/tls-codec/src/primitives.rs
+++ b/tls-codec/src/primitives.rs
@@ -1,3 +1,5 @@
+//! Codec implementations for unsigned integer primitives.
+
 use super::{Cursor, Deserialize, Error, Serialize};
 
 use std::convert::TryInto;

--- a/tls-codec/src/tls_vec.rs
+++ b/tls-codec/src/tls_vec.rs
@@ -59,9 +59,9 @@ macro_rules! impl_tls_vec {
             }
         }
 
-        impl<T: Serialize + Deserialize + Clone + PartialEq> Into<Vec<T>> for $name<T> {
-            fn into(self) -> Vec<T> {
-                self.vec
+        impl<T: Serialize + Deserialize + Clone + PartialEq> From<$name<T>> for Vec<T> {
+            fn from(v: $name<T>) -> Self {
+                v.vec
             }
         }
 
@@ -210,7 +210,7 @@ macro_rules! impl_tls_vec {
 impl_tls_vec!(u8, TlsVecU8);
 impl_tls_vec!(u16, TlsVecU16);
 impl_tls_vec!(u32, TlsVecU32);
-impl_tls_vec!(u64, TlsVecU64);
+// TODO: #319 impl_tls_vec!(u64, TlsVecU64);
 
 impl From<std::num::TryFromIntError> for Error {
     fn from(_e: std::num::TryFromIntError) -> Self {

--- a/tls-codec/src/tls_vec.rs
+++ b/tls-codec/src/tls_vec.rs
@@ -1,0 +1,225 @@
+//! A vector with a length field for TLS serialisation.
+//! Use this for any vector that is serialised.
+
+use serde::ser::SerializeStruct;
+use std::convert::TryInto;
+
+use crate::{Cursor, Deserialize, Error, Serialize};
+
+macro_rules! impl_tls_vec {
+    ($size:ty, $name:ident) => {
+        #[derive(PartialEq, Clone, Debug)]
+        pub struct $name<T: Serialize + Deserialize + Clone + PartialEq> {
+            vec: Vec<T>,
+        }
+
+        impl<T: Serialize + Deserialize + Clone + PartialEq> $name<T> {
+            /// Create a new `TlsVec` from a Rust Vec.
+            pub fn new(vec: Vec<T>) -> Self {
+                Self { vec }
+            }
+
+            /// Create a new `TlsVec` from a slice.
+            pub fn from_slice(slice: &[T]) -> Self {
+                Self {
+                    vec: slice.to_vec(),
+                }
+            }
+
+            /// Get a slice to the raw vector.
+            pub fn as_slice(&self) -> &[T] {
+                &self.vec
+            }
+
+            /// Get a copy of the underlying vector.
+            pub fn to_vec(&self) -> Vec<T> {
+                self.vec.clone()
+            }
+
+            /// Add an element to this.
+            pub fn push(&mut self, value: T) {
+                self.vec.push(value);
+            }
+
+            /// Remove the last element.
+            pub fn pop(&mut self) -> Option<T> {
+                self.vec.pop()
+            }
+        }
+
+        impl<T: Serialize + Deserialize + Clone + PartialEq> From<Vec<T>> for $name<T> {
+            fn from(v: Vec<T>) -> Self {
+                Self::new(v)
+            }
+        }
+
+        impl<T: Serialize + Deserialize + Clone + PartialEq> From<&[T]> for $name<T> {
+            fn from(v: &[T]) -> Self {
+                Self::from_slice(v)
+            }
+        }
+
+        impl<T: Serialize + Deserialize + Clone + PartialEq> Into<Vec<T>> for $name<T> {
+            fn into(self) -> Vec<T> {
+                self.vec
+            }
+        }
+
+        impl<T: Serialize + Deserialize + Clone + PartialEq> Default for $name<T> {
+            fn default() -> Self {
+                Self { vec: Vec::new() }
+            }
+        }
+
+        impl<T> serde::Serialize for $name<T>
+        where
+            T: Serialize + Deserialize + Clone + PartialEq + serde::Serialize,
+        {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                let mut state = serializer.serialize_struct(stringify!($name), 1)?;
+                state.serialize_field("vec", &self.vec)?;
+                state.end()
+            }
+        }
+
+        impl<'de, T> serde::de::Deserialize<'de> for $name<T>
+        where
+            T: Serialize + Deserialize + Clone + PartialEq + serde::de::Deserialize<'de>,
+        {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::de::Deserializer<'de>,
+            {
+                enum Field {
+                    Vec,
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for Field {
+                    fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+                    where
+                        D: serde::de::Deserializer<'de>,
+                    {
+                        struct FieldVisitor;
+
+                        impl<'de> serde::de::Visitor<'de> for FieldVisitor {
+                            type Value = Field;
+
+                            fn expecting(
+                                &self,
+                                formatter: &mut std::fmt::Formatter,
+                            ) -> std::fmt::Result {
+                                formatter.write_str("`vec`")
+                            }
+
+                            fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                            where
+                                E: serde::de::Error,
+                            {
+                                match value {
+                                    "vec" => Ok(Field::Vec),
+                                    _ => Err(serde::de::Error::unknown_field(value, &["vec"])),
+                                }
+                            }
+                        }
+
+                        deserializer.deserialize_identifier(FieldVisitor)
+                    }
+                }
+
+                struct TlsVecVisitor<T> {
+                    data: std::marker::PhantomData<T>,
+                }
+
+                impl<'de, T> serde::de::Visitor<'de> for TlsVecVisitor<T>
+                where
+                    T: Serialize + Deserialize + Clone + PartialEq + serde::de::Deserialize<'de>,
+                {
+                    type Value = $name<T>;
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_fmt(format_args!("struct {}<T>", stringify!($name)))
+                    }
+                    fn visit_seq<V>(self, mut seq: V) -> Result<$name<T>, V::Error>
+                    where
+                        V: serde::de::SeqAccess<'de>,
+                    {
+                        let vec = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                        Ok($name::<T>::new(vec))
+                    }
+                    fn visit_map<V>(self, mut map: V) -> Result<$name<T>, V::Error>
+                    where
+                        V: serde::de::MapAccess<'de>,
+                    {
+                        let mut vec = None;
+                        while let Some(key) = map.next_key()? {
+                            match key {
+                                Field::Vec => {
+                                    if vec.is_some() {
+                                        return Err(serde::de::Error::duplicate_field("vec"));
+                                    }
+                                    vec = Some(map.next_value()?);
+                                }
+                            }
+                        }
+                        let vec = vec.ok_or_else(|| serde::de::Error::missing_field("vec"))?;
+                        Ok($name::<T>::new(vec))
+                    }
+                }
+                deserializer.deserialize_struct(
+                    stringify!($name),
+                    &["vec"],
+                    TlsVecVisitor {
+                        data: std::marker::PhantomData,
+                    },
+                )
+            }
+        }
+
+        impl<T: Serialize + Deserialize + Clone + PartialEq> Serialize for $name<T> {
+            fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error> {
+                let len = self.vec.len();
+                if len > (<$size>::MAX as usize) {
+                    return Err(Error::InvalidVectorLength);
+                }
+                (self.vec.len() as $size).tls_serialize(buffer)?;
+                for e in self.vec.iter() {
+                    e.tls_serialize(buffer)?;
+                }
+                Ok(())
+            }
+        }
+
+        impl<T: Serialize + Deserialize + Clone + PartialEq> Deserialize for $name<T> {
+            fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error> {
+                let mut result = Self { vec: Vec::new() };
+                let len = <$size>::tls_deserialize(cursor)?;
+                let sub_cursor = cursor.sub_cursor(len.try_into()?)?;
+                while sub_cursor.has_more() {
+                    result.push(T::tls_deserialize(&sub_cursor)?);
+                }
+                Ok(result)
+            }
+        }
+    };
+}
+
+impl_tls_vec!(u8, TlsVecU8);
+impl_tls_vec!(u16, TlsVecU16);
+impl_tls_vec!(u32, TlsVecU32);
+impl_tls_vec!(u64, TlsVecU64);
+
+impl From<std::num::TryFromIntError> for Error {
+    fn from(_e: std::num::TryFromIntError) -> Self {
+        Self::InvalidVectorLength
+    }
+}
+
+impl From<std::convert::Infallible> for Error {
+    fn from(_e: std::convert::Infallible) -> Self {
+        Self::InvalidVectorLength
+    }
+}

--- a/tls-codec/tests/decode.rs
+++ b/tls-codec/tests/decode.rs
@@ -1,0 +1,31 @@
+use tls_codec::{Cursor, Deserialize, TlsVecU8};
+
+#[test]
+fn deserialize_primitives() {
+    let b = [77, 88, 1, 99];
+    let cursor = Cursor::new(&b);
+
+    let a = u8::tls_deserialize(&cursor).expect("Unable to tls_deserialize");
+    assert_eq!(77, a);
+    let a = u8::tls_deserialize(&cursor).expect("Unable to tls_deserialize");
+    assert_eq!(88, a);
+    let a = u16::tls_deserialize(&cursor).expect("Unable to tls_deserialize");
+    assert_eq!(355, a);
+
+    // It's empty now.
+    assert!(u8::tls_deserialize(&cursor).is_err())
+}
+
+#[test]
+fn deserialize_tls_vec() {
+    let b = [1, 4, 77, 88, 1, 99];
+    let cursor = Cursor::new(&b);
+
+    let a = u8::tls_deserialize(&cursor).expect("Unable to tls_deserialize");
+    assert_eq!(1, a);
+    let v = TlsVecU8::<u8>::tls_deserialize(&cursor).expect("Unable to tls_deserialize");
+    assert_eq!(&[77, 88, 1, 99], v.as_slice());
+
+    // It's empty now.
+    assert!(u8::tls_deserialize(&cursor).is_err())
+}

--- a/tls-codec/tests/decode.rs
+++ b/tls-codec/tests/decode.rs
@@ -27,5 +27,5 @@ fn deserialize_tls_vec() {
     assert_eq!(&[77, 88, 1, 99], v.as_slice());
 
     // It's empty now.
-    assert!(u8::tls_deserialize(&cursor).is_err())
+    assert!(u8::tls_deserialize(&cursor).is_err());
 }

--- a/tls-codec/tests/encode.rs
+++ b/tls-codec/tests/encode.rs
@@ -6,8 +6,8 @@ fn serialize_primitives() {
     77u8.tls_serialize(&mut v).expect("Error encoding u8");
     88u8.tls_serialize(&mut v).expect("Error encoding u8");
     355u16.tls_serialize(&mut v).expect("Error encoding u8");
-    let b = [77, 88, 1, 99];
-    assert_eq!(&b[..], &v);
+    let b = [77u8, 88, 1, 99];
+    assert_eq!(&b[..], &v[..]);
 }
 
 #[test]
@@ -18,6 +18,6 @@ fn serialize_tls_vec() {
         .tls_serialize(&mut v)
         .expect("Error encoding u8");
 
-    let b = [1, 0, 4, 77, 88, 1, 99];
-    assert_eq!(&b[..], &v);
+    let b = [1u8, 0, 4, 77, 88, 1, 99];
+    assert_eq!(&b[..], &v[..]);
 }

--- a/tls-codec/tests/encode.rs
+++ b/tls-codec/tests/encode.rs
@@ -1,0 +1,23 @@
+use tls_codec::{Serialize, TlsVecU16};
+
+#[test]
+fn serialize_primitives() {
+    let mut v = Vec::new();
+    77u8.tls_serialize(&mut v).expect("Error encoding u8");
+    88u8.tls_serialize(&mut v).expect("Error encoding u8");
+    355u16.tls_serialize(&mut v).expect("Error encoding u8");
+    let b = [77, 88, 1, 99];
+    assert_eq!(&b[..], &v);
+}
+
+#[test]
+fn serialize_tls_vec() {
+    let mut v = Vec::new();
+    1u8.tls_serialize(&mut v).expect("Error encoding u8");
+    TlsVecU16::<u8>::from_slice(&[77, 88, 1, 99])
+        .tls_serialize(&mut v)
+        .expect("Error encoding u8");
+
+    let b = [1, 0, 4, 77, 88, 1, 99];
+    assert_eq!(&b[..], &v);
+}

--- a/tls-codec/tests/encode.rs
+++ b/tls-codec/tests/encode.rs
@@ -5,7 +5,7 @@ fn serialize_primitives() {
     let mut v = Vec::new();
     77u8.tls_serialize(&mut v).expect("Error encoding u8");
     88u8.tls_serialize(&mut v).expect("Error encoding u8");
-    355u16.tls_serialize(&mut v).expect("Error encoding u8");
+    355u16.tls_serialize(&mut v).expect("Error encoding u16");
     let b = [77u8, 88, 1, 99];
     assert_eq!(&b[..], &v[..]);
 }


### PR DESCRIPTION
This PR implements the TLS codec in a separate crate as well as corresponding derive macros for serialization and de-serialization.

This will allow us to remove (almost) all `Codec` related code. I'll do so in follow ups.