### PR TITLE
Reformat comments one last time and remove formatting rule

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,3 @@
-comment_width = 80
 wrap_comments = true
 edition = "2018"
 format_code_in_doc_comments = true

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -623,7 +623,8 @@ impl<'a> ManagedGroup<'a> {
         self.group.authentication_secret().to_vec()
     }
 
-    /// Returns a resumption secret for a given epoch. If no resumption secret is available `None` is returned.
+    /// Returns a resumption secret for a given epoch. If no resumption secret
+    /// is available `None` is returned.
     pub fn get_resumption_secret(&self, epoch: GroupEpoch) -> Option<&ResumptionSecret> {
         self.resumption_secret_store.get(epoch)
     }

--- a/src/group/managed_group/resumption.rs
+++ b/src/group/managed_group/resumption.rs
@@ -1,6 +1,7 @@
 use super::*;
 
-/// Resumption secrets store. This is where the resumption secrets are kept in a rollover list.
+/// Resumption secrets store. This is where the resumption secrets are kept in a
+/// rollover list.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub(crate) struct ResumptionSecretStore {
@@ -35,7 +36,8 @@ impl ResumptionSecretStore {
         }
     }
 
-    /// Find an entry for a give epoch number and optionally return the corresponding secret.
+    /// Find an entry for a give epoch number and optionally return the
+    /// corresponding secret.
     pub(crate) fn get(&self, epoch: GroupEpoch) -> Option<&ResumptionSecret> {
         self.resumption_secrets
             .iter()

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -472,8 +472,9 @@ impl MlsGroup {
 // Callback functions
 
 /// This callback function is used in several places in `MlsGroup`.
-/// It gets called whenever the key schedule is advanced and references to PSKs are encountered.
-/// Since the PSKs are to be trandmitted out-of-band, they need to be fetched from wherever they are stored.
+/// It gets called whenever the key schedule is advanced and references to PSKs
+/// are encountered. Since the PSKs are to be trandmitted out-of-band, they need
+/// to be fetched from wherever they are stored.
 pub type PskFetcher = fn(psks: &PreSharedKeys) -> Option<Vec<Secret>>;
 
 // Helper functions

--- a/src/schedule/psk.rs
+++ b/src/schedule/psk.rs
@@ -83,7 +83,8 @@ impl ExternalPsk {
     }
 }
 
-/// External PSK Bundle. This contains the secret part of the PSK as well as the public part that is used as a marker for injection into the key schedule.
+/// External PSK Bundle. This contains the secret part of the PSK as well as the
+/// public part that is used as a marker for injection into the key schedule.
 pub struct ExternalPskBundle {
     secret: Secret,
     nonce: Vec<u8>,
@@ -156,8 +157,8 @@ pub enum Psk {
     Branch(BranchPsk),
 }
 
-/// A `PreSharedKeyID` is used to uniquely identify the PSKs that get injected in the key schedule.
-/// ```text
+/// A `PreSharedKeyID` is used to uniquely identify the PSKs that get injected
+/// in the key schedule. ```text
 /// struct {
 ///   PSKType psktype;
 ///   select (PreSharedKeyID.psktype) {
@@ -220,8 +221,8 @@ impl PreSharedKeys {
     }
 }
 
-/// `PskLabel` is used in the final concatentation of PSKs before they are injected in the key schedule.
-/// struct {
+/// `PskLabel` is used in the final concatentation of PSKs before they are
+/// injected in the key schedule. struct {
 ///     PreSharedKeyID id;
 ///     uint16 index;
 ///     uint16 count;
@@ -239,7 +240,8 @@ impl<'a> PskLabel<'a> {
     }
 }
 
-/// This contains the `psk-secret` calculated from the PSKs contained in a Commit or a PreSharedKey proposal.
+/// This contains the `psk-secret` calculated from the PSKs contained in a
+/// Commit or a PreSharedKey proposal.
 pub struct PskSecret {
     secret: Secret,
 }

--- a/src/schedule/psk.rs
+++ b/src/schedule/psk.rs
@@ -158,7 +158,8 @@ pub enum Psk {
 }
 
 /// A `PreSharedKeyID` is used to uniquely identify the PSKs that get injected
-/// in the key schedule. ```text
+/// in the key schedule.
+/// ```text
 /// struct {
 ///   PSKType psktype;
 ///   select (PreSharedKeyID.psktype) {


### PR DESCRIPTION
Since we have too many unrelated changes due to comment formatting I removed the rule for now. Hopefully this will be in stable at some point and then we can re-enable it.