### PR TITLE
KeyPackage constructor check for mismatch

### DIFF
--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -70,6 +70,14 @@ impl Credential {
             MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }
+    /// Get the signature scheme used by the credential.
+    pub fn signature_scheme(&self) -> SignatureScheme {
+        match &self.credential {
+            MLSCredentialType::Basic(basic_credential) => basic_credential.signature_scheme,
+            // TODO: implement getter for signature scheme for X509 certificates. See issue #134.
+            MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+        }
+    }
 }
 
 impl From<MLSCredentialType> for Credential {

--- a/src/key_packages/errors.rs
+++ b/src/key_packages/errors.rs
@@ -17,6 +17,7 @@ implement_error! {
             DuplicateExtension = "Duplicate extensions are not allowed.",
             NoCiphersuitesSupplied = "Creating a new key package requires at least one ciphersuite.",
             CiphersuiteMismatch = "The list of ciphersuites is not consistent with the capabilities extension.",
+            CiphersuiteSignatureSchemeMismatch = "The ciphersuite does not match the signature scheme.",
         }
         Complex {
             ExtensionError(ExtensionError) =

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -21,7 +21,7 @@ mod codec;
 pub mod errors;
 pub(crate) use errors::*;
 
-#[cfg(tests)]
+#[cfg(test)]
 mod test_key_packages;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -153,6 +153,11 @@ impl KeyPackage {
         credential_bundle: &CredentialBundle,
         extensions: Vec<Box<dyn Extension>>,
     ) -> Result<Self, KeyPackageError> {
+        if SignatureScheme::from(ciphersuite_name)
+            != credential_bundle.credential().signature_scheme()
+        {
+            return Err(KeyPackageError::CiphersuiteSignatureSchemeMismatch);
+        }
         let mut key_package = Self {
             // TODO: #85 Take from global config.
             protocol_version: ProtocolVersion::default(),
@@ -258,6 +263,11 @@ impl KeyPackageBundle {
         credential_bundle: &CredentialBundle,
         extensions: Vec<Box<dyn Extension>>,
     ) -> Result<Self, KeyPackageError> {
+        if SignatureScheme::from(ciphersuites[0])
+            != credential_bundle.credential().signature_scheme()
+        {
+            return Err(KeyPackageError::CiphersuiteSignatureSchemeMismatch);
+        }
         debug_assert!(!ciphersuites.is_empty());
         let ciphersuite = Config::ciphersuite(ciphersuites[0]).unwrap();
         let leaf_secret = Secret::from(get_random_vec(ciphersuite.hash_length()));

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -1,14 +1,15 @@
-#[cfg(test)]
 use crate::config::*;
-#[cfg(test)]
 use crate::{extensions::*, key_packages::*};
 
 #[test]
 fn generate_key_package() {
     for ciphersuite in Config::supported_ciphersuites() {
-        let credential_bundle =
-            CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, ciphersuite.name())
-                .unwrap();
+        let credential_bundle = CredentialBundle::new(
+            vec![1, 2, 3],
+            CredentialType::Basic,
+            ciphersuite.name().into(),
+        )
+        .unwrap();
 
         // Generate a valid KeyPackage.
         let lifetime_extension = Box::new(LifetimeExtension::new(60));
@@ -18,7 +19,7 @@ fn generate_key_package() {
             vec![lifetime_extension],
         )
         .unwrap();
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        std::thread::sleep(std::time::Duration::from_millis(1));
         assert!(kpb.key_package().verify().is_ok());
 
         // Now we add an invalid lifetime.
@@ -29,7 +30,7 @@ fn generate_key_package() {
             vec![lifetime_extension],
         )
         .unwrap();
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        std::thread::sleep(std::time::Duration::from_millis(1));
         assert!(kpb.key_package().verify().is_err());
 
         // Now with two lifetime extensions, the key package should be invalid.
@@ -48,7 +49,7 @@ fn test_codec() {
     for ciphersuite in Config::supported_ciphersuites() {
         let id = vec![1, 2, 3];
         let credential_bundle =
-            CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name()).unwrap();
+            CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name().into()).unwrap();
         let mut kpb =
             KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new()).unwrap();
 
@@ -68,7 +69,7 @@ fn key_package_id_extension() {
     for ciphersuite in Config::supported_ciphersuites() {
         let id = vec![1, 2, 3];
         let credential_bundle =
-            CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name()).unwrap();
+            CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name().into()).unwrap();
         let mut kpb = KeyPackageBundle::new(
             &[ciphersuite.name()],
             &credential_bundle,
@@ -90,6 +91,34 @@ fn key_package_id_extension() {
         assert!(kpb.key_package().verify().is_ok());
 
         // Check ID
-        assert_eq!(&id[..], &kpb.key_package().id().unwrap()[..]);
+        assert_eq!(&id[..], &kpb.key_package().key_id().expect("No key ID")[..]);
     }
+}
+
+#[test]
+fn test_mismatch() {
+    // === KeyPackageBundle negative test ===
+
+    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let signature_scheme = SignatureScheme::ECDSA_SECP256R1_SHA256;
+
+    let credential_bundle =
+        CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, signature_scheme)
+            .expect("Could not create credential bundle");
+
+    assert_eq!(
+        KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, vec![],),
+        Err(KeyPackageError::CiphersuiteSignatureSchemeMismatch)
+    );
+
+    // === KeyPackageBundle positive test ===
+
+    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let signature_scheme = SignatureScheme::ED25519;
+
+    let credential_bundle =
+        CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, signature_scheme)
+            .expect("Could not create credential bundle");
+
+    assert!(KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, vec![]).is_ok());
 }


### PR DESCRIPTION
Fixes #294 and re-enables the key package unit tests that seem to have been de-activated for a while.