### PR TITLE
key schedule reorg

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Tests
         run: cargo test --verbose
-      - name: KAT
-        run: cargo test  --verbose --features="test-vectors" kat
   checks:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ evercrypt = { version = "0.0.6", features = ["serialization"] }
 [features]
 default = ["rust-crypto"]
 rust-crypto = ["evercrypt/rust-crypto-aes"]
-test-vectors = []
 
 [dev-dependencies]
 criterion = "^0.3"

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -234,12 +234,6 @@ impl Secret {
     pub(crate) fn to_bytes(&self) -> &[u8] {
         &self.value
     }
-
-    #[cfg(all(test, feature = "test-vectors"))]
-    #[doc(hidden)]
-    pub(crate) fn to_vec(&self) -> Vec<u8> {
-        self.value.clone()
-    }
 }
 
 impl Default for Secret {

--- a/src/framing/ciphertext.rs
+++ b/src/framing/ciphertext.rs
@@ -17,7 +17,7 @@ pub struct MLSCiphertext {
 
 impl MLSCiphertext {
     /// Try to create a new `MLSCiphertext` from an `MLSPlaintext`
-    pub fn try_from_plaintext(
+    pub(crate) fn try_from_plaintext(
         mls_plaintext: &MLSPlaintext,
         ciphersuite: &Ciphersuite,
         context: &GroupContext,

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -9,7 +9,7 @@ use crate::config::ConfigError;
 use crate::framing::errors::{MLSCiphertextError, VerificationError};
 use crate::messages::errors::ProposalQueueError;
 use crate::schedule::errors::KeyScheduleError;
-use crate::tree::{ParentHashError, TreeError, treemath::TreeMathError};
+use crate::tree::{treemath::TreeMathError, ParentHashError, TreeError};
 
 implement_error! {
     pub enum GroupError {

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -9,28 +9,36 @@ use crate::config::ConfigError;
 use crate::framing::errors::{MLSCiphertextError, VerificationError};
 use crate::messages::errors::ProposalQueueError;
 use crate::schedule::errors::KeyScheduleError;
-use crate::tree::{ParentHashError, TreeError};
+use crate::tree::{ParentHashError, TreeError, treemath::TreeMathError};
 
 implement_error! {
     pub enum GroupError {
-        MLSCiphertextError(MLSCiphertextError) =
-            "See [`MLSCiphertextError`](`crate::framing::errors::MLSCiphertextError`) for details.",
-        WelcomeError(WelcomeError) =
-            "See [`WelcomeError`](`WelcomeError`) for details.",
-        ApplyCommitError(ApplyCommitError) =
-            "See [`ApplyCommitError`](`ApplyCommitError`) for details.",
-        CreateCommitError(CreateCommitError) =
-            "See [`CreateCommitError`](`CreateCommitError`) for details.",
-        ConfigError(ConfigError) =
-            "See [`ConfigError`](`crate::config::ConfigError`) for details.",
-        ExporterError(ExporterError) =
-            "See [`ExporterError`](`ExporterError`) for details.",
-        ProposalQueueError(ProposalQueueError) =
-            "See [`ProposalQueueError`](`crate::messages::errors::ProposalQueueError`) for details.",
-        CodecError(CodecError) =
-            "Codec error occurred.",
-        KeyScheduleError(KeyScheduleError) =
-            "An error occurred in the key schedule.",
+        Simple {
+            InitSecretNotFound =
+                "Missing init secret when creating commit.",
+        }
+        Complex {
+            MLSCiphertextError(MLSCiphertextError) =
+                "See [`MLSCiphertextError`](`crate::framing::errors::MLSCiphertextError`) for details.",
+            WelcomeError(WelcomeError) =
+                "See [`WelcomeError`](`WelcomeError`) for details.",
+            ApplyCommitError(ApplyCommitError) =
+                "See [`ApplyCommitError`](`ApplyCommitError`) for details.",
+            CreateCommitError(CreateCommitError) =
+                "See [`CreateCommitError`](`CreateCommitError`) for details.",
+            ConfigError(ConfigError) =
+                "See [`ConfigError`](`crate::config::ConfigError`) for details.",
+            ExporterError(ExporterError) =
+                "See [`ExporterError`](`ExporterError`) for details.",
+            ProposalQueueError(ProposalQueueError) =
+                "See [`ProposalQueueError`](`crate::messages::errors::ProposalQueueError`) for details.",
+            CodecError(CodecError) =
+                "Codec error occurred.",
+            KeyScheduleError(KeyScheduleError) =
+                "An error occurred in the key schedule.",
+            MathError(TreeMathError) =
+                "An error occurred during a tree math operation.",
+        }
     }
 }
 
@@ -100,6 +108,8 @@ implement_error! {
                 "The proposal queue is missing a proposal for the commit.",
             OwnKeyNotFound =
                   "Missing own key to apply proposal.",
+            InitSecretNotFound =
+                  "Missing init secret to apply proposal.",
         }
         Complex {
             PlaintextSignatureFailure(VerificationError) =

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -8,6 +8,7 @@ use crate::codec::CodecError;
 use crate::config::ConfigError;
 use crate::framing::errors::{MLSCiphertextError, VerificationError};
 use crate::messages::errors::ProposalQueueError;
+use crate::schedule::errors::KeyScheduleError;
 use crate::tree::{ParentHashError, TreeError};
 
 implement_error! {
@@ -28,6 +29,8 @@ implement_error! {
             "See [`ProposalQueueError`](`crate::messages::errors::ProposalQueueError`) for details.",
         CodecError(CodecError) =
             "Codec error occurred.",
+        KeyScheduleError(KeyScheduleError) =
+            "An error occurred in the key schedule.",
     }
 }
 
@@ -64,6 +67,8 @@ implement_error! {
                 "Unable to decrypt the EncryptedGroupSecrets.",
             CodecError(CodecError) =
                 "Codec error occurred.",
+            KeyScheduleError(KeyScheduleError) =
+                "An error occurred in the key schedule.",
         }
     }
 }
@@ -103,6 +108,8 @@ implement_error! {
                 "A matching EncryptedPathSecret failed to decrypt.",
             CodecError(CodecError) =
                 "Codec error occurred.",
+            KeyScheduleError(KeyScheduleError) =
+                "An error occurred in the key schedule.",
         }
     }
 }

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -112,6 +112,8 @@ impl MlsGroup {
             &self.interim_transcript_hash,
         )?;
 
+        // TODO #186: Implement extensions
+
         let provisional_group_context = GroupContext::new(
             self.group_context.group_id.clone(),
             provisional_epoch,

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -40,62 +40,34 @@ impl MlsGroup {
         if apply_proposals_values.self_removed {
             return Err(CreateCommitError::CannotRemoveSelf.into());
         }
-        // Determine if Commit needs path field
-        let path_required =
-            apply_proposals_values.path_required || contains_own_updates || force_self_update;
 
-        let (commit_secret, path, path_secrets_option, kpb_option) = if path_required {
-            // If path is needed, compute path values
-            let (commit_secret, path, path_secrets, key_package_bundle) = provisional_tree
-                .refresh_private_tree(
+        let (path, kpb_option) =
+            if apply_proposals_values.path_required || contains_own_updates || force_self_update {
+                // If path is needed, compute path values
+                let (path, key_package_bundle) = provisional_tree.refresh_private_tree(
                     credential_bundle,
                     &self.group_context.serialized(),
                     apply_proposals_values.exclusion_list(),
                 );
-            (
-                Some(commit_secret),
-                Some(path),
-                Some(path_secrets),
-                Some(key_package_bundle),
-            )
-        } else {
-            // If path is not needed, return empty commit secret
-            (None, None, None, None)
-        };
+                (Some(path), Some(key_package_bundle))
+            } else {
+                // If path is not needed, return empty commit secret
+                (None, None)
+            };
+
         // Create commit message
         let commit = Commit {
             proposals: proposal_reference_list,
             path,
         };
+
         // Create provisional group state
         let mut provisional_epoch = self.group_context.epoch;
         provisional_epoch.increment();
-        // We clone the init secret here, as the `joiner_secret` is only for the
-        // provisional group state.
-        let joiner_secret = JoinerSecret::from_commit_and_init_secret(
-            ciphersuite,
-            commit_secret,
-            &self.init_secret,
-        );
-        // Create group secrets for later use, so we can afterwards consume the
-        // `joiner_secret`.
-        let plaintext_secrets = joiner_secret.group_secrets(
-            apply_proposals_values.invitation_list,
-            &provisional_tree,
-            path_secrets_option,
-        )?;
-        // TODO #141: Implement PSK
-        let intermediate_secret = IntermediateSecret::new(ciphersuite, joiner_secret, None);
-        let welcome_secret = WelcomeSecret::new(ciphersuite, &intermediate_secret);
-
-        // Derive the welcome key material before consuming the `MemberSecret`
-        // immediately afterwards.
-        let (welcome_key, welcome_nonce) = welcome_secret.derive_welcome_key_nonce(ciphersuite);
 
         // Build MLSPlaintext
         let content = MLSPlaintextContentType::Commit(commit);
         let sender = Sender::member(sender_index);
-
         let mut mls_plaintext = MLSPlaintext {
             group_id: self.context().group_id.clone(),
             epoch: self.context().epoch,
@@ -131,13 +103,25 @@ impl MlsGroup {
             &[],
         )?;
 
-        let epoch_secret =
-            EpochSecret::new(ciphersuite, intermediate_secret, &provisional_group_context);
+        let joiner_secret = JoinerSecret::new(
+            ciphersuite,
+            provisional_tree.commit_secret(),
+            &self.init_secret,
+        );
 
-        // The init- and encryption secrets are not used here. They come into
-        // play when the provisional group state is applied in `apply_commit`.
-        let (provisional_epoch_secrets, _provisional_init_secret, _provisional_encryption_secret) =
-            EpochSecrets::derive_epoch_secrets(&ciphersuite, epoch_secret);
+        // Create group secrets for later use, so we can afterwards consume the
+        // `joiner_secret`.
+        let plaintext_secrets = PlaintextSecret::new(
+            &joiner_secret,
+            apply_proposals_values.invitation_list,
+            &provisional_tree,
+        )?;
+
+        // TODO #141: Implement PSK
+        let mut key_schedule = KeySchedule::init(ciphersuite, joiner_secret, None);
+        let welcome_secret = key_schedule.welcome()?;
+        key_schedule.add_context(&provisional_group_context)?;
+        let provisional_epoch_secrets = key_schedule.epoch_secrets()?;
 
         // Calculate the confirmation tag
         let confirmation_tag = ConfirmationTag::new(
@@ -145,6 +129,7 @@ impl MlsGroup {
             &provisional_epoch_secrets.confirmation_key(),
             &confirmed_transcript_hash,
         );
+
         // Set the confirmation tag
         mls_plaintext.confirmation_tag = Some(confirmation_tag.clone());
 
@@ -152,7 +137,7 @@ impl MlsGroup {
         mls_plaintext.add_membership_tag(
             ciphersuite,
             serialized_context,
-            &self.epoch_secrets().membership_key,
+            self.epoch_secrets().membership_key(),
         )?;
 
         // Check if new members were added an create welcome message
@@ -180,7 +165,9 @@ impl MlsGroup {
                 sender_index,
             );
             group_info.set_signature(group_info.sign(credential_bundle));
+
             // Encrypt GroupInfo object
+            let (welcome_key, welcome_nonce) = welcome_secret.derive_welcome_key_nonce(ciphersuite);
             let encrypted_group_info = welcome_key
                 .aead_seal(&group_info.encode_detached().unwrap(), &[], &welcome_nonce)
                 .unwrap();
@@ -213,5 +200,69 @@ impl MlsGroup {
         } else {
             Ok((mls_plaintext, None, kpb_option))
         }
+    }
+}
+
+pub(crate) struct PlaintextSecret {
+    pub(crate) public_key: HPKEPublicKey,
+    pub(crate) group_secrets_bytes: Vec<u8>,
+    pub(crate) key_package_hash: Vec<u8>,
+}
+
+impl PlaintextSecret {
+    /// Prepare the `GroupSecrets` for a number of `invited_members` based on a
+    /// provisional `RatchetTree`. If there are `path_secrets` in the provisional
+    /// tree, we need to include a `path_secret` into the `GroupSecrets`.
+    pub(crate) fn new(
+        joiner_secret: &JoinerSecret,
+        invited_members: Vec<(NodeIndex, AddProposal)>,
+        provisional_tree: &RatchetTree,
+    ) -> Result<Vec<Self>, CodecError> {
+        // Get a Vector containing the node indices of the direct path to the
+        // root from our own leaf.
+        let dirpath = treemath::leaf_direct_path(
+            provisional_tree.own_node_index().into(),
+            provisional_tree.leaf_count(),
+        )
+        .expect("create_commit_internal: TreeMath error when computing direct path.");
+
+        let mut plaintext_secrets = vec![];
+        for (index, add_proposal) in invited_members {
+            let key_package = add_proposal.key_package;
+            let key_package_hash = key_package.hash();
+
+            let path_secrets = provisional_tree.path_secrets();
+            let path_secret = if !path_secrets.is_empty() {
+                // Compute the index of the common ancestor lowest in the
+                // tree of our own leaf and the given index.
+                let common_ancestor_index = treemath::common_ancestor_index(
+                    index,
+                    provisional_tree.own_node_index().into(),
+                );
+                // Get the position of the node index that represents the
+                // common ancestor in the direct path. We can unwrap here,
+                // because the direct path must contain the shared ancestor.
+                let position = dirpath
+                    .iter()
+                    .position(|&x| x == common_ancestor_index)
+                    .unwrap();
+                // We have to clone the element of the vector here to
+                // preserve its order.
+                let path_secret = path_secrets[position].clone();
+                Some(PathSecret { path_secret })
+            } else {
+                None
+            };
+
+            // Create the GroupSecrets object for the respective member.
+            // TODO #141: Implement PSK
+            let group_secrets_bytes = GroupSecrets::new_encoded(joiner_secret, path_secret, None)?;
+            plaintext_secrets.push(PlaintextSecret {
+                public_key: key_package.hpke_init_key().clone(),
+                group_secrets_bytes,
+                key_package_hash,
+            });
+        }
+        Ok(plaintext_secrets)
     }
 }

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -106,7 +106,9 @@ impl MlsGroup {
         let joiner_secret = JoinerSecret::new(
             ciphersuite,
             provisional_tree.commit_secret(),
-            self.epoch_secrets().init_secret().ok_or(GroupError::InitSecretNotFound)?,
+            self.epoch_secrets()
+                .init_secret()
+                .ok_or(GroupError::InitSecretNotFound)?,
         );
 
         // Create group secrets for later use, so we can afterwards consume the
@@ -203,9 +205,9 @@ impl MlsGroup {
     }
 }
 
-/// Helper struct holding values that are encryptedin the `EncryptedGroupSecrets`.
-/// In particular, the `group_secrets_bytes` are encrypted for the `public_key`
-/// into `encrypted_group_secrets` later.
+/// Helper struct holding values that are encryptedin the
+/// `EncryptedGroupSecrets`. In particular, the `group_secrets_bytes` are
+/// encrypted for the `public_key` into `encrypted_group_secrets` later.
 pub(crate) struct PlaintextSecret {
     pub(crate) public_key: HPKEPublicKey,
     pub(crate) group_secrets_bytes: Vec<u8>,
@@ -214,8 +216,9 @@ pub(crate) struct PlaintextSecret {
 
 impl PlaintextSecret {
     /// Prepare the `GroupSecrets` for a number of `invited_members` based on a
-    /// provisional `RatchetTree`. If there are `path_secrets` in the provisional
-    /// tree, we need to include a `path_secret` into the `GroupSecrets`.
+    /// provisional `RatchetTree`. If there are `path_secrets` in the
+    /// provisional tree, we need to include a `path_secret` into the
+    /// `GroupSecrets`.
     pub(crate) fn new(
         joiner_secret: &JoinerSecret,
         invited_members: Vec<(NodeIndex, AddProposal)>,

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -39,7 +39,6 @@ pub struct MlsGroup {
     ciphersuite: &'static Ciphersuite,
     group_context: GroupContext,
     epoch_secrets: EpochSecrets,
-    init_secret: InitSecret,
     secret_tree: RefCell<SecretTree>,
     tree: RefCell<RatchetTree>,
     interim_transcript_hash: Vec<u8>,
@@ -52,7 +51,6 @@ pub struct MlsGroup {
 implement_persistence!(
     MlsGroup,
     group_context,
-    init_secret,
     epoch_secrets,
     secret_tree,
     tree,
@@ -93,8 +91,7 @@ impl MlsGroup {
         // TODO #141: Implement PSK
         let mut key_schedule = KeySchedule::init(ciphersuite, joiner_secret, None);
         key_schedule.add_context(&group_context)?;
-        let init_secret = key_schedule.init_secret()?;
-        let epoch_secrets = key_schedule.epoch_secrets()?;
+        let epoch_secrets = key_schedule.epoch_secrets(true)?;
 
         let secret_tree = epoch_secrets
             .encryption_secret()
@@ -104,7 +101,6 @@ impl MlsGroup {
             ciphersuite,
             group_context,
             epoch_secrets,
-            init_secret,
             secret_tree: RefCell::new(secret_tree),
             tree: RefCell::new(tree),
             interim_transcript_hash,

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -84,17 +84,21 @@ impl MlsGroup {
         // Derive an initial joiner secret based on the commit secret.
         // Derive an epoch secret from the joiner secret.
         // We use a random `InitSecret` for initialization.
-        let joiner_secret = JoinerSecret::from_commit_and_init_secret(
+        let joiner_secret = JoinerSecret::new(
             ciphersuite,
-            Some(commit_secret),
+            commit_secret,
             &InitSecret::random(ciphersuite.hash_length()),
         );
+
         // TODO #141: Implement PSK
-        let intermediate_secret = IntermediateSecret::new(ciphersuite, joiner_secret, None);
-        let epoch_secret = EpochSecret::new(ciphersuite, intermediate_secret, &group_context);
-        let (epoch_secrets, init_secret, encryption_secret) =
-            EpochSecrets::derive_epoch_secrets(ciphersuite, epoch_secret);
-        let secret_tree = encryption_secret.create_secret_tree(LeafIndex::from(1u32));
+        let mut key_schedule = KeySchedule::init(ciphersuite, joiner_secret, None);
+        key_schedule.add_context(&group_context)?;
+        let init_secret = key_schedule.init_secret()?;
+        let epoch_secrets = key_schedule.epoch_secrets()?;
+
+        let secret_tree = epoch_secrets
+            .encryption_secret()
+            .create_secret_tree(LeafIndex::from(1u32));
         let interim_transcript_hash = vec![];
         Ok(MlsGroup {
             ciphersuite,
@@ -141,7 +145,7 @@ impl MlsGroup {
             proposal,
             credential_bundle,
             &self.context(),
-            &self.epoch_secrets().membership_key,
+            self.epoch_secrets().membership_key(),
         )
         .map_err(GroupError::CodecError)
     }
@@ -165,7 +169,7 @@ impl MlsGroup {
             proposal,
             credential_bundle,
             &self.context(),
-            &self.epoch_secrets().membership_key,
+            self.epoch_secrets().membership_key(),
         )
         .map_err(GroupError::CodecError)
     }
@@ -191,7 +195,7 @@ impl MlsGroup {
             proposal,
             credential_bundle,
             &self.context(),
-            &self.epoch_secrets().membership_key,
+            self.epoch_secrets().membership_key(),
         )
         .map_err(GroupError::CodecError)
     }
@@ -247,7 +251,7 @@ impl MlsGroup {
             msg,
             credential_bundle,
             &self.context(),
-            &self.epoch_secrets().membership_key,
+            self.epoch_secrets().membership_key(),
         )?;
         self.encrypt(mls_plaintext, padding_size)
     }
@@ -317,7 +321,7 @@ impl MlsGroup {
             .verify_membership_tag(
                 self.ciphersuite,
                 serialized_context,
-                &self.epoch_secrets().membership_key,
+                self.epoch_secrets().membership_key(),
             )
             .map_err(|_| MLSPlaintextError::InvalidSignature)
     }
@@ -329,7 +333,7 @@ impl MlsGroup {
         if key_length > u16::MAX.into() {
             return Err(ExporterError::KeyLengthTooLong.into());
         }
-        Ok(self.epoch_secrets.exporter_secret.derive_exported_secret(
+        Ok(self.epoch_secrets.exporter_secret().derive_exported_secret(
             self.ciphersuite(),
             label,
             &self.context(),
@@ -363,7 +367,7 @@ impl MlsGroup {
     }
 
     /// Get the ciphersuite implementation used in this group.
-    pub fn ciphersuite(&self) -> &Ciphersuite {
+    pub fn ciphersuite(&self) -> &'static Ciphersuite {
         self.ciphersuite
     }
 
@@ -419,12 +423,12 @@ impl MlsGroup {
         &self.interim_transcript_hash
     }
 
-    #[cfg(all(test, feature = "test-vectors"))]
+    #[cfg(test)]
     pub(crate) fn epoch_secrets_mut(&mut self) -> &mut EpochSecrets {
         &mut self.epoch_secrets
     }
 
-    #[cfg(all(test, feature = "test-vectors"))]
+    #[cfg(test)]
     pub(crate) fn context_mut(&mut self) -> &mut GroupContext {
         &mut self.group_context
     }

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -45,11 +45,9 @@ impl MlsGroup {
             .welcome()?
             .derive_welcome_key_nonce(ciphersuite);
 
-        let group_info_bytes =
-            match welcome_key.aead_open(welcome.encrypted_group_info(), &[], &welcome_nonce) {
-                Ok(bytes) => bytes,
-                Err(_) => return Err(WelcomeError::GroupInfoDecryptionFailure),
-            };
+        let group_info_bytes = welcome_key
+            .aead_open(welcome.encrypted_group_info(), &[], &welcome_nonce)
+            .map_err(|_| WelcomeError::GroupInfoDecryptionFailure)?;
         let mut group_info = GroupInfo::decode_detached(&group_info_bytes)?;
         let path_secret_option = group_secrets.path_secret;
 

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -161,8 +161,7 @@ impl MlsGroup {
         )?;
         // TODO #141: Implement PSK
         key_schedule.add_context(&group_context)?;
-        let init_secret = key_schedule.init_secret()?;
-        let epoch_secrets = key_schedule.epoch_secrets()?;
+        let epoch_secrets = key_schedule.epoch_secrets(true)?;
 
         let secret_tree = epoch_secrets
             .encryption_secret()
@@ -187,7 +186,6 @@ impl MlsGroup {
                 ciphersuite,
                 group_context,
                 epoch_secrets,
-                init_secret,
                 secret_tree: RefCell::new(secret_tree),
                 tree: RefCell::new(tree),
                 interim_transcript_hash,

--- a/src/group/mls_group/test_mls_group.rs
+++ b/src/group/mls_group/test_mls_group.rs
@@ -296,7 +296,7 @@ fn test_update_path() {
             .add_membership_tag(
                 ciphersuite,
                 serialized_context,
-                &group_bob.epoch_secrets.membership_key,
+                group_bob.epoch_secrets.membership_key(),
             )
             .expect("Could not add membership key");
 

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -67,7 +67,7 @@ pub struct GroupContext {
     serialized: Vec<u8>,
 }
 
-#[cfg(all(test, feature = "test-vectors"))]
+#[cfg(test)]
 impl GroupContext {
     pub(crate) fn set_epoch(&mut self, epoch: GroupEpoch) {
         self.epoch = epoch;

--- a/src/schedule/errors.rs
+++ b/src/schedule/errors.rs
@@ -3,10 +3,7 @@ implement_error! {
         NotInit = "Expected to be in initial state.",
         NotEpoch = "Expected to be in epoch state.",
         NotContext = "Expected to be in a state where the context is added.",
-        NotEpochOrInit = "Expected to be in epoch or init state.",
-        NotInitSecret = "Expected to be in the state to derive the init secret.",
         NotEpochSecrets = "Expected to be in the state to derive the epoch secrets.",
-        NotDone = "Expected to be in done state.",
     }
 }
 

--- a/src/schedule/errors.rs
+++ b/src/schedule/errors.rs
@@ -1,0 +1,18 @@
+implement_error! {
+    pub enum ErrorState {
+        NotInit = "Expected to be in initial state.",
+        NotEpoch = "Expected to be in epoch state.",
+        NotContext = "Expected to be in a state where the context is added.",
+        NotEpochOrInit = "Expected to be in epoch or init state.",
+        NotInitSecret = "Expected to be in the state to derive the init secret.",
+        NotEpochSecrets = "Expected to be in the state to derive the epoch secrets.",
+        NotDone = "Expected to be in done state.",
+    }
+}
+
+implement_error! {
+    pub enum KeyScheduleError {
+        InvalidState(ErrorState) =
+            "The requested operation is not valid on the key schedule state.",
+    }
+}

--- a/src/schedule/errors.rs
+++ b/src/schedule/errors.rs
@@ -3,7 +3,6 @@ implement_error! {
         NotInit = "Expected to be in initial state.",
         NotEpoch = "Expected to be in epoch state.",
         NotContext = "Expected to be in a state where the context is added.",
-        NotEpochSecrets = "Expected to be in the state to derive the epoch secrets.",
     }
 }
 

--- a/src/tree/kat_treemath.rs
+++ b/src/tree/kat_treemath.rs
@@ -1,8 +1,8 @@
 //! # Known Answer Tests for treemath
 //!
 //! This test file generates and read test vectors for tree math.
-//! This currently differs from the test vectors in https://github.com/mlswg/mls-implementations/blob/master/test-vectors.md
-//! See https://github.com/mlswg/mls-implementations/issues/32 for a discussion.
+//! See https://github.com/mlswg/mls-implementations/blob/master/test-vectors.md
+//! for more description on the test vectors.
 //!
 //! ## Parameter:
 //! Number of leaves `n_leaves`.
@@ -22,16 +22,12 @@
 //! Any value that is invalid is represented as `null`.
 //!
 //! ## Verification:
-//! * `root` is the node index of the left child of the root node index of the
-//!   tree with `i+1` leaves.
-//! * `left[i]` is the node index of the left child of the node with index `i`
-//!   in a tree with `n_leaves` leaves
-//! * `right[i]` is the node index of the right child of the node with index `i`
-//!   in a tree with `n_leaves` leaves
-//! * `parent[i]` is the node index of the parent of the node with index `i` in
-//!   a tree with `n_leaves` leaves
-//! * `sibling[i]` is the node index of the sibling of the node with index `i`
-//!   in a tree with `n_leaves` leaves
+//! * `n_nodes` is the number of nodes in the tree with `n_leaves` leaves
+//! * `root[i]` is the root node index of the tree with `i+1` leaves
+//! * `left[i]` is the node index of the left child of the node with index `i` in a tree with `n_leaves` leaves
+//! * `right[i]` is the node index of the right child of the node with index `i` in a tree with `n_leaves` leaves
+//! * `parent[i]` is the node index of the parent of the node with index `i` in a tree with `n_leaves` leaves
+//! * `sibling[i]` is the node index of the sibling of the node with index `i` in a tree with `n_leaves` leaves
 
 use crate::{
     test_util::*,

--- a/src/tree/kat_treemath.rs
+++ b/src/tree/kat_treemath.rs
@@ -24,10 +24,14 @@
 //! ## Verification:
 //! * `n_nodes` is the number of nodes in the tree with `n_leaves` leaves
 //! * `root[i]` is the root node index of the tree with `i+1` leaves
-//! * `left[i]` is the node index of the left child of the node with index `i` in a tree with `n_leaves` leaves
-//! * `right[i]` is the node index of the right child of the node with index `i` in a tree with `n_leaves` leaves
-//! * `parent[i]` is the node index of the parent of the node with index `i` in a tree with `n_leaves` leaves
-//! * `sibling[i]` is the node index of the sibling of the node with index `i` in a tree with `n_leaves` leaves
+//! * `left[i]` is the node index of the left child of the node with index `i`
+//!   in a tree with `n_leaves` leaves
+//! * `right[i]` is the node index of the right child of the node with index `i`
+//!   in a tree with `n_leaves` leaves
+//! * `parent[i]` is the node index of the parent of the node with index `i` in
+//!   a tree with `n_leaves` leaves
+//! * `sibling[i]` is the node index of the sibling of the node with index `i`
+//!   in a tree with `n_leaves` leaves
 
 use crate::{
     test_util::*,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -461,12 +461,7 @@ impl RatchetTree {
         // Update it in the KeyPackageBundle
         key_package_bundle.set_key_package(key_package.clone());
 
-        (
-            // self.private_tree.commit_secret(),
-            path,
-            // self.private_tree.path_secrets().to_vec(),
-            key_package_bundle,
-        )
+        (path, key_package_bundle)
     }
 
     /// Replace the private tree with a new one based on the

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -21,9 +21,9 @@ pub(crate) use errors::*;
 pub use hashes::*;
 use index::*;
 use node::*;
-use private_tree::{PathSecrets, PrivateTree};
+use private_tree::PrivateTree;
 
-use self::private_tree::CommitSecret;
+use crate::schedule::CommitSecret;
 pub(crate) use serde::{
     de::{self, MapAccess, SeqAccess, Visitor},
     ser::{SerializeStruct, Serializer},
@@ -34,9 +34,9 @@ use std::collections::HashSet;
 use std::convert::TryInto;
 
 // Internal tree tests
-#[cfg(all(test, feature = "test-vectors"))]
+#[cfg(test)]
 mod kat_encryption;
-#[cfg(all(test, feature = "test-vectors"))]
+#[cfg(test)]
 mod kat_treemath;
 #[cfg(test)]
 mod test_hashes;
@@ -425,12 +425,14 @@ impl RatchetTree {
     }
 
     /// Update the private tree.
+    ///
+    /// Returns the update path and an updated key package bundle.
     pub(crate) fn refresh_private_tree(
         &mut self,
         credential_bundle: &CredentialBundle,
         group_context: &[u8],
         new_leaves_indexes: HashSet<&NodeIndex>,
-    ) -> (&CommitSecret, UpdatePath, PathSecrets, KeyPackageBundle) {
+    ) -> (UpdatePath, KeyPackageBundle) {
         // Generate new keypair
         let own_index = self.own_node_index();
 
@@ -460,9 +462,9 @@ impl RatchetTree {
         key_package_bundle.set_key_package(key_package.clone());
 
         (
-            self.private_tree.commit_secret(),
+            // self.private_tree.commit_secret(),
             path,
-            self.private_tree.path_secrets().to_vec(),
+            // self.private_tree.path_secrets().to_vec(),
             key_package_bundle,
         )
     }
@@ -761,6 +763,16 @@ impl RatchetTree {
         if new_tree_size > 0 {
             self.nodes.truncate(new_tree_size);
         }
+    }
+
+    /// Get a reference to the commit secret.
+    pub(crate) fn commit_secret(&self) -> &CommitSecret {
+        self.private_tree.commit_secret()
+    }
+
+    /// Get a slice with the path secrets.
+    pub(crate) fn path_secrets(&self) -> &[Secret] {
+        self.private_tree.path_secrets()
     }
 }
 

--- a/src/tree/secret_tree.rs
+++ b/src/tree/secret_tree.rs
@@ -75,7 +75,7 @@ impl SecretTree {
     /// `size`. The inner nodes of the tree and the SenderRatchets only get
     /// initialized when secrets are requested either through `secret()`
     /// or `next_secret()`.
-    pub fn new(encryption_secret: EncryptionSecret, size: LeafIndex) -> Self {
+    pub(crate) fn new(encryption_secret: EncryptionSecret, size: LeafIndex) -> Self {
         let root = root(size);
         let num_indices = NodeIndex::from(size).as_usize() - 1;
         let mut nodes = vec![None; num_indices];

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,7 @@ pub(crate) fn random_u32() -> u32 {
     OsRng.next_u32()
 }
 
-#[cfg(all(test, feature = "test-vectors"))]
+#[cfg(test)]
 pub(crate) fn random_u64() -> u64 {
     OsRng.next_u64()
 }


### PR DESCRIPTION
In preparation for the key schedule test vectors I re-organized the
key schedule and moved the logic into the actual key schedule module
instead of the group.

There are no changes to functionality PR, only moving code around.

This PR also removes the test-vector feature as it is no longer needed.