### PR TITLE
ciphersuite secret cleanup

### DIFF
--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -24,13 +24,11 @@ pub(crate) mod signable;
 
 mod ser;
 
-use crate::codec::*;
-use crate::config::{Config, ConfigError};
-use crate::schedule::ExporterSecret;
-use crate::schedule::SenderDataSecret;
-use crate::schedule::WelcomeSecret;
-use crate::utils::random_u32;
-use crate::utils::zero;
+use crate::{
+    codec::*,
+    config::{Config, ConfigError},
+};
+
 use ciphersuites::*;
 pub(crate) use errors::*;
 
@@ -285,25 +283,6 @@ impl From<&[u8]> for Secret {
     }
 }
 
-impl ExporterSecret {
-    /// Derive a `Secret` from the exporter secret. We return `Vec<u8>` here, so
-    /// it can be used outside of OpenMLS. This function is made available for
-    /// use from the outside through [`crate::group::mls_group::export_secret`].
-    pub(crate) fn derive_exported_secret(
-        &self,
-        ciphersuite: &Ciphersuite,
-        label: &str,
-        context: &[u8],
-        key_length: usize,
-    ) -> Vec<u8> {
-        let context_hash = &ciphersuite.hash(context);
-        self.secret()
-            .derive_secret(ciphersuite, label)
-            .kdf_expand_label(ciphersuite, label, context_hash, key_length)
-            .value
-    }
-}
-
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct AeadKey {
@@ -321,8 +300,9 @@ pub struct ReuseGuard {
 impl ReuseGuard {
     /// Samples a fresh reuse guard uniformly at random.
     pub fn from_random() -> Self {
-        let reuse_guard: [u8; REUSE_GUARD_BYTES] = random_u32().to_be_bytes();
-        ReuseGuard { value: reuse_guard }
+        Self {
+            value: get_random_array(),
+        }
     }
 }
 
@@ -440,17 +420,16 @@ impl Ciphersuite {
         hkdf_extract(self.hmac, salt.value.as_slice(), ikm.value.as_slice())
     }
 
-    /// Get the length of the used mac algorithm.
+    /// Get the length of the AEAD tag.
     pub(crate) fn mac_length(&self) -> usize {
-        // TODO: don't hard-code tag bytes, but use the mac_size func (Issue #205)
-        16
+        aead_tag_size(&self.aead)
     }
 
     /// HKDF extract.
     pub(crate) fn hkdf_extract(&self, salt: &Secret, ikm_option: Option<&Secret>) -> Secret {
         log::trace!("HKDF extract with {:?}", self.name);
         log_crypto!(trace, "  salt: {:x?}", salt.value);
-        let zero_secret = Secret::from(zero(self.hash_length()));
+        let zero_secret = Secret::from(vec![0u8; self.hash_length()]);
         let ikm = ikm_option.unwrap_or(&zero_secret);
         log_crypto!(trace, "  ikm:  {:x?}", ikm.value);
         Secret {
@@ -478,7 +457,7 @@ impl Ciphersuite {
     }
 
     /// Returns the length of the nonce in the AEAD.
-    pub(crate) fn aead_nonce_length(&self) -> usize {
+    pub(crate) const fn aead_nonce_length(&self) -> usize {
         NONCE_BYTES
     }
 
@@ -552,49 +531,6 @@ impl AeadKey {
         }
     }
 
-    /// Derive a new AEAD key from a `SenderDataSecret`.
-    pub(crate) fn from_sender_data_secret(
-        ciphersuite: &Ciphersuite,
-        ciphertext: &[u8],
-        sender_data_secret: &SenderDataSecret,
-    ) -> Self {
-        let ciphertext_sample = ciphertext_sample(ciphersuite, ciphertext);
-        log::debug!(
-            "AeadKey::from_sender_data_secret ciphertext sample: {:x?}",
-            ciphertext_sample
-        );
-        let key = sender_data_secret.secret().kdf_expand_label(
-            ciphersuite,
-            "key",
-            &ciphertext_sample,
-            ciphersuite.aead_key_length(),
-        );
-        AeadKey {
-            aead_mode: ciphersuite.aead,
-            value: key.value,
-            mac_len: ciphersuite.mac_length(),
-        }
-    }
-
-    /// Derive a new AEAD key from a `WelcomeSecret`.
-    pub(crate) fn from_welcome_secret(
-        ciphersuite: &Ciphersuite,
-        welcome_secret: &WelcomeSecret,
-    ) -> AeadKey {
-        let aead_secret = ciphersuite
-            .hkdf_expand(
-                &welcome_secret.secret(),
-                b"key",
-                ciphersuite.aead_key_length(),
-            )
-            .unwrap();
-        AeadKey {
-            aead_mode: ciphersuite.aead,
-            value: aead_secret.value,
-            mac_len: ciphersuite.mac_length(),
-        }
-    }
-
     #[cfg(test)]
     /// Generate a random AEAD Key
     pub fn from_random(ciphersuite: &Ciphersuite) -> Self {
@@ -656,61 +592,12 @@ impl AeadKey {
     }
 }
 
-// Get a ciphertext sample of `hash_length` from the ciphertext.
-fn ciphertext_sample<'a>(ciphersuite: &Ciphersuite, ciphertext: &'a [u8]) -> &'a [u8] {
-    let sample_length = ciphersuite.hash_length();
-    log::debug!("Getting ciphertext sample of length {:?}", sample_length);
-    if ciphertext.len() <= sample_length {
-        ciphertext
-    } else {
-        &ciphertext[0..sample_length]
-    }
-}
-
 impl AeadNonce {
     /// Create an `AeadNonce` from a `Secret`. TODO: This function should
     /// disappear when tackling issue #103.
     pub fn from_secret(secret: Secret) -> Self {
         let mut nonce = [0u8; NONCE_BYTES];
         nonce.clone_from_slice(&secret.value);
-        AeadNonce { value: nonce }
-    }
-    /// Derive a new AEAD nonce from a `SenderDataSecret`.
-    pub(crate) fn from_sender_data_secret(
-        ciphersuite: &Ciphersuite,
-        ciphertext: &[u8],
-        sender_data_secret: &SenderDataSecret,
-    ) -> Self {
-        let ciphertext_sample = ciphertext_sample(ciphersuite, ciphertext);
-        log::debug!(
-            "AeadNonce::from_sender_data_secret ciphertext sample: {:x?}",
-            ciphertext_sample
-        );
-        let nonce_secret = sender_data_secret.secret().kdf_expand_label(
-            ciphersuite,
-            "nonce",
-            &ciphertext_sample,
-            ciphersuite.aead_nonce_length(),
-        );
-        let mut nonce = [0u8; NONCE_BYTES];
-        nonce.clone_from_slice(nonce_secret.value.as_slice());
-        AeadNonce { value: nonce }
-    }
-
-    /// Derive a new AEAD key from a `WelcomeSecret`.
-    pub(crate) fn from_welcome_secret(
-        ciphersuite: &Ciphersuite,
-        welcome_secret: &WelcomeSecret,
-    ) -> Self {
-        let nonce_secret = ciphersuite
-            .hkdf_expand(
-                &welcome_secret.secret(),
-                b"nonce",
-                ciphersuite.aead_nonce_length(),
-            )
-            .unwrap();
-        let mut nonce = [0u8; NONCE_BYTES];
-        nonce.clone_from_slice(nonce_secret.value.as_slice());
         AeadNonce { value: nonce }
     }
 

--- a/src/framing/ciphertext.rs
+++ b/src/framing/ciphertext.rs
@@ -56,17 +56,13 @@ impl MLSCiphertext {
             )
             .map_err(|_| MLSCiphertextError::EncryptionError)?;
         // Derive the sender data key from the key schedule using the ciphertext.
-        let sender_data_key = AeadKey::from_sender_data_secret(
-            ciphersuite,
-            &ciphertext,
-            epoch_secrets.sender_data_secret(),
-        );
+        let sender_data_key = epoch_secrets
+            .sender_data_secret()
+            .derive_aead_key(ciphersuite, &ciphertext);
         // Derive initial nonce from the key schedule using the ciphertext.
-        let sender_data_nonce = AeadNonce::from_sender_data_secret(
-            ciphersuite,
-            &ciphertext,
-            epoch_secrets.sender_data_secret(),
-        );
+        let sender_data_nonce = epoch_secrets
+            .sender_data_secret()
+            .derive_aead_nonce(ciphersuite, &ciphertext);
         // Compute sender data nonce by xoring reuse guard and key schedule
         // nonce as per spec.
         let mls_sender_data_aad = MLSSenderDataAAD::new(
@@ -103,17 +99,13 @@ impl MLSCiphertext {
     ) -> Result<MLSPlaintext, MLSCiphertextError> {
         log::debug!("Decrypting MLSCiphertext");
         // Derive key from the key schedule using the ciphertext.
-        let sender_data_key = AeadKey::from_sender_data_secret(
-            ciphersuite,
-            &self.ciphertext,
-            epoch_secrets.sender_data_secret(),
-        );
+        let sender_data_key = epoch_secrets
+            .sender_data_secret()
+            .derive_aead_key(ciphersuite, &self.ciphertext);
         // Derive initial nonce from the key schedule using the ciphertext.
-        let sender_data_nonce = AeadNonce::from_sender_data_secret(
-            ciphersuite,
-            &self.ciphertext,
-            epoch_secrets.sender_data_secret(),
-        );
+        let sender_data_nonce = epoch_secrets
+            .sender_data_secret()
+            .derive_aead_nonce(ciphersuite, &self.ciphertext);
         // Serialize sender data AAD
         let mls_sender_data_aad =
             MLSSenderDataAAD::new(self.group_id.clone(), self.epoch, self.content_type);

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -648,7 +648,7 @@ impl<'a> ManagedGroup<'a> {
 
     /// Returns the authentication secret
     pub fn authentication_secret(&self) -> Vec<u8> {
-        self.group.authentication_secret().to_vec()
+        self.group.authentication_secret()
     }
 
     /// Returns a resumption secret for a given epoch. If no resumption secret

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -3,7 +3,6 @@ use crate::framing::*;
 use crate::group::mls_group::*;
 use crate::group::*;
 use crate::key_packages::*;
-use crate::messages::*;
 use crate::schedule::CommitSecret;
 
 impl MlsGroup {
@@ -160,11 +159,9 @@ impl MlsGroup {
         )?;
 
         // Verify confirmation tag
-        let own_confirmation_tag = ConfirmationTag::new(
-            &ciphersuite,
-            &provisional_epoch_secrets.confirmation_key(),
-            &confirmed_transcript_hash,
-        );
+        let own_confirmation_tag = provisional_epoch_secrets
+            .confirmation_key()
+            .tag(&ciphersuite, &confirmed_transcript_hash);
         if &own_confirmation_tag != received_confirmation_tag {
             return Err(ApplyCommitError::ConfirmationTagMismatch);
         }

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -142,11 +142,9 @@ impl MlsGroup {
         let provisional_epoch_secrets = key_schedule.epoch_secrets(false)?;
 
         // Calculate the confirmation tag
-        let confirmation_tag = ConfirmationTag::new(
-            &ciphersuite,
-            &provisional_epoch_secrets.confirmation_key(),
-            &confirmed_transcript_hash,
-        );
+        let confirmation_tag = provisional_epoch_secrets
+            .confirmation_key()
+            .tag(&ciphersuite, &confirmed_transcript_hash);
 
         // Set the confirmation tag
         mls_plaintext.confirmation_tag = Some(confirmation_tag.clone());

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -386,11 +386,7 @@ impl MlsGroup {
 
     /// Returns the authentication secret
     pub fn authentication_secret(&self) -> Vec<u8> {
-        self.epoch_secrets()
-            .authentication_secret()
-            .secret()
-            .to_bytes()
-            .to_vec()
+        self.epoch_secrets().authentication_secret().export()
     }
 
     /// Loads the state from persisted state

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -180,11 +180,9 @@ impl MlsGroup {
             .encryption_secret()
             .create_secret_tree(tree.leaf_count());
 
-        let confirmation_tag = ConfirmationTag::new(
-            &ciphersuite,
-            &epoch_secrets.confirmation_key(),
-            &group_context.confirmed_transcript_hash,
-        );
+        let confirmation_tag = epoch_secrets
+            .confirmation_key()
+            .tag(&ciphersuite, &group_context.confirmed_transcript_hash);
         let interim_transcript_hash = update_interim_transcript_hash(
             &ciphersuite,
             &MLSPlaintextCommitAuthData::from(&confirmation_tag),

--- a/src/group/tests/kat_transcripts.rs
+++ b/src/group/tests/kat_transcripts.rs
@@ -16,7 +16,7 @@ use crate::{
         update_confirmed_transcript_hash, update_interim_transcript_hash, GroupContext, GroupEpoch,
         GroupId,
     },
-    messages::{Commit, ConfirmationTag},
+    messages::Commit,
     prelude::{
         random_u32, random_u64, randombytes, sender::SenderType, ContentType, LeafIndex,
         MLSPlaintext, MLSPlaintextCommitAuthData, MLSPlaintextCommitContent,
@@ -81,11 +81,7 @@ pub fn generate_test_vector(ciphersuite: &Ciphersuite) -> TranscriptTestVector {
         &[], // extensions
     )
     .expect("Error creating group context");
-    let confirmation_tag = ConfirmationTag::new(
-        ciphersuite,
-        &confirmation_key,
-        &confirmed_transcript_hash_before,
-    );
+    let confirmation_tag = confirmation_key.tag(ciphersuite, &confirmed_transcript_hash_before);
     commit.confirmation_tag = Some(confirmation_tag);
     commit
         .add_membership_tag(ciphersuite, context.serialized(), &membership_key)
@@ -188,11 +184,7 @@ pub fn run_test_vector(test_vector: TranscriptTestVector) -> Result<(), Transcri
         return Err(TranscriptTestVectorError::MembershipTagVerificationError);
     }
 
-    let my_confirmation_tag = ConfirmationTag::new(
-        &ciphersuite,
-        &confirmation_key,
-        &confirmed_transcript_hash_before,
-    );
+    let my_confirmation_tag = confirmation_key.tag(ciphersuite, &confirmed_transcript_hash_before);
     if &my_confirmation_tag
         != commit
             .confirmation_tag

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -7,7 +7,7 @@ use crate::extensions::*;
 use crate::framing::Mac;
 use crate::group::*;
 use crate::schedule::psk::PreSharedKeys;
-use crate::schedule::{ConfirmationKey, JoinerSecret};
+use crate::schedule::JoinerSecret;
 use crate::tree::{index::*, *};
 
 use serde::{Deserialize, Serialize};
@@ -116,31 +116,6 @@ impl Commit {
 /// around a `Mac`.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ConfirmationTag(pub(crate) Mac);
-
-impl ConfirmationTag {
-    /// Create a new confirmation tag.
-    ///
-    /// >  11.2. Commit
-    ///
-    /// ```text
-    /// MLSPlaintext.confirmation_tag =
-    ///     MAC(confirmation_key, GroupContext.confirmed_transcript_hash)
-    /// ```
-    pub fn new(
-        ciphersuite: &Ciphersuite,
-        confirmation_key: &ConfirmationKey,
-        confirmed_transcript_hash: &[u8],
-    ) -> Self {
-        ConfirmationTag(
-            ciphersuite
-                .mac(
-                    confirmation_key.secret(),
-                    &Secret::from(confirmed_transcript_hash.to_vec()),
-                )
-                .into(),
-        )
-    }
-}
 
 impl From<ConfirmationTag> for Vec<u8> {
     fn from(confirmation_tag: ConfirmationTag) -> Self {

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -403,20 +403,31 @@ impl WelcomeSecret {
         WelcomeSecret { secret }
     }
 
-    /// Get the `Secret` of the `WelcomeSecret`.
-    pub(crate) fn secret(&self) -> &Secret {
-        &self.secret
-    }
-
     /// Derive an `AeadKey` and an `AeadNonce` from the `WelcomeSecret`,
     /// consuming it in the process.
     pub(crate) fn derive_welcome_key_nonce(
         self,
         ciphersuite: &Ciphersuite,
     ) -> (AeadKey, AeadNonce) {
-        let welcome_nonce = AeadNonce::from_welcome_secret(ciphersuite, &self);
-        let welcome_key = AeadKey::from_welcome_secret(ciphersuite, &self);
+        let welcome_nonce = self.derive_aead_nonce(ciphersuite);
+        let welcome_key = self.derive_aead_key(ciphersuite);
         (welcome_key, welcome_nonce)
+    }
+
+    /// Derive a new AEAD key from a `WelcomeSecret`.
+    fn derive_aead_key(&self, ciphersuite: &Ciphersuite) -> AeadKey {
+        let aead_secret = ciphersuite
+            .hkdf_expand(&self.secret, b"key", ciphersuite.aead_key_length())
+            .unwrap();
+        AeadKey::from_secret(ciphersuite, aead_secret)
+    }
+
+    /// Derive a new AEAD nonce from a `WelcomeSecret`.
+    fn derive_aead_nonce(&self, ciphersuite: &Ciphersuite) -> AeadNonce {
+        let nonce_secret = ciphersuite
+            .hkdf_expand(&self.secret, b"nonce", ciphersuite.aead_nonce_length())
+            .unwrap();
+        AeadNonce::from_secret(nonce_secret)
     }
 
     #[cfg(any(feature = "expose-test-vectors", test))]
@@ -514,14 +525,27 @@ impl ExporterSecret {
         ExporterSecret { secret }
     }
 
-    /// Get the `Secret` of the `ExporterSecret`.
-    pub(crate) fn secret(&self) -> &Secret {
-        &self.secret
-    }
-
     #[cfg(any(feature = "expose-test-vectors", test))]
     pub(crate) fn as_slice(&self) -> &[u8] {
         self.secret.to_bytes()
+    }
+
+    /// Derive a `Secret` from the exporter secret. We return `Vec<u8>` here, so
+    /// it can be used outside of OpenMLS. This function is made available for
+    /// use from the outside through [`crate::group::mls_group::export_secret`].
+    pub(crate) fn derive_exported_secret(
+        &self,
+        ciphersuite: &Ciphersuite,
+        label: &str,
+        context: &[u8],
+        key_length: usize,
+    ) -> Vec<u8> {
+        let context_hash = &ciphersuite.hash(context);
+        self.secret
+            .derive_secret(ciphersuite, label)
+            .kdf_expand_label(ciphersuite, label, context_hash, key_length)
+            .to_bytes()
+            .to_vec()
     }
 }
 
@@ -663,6 +687,17 @@ impl ResumptionSecret {
     }
 }
 
+// Get a ciphertext sample of `hash_length` from the ciphertext.
+fn ciphertext_sample<'a>(ciphersuite: &Ciphersuite, ciphertext: &'a [u8]) -> &'a [u8] {
+    let sample_length = ciphersuite.hash_length();
+    log::debug!("Getting ciphertext sample of length {:?}", sample_length);
+    if ciphertext.len() <= sample_length {
+        ciphertext
+    } else {
+        &ciphertext[0..sample_length]
+    }
+}
+
 /// A key that can be used to derive an `AeadKey` and an `AeadNonce`.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
@@ -679,9 +714,40 @@ impl SenderDataSecret {
         SenderDataSecret { secret }
     }
 
-    /// Get the `Secret` of the `ExporterSecret`.
-    pub(crate) fn secret(&self) -> &Secret {
-        &self.secret
+    /// Derive a new AEAD key from a `SenderDataSecret`.
+    pub(crate) fn derive_aead_key(&self, ciphersuite: &Ciphersuite, ciphertext: &[u8]) -> AeadKey {
+        let ciphertext_sample = ciphertext_sample(ciphersuite, ciphertext);
+        log::debug!(
+            "SenderDataSecret::derive_aead_key ciphertext sample: {:x?}",
+            ciphertext_sample
+        );
+        let secret = self.secret.kdf_expand_label(
+            ciphersuite,
+            "key",
+            &ciphertext_sample,
+            ciphersuite.aead_key_length(),
+        );
+        AeadKey::from_secret(ciphersuite, secret)
+    }
+
+    /// Derive a new AEAD nonce from a `SenderDataSecret`.
+    pub(crate) fn derive_aead_nonce(
+        &self,
+        ciphersuite: &Ciphersuite,
+        ciphertext: &[u8],
+    ) -> AeadNonce {
+        let ciphertext_sample = ciphertext_sample(ciphersuite, ciphertext);
+        log::debug!(
+            "SenderDataSecret::derive_aead_nonce ciphertext sample: {:x?}",
+            ciphertext_sample
+        );
+        let nonce_secret = self.secret.kdf_expand_label(
+            ciphersuite,
+            "nonce",
+            &ciphertext_sample,
+            ciphersuite.aead_nonce_length(),
+        );
+        AeadNonce::from_secret(nonce_secret)
     }
 
     #[cfg(any(feature = "expose-test-vectors", test))]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ pub(crate) fn randombytes(n: usize) -> Vec<u8> {
     get_random_vec(n)
 }
 
-#[cfg(test)]
+#[cfg(any(feature = "expose-test-vectors", test))]
 pub(crate) fn random_u32() -> u32 {
     OsRng.next_u32()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,13 +3,14 @@ use crate::tree::{index::*, node::*, *};
 
 use evercrypt::prelude::*;
 
-use rand::rngs::OsRng;
-use rand::RngCore;
+#[cfg(any(feature = "expose-test-vectors", test))]
+use rand::{rngs::OsRng, RngCore};
 
 pub(crate) fn randombytes(n: usize) -> Vec<u8> {
     get_random_vec(n)
 }
 
+#[cfg(test)]
 pub(crate) fn random_u32() -> u32 {
     OsRng.next_u32()
 }


### PR DESCRIPTION
After looking at dependencies between the modules I started cleaning up the ciphersuite and key schedule. There are a couple more things that could be done here but this would require having something like a `trait Secret`.
Similar cleanups are needed for the other modules as well.