### PR TITLE
Fix doc tests

### DIFF
--- a/src/schedule/psk.rs
+++ b/src/schedule/psk.rs
@@ -156,7 +156,8 @@ pub enum Psk {
     Branch(BranchPsk),
 }
 
-/// A `PreSharedKeyID` is used to uniquely identify the PSKs that get injected in the key schedule.
+/// A `PreSharedKeyID` is used to uniquely identify the PSKs that get injected
+/// in the key schedule.
 /// ```text
 /// struct {
 ///   PSKType psktype;


### PR DESCRIPTION
There was a missing line break in a comment that threw off the doc tests.
Probably another reason to deactivate comment formatting for now (see #351).