### PR TITLE
test macro and codecov fix

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "tests/utils/managed_utils/*"
+  - "tests/utils/mls_utils/*"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,0 @@
-ignore:
-  - "tests/utils/managed_utils/*"
-  - "tests/utils/mls_utils/*"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
 
       - name: Run cargo-tarpaulin

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,11 +12,14 @@ jobs:
         with:
           submodules: true
 
-      - name: Install stable toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
+
+      - name: Clean
+        run: cargo clean
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
+        with:
+          timeout: "300"
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,4 @@
 name: test coverage
-ignore:
-  - "tests/utils/managed_utils/*"
-  - "tests/utils/mls_utils/*"
 
 on: [push]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ default-members = [
     ".",
     "test_macros",
     "tls-codec",
-    "tls-codec-derive",
 ]
 
 [dependencies]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
 ignore:
   - "delivery-service/**/*"  # ignore PoC DS server and lib
   - "cli/**/*"  # ignore PoC cli
+  # ignore test frameworks
+  - "tests/utils/managed_utils/*"
+  - "tests/utils/mls_utils/*"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,7 +24,7 @@ const DEFAULT_KEY_PACKAGE_LIFETIME_MARGIN: u64 = 60 * 60; // in Seconds
 
 /// Supported ciphersuites
 /// TODO #13: This should come from the crypto provider
