### PR TITLE
Fix Windows build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ serde_json = "^1.0"
 tls-codec = { version = "0.1", path = "tls-codec", features = ["derive", "hpke"] }
 log = { version = "0.4", features = ["std"] }
 typetag = "0.1"
-hpke = { version = "0.0.5", package = "hpke-rs", features = ["hazmat", "serialization"] }
-evercrypt = { version = "0.0.7", features = ["serialization"] }
+hpke = { version = "0.0.6", package = "hpke-rs", features = ["hazmat", "serialization"] }
+evercrypt = { version = "0.0.8", features = ["serialization"] }
 
 [features]
 default = ["rust-crypto"]

--- a/tls-codec/Cargo.toml
+++ b/tls-codec/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 tls-codec-derive = { version = "0.1", path = "../tls-codec-derive", optional = true }
-hpke-rs = { version = "0.0.5", package = "hpke-rs", features = ["hazmat", "serialization"], optional = true }
+hpke-rs = { version = "0.0.6", package = "hpke-rs", features = ["hazmat", "serialization"], optional = true }
 
 [features]
 derive = [ "tls-codec-derive" ]


### PR DESCRIPTION
Fixes #246.

The fix in `evercrypt-rust` should make it easier to build OpenMLS on Windows.