### PR TITLE
Add ctest_panic macro

### DIFF
--- a/test_macros/src/lib.rs
+++ b/test_macros/src/lib.rs
@@ -24,12 +24,25 @@ impl Parse for TestInput {
 #[proc_macro]
 pub fn ctest(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as TestInput);
-    impl_ciphersuite_tests(input).unwrap()
+    impl_ciphersuite_tests(input, false).unwrap()
 }
 
-fn impl_ciphersuite_tests(input: TestInput) -> Result<TokenStream> {
+#[proc_macro]
+pub fn ctest_panic(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as TestInput);
+    impl_ciphersuite_tests(input, true).unwrap()
+}
+
+fn impl_ciphersuite_tests(input: TestInput, should_panic: bool) -> Result<TokenStream> {
     let ast = input.body;
     let test_name = input.test_name;
+    let should_panic = if should_panic {
+        quote! {
+            #[should_panic]
+        }
+    } else {
+        quote! {}
+    };
     let tests = openmls::config::Config::supported_ciphersuite_names()
         .into_iter()
         .map(|&ciphersuite_name| {
@@ -40,6 +53,7 @@ fn impl_ciphersuite_tests(input: TestInput) -> Result<TokenStream> {
             );
             quote! {
                 #[test]
+                #should_panic
                 fn #test_name () {
                     let _ciphersuite_code = #ciphersuite_code;
                     #ast


### PR DESCRIPTION
Adds a macro that allows indicating that we expect a test to fail when using the ciphersuite proc macros.

I built this for the interop test scenario PR, but ended up not using it. It might be useful for the future, though.