### PR TITLE
Fix codecov test coverage reporting

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "tests/utils/managed_utils/*"
+  - "tests/utils/mls_utils/*"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,0 @@
-ignore:
-  - "tests/utils/managed_utils/*"
-  - "tests/utils/mls_utils/*"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
 
       - name: Run cargo-tarpaulin

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,11 +12,14 @@ jobs:
         with:
           submodules: true
 
-      - name: Install stable toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
+
+      - name: Clean
+        run: cargo clean
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,4 @@
 name: test coverage
-ignore:
-  - "tests/utils/managed_utils/*"
-  - "tests/utils/mls_utils/*"
 
 on: [push]
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
 ignore:
   - "delivery-service/**/*"  # ignore PoC DS server and lib
   - "cli/**/*"  # ignore PoC cli
+  # ignore test frameworks
+  - "tests/utils/managed_utils/*"
+  - "tests/utils/mls_utils/*"


### PR DESCRIPTION
This PR moves the `ignore` section from `.github/workflows/coverage.yml` to a new file `.github/codecov.yml`.

According to the [documentation](https://docs.codecov.io/docs/codecov-yaml), this should fix codecov test coverage testing.

