### PR TITLE
Expose key schedule test vector generation and checking behind flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ evercrypt = { version = "0.0.7", features = ["serialization"] }
 [features]
 default = ["rust-crypto"]
 rust-crypto = ["evercrypt/rust-crypto-aes"]
+expose-test-vectors = []
 
 [dev-dependencies]
 criterion = "^0.3"

--- a/src/group/tests/kat_transcripts.rs
+++ b/src/group/tests/kat_transcripts.rs
@@ -6,7 +6,7 @@
 use std::convert::TryFrom;
 
 use crate::{
-    ciphersuite::{CiphersuiteName, Secret, Signature},
+    ciphersuite::{Ciphersuite, CiphersuiteName, Secret, Signature},
     codec::Codec,
     config::Config,
     group::{
@@ -26,7 +26,7 @@ use crate::{
 use serde::{self, Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
-struct TranscriptTestVector {
+pub struct TranscriptTestVector {
     cipher_suite: u16,
     group_id: String,
     epoch: u64,
@@ -41,89 +41,92 @@ struct TranscriptTestVector {
     interim_transcript_hash_after: String,
 }
 
+#[cfg(any(feature = "expose-test-vectors", test))]
+fn generate_test_vector(ciphersuite: &Ciphersuite) -> TranscriptTestVector {
+    // Generate random values.
+    let group_id = GroupId::random();
+    let epoch = random_u64();
+    let tree_hash_before = randombytes(ciphersuite.hash_length());
+    let confirmed_transcript_hash_before = randombytes(ciphersuite.hash_length());
+    let interim_transcript_hash_before = randombytes(ciphersuite.hash_length());
+    let membership_key = MembershipKey::from_secret(Secret::random(ciphersuite.hash_length()));
+    let confirmation_key = ConfirmationKey::from_secret(Secret::random(ciphersuite.hash_length()));
+
+    // Build plaintext commit message.
+    let mut commit = MLSPlaintext {
+        group_id: GroupId::random(),
+        epoch: GroupEpoch(epoch),
+        sender: Sender {
+            sender_type: SenderType::Member,
+            sender: LeafIndex::from(random_u32()),
+        },
+        authenticated_data: randombytes(48),
+        content_type: ContentType::Commit,
+        content: MLSPlaintextContentType::Commit(Commit {
+            proposals: vec![],
+            path: None,
+        }),
+        signature: Signature::new_empty(),
+        confirmation_tag: None,
+        membership_tag: None,
+    };
+    let context = GroupContext::new(
+        group_id.clone(),
+        GroupEpoch(epoch),
+        tree_hash_before.clone(),
+        confirmed_transcript_hash_before.clone(),
+        &[], // extensions
+    )
+    .expect("Error creating group context");
+    let confirmation_tag = ConfirmationTag::new(
+        ciphersuite,
+        &confirmation_key,
+        &confirmed_transcript_hash_before,
+    );
+    commit.confirmation_tag = Some(confirmation_tag);
+    commit
+        .add_membership_tag(ciphersuite, context.serialized(), &membership_key)
+        .expect("Error adding membership tag");
+
+    // Compute new transcript hashes.
+    let confirmed_transcript_hash_after = update_confirmed_transcript_hash(
+        ciphersuite,
+        &MLSPlaintextCommitContent::try_from(&commit).unwrap(),
+        &interim_transcript_hash_before,
+    )
+    .expect("Error updating confirmed transcript hash");
+
+    let interim_transcript_hash_after = update_interim_transcript_hash(
+        &ciphersuite,
+        &MLSPlaintextCommitAuthData::try_from(&commit).unwrap(),
+        &confirmed_transcript_hash_after,
+    )
+    .expect("Error updating interim transcript hash");
+
+    TranscriptTestVector {
+        cipher_suite: ciphersuite.name() as u16,
+        group_id: bytes_to_hex(&group_id.as_slice()),
+        epoch,
+        tree_hash_before: bytes_to_hex(&tree_hash_before),
+        confirmed_transcript_hash_before: bytes_to_hex(&confirmed_transcript_hash_before),
+        interim_transcript_hash_before: bytes_to_hex(&interim_transcript_hash_before),
+        membership_key: bytes_to_hex(membership_key.as_slice()),
+        confirmation_key: bytes_to_hex(confirmation_key.as_slice()),
+        commit: bytes_to_hex(&commit.encode_detached().expect("Error encoding commit")),
+
+        confirmed_transcript_hash_after: bytes_to_hex(&confirmed_transcript_hash_after),
+        interim_transcript_hash_after: bytes_to_hex(&interim_transcript_hash_after),
+    }
+}
+
 #[test]
-fn generate_test_vectors() {
+fn write_test_vectors() {
     let mut tests = Vec::new();
     const NUM_TESTS: usize = 100;
 
     for ciphersuite in Config::supported_ciphersuites() {
         for _ in 0..NUM_TESTS {
-            // Generate random values.
-            let group_id = GroupId::random();
-            let epoch = random_u64();
-            let tree_hash_before = randombytes(ciphersuite.hash_length());
-            let confirmed_transcript_hash_before = randombytes(ciphersuite.hash_length());
-            let interim_transcript_hash_before = randombytes(ciphersuite.hash_length());
-            let membership_key =
-                MembershipKey::from_secret(Secret::random(ciphersuite.hash_length()));
-            let confirmation_key =
-                ConfirmationKey::from_secret(Secret::random(ciphersuite.hash_length()));
-
-            // Build plaintext commit message.
-            let mut commit = MLSPlaintext {
-                group_id: GroupId::random(),
-                epoch: GroupEpoch(epoch),
-                sender: Sender {
-                    sender_type: SenderType::Member,
-                    sender: LeafIndex::from(random_u32()),
-                },
-                authenticated_data: randombytes(48),
-                content_type: ContentType::Commit,
-                content: MLSPlaintextContentType::Commit(Commit {
-                    proposals: vec![],
-                    path: None,
-                }),
-                signature: Signature::new_empty(),
-                confirmation_tag: None,
-                membership_tag: None,
-            };
-            let context = GroupContext::new(
-                group_id.clone(),
-                GroupEpoch(epoch),
-                tree_hash_before.clone(),
-                confirmed_transcript_hash_before.clone(),
-                &[], // extensions
-            )
-            .expect("Error creating group context");
-            let confirmation_tag = ConfirmationTag::new(
-                ciphersuite,
-                &confirmation_key,
-                &confirmed_transcript_hash_before,
-            );
-            commit.confirmation_tag = Some(confirmation_tag);
-            commit
-                .add_membership_tag(ciphersuite, context.serialized(), &membership_key)
-                .expect("Error adding membership tag");
-
-            // Compute new transcript hashes.
-            let confirmed_transcript_hash_after = update_confirmed_transcript_hash(
-                ciphersuite,
-                &MLSPlaintextCommitContent::try_from(&commit).unwrap(),
-                &interim_transcript_hash_before,
-            )
-            .expect("Error updating confirmed transcript hash");
-
-            let interim_transcript_hash_after = update_interim_transcript_hash(
-                &ciphersuite,
-                &MLSPlaintextCommitAuthData::try_from(&commit).unwrap(),
-                &confirmed_transcript_hash_after,
-            )
-            .expect("Error updating interim transcript hash");
-
-            let test = TranscriptTestVector {
-                cipher_suite: ciphersuite.name() as u16,
-                group_id: bytes_to_hex(&group_id.as_slice()),
-                epoch,
-                tree_hash_before: bytes_to_hex(&tree_hash_before),
-                confirmed_transcript_hash_before: bytes_to_hex(&confirmed_transcript_hash_before),
-                interim_transcript_hash_before: bytes_to_hex(&interim_transcript_hash_before),
-                membership_key: bytes_to_hex(membership_key.as_slice()),
-                confirmation_key: bytes_to_hex(confirmation_key.as_slice()),
-                commit: bytes_to_hex(&commit.encode_detached().expect("Error encoding commit")),
-
-                confirmed_transcript_hash_after: bytes_to_hex(&confirmed_transcript_hash_after),
-                interim_transcript_hash_after: bytes_to_hex(&interim_transcript_hash_after),
-            };
+            let test = generate_test_vector(ciphersuite);
             tests.push(test);
         }
     }
@@ -131,89 +134,93 @@ fn generate_test_vectors() {
     write("test_vectors/kat_transcripts-new.json", &tests);
 }
 
+#[cfg(any(feature = "expose-test-vectors", test))]
+pub fn run_test_vectors(test_vector: TranscriptTestVector) {
+    let ciphersuite =
+        CiphersuiteName::try_from(test_vector.cipher_suite).expect("Invalid ciphersuite");
+    let ciphersuite = match Config::ciphersuite(ciphersuite) {
+        Ok(cs) => cs,
+        Err(_) => {
+            println!(
+                "Unsupported ciphersuite {} in test vector. Skipping ...",
+                ciphersuite
+            );
+            return;
+        }
+    };
+    println!("Testing test vector for ciphersuite {:?}", ciphersuite);
+
+    // Read input values.
+    let group_id = GroupId {
+        value: hex_to_bytes(&test_vector.group_id),
+    };
+    let epoch = test_vector.epoch;
+    let tree_hash_before = hex_to_bytes(&test_vector.tree_hash_before);
+    let confirmed_transcript_hash_before =
+        hex_to_bytes(&test_vector.confirmed_transcript_hash_before);
+    let interim_transcript_hash_before = hex_to_bytes(&test_vector.interim_transcript_hash_before);
+    let membership_key =
+        MembershipKey::from_secret(Secret::from(hex_to_bytes(&test_vector.membership_key)));
+    let confirmation_key =
+        ConfirmationKey::from_secret(Secret::from(hex_to_bytes(&test_vector.confirmation_key)));
+
+    // Check membership and confirmation tags.
+    let commit = MLSPlaintext::decode_detached(&hex_to_bytes(&test_vector.commit))
+        .expect("Error decoding commit");
+    let context = GroupContext::new(
+        group_id.clone(),
+        GroupEpoch(epoch),
+        tree_hash_before.clone(),
+        confirmed_transcript_hash_before.clone(),
+        &[], // extensions
+    )
+    .expect("Error creating group context");
+    assert!(commit
+        .verify_membership_tag(ciphersuite, context.serialized(), &membership_key)
+        .is_ok());
+
+    let my_confirmation_tag = ConfirmationTag::new(
+        &ciphersuite,
+        &confirmation_key,
+        &confirmed_transcript_hash_before,
+    );
+    assert_eq!(
+        &my_confirmation_tag,
+        commit
+            .confirmation_tag
+            .as_ref()
+            .expect("Confirmation tag is missing")
+    );
+
+    // Compute new transcript hashes.
+    let my_confirmed_transcript_hash_after = update_confirmed_transcript_hash(
+        ciphersuite,
+        &MLSPlaintextCommitContent::try_from(&commit).unwrap(),
+        &interim_transcript_hash_before,
+    )
+    .expect("Error updating confirmed transcript hash");
+    assert_eq!(
+        &my_confirmed_transcript_hash_after,
+        &hex_to_bytes(&test_vector.confirmed_transcript_hash_after)
+    );
+
+    let my_interim_transcript_hash_after = update_interim_transcript_hash(
+        &ciphersuite,
+        &MLSPlaintextCommitAuthData::try_from(&commit).unwrap(),
+        &my_confirmed_transcript_hash_after,
+    )
+    .expect("Error updating interim transcript hash");
+    assert_eq!(
+        &my_interim_transcript_hash_after,
+        &hex_to_bytes(&test_vector.interim_transcript_hash_after)
+    );
+}
+
 #[test]
-fn run_test_vectors() {
+fn read_test_vectors() {
     let tests: Vec<TranscriptTestVector> = read("test_vectors/kat_transcripts.json");
 
     for test_vector in tests {
-        let ciphersuite =
-            CiphersuiteName::try_from(test_vector.cipher_suite).expect("Invalid ciphersuite");
-        let ciphersuite = match Config::ciphersuite(ciphersuite) {
-            Ok(cs) => cs,
-            Err(_) => {
-                println!(
-                    "Unsupported ciphersuite {} in test vector. Skipping ...",
-                    ciphersuite
-                );
-                continue;
-            }
-        };
-        println!("Testing test vector for ciphersuite {:?}", ciphersuite);
-
-        // Read input values.
-        let group_id = GroupId {
-            value: hex_to_bytes(&test_vector.group_id),
-        };
-        let epoch = test_vector.epoch;
-        let tree_hash_before = hex_to_bytes(&test_vector.tree_hash_before);
-        let confirmed_transcript_hash_before =
-            hex_to_bytes(&test_vector.confirmed_transcript_hash_before);
-        let interim_transcript_hash_before =
-            hex_to_bytes(&test_vector.interim_transcript_hash_before);
-        let membership_key =
-            MembershipKey::from_secret(Secret::from(hex_to_bytes(&test_vector.membership_key)));
-        let confirmation_key =
-            ConfirmationKey::from_secret(Secret::from(hex_to_bytes(&test_vector.confirmation_key)));
-
-        // Check membership and confirmation tags.
-        let commit = MLSPlaintext::decode_detached(&hex_to_bytes(&test_vector.commit))
-            .expect("Error decoding commit");
-        let context = GroupContext::new(
-            group_id.clone(),
-            GroupEpoch(epoch),
-            tree_hash_before.clone(),
-            confirmed_transcript_hash_before.clone(),
-            &[], // extensions
-        )
-        .expect("Error creating group context");
-        assert!(commit
-            .verify_membership_tag(ciphersuite, context.serialized(), &membership_key)
-            .is_ok());
-
-        let my_confirmation_tag = ConfirmationTag::new(
-            &ciphersuite,
-            &confirmation_key,
-            &confirmed_transcript_hash_before,
-        );
-        assert_eq!(
-            &my_confirmation_tag,
-            commit
-                .confirmation_tag
-                .as_ref()
-                .expect("Confirmation tag is missing")
-        );
-
-        // Compute new transcript hashes.
-        let my_confirmed_transcript_hash_after = update_confirmed_transcript_hash(
-            ciphersuite,
-            &MLSPlaintextCommitContent::try_from(&commit).unwrap(),
-            &interim_transcript_hash_before,
-        )
-        .expect("Error updating confirmed transcript hash");
-        assert_eq!(
-            &my_confirmed_transcript_hash_after,
-            &hex_to_bytes(&test_vector.confirmed_transcript_hash_after)
-        );
-
-        let my_interim_transcript_hash_after = update_interim_transcript_hash(
-            &ciphersuite,
-            &MLSPlaintextCommitAuthData::try_from(&commit).unwrap(),
-            &my_confirmed_transcript_hash_after,
-        )
-        .expect("Error updating interim transcript hash");
-        assert_eq!(
-            &my_interim_transcript_hash_after,
-            &hex_to_bytes(&test_vector.interim_transcript_hash_after)
-        );
+        run_test_vectors(test_vector)
     }
 }

--- a/src/schedule/errors.rs
+++ b/src/schedule/errors.rs
@@ -19,3 +19,21 @@ implement_error! {
         DifferentLength = "The IDs and secrets vectors have different lengths.",
     }
 }
+
+#[cfg(any(feature = "expose-test-vectors", test))]
+implement_error! {
+    pub enum KSTestVectorError {
+        JoinerSecretMismatch = "The computed joiner secret doesn't match the one in the test vector.",
+        WelcomeSecretMismatch = "The computed welcome secret doesn't match the one in the test vector.",
+        InitSecretMismatch = "The computed init secret doesn't match the one in the test vector.",
+        SenderDataSecretMismatch = "The computed sender data secret doesn't match the one in the test vector.",
+        EncryptionSecretMismatch = "The computed encryption secret doesn't match the one in the test vector.",
+        ExporterSecretMismatch = "The computed exporter secret doesn't match the one in the test vector.",
+        AuthenticationSecretMismatch = "The computed authentication secret doesn't match the one in the test vector.",
+        ExternalSecretMismatch = "The computed external secret doesn't match the one in the test vector.",
+        ConfirmationKeyMismatch = "The computed confirmation key doesn't match the one in the test vector.",
+        MembershipKeyMismatch = "The computed membership key doesn't match the one in the test vector.",
+        ResumptionSecretMismatch = "The computed resumption secret doesn't match the one in the test vector.",
+        ExternalPubMismatch = "The computed external public key doesn't match the one in the test vector.",
+    }
+}

--- a/src/tree/tests/kat_encryption.rs
+++ b/src/tree/tests/kat_encryption.rs
@@ -115,7 +115,7 @@ struct LeafSequence {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-struct EncryptionTestVector {
+pub struct EncryptionTestVector {
     cipher_suite: u16,
     n_leaves: u32,
     encryption_secret: String,
@@ -231,107 +231,103 @@ fn build_application_messages(leaf: LeafIndex, group: &mut MlsGroup) -> (Vec<u8>
         ciphertext.encode_detached().unwrap(),
     )
 }
+
+#[cfg(any(feature = "expose-test-vectors", test))]
+pub fn generate_test_vector(
+    n_generations: u32,
+    n_leaves: u32,
+    ciphersuite: &Ciphersuite,
+) -> EncryptionTestVector {
+    let ciphersuite_name = ciphersuite.name();
+    let epoch_secret = randombytes(ciphersuite.hash_length());
+    let encryption_secret = EncryptionSecret::from(&epoch_secret[..]);
+    let encryption_secret_group = EncryptionSecret::from(&epoch_secret[..]);
+    let encryption_secret_bytes = encryption_secret.as_slice().to_vec();
+    let sender_data_secret = SenderDataSecret::from_random(32);
+    let sender_data_secret_bytes = sender_data_secret.as_slice();
+    let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(n_leaves));
+    let group_secret_tree = SecretTree::new(encryption_secret_group, LeafIndex::from(n_leaves));
+
+    // Create sender_data_key/secret
+    let ciphertext = randombytes(77);
+    let sender_data_key =
+        AeadKey::from_sender_data_secret(ciphersuite, &ciphertext, &sender_data_secret);
+    // Derive initial nonce from the key schedule using the ciphertext.
+    let sender_data_nonce =
+        AeadNonce::from_sender_data_secret(ciphersuite, &ciphertext, &sender_data_secret);
+    let sender_data_info = SenderDataInfo {
+        ciphertext: bytes_to_hex(&ciphertext),
+        key: bytes_to_hex(sender_data_key.as_slice()),
+        nonce: bytes_to_hex(sender_data_nonce.as_slice()),
+    };
+
+    let mut group = group(ciphersuite);
+    *group.epoch_secrets_mut().sender_data_secret_mut() =
+        SenderDataSecret::from(sender_data_secret_bytes);
+    *group.secret_tree_mut() = group_secret_tree;
+
+    let mut leaves = Vec::new();
+    for leaf in 0..n_leaves {
+        let leaf = LeafIndex::from(leaf);
+        let mut handshake = Vec::new();
+        let mut application = Vec::new();
+        for generation in 0..n_generations {
+            // Application
+            let (application_secret_key, application_secret_nonce) = secret_tree
+                .secret_for_decryption(ciphersuite, leaf, SecretType::ApplicationSecret, generation)
+                .expect("Error getting decryption secret");
+            let application_key_string = bytes_to_hex(application_secret_key.as_slice());
+            let application_nonce_string = bytes_to_hex(application_secret_nonce.as_slice());
+            let (application_plaintext, application_ciphertext) =
+                build_application_messages(leaf, &mut group);
+            application.push((
+                application_key_string,
+                application_nonce_string,
+                bytes_to_hex(&application_plaintext),
+                bytes_to_hex(&application_ciphertext),
+            ));
+
+            // Handshake
+            let (handshake_secret_key, handshake_secret_nonce) = secret_tree
+                .secret_for_decryption(ciphersuite, leaf, SecretType::HandshakeSecret, generation)
+                .expect("Error getting decryption secret");
+            let handshake_key_string = bytes_to_hex(handshake_secret_key.as_slice());
+            let handshake_nonce_string = bytes_to_hex(handshake_secret_nonce.as_slice());
+
+            let (handshake_plaintext, handshake_ciphertext) =
+                build_handshake_messages(leaf, &mut group);
+            handshake.push((
+                handshake_key_string,
+                handshake_nonce_string,
+                bytes_to_hex(&handshake_plaintext),
+                bytes_to_hex(&handshake_ciphertext),
+            ));
+        }
+        leaves.push(LeafSequence {
+            generations: n_generations,
+            handshake,
+            application,
+        });
+    }
+
+    EncryptionTestVector {
+        cipher_suite: ciphersuite_name as u16,
+        n_leaves,
+        encryption_secret: bytes_to_hex(&encryption_secret_bytes),
+        sender_data_secret: bytes_to_hex(sender_data_secret_bytes),
+        sender_data_info,
+        leaves,
+    }
+}
+
 #[test]
-fn generate_test_vectors() {
+fn write_test_vectors() {
     let mut tests = Vec::new();
     const NUM_GENERATIONS: u32 = 20;
 
-    fn generate_test_vector(n_leaves: u32, ciphersuite: &Ciphersuite) -> EncryptionTestVector {
-        let ciphersuite_name = ciphersuite.name();
-        let epoch_secret = randombytes(ciphersuite.hash_length());
-        let encryption_secret = EncryptionSecret::from(&epoch_secret[..]);
-        let encryption_secret_group = EncryptionSecret::from(&epoch_secret[..]);
-        let encryption_secret_bytes = encryption_secret.as_slice().to_vec();
-        let sender_data_secret = SenderDataSecret::from_random(32);
-        let sender_data_secret_bytes = sender_data_secret.as_slice();
-        let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(n_leaves));
-        let group_secret_tree = SecretTree::new(encryption_secret_group, LeafIndex::from(n_leaves));
-
-        // Create sender_data_key/secret
-        let ciphertext = randombytes(77);
-        let sender_data_key =
-            AeadKey::from_sender_data_secret(ciphersuite, &ciphertext, &sender_data_secret);
-        // Derive initial nonce from the key schedule using the ciphertext.
-        let sender_data_nonce =
-            AeadNonce::from_sender_data_secret(ciphersuite, &ciphertext, &sender_data_secret);
-        let sender_data_info = SenderDataInfo {
-            ciphertext: bytes_to_hex(&ciphertext),
-            key: bytes_to_hex(sender_data_key.as_slice()),
-            nonce: bytes_to_hex(sender_data_nonce.as_slice()),
-        };
-
-        let mut group = group(ciphersuite);
-        *group.epoch_secrets_mut().sender_data_secret_mut() =
-            SenderDataSecret::from(sender_data_secret_bytes);
-        *group.secret_tree_mut() = group_secret_tree;
-
-        let mut leaves = Vec::new();
-        for leaf in 0..n_leaves {
-            let leaf = LeafIndex::from(leaf);
-            let mut handshake = Vec::new();
-            let mut application = Vec::new();
-            for generation in 0..NUM_GENERATIONS {
-                // Application
-                let (application_secret_key, application_secret_nonce) = secret_tree
-                    .secret_for_decryption(
-                        ciphersuite,
-                        leaf,
-                        SecretType::ApplicationSecret,
-                        generation,
-                    )
-                    .expect("Error getting decryption secret");
-                let application_key_string = bytes_to_hex(application_secret_key.as_slice());
-                let application_nonce_string = bytes_to_hex(application_secret_nonce.as_slice());
-                let (application_plaintext, application_ciphertext) =
-                    build_application_messages(leaf, &mut group);
-                application.push((
-                    application_key_string,
-                    application_nonce_string,
-                    bytes_to_hex(&application_plaintext),
-                    bytes_to_hex(&application_ciphertext),
-                ));
-
-                // Handshake
-                let (handshake_secret_key, handshake_secret_nonce) = secret_tree
-                    .secret_for_decryption(
-                        ciphersuite,
-                        leaf,
-                        SecretType::HandshakeSecret,
-                        generation,
-                    )
-                    .expect("Error getting decryption secret");
-                let handshake_key_string = bytes_to_hex(handshake_secret_key.as_slice());
-                let handshake_nonce_string = bytes_to_hex(handshake_secret_nonce.as_slice());
-
-                let (handshake_plaintext, handshake_ciphertext) =
-                    build_handshake_messages(leaf, &mut group);
-                handshake.push((
-                    handshake_key_string,
-                    handshake_nonce_string,
-                    bytes_to_hex(&handshake_plaintext),
-                    bytes_to_hex(&handshake_ciphertext),
-                ));
-            }
-            leaves.push(LeafSequence {
-                generations: NUM_GENERATIONS,
-                handshake,
-                application,
-            });
-        }
-
-        EncryptionTestVector {
-            cipher_suite: ciphersuite_name as u16,
-            n_leaves,
-            encryption_secret: bytes_to_hex(&encryption_secret_bytes),
-            sender_data_secret: bytes_to_hex(sender_data_secret_bytes),
-            sender_data_info,
-            leaves,
-        }
-    }
-
     for ciphersuite in Config::supported_ciphersuites() {
         for n_leaves in 1u32..20 {
-            let test = generate_test_vector(n_leaves, ciphersuite);
+            let test = generate_test_vector(NUM_GENERATIONS, n_leaves, ciphersuite);
             tests.push(test);
         }
     }
@@ -339,133 +335,136 @@ fn generate_test_vectors() {
     write("test_vectors/kat_encryption_openmls-new.json", &tests);
 }
 
+#[cfg(any(feature = "expose-test-vectors", test))]
+pub fn run_test_vector(test_vector: EncryptionTestVector) {
+    let n_leaves = test_vector.n_leaves;
+    assert_eq!(n_leaves, test_vector.leaves.len() as u32);
+    let ciphersuite =
+        CiphersuiteName::try_from(test_vector.cipher_suite).expect("Invalid ciphersuite");
+    let ciphersuite = match Config::ciphersuite(ciphersuite) {
+        Ok(cs) => cs,
+        Err(_) => {
+            println!(
+                "Unsupported ciphersuite {} in test vector. Skipping ...",
+                ciphersuite
+            );
+            return;
+        }
+    };
+
+    let mut secret_tree = SecretTree::new(
+        EncryptionSecret::from(hex_to_bytes(&test_vector.encryption_secret).as_slice()),
+        LeafIndex::from(n_leaves),
+    );
+    let sender_data_secret =
+        SenderDataSecret::from(hex_to_bytes(&test_vector.sender_data_secret).as_slice());
+
+    let sender_data_key = AeadKey::from_sender_data_secret(
+        ciphersuite,
+        &hex_to_bytes(&test_vector.sender_data_info.ciphertext),
+        &sender_data_secret,
+    );
+    let sender_data_nonce = AeadNonce::from_sender_data_secret(
+        ciphersuite,
+        &hex_to_bytes(&test_vector.sender_data_info.ciphertext),
+        &sender_data_secret,
+    );
+    assert_eq!(
+        hex_to_bytes(&test_vector.sender_data_info.key),
+        sender_data_key.as_slice()
+    );
+    assert_eq!(
+        hex_to_bytes(&test_vector.sender_data_info.nonce),
+        sender_data_nonce.as_slice()
+    );
+
+    for (leaf_index, leaf) in test_vector.leaves.iter().enumerate() {
+        assert_eq!(leaf.generations, leaf.application.len() as u32);
+        assert_eq!(leaf.generations, leaf.handshake.len() as u32);
+        let leaf_index = LeafIndex::from(leaf_index);
+
+        for (generation, application, handshake) in
+            izip!((0..leaf.generations), &leaf.application, &leaf.handshake,)
+        {
+            // Check application keys
+            let (application_secret_key, application_secret_nonce) = secret_tree
+                .secret_for_decryption(
+                    ciphersuite,
+                    leaf_index,
+                    SecretType::ApplicationSecret,
+                    generation,
+                )
+                .expect("Error getting decryption secret");
+            assert_eq!(
+                hex_to_bytes(&application.0),
+                application_secret_key.as_slice()
+            );
+            assert_eq!(
+                hex_to_bytes(&application.1),
+                application_secret_nonce.as_slice()
+            );
+
+            // Setup group
+            let mls_ciphertext_application =
+                MLSCiphertext::decode(&mut Cursor::new(&hex_to_bytes(&application.3)))
+                    .expect("Error parsing MLSCiphertext");
+            let mut group = receiver_group(ciphersuite, &mls_ciphertext_application.group_id);
+            *group.epoch_secrets_mut().sender_data_secret_mut() =
+                SenderDataSecret::from(hex_to_bytes(&test_vector.sender_data_secret).as_slice());
+
+            // Decrypt and check application message
+            let mls_plaintext_application = mls_ciphertext_application
+                .to_plaintext(ciphersuite, group.epoch_secrets(), &mut secret_tree)
+                .expect("Error decrypting MLSCiphertext");
+            assert_eq!(
+                hex_to_bytes(&application.2),
+                mls_plaintext_application
+                    .encode_detached()
+                    .expect("Error encoding MLSPlaintext")
+            );
+
+            // Check handshake keys
+            let (handshake_secret_key, handshake_secret_nonce) = secret_tree
+                .secret_for_decryption(
+                    ciphersuite,
+                    leaf_index,
+                    SecretType::HandshakeSecret,
+                    generation,
+                )
+                .expect("Error getting decryption secret");
+            assert_eq!(hex_to_bytes(&handshake.0), handshake_secret_key.as_slice());
+            assert_eq!(
+                hex_to_bytes(&handshake.1),
+                handshake_secret_nonce.as_slice()
+            );
+
+            // Setup group
+            let mls_ciphertext_handshake =
+                MLSCiphertext::decode(&mut Cursor::new(&hex_to_bytes(&handshake.3)))
+                    .expect("Error parsing MLSCiphertext");
+            let mut group = receiver_group(ciphersuite, &mls_ciphertext_handshake.group_id);
+            *group.epoch_secrets_mut().sender_data_secret_mut() =
+                SenderDataSecret::from(hex_to_bytes(&test_vector.sender_data_secret).as_slice());
+
+            // Decrypt and check message
+            let mls_plaintext_handshake = mls_ciphertext_handshake
+                .to_plaintext(ciphersuite, group.epoch_secrets(), &mut secret_tree)
+                .expect("Error decrypting MLSCiphertext");
+            assert_eq!(
+                hex_to_bytes(&handshake.2),
+                mls_plaintext_handshake
+                    .encode_detached()
+                    .expect("Error encoding MLSPlaintext")
+            );
+        }
+    }
+}
+
 #[test]
-fn run_test_vectors() {
+fn read_test_vectors() {
     let tests: Vec<EncryptionTestVector> = read("test_vectors/kat_encryption_openmls.json");
 
     for test_vector in tests {
-        let n_leaves = test_vector.n_leaves;
-        assert_eq!(n_leaves, test_vector.leaves.len() as u32);
-        let ciphersuite =
-            CiphersuiteName::try_from(test_vector.cipher_suite).expect("Invalid ciphersuite");
-        let ciphersuite = match Config::ciphersuite(ciphersuite) {
-            Ok(cs) => cs,
-            Err(_) => {
-                println!(
-                    "Unsupported ciphersuite {} in test vector. Skipping ...",
-                    ciphersuite
-                );
-                continue;
-            }
-        };
-
-        let mut secret_tree = SecretTree::new(
-            EncryptionSecret::from(hex_to_bytes(&test_vector.encryption_secret).as_slice()),
-            LeafIndex::from(n_leaves),
-        );
-        let sender_data_secret =
-            SenderDataSecret::from(hex_to_bytes(&test_vector.sender_data_secret).as_slice());
-
-        let sender_data_key = AeadKey::from_sender_data_secret(
-            ciphersuite,
-            &hex_to_bytes(&test_vector.sender_data_info.ciphertext),
-            &sender_data_secret,
-        );
-        let sender_data_nonce = AeadNonce::from_sender_data_secret(
-            ciphersuite,
-            &hex_to_bytes(&test_vector.sender_data_info.ciphertext),
-            &sender_data_secret,
-        );
-        assert_eq!(
-            hex_to_bytes(&test_vector.sender_data_info.key),
-            sender_data_key.as_slice()
-        );
-        assert_eq!(
-            hex_to_bytes(&test_vector.sender_data_info.nonce),
-            sender_data_nonce.as_slice()
-        );
-
-        for (leaf_index, leaf) in test_vector.leaves.iter().enumerate() {
-            assert_eq!(leaf.generations, leaf.application.len() as u32);
-            assert_eq!(leaf.generations, leaf.handshake.len() as u32);
-            let leaf_index = LeafIndex::from(leaf_index);
-
-            for (generation, application, handshake) in
-                izip!((0..leaf.generations), &leaf.application, &leaf.handshake,)
-            {
-                // Check application keys
-                let (application_secret_key, application_secret_nonce) = secret_tree
-                    .secret_for_decryption(
-                        ciphersuite,
-                        leaf_index,
-                        SecretType::ApplicationSecret,
-                        generation,
-                    )
-                    .expect("Error getting decryption secret");
-                assert_eq!(
-                    hex_to_bytes(&application.0),
-                    application_secret_key.as_slice()
-                );
-                assert_eq!(
-                    hex_to_bytes(&application.1),
-                    application_secret_nonce.as_slice()
-                );
-
-                // Setup group
-                let mls_ciphertext_application =
-                    MLSCiphertext::decode(&mut Cursor::new(&hex_to_bytes(&application.3)))
-                        .expect("Error parsing MLSCiphertext");
-                let mut group = receiver_group(ciphersuite, &mls_ciphertext_application.group_id);
-                *group.epoch_secrets_mut().sender_data_secret_mut() = SenderDataSecret::from(
-                    hex_to_bytes(&test_vector.sender_data_secret).as_slice(),
-                );
-
-                // Decrypt and check application message
-                let mls_plaintext_application = mls_ciphertext_application
-                    .to_plaintext(ciphersuite, group.epoch_secrets(), &mut secret_tree)
-                    .expect("Error decrypting MLSCiphertext");
-                assert_eq!(
-                    hex_to_bytes(&application.2),
-                    mls_plaintext_application
-                        .encode_detached()
-                        .expect("Error encoding MLSPlaintext")
-                );
-
-                // Check handshake keys
-                let (handshake_secret_key, handshake_secret_nonce) = secret_tree
-                    .secret_for_decryption(
-                        ciphersuite,
-                        leaf_index,
-                        SecretType::HandshakeSecret,
-                        generation,
-                    )
-                    .expect("Error getting decryption secret");
-                assert_eq!(hex_to_bytes(&handshake.0), handshake_secret_key.as_slice());
-                assert_eq!(
-                    hex_to_bytes(&handshake.1),
-                    handshake_secret_nonce.as_slice()
-                );
-
-                // Setup group
-                let mls_ciphertext_handshake =
-                    MLSCiphertext::decode(&mut Cursor::new(&hex_to_bytes(&handshake.3)))
-                        .expect("Error parsing MLSCiphertext");
-                let mut group = receiver_group(ciphersuite, &mls_ciphertext_handshake.group_id);
-                *group.epoch_secrets_mut().sender_data_secret_mut() = SenderDataSecret::from(
-                    hex_to_bytes(&test_vector.sender_data_secret).as_slice(),
-                );
-
-                // Decrypt and check message
-                let mls_plaintext_handshake = mls_ciphertext_handshake
-                    .to_plaintext(ciphersuite, group.epoch_secrets(), &mut secret_tree)
-                    .expect("Error decrypting MLSCiphertext");
-                assert_eq!(
-                    hex_to_bytes(&handshake.2),
-                    mls_plaintext_handshake
-                        .encode_detached()
-                        .expect("Error encoding MLSPlaintext")
-                );
-            }
-        }
+        run_test_vector(test_vector);
     }
 }

--- a/src/tree/tests/kat_treemath.rs
+++ b/src/tree/tests/kat_treemath.rs
@@ -60,39 +60,40 @@ macro_rules! convert {
     };
 }
 
-#[test]
-fn generate_test_vectors() {
-    let mut tests = Vec::new();
+#[cfg(any(feature = "expose-test-vectors", test))]
+fn generate_test_vector(n_leaves: u32) -> TreeMathTestVector {
+    let leaves = LeafIndex::from(n_leaves);
+    let n_nodes = node_width(leaves.as_usize()) as u32;
+    let mut test_vector = TreeMathTestVector {
+        n_leaves,
+        n_nodes,
+        root: Vec::new(),
+        left: Vec::new(),
+        right: Vec::new(),
+        parent: Vec::new(),
+        sibling: Vec::new(),
+    };
 
-    fn generate_test_vector(n_leaves: u32) -> TreeMathTestVector {
-        let leaves = LeafIndex::from(n_leaves);
-        let n_nodes = node_width(leaves.as_usize()) as u32;
-        let mut test_vector = TreeMathTestVector {
-            n_leaves,
-            n_nodes,
-            root: Vec::new(),
-            left: Vec::new(),
-            right: Vec::new(),
-            parent: Vec::new(),
-            sibling: Vec::new(),
-        };
-
-        for i in 0..n_leaves {
-            test_vector.root.push(root(LeafIndex::from(i + 1)).as_u32());
-            test_vector.left.push(convert!(left(NodeIndex::from(i))));
-            test_vector
-                .right
-                .push(convert!(right(NodeIndex::from(i), leaves)));
-            test_vector
-                .parent
-                .push(convert!(parent(NodeIndex::from(i), leaves)));
-            test_vector
-                .sibling
-                .push(convert!(sibling(NodeIndex::from(i), leaves)));
-        }
-
+    for i in 0..n_leaves {
+        test_vector.root.push(root(LeafIndex::from(i + 1)).as_u32());
+        test_vector.left.push(convert!(left(NodeIndex::from(i))));
         test_vector
+            .right
+            .push(convert!(right(NodeIndex::from(i), leaves)));
+        test_vector
+            .parent
+            .push(convert!(parent(NodeIndex::from(i), leaves)));
+        test_vector
+            .sibling
+            .push(convert!(sibling(NodeIndex::from(i), leaves)));
     }
+
+    test_vector
+}
+
+#[test]
+fn write_test_vectors() {
+    let mut tests = Vec::new();
 
     for n_leaves in 1..99 {
         let test_vector = generate_test_vector(n_leaves);
@@ -102,30 +103,53 @@ fn generate_test_vectors() {
     write("test_vectors/kat_treemath_openmls-new.json", &tests);
 }
 
-#[test]
-fn run_test_vectors() {
-    let tests: Vec<TreeMathTestVector> = read("test_vectors/kat_treemath_openmls.json");
+#[cfg(any(feature = "expose-test-vectors", test))]
+fn run_test_vector(test_vector: TreeMathTestVector) -> Result<(), TMTestVectorError> {
+    let n_leaves = test_vector.n_leaves;
+    let leaves = LeafIndex::from(n_leaves);
+    if test_vector.n_nodes != node_width(leaves.as_usize()) as u32 {
+        return Err(TMTestVectorError::TreeSizeMismatch);
+    }
 
-    for test_vector in tests {
-        let n_leaves = test_vector.n_leaves;
-        let leaves = LeafIndex::from(n_leaves);
-        assert_eq!(test_vector.n_nodes, node_width(leaves.as_usize()) as u32);
-
-        for i in 0..(n_leaves as usize) {
-            assert_eq!(test_vector.root[i], root(LeafIndex::from(i + 1)).as_u32());
-            assert_eq!(test_vector.left[i], convert!(left(NodeIndex::from(i))));
-            assert_eq!(
-                test_vector.right[i],
-                convert!(right(NodeIndex::from(i), leaves))
-            );
-            assert_eq!(
-                test_vector.parent[i],
-                convert!(parent(NodeIndex::from(i), leaves))
-            );
-            assert_eq!(
-                test_vector.sibling[i],
-                convert!(sibling(NodeIndex::from(i), leaves))
-            );
+    for i in 0..(n_leaves as usize) {
+        if test_vector.root[i] != root(LeafIndex::from(i + 1)).as_u32() {
+            return Err(TMTestVectorError::RootIndexMismatch);
         }
+        if test_vector.left[i] != convert!(left(NodeIndex::from(i))) {
+            return Err(TMTestVectorError::LeftIndexMismatch);
+        }
+        if test_vector.right[i] != convert!(right(NodeIndex::from(i), leaves)) {
+            return Err(TMTestVectorError::RightIndexMismatch);
+        }
+        if test_vector.parent[i] != convert!(parent(NodeIndex::from(i), leaves)) {
+            return Err(TMTestVectorError::ParentIndexMismatch);
+        }
+        if test_vector.sibling[i] != convert!(sibling(NodeIndex::from(i), leaves)) {
+            return Err(TMTestVectorError::SiblingIndexMismatch);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn read_test_vectors() {
+    let tests: Vec<TreeMathTestVector> = read("test_vectors/kat_treemath_openmls.json");
+    for test_vector in tests {
+        match run_test_vector(test_vector) {
+            Ok(_) => {}
+            Err(e) => panic!("Error while checking tree math test vector.\n{:?}", e),
+        }
+    }
+}
+
+#[cfg(any(feature = "expose-test-vectors", test))]
+implement_error! {
+    pub enum TMTestVectorError {
+        TreeSizeMismatch = "The computed tree size doesn't match the one in the test vector.",
+        RootIndexMismatch = "The computed root index doesn't match the one in the test vector.",
+        LeftIndexMismatch = "A computed left child index doesn't match the one in the test vector.",
+        RightIndexMismatch = "A computed right child index doesn't match the one in the test vector.",
+        ParentIndexMismatch = "A computed parent index doesn't match the one in the test vector.",
+        SiblingIndexMismatch = "A computed sibling index doesn't match the one in the test vector.",
     }
 }


### PR DESCRIPTION
This PR exposes the generation and checking of the key schedule test vector behind a feature flag. This is necessary to enable the test vector functionality of the (planned) interop client.

To make the code a bit more usable, I've replaced the asserts in the kat-checking code with Errors.

The goal is to expose all test vectors this way, but I'm starting with the key schedule one to discuss how to best go about this. Once we decide on a way to do this, I'll create a follow-up PR with the rest of the test vectors.