### PR TITLE
Consolidate direct_path functions in TreeMath

### DIFF
--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -123,7 +123,7 @@ impl MlsGroup {
             // We can unwrap here, because, upon closer inspection,
             // `dirpath_long` will never throw an error.
             let common_path =
-                treemath::dirpath_long(common_ancestor_index, tree.leaf_count()).unwrap();
+                treemath::parent_direct_path(common_ancestor_index, tree.leaf_count()).unwrap();
 
             // Update the private tree.
             let private_tree = tree.private_tree_mut();

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -48,8 +48,7 @@ use crate::ciphersuite::*;
 use crate::codec::*;
 use crate::group::*;
 use crate::messages::{proposals::AddProposal, GroupSecrets, PathSecret};
-use crate::tree::index::LeafIndex;
-use crate::tree::index::NodeIndex;
+use crate::tree::index::{LeafIndex, NodeIndex};
 use crate::tree::private_tree::CommitSecret;
 use crate::tree::secret_tree::SecretTree;
 use crate::tree::treemath;
@@ -117,8 +116,8 @@ impl JoinerSecret {
     ) -> Result<Vec<PlaintextSecret>, CodecError> {
         // Get a Vector containing the node indices of the direct path to the
         // root from our own leaf.
-        let dirpath = treemath::direct_path_root(
-            provisional_tree.own_node_index().into(),
+        let dirpath = treemath::leaf_direct_path(
+            provisional_tree.own_node_index(),
             provisional_tree.leaf_count(),
         )
         .expect("create_commit_internal: TreeMath error when computing direct path.");

--- a/src/tree/secret_tree.rs
+++ b/src/tree/secret_tree.rs
@@ -129,10 +129,9 @@ impl SecretTree {
         let index_in_tree = NodeIndex::from(index);
         let mut dir_path = vec![index_in_tree];
         dir_path.extend(
-            dirpath(index_in_tree, self.size)
+            leaf_direct_path(index, self.size)
                 .expect("initialize_sender_ratchets: Error while computing direct path."),
         );
-        dir_path.push(root(self.size));
         let mut empty_nodes: Vec<NodeIndex> = vec![];
         for n in dir_path {
             empty_nodes.push(n);


### PR DESCRIPTION
Fixes #96.

I cleaned up the direct path mess in `treemath`. Now there are only two functions, depending on whether the direct path starts from a leaf or an intermediary node. Adds some type safety as well, because `LeafIndex` is used more often now.