### PR TITLE
Fix remover bug

### DIFF
--- a/src/group/managed_group/callbacks.rs
+++ b/src/group/managed_group/callbacks.rs
@@ -194,7 +194,7 @@ impl<'a> Removal<'a> {
         } else if leaver_credential == remover_credential {
             Self::TheyLeft(leaver_credential)
         } else {
-            Self::TheyWereRemovedBy(remover_credential, leaver_credential)
+            Self::TheyWereRemovedBy(leaver_credential, remover_credential)
         }
     }
 }

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -456,7 +456,7 @@ impl<'a> ManagedGroup<'a> {
                             self.send_events(
                                 self.ciphersuite(),
                                 &commit.proposals,
-                                &plaintext.sender.sender,
+                                plaintext.sender.sender,
                                 &indexed_members,
                             );
                             // We don't need the pending proposals and key package bundles any
@@ -470,7 +470,7 @@ impl<'a> ManagedGroup<'a> {
                                 self.send_events(
                                     self.ciphersuite(),
                                     &commit.proposals,
-                                    &plaintext.sender.sender,
+                                    plaintext.sender.sender,
                                     &indexed_members,
                                 );
                                 // The group is no longer active
@@ -877,7 +877,7 @@ impl<'a> ManagedGroup<'a> {
         &self,
         ciphersuite: &Ciphersuite,
         proposals: &[ProposalOrRef],
-        sender: &LeafIndex,
+        sender: LeafIndex,
         indexed_members: &HashMap<LeafIndex, Credential>,
     ) {
         // We want to send the events in the order specified by the committer.
@@ -898,7 +898,7 @@ impl<'a> ManagedGroup<'a> {
                     if let Some(queued_proposal) = pending_proposals_queue.get(proposal_reference) {
                         self.send_proposal_event(
                             queued_proposal.proposal(),
-                            &queued_proposal.sender().to_leaf_index(),
+                            queued_proposal.sender().to_leaf_index(),
                             indexed_members,
                         );
                     }
@@ -911,10 +911,10 @@ impl<'a> ManagedGroup<'a> {
     fn send_proposal_event(
         &self,
         proposal: &Proposal,
-        sender: &LeafIndex,
+        sender: LeafIndex,
         indexed_members: &HashMap<LeafIndex, Credential>,
     ) {
-        let sender_credential = &indexed_members[sender];
+        let sender_credential = &indexed_members[&sender];
         match proposal {
             // Add proposals
             Proposal::Add(add_proposal) => {

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -898,7 +898,7 @@ impl<'a> ManagedGroup<'a> {
                     if let Some(queued_proposal) = pending_proposals_queue.get(proposal_reference) {
                         self.send_proposal_event(
                             queued_proposal.proposal(),
-                            sender,
+                            &queued_proposal.sender().to_leaf_index(),
                             indexed_members,
                         );
                     }

--- a/src/group/managed_group/test_managed_group.rs
+++ b/src/group/managed_group/test_managed_group.rs
@@ -56,7 +56,8 @@ fn test_managed_group_persistence() {
     assert_eq!(alice_group, alice_group_deserialized);
 }
 
-// This tests if the remover is correctly passed to the callback when one member issues a RemoveProposal and another members issues the next Commit.
+// This tests if the remover is correctly passed to the callback when one member
+// issues a RemoveProposal and another members issues the next Commit.
 #[test]
 fn remover() {
     // Callback

--- a/src/group/managed_group/test_managed_group.rs
+++ b/src/group/managed_group/test_managed_group.rs
@@ -55,3 +55,136 @@ fn test_managed_group_persistence() {
 
     assert_eq!(alice_group, alice_group_deserialized);
 }
+
+// This tests if the remover is correctly passed to the callback when one member issues a RemoveProposal and another members issues the next Commit.
+#[test]
+fn remover() {
+    // Callback
+    fn member_removed(_managed_group: &ManagedGroup, _aad: &[u8], removal: &Removal) {
+        match removal {
+            Removal::TheyWereRemovedBy(leaver, remover) => {
+                assert_eq!(remover.identity(), b"Alice");
+                assert_eq!(leaver.identity(), b"Bob");
+            }
+            _ => {
+                unreachable!("We should not be here")
+            }
+        }
+    }
+
+    let ciphersuite = &Config::supported_ciphersuites()[0];
+    let group_id = GroupId::from_slice(b"Test Group");
+
+    // Define credential bundles
+    let alice_credential_bundle = CredentialBundle::new(
+        "Alice".into(),
+        CredentialType::Basic,
+        ciphersuite.signature_scheme(),
+    )
+    .expect("Could not create credential bundle");
+    let bob_credential_bundle = CredentialBundle::new(
+        "Bob".into(),
+        CredentialType::Basic,
+        ciphersuite.signature_scheme(),
+    )
+    .expect("Could not create credential bundle");
+    let charlie_credential_bundle = CredentialBundle::new(
+        "Charlie".into(),
+        CredentialType::Basic,
+        ciphersuite.signature_scheme(),
+    )
+    .expect("Could not create credential bundle");
+
+    // Generate KeyPackages
+    let alice_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite.name()], &alice_credential_bundle, vec![]).unwrap();
+
+    let bob_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle, vec![]).unwrap();
+
+    let charlie_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite.name()], &charlie_credential_bundle, vec![]).unwrap();
+
+    // Define the managed group configuration
+
+    let update_policy = UpdatePolicy::default();
+    let callbacks = ManagedGroupCallbacks::default();
+    let mut managed_group_config = ManagedGroupConfig::new(
+        HandshakeMessageFormat::Plaintext,
+        update_policy,
+        0,
+        callbacks,
+    );
+
+    // === Alice creates a group ===
+    let mut alice_group = ManagedGroup::new(
+        &alice_credential_bundle,
+        &managed_group_config,
+        group_id,
+        alice_key_package_bundle,
+    )
+    .unwrap();
+
+    // === Alice adds Bob ===
+    let (queued_messages, welcome) =
+        match alice_group.add_members(&[bob_key_package_bundle.key_package().clone()]) {
+            Ok((qm, welcome)) => (qm, welcome),
+            Err(e) => panic!("Could not add member to group: {:?}", e),
+        };
+
+    alice_group
+        .process_messages(queued_messages)
+        .expect("The group is no longer active");
+
+    let mut bob_group = ManagedGroup::new_from_welcome(
+        &bob_credential_bundle,
+        &managed_group_config,
+        welcome,
+        Some(alice_group.export_ratchet_tree()),
+        bob_key_package_bundle,
+    )
+    .expect("Error creating group from Welcome");
+
+    // === Bob adds Charlie ===
+    let (queued_messages, welcome) =
+        match bob_group.add_members(&[charlie_key_package_bundle.key_package().clone()]) {
+            Ok((qm, welcome)) => (qm, welcome),
+            Err(e) => panic!("Could not add member to group: {:?}", e),
+        };
+
+    alice_group
+        .process_messages(queued_messages.clone())
+        .expect("The group is no longer active");
+    bob_group
+        .process_messages(queued_messages)
+        .expect("The group is no longer active");
+
+    let charlie_callbacks = ManagedGroupCallbacks::new().with_member_removed(member_removed);
+    managed_group_config.set_callbacks(&charlie_callbacks);
+    let mut charlie_group = ManagedGroup::new_from_welcome(
+        &charlie_credential_bundle,
+        &managed_group_config,
+        welcome,
+        Some(bob_group.export_ratchet_tree()),
+        charlie_key_package_bundle,
+    )
+    .expect("Error creating group from Welcome");
+
+    // === Alice removes Bob & Charlie commits ===
+
+    let queued_messages = alice_group
+        .propose_remove_members(&[1])
+        .expect("Could not propose removal");
+
+    charlie_group
+        .process_messages(queued_messages)
+        .expect("Could not process messages");
+
+    let (queued_messages, _welcome) = charlie_group
+        .process_pending_proposals()
+        .expect("Could not commit proposal");
+
+    charlie_group
+        .process_messages(queued_messages)
+        .expect("Could not process messages");
+}


### PR DESCRIPTION
This PR fixes #329 by passing the correct sender to the event dispatcher and additionally fixes the wrong order of leaver and remover in the callback.

A small step in code change, a huge leap in testing.

