### PR TITLE
Add rustc minimum version to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Deploy Docs](https://github.com/openmls/openmls/workflows/Deploy%20Docs/badge.svg)](https://openmls.github.io/openmls/openmls/index.html)
 [![codecov](https://codecov.io/gh/openmls/openmls/branch/main/graph/badge.svg?token=5SDRDRTZI0)](https://codecov.io/gh/openmls/openmls)
 [![OpenMLS List][list-image]][list-link]
+![Rust Version][rustc-image]
 
 A WIP Rust implementation of [Messaging Layer Security](https://github.com/mlswg/mls-protocol/blob/master/draft-ietf-mls-protocol.md) based on draft 9+.
 
@@ -26,6 +27,8 @@ A WIP Rust implementation of [Messaging Layer Security](https://github.com/mlswg
 OpenMLS relies on [EverCrypt](https://github.com/project-everest/hacl-star/tree/master/providers/evercrypt), a high-performance, cross-platform, formally verified modern cryptographic provider through [EverCrypt Rust bindings](https://crates.io/crates/evercrypt).
 
 ## Development
+
+OpenMLS requires at least Rust 1.50.0.
 
 ### Build
 
@@ -73,3 +76,4 @@ OpenMLS adheres to the [Contributor Covenant](https://www.contributor-covenant.o
 [chat-link]: https://openmls.zulipchat.com
 [list-image]: https://img.shields.io/badge/mailing-list-blue.svg
 [list-link]: https://groups.google.com/u/0/g/openmls-dev
+[rustc-image]: https://img.shields.io/badge/rustc-1.50+-blue.svg


### PR DESCRIPTION
In the light of #364 we should make clear what's the minimum rustc version is OpenMLS requires.