### PR TITLE
Make results of sign/verify consistent

### DIFF
--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -698,7 +698,7 @@ impl SignatureKeypair {
 
     /// Verify a `Signature` on the `payload` byte slice with the key pair's
     /// public key.
-    pub fn verify(&self, signature: &Signature, payload: &[u8]) -> bool {
+    pub fn verify(&self, signature: &Signature, payload: &[u8]) -> Result<(), SignatureError> {
         self.public_key.verify(signature, payload)
     }
 
@@ -758,8 +758,8 @@ impl SignaturePublicKey {
     }
     /// Verify a `Signature` on the `payload` byte slice with the key pair's
     /// public key.
-    pub fn verify(&self, signature: &Signature, payload: &[u8]) -> bool {
-        verify(
+    pub fn verify(&self, signature: &Signature, payload: &[u8]) -> Result<(), SignatureError> {
+        if verify(
             // It's ok to use `unwrap()` here, since we checked the signature scheme is supported
             // when the public key was created.
             SignatureMode::try_from(self.signature_scheme).unwrap(),
@@ -769,6 +769,11 @@ impl SignaturePublicKey {
             payload,
         )
         .unwrap()
+        {
+            Ok(())
+        } else {
+            Err(SignatureError::InvalidSignature)
+        }
     }
 }
 

--- a/src/ciphersuite/signable.rs
+++ b/src/ciphersuite/signable.rs
@@ -16,7 +16,7 @@ pub trait Signable: Sized {
 
     /// Verifies the payload against the given `credential` and `signature`.
     ///
-    /// Returns a `Ok(())` if the signature is valid and `CredentialError::InvalidSignature` otherwise.
+    /// Returns `Ok(())` if the signature is valid and `CredentialError::InvalidSignature` otherwise.
     fn verify(
         &self,
         credential: &Credential,

--- a/src/ciphersuite/signable.rs
+++ b/src/ciphersuite/signable.rs
@@ -16,8 +16,12 @@ pub trait Signable: Sized {
 
     /// Verifies the payload against the given `credential` and `signature`.
     ///
-    /// Returns a `true` if the signature is valid and `false` otherwise.
-    fn verify(&self, credential: &Credential, signature: &Signature) -> bool {
+    /// Returns a `Ok(())` if the signature is valid and `CredentialError::InvalidSignature` otherwise.
+    fn verify(
+        &self,
+        credential: &Credential,
+        signature: &Signature,
+    ) -> Result<(), CredentialError> {
         let payload = self.unsigned_payload().unwrap();
         credential.verify(&payload, signature)
     }

--- a/src/ciphersuite/test_ciphersuite.rs
+++ b/src/ciphersuite/test_ciphersuite.rs
@@ -53,7 +53,7 @@ fn test_sign_verify() {
         let keypair = ciphersuite.signature_scheme().new_keypair().unwrap();
         let payload = &[1, 2, 3];
         let signature = keypair.sign(payload).unwrap();
-        assert!(keypair.verify(&signature, payload));
+        assert!(keypair.verify(&signature, payload).is_ok());
     }
 }
 

--- a/src/credentials/errors.rs
+++ b/src/credentials/errors.rs
@@ -4,7 +4,8 @@ use crate::config::ConfigError;
 implement_error! {
     pub enum CredentialError {
         Simple {
-            UnsupportedCredentialType = "Unsupported credential type",
+            UnsupportedCredentialType = "Unsupported credential type.",
+            InvalidSignature = "Invalid signature.",
         }
         Complex {
             ConfigError(ConfigError) = "See `ConfigError` for details.",

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -53,11 +53,12 @@ pub struct Credential {
 impl Credential {
     /// Verify a signature of a given payload against the public key contained
     /// in a credential.
-    pub fn verify(&self, payload: &[u8], signature: &Signature) -> bool {
+    pub fn verify(&self, payload: &[u8], signature: &Signature) -> Result<(), CredentialError> {
         match &self.credential {
-            MLSCredentialType::Basic(basic_credential) => {
-                basic_credential.public_key.verify(signature, payload)
-            }
+            MLSCredentialType::Basic(basic_credential) => basic_credential
+                .public_key
+                .verify(signature, payload)
+                .map_err(|_| CredentialError::InvalidSignature),
             // TODO: implement verification for X509 certificates. See issue #134.
             MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
@@ -92,8 +93,10 @@ pub struct BasicCredential {
 }
 
 impl BasicCredential {
-    pub fn verify(&self, payload: &[u8], signature: &Signature) -> bool {
-        self.public_key.verify(signature, payload)
+    pub fn verify(&self, payload: &[u8], signature: &Signature) -> Result<(), CredentialError> {
+        self.public_key
+            .verify(signature, payload)
+            .map_err(|_| CredentialError::InvalidSignature)
     }
 }
 

--- a/src/framing/errors.rs
+++ b/src/framing/errors.rs
@@ -4,6 +4,7 @@
 //! handling `MLSPlaintext` and `MLSCiphertext`.
 
 use crate::codec::CodecError;
+use crate::credentials::CredentialError;
 use crate::tree::secret_tree::SecretTreeError;
 
 implement_error! {
@@ -34,12 +35,12 @@ implement_error! {
 implement_error! {
     pub enum VerificationError {
         Simple {
-            InvalidSignature = "The MLSPlaintext signature is invalid",
             MissingMembershipTag = "The MLSPlaintext membership tag is missing",
             InvalidMembershipTag = "The MLSPlaintext membership tag is invalid",
         }
         Complex {
             CodecError(CodecError) = "Codec error",
+            CredentialError(CredentialError) = "Credential error",
         }
     }
 }

--- a/src/framing/plaintext.rs
+++ b/src/framing/plaintext.rs
@@ -464,11 +464,9 @@ impl<'a> MLSPlaintextTBS<'a> {
         signature: &Signature,
     ) -> Result<(), VerificationError> {
         let bytes = self.encode_detached()?;
-        if credential.verify(&bytes, &signature) {
-            Ok(())
-        } else {
-            Err(VerificationError::InvalidSignature)
-        }
+        credential
+            .verify(&bytes, &signature)
+            .map_err(VerificationError::CredentialError)
     }
 }
 

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -8,7 +8,7 @@ use crate::codec::CodecError;
 use crate::config::ConfigError;
 use crate::framing::errors::{MLSCiphertextError, VerificationError};
 use crate::messages::errors::ProposalQueueError;
-use crate::tree::TreeError;
+use crate::tree::{ParentHashError, TreeError};
 
 implement_error! {
     pub enum GroupError {
@@ -58,6 +58,8 @@ implement_error! {
         Complex {
             InvalidRatchetTree(TreeError) =
                 "Invalid ratchet tree in Welcome message.",
+            ParentHashMismatch(ParentHashError) =
+                "The parent hash verification failed.",
             GroupSecretsDecryptionFailure(CryptoError) =
                 "Unable to decrypt the EncryptedGroupSecrets.",
             CodecError(CodecError) =

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -98,20 +98,17 @@ impl MlsGroup {
         }
 
         // Verify parent hashes
-        if !tree.verify_parent_hashes() {
-            return Err(WelcomeError::InvalidRatchetTree(TreeError::InvalidTree));
-        }
+        tree.verify_parent_hashes()?;
 
         // Verify GroupInfo signature
         let signer_node = tree.nodes[group_info.signer_index()].clone();
         let signer_key_package = signer_node.key_package.unwrap();
         let payload = group_info.unsigned_payload().unwrap();
-        if !signer_key_package
+
+        signer_key_package
             .credential()
             .verify(&payload, group_info.signature())
-        {
-            return Err(WelcomeError::InvalidGroupInfoSignature);
-        }
+            .map_err(|_| WelcomeError::InvalidGroupInfoSignature)?;
 
         // Compute path secrets
         // TODO: #36 check if path_secret has to be optional

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -92,7 +92,7 @@ impl KeyPackage {
         self.credential
             .verify(&self.unsigned_payload().unwrap(), &self.signature)
             .map_err(|_| {
-                log::error!("Key package signature is empty.");
+                log::error!("Key package signature is invalid.");
                 KeyPackageError::InvalidSignature
             })
     }

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -89,15 +89,12 @@ impl KeyPackage {
         }
 
         // Verify the signature on this key package.
-        if self
-            .credential
+        self.credential
             .verify(&self.unsigned_payload().unwrap(), &self.signature)
-        {
-            Ok(())
-        } else {
-            log::error!("Key package signature is empty.");
-            Err(KeyPackageError::InvalidSignature)
-        }
+            .map_err(|_| {
+                log::error!("Key package signature is empty.");
+                KeyPackageError::InvalidSignature
+            })
     }
 
     /// Compute the hash of the encoding of this key package.

--- a/src/tree/hashes.rs
+++ b/src/tree/hashes.rs
@@ -259,15 +259,13 @@ impl RatchetTree {
 
     /// Verify the parent hashes of the tree nodes. Returns `true` if all parent
     /// hashes have successfully been verified and `false` otherwise.
-    pub fn verify_parent_hashes(&self) -> bool {
-        self.nodes.iter().enumerate().all(|(index, node)| {
+    pub fn verify_parent_hashes(&self) -> Result<(), ParentHashError> {
+        for (index, node) in self.nodes.iter().enumerate() {
             if NodeIndex::from(index).is_parent() && node.is_full_parent() {
-                self.verify_parent_hash(NodeIndex::from(index), node)
-                    .is_ok()
-            } else {
-                true
+                self.verify_parent_hash(NodeIndex::from(index), node)?;
             }
-        })
+        }
+        Ok(())
     }
 
     // === Tree hash ===

--- a/src/tree/hashes.rs
+++ b/src/tree/hashes.rs
@@ -205,6 +205,71 @@ impl RatchetTree {
         node_parent_hash(self, index.into(), index.into())
     }
 
+    /// Verify the parent hash of a tree node. Returns `Ok(())` if the parent
+    /// hash has successfully been verified and `false` otherwise.
+    pub fn verify_parent_hash(&self, index: NodeIndex, node: &Node) -> Result<(), ParentHashError> {
+        // "Let L and R be the left and right children of P, respectively"
+        let left = treemath::left(index).map_err(|_| ParentHashError::InputNotParentNode)?;
+        let right = treemath::right(index, self.leaf_count()).unwrap();
+        // Extract the parent hash field
+        let parent_hash_field = match node.parent_hash() {
+            Some(parent_hash) => parent_hash,
+            None => return Err(ParentHashError::InputNotParentNode),
+        };
+        // Current hash with right child resolution
+        let current_hash_right =
+            ParentHashInput::new(&self, index, right, parent_hash_field)?.hash(&self.ciphersuite);
+
+        // "If L.parent_hash is equal to the Parent Hash of P with Co-Path Child R, the check passes"
+        if let Some(left_parent_hash_field) = self.nodes[left].parent_hash() {
+            if left_parent_hash_field == current_hash_right {
+                return Ok(());
+            }
+        }
+
+        // "If R is blank, replace R with its left child until R is either non-blank or a leaf node"
+        let mut child = right;
+        while self.nodes[child].is_blank() && child.is_parent() {
+            // Unwrapping here is safe, because we know it is a full parent node
+            child = treemath::left(child).unwrap();
+        }
+        let right = child;
+
+        // "If R is a leaf node, the check fails"
+        if right.is_leaf() {
+            return Err(ParentHashError::EndedWithLeafNode);
+        }
+
+        // Current hash with left child resolution
+        let current_hash_left = ParentHashInput::new(&self, index, left, parent_hash_field)
+            // Unwrapping here is safe, since we can be sure the node is not blank
+            .unwrap()
+            .hash(&self.ciphersuite);
+
+        // "If R.parent_hash is equal to the Parent Hash of P with Co-Path Child L, the check passes"
+        if let Some(right_parent_hash_field) = self.nodes[right].parent_hash() {
+            if right_parent_hash_field == current_hash_left {
+                return Ok(());
+            }
+        }
+
+        // "Otherwise, the check fails"
+        Err(ParentHashError::AllChecksFailed)
+    }
+
+    /// Verify the parent hashes of the tree nodes. Returns `true` if all parent
+    /// hashes have successfully been verified and `false` otherwise.
+    pub fn verify_parent_hashes(&self) -> bool {
+        self.nodes.iter().enumerate().all(|(index, node)| {
+            if NodeIndex::from(index).is_parent() && node.is_full_parent() {
+                self.verify_parent_hash(NodeIndex::from(index), node)
+                    .is_ok()
+            } else {
+                true
+            }
+        })
+    }
+
     // === Tree hash ===
 
     /// Computes and returns the tree hash

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -8,7 +8,7 @@ use crate::messages::proposals::*;
 // Tree modules
 pub(crate) mod codec;
 pub(crate) mod errors;
-pub(crate) mod hash_input;
+pub(crate) mod hashes;
 pub mod index;
 pub mod node;
 pub(crate) mod path_keys;
@@ -18,7 +18,7 @@ pub(crate) mod sender_ratchet;
 pub(crate) mod treemath;
 
 pub(crate) use errors::*;
-pub use hash_input::*;
+pub use hashes::*;
 use index::*;
 use node::*;
 use private_tree::{PathSecrets, PrivateTree};
@@ -752,71 +752,6 @@ impl RatchetTree {
         if new_tree_size > 0 {
             self.nodes.truncate(new_tree_size);
         }
-    }
-
-    /// Verify the parent hash of a tree node. Returns `Ok(())` if the parent
-    /// hash has successfully been verified and `false` otherwise.
-    pub fn verify_parent_hash(&self, index: NodeIndex, node: &Node) -> Result<(), ParentHashError> {
-        // "Let L and R be the left and right children of P, respectively"
-        let left = treemath::left(index).map_err(|_| ParentHashError::InputNotParentNode)?;
-        let right = treemath::right(index, self.leaf_count()).unwrap();
-        // Extract the parent hash field
-        let parent_hash_field = match node.parent_hash() {
-            Some(parent_hash) => parent_hash,
-            None => return Err(ParentHashError::InputNotParentNode),
-        };
-        // Current hash with right child resolution
-        let current_hash_right =
-            ParentHashInput::new(&self, index, right, parent_hash_field)?.hash(&self.ciphersuite);
-
-        // "If L.parent_hash is equal to the Parent Hash of P with Co-Path Child R, the check passes"
-        if let Some(left_parent_hash_field) = self.nodes[left].parent_hash() {
-            if left_parent_hash_field == current_hash_right {
-                return Ok(());
-            }
-        }
-
-        // "If R is blank, replace R with its left child until R is either non-blank or a leaf node"
-        let mut child = right;
-        while self.nodes[child].is_blank() && child.is_parent() {
-            // Unwrapping here is safe, because we know it is a full parent node
-            child = treemath::left(child).unwrap();
-        }
-        let right = child;
-
-        // "If R is a leaf node, the check fails"
-        if right.is_leaf() {
-            return Err(ParentHashError::EndedWithLeafNode);
-        }
-
-        // Current hash with left child resolution
-        let current_hash_left = ParentHashInput::new(&self, index, left, parent_hash_field)
-            // Unwrapping here is safe, since we can be sure the node is not blank
-            .unwrap()
-            .hash(&self.ciphersuite);
-
-        // "If R.parent_hash is equal to the Parent Hash of P with Co-Path Child L, the check passes"
-        if let Some(right_parent_hash_field) = self.nodes[right].parent_hash() {
-            if right_parent_hash_field == current_hash_left {
-                return Ok(());
-            }
-        }
-
-        // "Otherwise, the check fails"
-        Err(ParentHashError::AllChecksFailed)
-    }
-
-    /// Verify the parent hashes of the tree nodes. Returns `true` if all parent
-    /// hashes have successfully been verified and `false` otherwise.
-    pub fn verify_parent_hashes(&self) -> bool {
-        self.nodes.iter().enumerate().all(|(index, node)| {
-            if NodeIndex::from(index).is_parent() && node.is_full_parent() {
-                self.verify_parent_hash(NodeIndex::from(index), node)
-                    .is_ok()
-            } else {
-                true
-            }
-        })
     }
 }
 

--- a/src/tree/test_hashes.rs
+++ b/src/tree/test_hashes.rs
@@ -40,7 +40,7 @@ fn test_parent_hash() {
         let mut tree =
             RatchetTree::new_from_nodes(&ciphersuite, key_package_bundle, &nodes).unwrap();
 
-        assert!(tree.verify_parent_hashes());
+        assert!(tree.verify_parent_hashes().is_ok());
 
         // Populate the parent nodes with fake values
         for index in 0..tree.tree_size().as_usize() {


### PR DESCRIPTION
Fixes #297. Follow-up to #293.

Some of the return values of verification functions were still `bool`. Now the return types are consistently `Result<(), Error>`.