-const SUPPORTED_CIPHERSUITE_NAMES: &[CiphersuiteName] = &[
+pub(crate) const SUPPORTED_CIPHERSUITE_NAMES: &[CiphersuiteName] = &[
     CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
     CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256,
     CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,

--- a/src/extensions/test_extensions.rs
+++ b/src/extensions/test_extensions.rs
@@ -9,8 +9,6 @@ use crate::{
     prelude::*,
 };
 
-use test_macros::ctest;
-
 #[test]
 fn capabilities() {
     // A capabilities extension with the default values for openmls.
@@ -60,9 +58,8 @@ fn lifetime() {
 
 // This tests the ratchet tree extension to deliver the public ratcheting tree
 // in-band
-
-ctest!(ratchet_tree_extension {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+ctest_ciphersuites!(ratchet_tree_extension, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 

--- a/src/group/managed_group/test_managed_group.rs
+++ b/src/group/managed_group/test_managed_group.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use std::convert::TryFrom;
-use test_macros::ctest;
 
 #[test]
 fn test_managed_group_persistence() {
@@ -194,8 +193,8 @@ fn remover() {
     }
 }
 
-ctest!(export_secret {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+ctest_ciphersuites!(export_secret, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
     let group_id = GroupId::from_slice(b"Test Group");

--- a/src/group/mls_group/test_duplicate_extension.rs
+++ b/src/group/mls_group/test_duplicate_extension.rs
@@ -10,11 +10,9 @@ use crate::{
     schedule::KeySchedule,
 };
 
-use test_macros::ctest;
-
 // This tests the ratchet tree extension to test if the duplicate detection works
-ctest!(duplicate_ratchet_tree_extension {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 

--- a/src/group/mls_group/test_mls_group.rs
+++ b/src/group/mls_group/test_mls_group.rs
@@ -1,5 +1,3 @@
-use test_macros::ctest;
-
 use crate::{
     group::GroupEpoch,
     messages::{Commit, ConfirmationTag, EncryptedGroupSecrets, GroupInfo},
@@ -322,28 +320,28 @@ fn test_update_path() {
 }
 
 // Test several scenarios when PSKs are used in a group
-ctest!(test_psks {
-        fn psk_fetcher(psks: &PreSharedKeys) -> Option<Vec<Secret>> {
-            let psk_id = vec![1u8, 2, 3];
-            let secret = Secret::from(vec![4u8, 5, 6]);
+ctest_ciphersuites!(test_psks, test(param: CiphersuiteName) {
+    fn psk_fetcher(psks: &PreSharedKeys) -> Option<Vec<Secret>> {
+        let psk_id = vec![1u8, 2, 3];
+        let secret = Secret::from(vec![4u8, 5, 6]);
 
-            let psk = &psks.psks[0];
-            if psk.psk_type == PSKType::External {
-                if let Psk::External(external_psk) = &psk.psk {
-                    if external_psk.psk_id() == psk_id {
-                        Some(vec![secret])
-                    } else {
-                        None
-                    }
+        let psk = &psks.psks[0];
+        if psk.psk_type == PSKType::External {
+            if let Psk::External(external_psk) = &psk.psk {
+                if external_psk.psk_id() == psk_id {
+                    Some(vec![secret])
                 } else {
                     None
                 }
             } else {
                 None
             }
+        } else {
+            None
         }
+    }
 
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
     // Basic group setup.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,10 @@ mod utils;
 #[macro_use]
 pub mod error;
 
+#[cfg(any(feature = "expose-test-vectors", test))]
+#[macro_use]
+mod test_util;
+
 mod ciphersuite;
 mod codec;
 pub mod config;
@@ -43,6 +47,3 @@ pub use crate::tree::node;
 
 /// Single place, re-exporting the most used public functions.
 pub mod prelude;
-
-#[cfg(any(feature = "expose-test-vectors", test))]
-mod test_util;

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -59,3 +59,21 @@ pub fn hex_to_bytes_option(hex: Option<String>) -> Vec<u8> {
         None => vec![],
     }
 }
+
+#[allow(unused_macros)]
+macro_rules! ctest_ciphersuites {
+    ($name:ident, test($param_name:ident: $t:ty) $body:block) => {
+        test_macros::ctest!(
+            $name
+            [
+                CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+                CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256,
+                CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+            ]
+            {
+                fn test($param_name: $t) $body
+                test(param)
+            }
+        );
+    };
+}

--- a/test_macros/Cargo.toml
+++ b/test_macros/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-openmls = { path = "../" }
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/test_macros/tests/tests.rs
+++ b/test_macros/tests/tests.rs
@@ -1,0 +1,64 @@
+use std::convert::TryFrom;
+
+use test_macros::ctest;
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone)]
+#[repr(u16)]
+pub enum CiphersuiteName {
+    MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519 = 0x0001,
+    MLS10_128_DHKEMP256_AES128GCM_SHA256_P256 = 0x0002,
+    MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 = 0x0003,
+    MLS10_256_DHKEMX448_AES256GCM_SHA512_Ed448 = 0x0004,
+    MLS10_256_DHKEMP521_AES256GCM_SHA512_P521 = 0x0005,
+    MLS10_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 = 0x0006,
+}
+
+impl TryFrom<u16> for CiphersuiteName {
+    type Error = &'static str;
+
+    fn try_from(v: u16) -> Result<Self, Self::Error> {
+        match v {
+            0x0001 => Ok(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519),
+            0x0002 => Ok(CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256),
+            0x0003 => Ok(CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519),
+            0x0004 => Ok(CiphersuiteName::MLS10_256_DHKEMX448_AES256GCM_SHA512_Ed448),
+            0x0005 => Ok(CiphersuiteName::MLS10_256_DHKEMP521_AES256GCM_SHA512_P521),
+            0x0006 => Ok(CiphersuiteName::MLS10_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448),
+            _ => Err("Unknown ciphersuite"),
+        }
+    }
+}
+
+ctest!(ciphersuite_test [
+    CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+    CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256,
+    CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+] {
+    println!("ciphersuite_code: {:?}", param);
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+    println!("Testing ciphersuite {:?}", ciphersuite_name);
+});
+
+macro_rules! ctest_ciphersuites {
+    ($name:ident, test($param_name:ident: $t:ty) $body:block) => {
+        ctest!(
+            $name
+            [
+                CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+                CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256,
+                CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+            ]
+            {
+                fn test($param_name: $t) $body
+                test(param)
+            }
+        );
+    };
+}
+
+ctest_ciphersuites!(better_test, test(param: CiphersuiteName) {
+    println!("ciphersuite_code: {:?}", param);
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+    println!("Testing ciphersuite {:?}", ciphersuite_name);
+});

--- a/tests/test_decryption_key_index.rs
+++ b/tests/test_decryption_key_index.rs
@@ -1,14 +1,14 @@
 //! Test decryption key index computation in larger trees.
 use openmls::prelude::*;
 
+#[macro_use]
 mod utils;
 
 use std::convert::TryFrom;
-use test_macros::ctest;
 use utils::managed_utils::*;
 
-ctest!(decryption_key_index_computation {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+ctest_ciphersuites!(decryption_key_index_computation, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 

--- a/tests/test_interop_scenarios.rs
+++ b/tests/test_interop_scenarios.rs
@@ -1,7 +1,7 @@
 use openmls::prelude::*;
 use std::convert::TryFrom;
-use test_macros::ctest;
 
+#[macro_use]
 mod utils;
 
 use utils::managed_utils::*;
@@ -23,8 +23,8 @@ fn default_managed_group_config() -> ManagedGroupConfig {
 // B->A: KeyPackage
 // A->B: Welcome
 // ***:  Verify group state
-ctest!(one_to_one_join {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+ctest_ciphersuites!(one_to_one_join, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
     let number_of_clients = 2;
@@ -59,8 +59,8 @@ ctest!(one_to_one_join {
 // A->B: Add(C), Commit
 // A->C: Welcome
 // ***:  Verify group state
-ctest!(three_party_join {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+ctest_ciphersuites!(three_party_join, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
@@ -103,8 +103,8 @@ ctest!(three_party_join {
 // A->B: Welcome
 // A->C: Welcome
 // ***:  Verify group state
-ctest!(multiple_joins {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+ctest_ciphersuites!(multiple_joins, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
@@ -141,8 +141,8 @@ ctest!(multiple_joins {
 // A->B: Welcome
 // A->B: Update, Commit
 // ***:  Verify group state
-ctest!(update {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+ctest_ciphersuites!(update, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
@@ -176,8 +176,8 @@ ctest!(update {
 // A->C: Welcome
 // A->B: Remove(B), Commit
 // ***:  Verify group state
-ctest!(remove {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+ctest_ciphersuites!(remove, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
@@ -215,8 +215,8 @@ ctest!(remove {
 // * All members update
 // * While the group size is >1, a randomly-chosen group member removes a
 //   randomly-chosen other group member
-ctest!(large_group_lifecycle {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+ctest_ciphersuites!(large_group_lifecycle, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -2,10 +2,12 @@
 
 use openmls::prelude::*;
 use std::convert::TryFrom;
-use test_macros::ctest;
 
-ctest!(key_package_generation {
-    let ciphersuite_name = CiphersuiteName::try_from(_ciphersuite_code).unwrap();
+#[macro_use]
+mod utils;
+
+ctest_ciphersuites!(key_package_generation, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -2,3 +2,21 @@
 pub mod managed_utils;
 /// A framework to create integration tests of the "raw" mls_group API.
 pub mod mls_utils;
+
+#[allow(unused_macros)]
+macro_rules! ctest_ciphersuites {
+    ($name:ident, test($param_name:ident: $t:ty) $body:block) => {
+        test_macros::ctest!(
+            $name
+            [
+                CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+                CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256,
+                CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+            ]
+            {
+                fn test($param_name: $t) $body
+                test(param)
+            }
+        );
+    };
+}


### PR DESCRIPTION
This includes the Code from #328 and changes the test proc macro. 
This still requires nightly (when merging I’ll file a follow up to use stable again once it’s released). The linking issue came from a cyclic dependency between the test macro and the main lib. While this is fine for the compiler tarpaulin appears to have issues with it. And since it’s not great in general I rewrote it a little. It’s not as seem less now but therefore more flexible and it fixes the codecov issues. 