### PR TITLE
Make Secret protocol version and cipher suite aware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ pretty_env_logger = "0.4.0"
 itertools = "0.10"
 test_macros = { path = "test_macros" }
 
-
 [[bench]]
 name = "benchmark"
 harness = false

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -236,6 +236,7 @@ impl User {
             kpb,
             config,
             None, /* Initial PSK */
+            None, /* MLS version */
         )
         .unwrap();
         let group = Group {

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -158,6 +158,7 @@ async fn test_group() {
         key_package_bundles.remove(0),
         GroupConfig::default(),
         None, /* Initial PSK */
+        None, /* MLS version */
     )
     .unwrap();
 

--- a/src/ciphersuite/codec.rs
+++ b/src/ciphersuite/codec.rs
@@ -95,7 +95,11 @@ impl Codec for Secret {
 
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
         let value = decode_vec(VecSize::VecU8, cursor)?;
-        Ok(Secret { value })
+        Ok(Secret {
+            value,
+            mls_version: ProtocolVersion::default(),
+            ciphersuite: Ciphersuite::default(),
+        })
     }
 }
 

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -266,9 +266,6 @@ impl Secret {
             ciphersuite.name,
             mls_version
         );
-        // if ciphersuite.name == CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256 {
-        //     log::trace!("{:?}", backtrace::Backtrace::new());
-        // }
         Secret {
             value: get_random_vec(ciphersuite.hash_length()),
             mls_version,

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -26,7 +26,7 @@ mod ser;
 
 use crate::{
     codec::*,
-    config::{Config, ConfigError},
+    config::{Config, ConfigError, ProtocolVersion},
 };
 
 use ciphersuites::*;
@@ -34,6 +34,8 @@ pub(crate) use errors::*;
 
 #[cfg(test)]
 mod test_ciphersuite;
+#[cfg(test)]
+mod test_secrets;
 
 pub(crate) const NONCE_BYTES: usize = 12;
 pub(crate) const REUSE_GUARD_BYTES: usize = 4;
@@ -175,22 +177,21 @@ struct KdfLabel {
 }
 
 impl KdfLabel {
-    fn serialized_label(context: &[u8], label: &str, length: usize) -> Vec<u8> {
+    fn serialized_label(context: &[u8], label: String, length: usize) -> Vec<u8> {
         // TODO: This should throw an error. Generally, keys length should be
         // checked. (see #228).
         if length > u16::MAX.into() {
             panic!("Library error: Trying to derive a key with a too large length field!")
         }
-        let full_label = "mls10 ".to_owned() + label;
         log::debug!(
             "KDF Label:\n length: {:?}\n label: {:?}\n context: {:x?}",
             length as u16,
-            full_label,
+            label,
             context
         );
         let kdf_label = KdfLabel {
             length: length as u16,
-            label: full_label,
+            label,
             context: context.to_vec(),
         };
         // It is ok to use unwrap() here, because the context is already serialized
@@ -201,84 +202,223 @@ impl KdfLabel {
 /// A struct to contain secrets. This is to provide better visibility into where
 /// and how secrets are used and to avoid passing secrets in their raw
 /// representation.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Clone, Debug)]
 pub struct Secret {
+    ciphersuite: &'static Ciphersuite,
     value: Vec<u8>,
+    mls_version: ProtocolVersion,
+}
+
+implement_persistence!(Secret, value, mls_version);
+
+impl Default for Secret {
+    fn default() -> Self {
+        Self {
+            ciphersuite: Ciphersuite::default(),
+            value: Vec::new(),
+            mls_version: ProtocolVersion::default(),
+        }
+    }
+}
+
+impl PartialEq for Secret {
+    // Constant time comparison.
+    fn eq(&self, other: &Secret) -> bool {
+        // These values can be considered public and checked before the actual
+        // comparison.
+        if self.ciphersuite != other.ciphersuite
+            || self.mls_version != other.mls_version
+            || self.value.len() != other.value.len()
+        {
+            log::error!("Incompatible secrets");
+            log::trace!(
+                "  {} {} {}",
+                self.ciphersuite.name,
+                self.mls_version,
+                self.value.len()
+            );
+            log::trace!(
+                "  {} {} {}",
+                other.ciphersuite.name,
+                other.mls_version,
+                other.value.len()
+            );
+            return false;
+        }
+        let mut diff = 0u8;
+        for (l, r) in self.value.iter().zip(other.value.iter()) {
+            diff |= l ^ r;
+        }
+        diff == 0
+    }
 }
 
 impl Secret {
     /// Randomly sample a fresh `Secret`.
-    pub(crate) fn random(length: usize) -> Self {
+    /// This default random initialiser uses the default Secret length of `hash_length`.
+    pub(crate) fn random(
+        ciphersuite: &'static Ciphersuite,
+        version: impl Into<Option<ProtocolVersion>>,
+    ) -> Self {
+        let mls_version = version.into().unwrap_or_default();
+        log::trace!(
+            "Creating a new random secret for {:?} and {:?}",
+            ciphersuite.name,
+            mls_version
+        );
+        // if ciphersuite.name == CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256 {
+        //     log::trace!("{:?}", backtrace::Backtrace::new());
+        // }
         Secret {
-            value: get_random_vec(length),
+            value: get_random_vec(ciphersuite.hash_length()),
+            mls_version,
+            ciphersuite,
         }
+    }
+
+    /// Create an all zero secret.
+    pub(crate) fn zero(ciphersuite: &'static Ciphersuite, mls_version: ProtocolVersion) -> Self {
+        Self {
+            value: vec![0u8; ciphersuite.hash_length()],
+            mls_version,
+            ciphersuite,
+        }
+    }
+
+    /// Create a new secret from a byte vector.
+    pub(crate) fn from_slice(
+        bytes: &[u8],
+        mls_version: ProtocolVersion,
+        ciphersuite: &'static Ciphersuite,
+    ) -> Self {
+        Secret {
+            value: bytes.to_vec(),
+            mls_version,
+            ciphersuite,
+        }
+    }
+
+    /// HMAC-Hash(salt, IKM). For all supported ciphersuites this is the same
+    /// HMAC that is also used in HKDF.
+    /// Compute the HMAC on `self` with key `ikm`.
+    pub(crate) fn mac(&self, ikm: &Secret) -> Self {
+        // FIXME: this should be on ikm and the other input shouldn't be a secret.
+        self.hkdf_extract(ikm)
+    }
+
+    /// HKDF extract where `self` is `salt`.
+    pub(crate) fn hkdf_extract<'a>(&self, ikm_option: impl Into<Option<&'a Secret>>) -> Self {
+        log::trace!("HKDF extract with {:?}", self.ciphersuite.name);
+        log_crypto!(trace, "  salt: {:x?}", self.value);
+        let zero_secret = Self::zero(self.ciphersuite, self.mls_version);
+        let ikm = ikm_option.into().unwrap_or(&zero_secret);
+        log_crypto!(trace, "  ikm:  {:x?}", ikm.value);
+
+        // We don't return an error here to keep the error propagation from
+        // blowing up. If this fails, something in the library is really wrong
+        // and we can't recover from it.
+        assert!(
+            self.mls_version == ikm.mls_version,
+            "{} != {}",
+            self.mls_version,
+            ikm.mls_version
+        );
+        assert!(
+            self.ciphersuite == ikm.ciphersuite,
+            "{} != {}",
+            self.ciphersuite,
+            ikm.ciphersuite
+        );
+
+        Self {
+            value: hkdf_extract(
+                self.ciphersuite.hmac,
+                self.value.as_slice(),
+                ikm.value.as_slice(),
+            ),
+            mls_version: self.mls_version,
+            ciphersuite: self.ciphersuite,
+        }
+    }
+
+    /// HKDF expand where `self` is `prk`.
+    pub(crate) fn hkdf_expand(&self, info: &[u8], okm_len: usize) -> Result<Self, HKDFError> {
+        let key = hkdf_expand(self.ciphersuite.hmac, &self.value, info, okm_len);
+        if key.is_empty() {
+            return Err(HKDFError::InvalidLength);
+        }
+        Ok(Self {
+            value: key,
+            mls_version: self.mls_version,
+            ciphersuite: self.ciphersuite,
+        })
     }
 
     /// Expand a `Secret` to a new `Secret` of length `length` including a
     /// `label` and a `context`.
-    pub fn kdf_expand_label(
-        &self,
-        ciphersuite: &Ciphersuite,
-        label: &str,
-        context: &[u8],
-        length: usize,
-    ) -> Secret {
-        let info = KdfLabel::serialized_label(context, label, length);
+    pub(crate) fn kdf_expand_label(&self, label: &str, context: &[u8], length: usize) -> Secret {
+        let full_label = format!("{} {}", self.mls_version, label);
         log::trace!(
             "KDF expand with label \"{}\" and {:?} with context {:x?}",
-            label,
-            ciphersuite.name(),
+            &full_label,
+            self.ciphersuite.name(),
             context
         );
+        let info = KdfLabel::serialized_label(context, full_label, length);
         log::trace!("  serialized context: {:x?}", info);
         log_crypto!(trace, "  secret: {:x?}", self.value);
-        ciphersuite.hkdf_expand(self, &info, length).unwrap()
+        self.hkdf_expand(&info, length).unwrap()
     }
 
     /// Derive a new `Secret` from the this one by expanding it with the given
     /// `label` and an empty `context`.
-    pub fn derive_secret(&self, ciphersuite: &Ciphersuite, label: &str) -> Secret {
+    pub(crate) fn derive_secret(&self, label: &str) -> Secret {
         log_crypto!(
             trace,
             "derive secret from {:x?} with label {} and {:?}",
             self.value,
             label,
-            ciphersuite.name()
+            self.ciphersuite.name()
         );
-        self.kdf_expand_label(ciphersuite, label, &[], ciphersuite.hash_length())
+        self.kdf_expand_label(label, &[], self.ciphersuite.hash_length())
+    }
+
+    /// Update the ciphersuite and MLS version of this secret.
+    /// Ideally we wouldn't need this function but the way decoding works right
+    /// now this is the easiest for now.
+    pub(crate) fn config(
+        &mut self,
+        ciphersuite: &'static Ciphersuite,
+        mls_version: ProtocolVersion,
+    ) {
+        self.ciphersuite = ciphersuite;
+        self.mls_version = mls_version;
     }
 
     /// Returns the inner bytes of a secret
     pub(crate) fn to_bytes(&self) -> &[u8] {
         &self.value
     }
-}
 
-impl Default for Secret {
-    fn default() -> Self {
-        Secret { value: vec![] }
+    /// Returns the MLS version of the secret
+    pub(crate) fn version(&self) -> ProtocolVersion {
+        self.mls_version
+    }
+
+    /// Returns the ciphersuite of the secret
+    pub(crate) fn ciphersuite(&self) -> &'static Ciphersuite {
+        self.ciphersuite
     }
 }
 
-static EMPTY_SECRET: Secret = Secret { value: vec![] };
-
-impl Default for &Secret {
-    fn default() -> Self {
-        &EMPTY_SECRET
-    }
-}
-
-impl From<Vec<u8>> for Secret {
-    fn from(bytes: Vec<u8>) -> Self {
-        Secret { value: bytes }
-    }
-}
-
+#[cfg(any(feature = "expose-test-vectors", test))]
 impl From<&[u8]> for Secret {
     fn from(bytes: &[u8]) -> Self {
+        log::trace!("Secret from slice");
         Secret {
             value: bytes.to_vec(),
+            mls_version: ProtocolVersion::default(),
+            ciphersuite: Ciphersuite::default(),
         }
     }
 }
@@ -388,6 +528,12 @@ impl Ciphersuite {
         })
     }
 
+    /// Get the default ciphersuite.
+    pub(crate) fn default() -> &'static Self {
+        Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+            .unwrap()
+    }
+
     /// Get the signature scheme of this ciphersuite.
     pub fn signature_scheme(&self) -> SignatureScheme {
         self.signature_scheme
@@ -414,41 +560,9 @@ impl Ciphersuite {
         get_digest_size(self.hash)
     }
 
-    /// HMAC-Hash(salt, IKM). For all supported ciphersuites this is the same
-    /// HMAC that is also used in HKDF.
-    pub(crate) fn mac(&self, salt: &Secret, ikm: &Secret) -> Vec<u8> {
-        hkdf_extract(self.hmac, salt.value.as_slice(), ikm.value.as_slice())
-    }
-
     /// Get the length of the AEAD tag.
     pub(crate) fn mac_length(&self) -> usize {
         aead_tag_size(&self.aead)
-    }
-
-    /// HKDF extract.
-    pub(crate) fn hkdf_extract(&self, salt: &Secret, ikm_option: Option<&Secret>) -> Secret {
-        log::trace!("HKDF extract with {:?}", self.name);
-        log_crypto!(trace, "  salt: {:x?}", salt.value);
-        let zero_secret = Secret::from(vec![0u8; self.hash_length()]);
-        let ikm = ikm_option.unwrap_or(&zero_secret);
-        log_crypto!(trace, "  ikm:  {:x?}", ikm.value);
-        Secret {
-            value: hkdf_extract(self.hmac, salt.value.as_slice(), ikm.value.as_slice()),
-        }
-    }
-
-    /// HKDF expand
-    pub(crate) fn hkdf_expand(
-        &self,
-        prk: &Secret,
-        info: &[u8],
-        okm_len: usize,
-    ) -> Result<Secret, HKDFError> {
-        let key = hkdf_expand(self.hmac, &prk.value, info, okm_len);
-        if key.is_empty() {
-            return Err(HKDFError::InvalidLength);
-        }
-        Ok(Secret { value: key })
     }
 
     /// Returns the key size of the used AEAD.
@@ -523,17 +637,18 @@ impl Ciphersuite {
 impl AeadKey {
     /// Create an `AeadKey` from a `Secret`. TODO: This function should
     /// disappear when tackling issue #103.
-    pub(crate) fn from_secret(ciphersuite: &Ciphersuite, secret: Secret) -> Self {
+    pub(crate) fn from_secret(secret: Secret) -> Self {
+        log::trace!("AeadKey::from_secret with {}", secret.ciphersuite);
         AeadKey {
-            aead_mode: ciphersuite.aead,
+            aead_mode: secret.ciphersuite.aead,
             value: secret.value,
-            mac_len: ciphersuite.mac_length(),
+            mac_len: secret.ciphersuite.mac_length(),
         }
     }
 
     #[cfg(test)]
     /// Generate a random AEAD Key
-    pub fn from_random(ciphersuite: &Ciphersuite) -> Self {
+    pub fn random(ciphersuite: &Ciphersuite) -> Self {
         AeadKey {
             aead_mode: ciphersuite.aead(),
             value: aead_key_gen(ciphersuite.aead()),
@@ -602,7 +717,7 @@ impl AeadNonce {
     }
 
     /// Generate a new random nonce.
-    pub fn from_random() -> Self {
+    pub fn random() -> Self {
         let mut nonce = [0u8; NONCE_BYTES];
         nonce.clone_from_slice(get_random_vec(NONCE_BYTES).as_slice());
         AeadNonce { value: nonce }
@@ -744,7 +859,7 @@ impl SignaturePrivateKey {
 #[test]
 fn test_xor() {
     let reuse_guard: ReuseGuard = ReuseGuard::from_random();
-    let original_nonce = AeadNonce::from_random();
+    let original_nonce = AeadNonce::random();
     let mut nonce = original_nonce.clone();
     nonce.xor_with_reuse_guard(&reuse_guard);
     assert_ne!(

--- a/src/ciphersuite/test_ciphersuite.rs
+++ b/src/ciphersuite/test_ciphersuite.rs
@@ -13,7 +13,7 @@ fn test_hpke_seal_open() {
         println!("Test {:?}", ciphersuite.name());
         println!("Ciphersuite {:?}", ciphersuite);
         let plaintext = &[1, 2, 3];
-        let kp = ciphersuite.derive_hpke_keypair(&Secret::from(vec![1, 2, 3]));
+        let kp = ciphersuite.derive_hpke_keypair(&Secret::random(ciphersuite, None));
         let ciphertext = ciphersuite.hpke_seal(kp.public_key(), &[], &[], plaintext);
         let decrypted_payload = ciphersuite
             .hpke_open(&ciphertext, kp.private_key(), &[], &[])

--- a/src/ciphersuite/test_secrets.rs
+++ b/src/ciphersuite/test_secrets.rs
@@ -1,0 +1,31 @@
+use crate::config::ProtocolVersion;
+
+use super::{Ciphersuite, Secret};
+
+#[test]
+fn secret_init() {
+    pretty_env_logger::init();
+
+    let csuite = Ciphersuite::default();
+
+    // These two secrets must be incompatible
+    let default_secret = Secret::random(csuite, None);
+    let draft_secret = Secret::random(csuite, ProtocolVersion::Mls10Draft12);
+
+    let derived_default_secret = default_secret.derive_secret("my_test_label");
+    let derived_draft_secret = draft_secret.derive_secret("my_test_label");
+    assert_ne!(derived_default_secret, derived_draft_secret);
+}
+
+#[test]
+#[should_panic]
+fn secret_incompatible() {
+    let csuite = Ciphersuite::default();
+
+    // These two secrets must be incompatible
+    let default_secret = Secret::random(csuite, None);
+    let draft_secret = Secret::random(csuite, ProtocolVersion::Mls10Draft12);
+
+    // This must panic because the two secrets have incompatible MLS versions.
+    let _default_extraced = default_secret.hkdf_extract(&draft_secret);
+}

--- a/src/ciphersuite/test_secrets.rs
+++ b/src/ciphersuite/test_secrets.rs
@@ -10,7 +10,7 @@ fn secret_init() {
 
     // These two secrets must be incompatible
     let default_secret = Secret::random(csuite, None);
-    let draft_secret = Secret::random(csuite, ProtocolVersion::Mls10Draft12);
+    let draft_secret = Secret::random(csuite, ProtocolVersion::Mls10Draft11);
 
     let derived_default_secret = default_secret.derive_secret("my_test_label");
     let derived_draft_secret = draft_secret.derive_secret("my_test_label");
@@ -24,7 +24,7 @@ fn secret_incompatible() {
 
     // These two secrets must be incompatible
     let default_secret = Secret::random(csuite, None);
-    let draft_secret = Secret::random(csuite, ProtocolVersion::Mls10Draft12);
+    let draft_secret = Secret::random(csuite, ProtocolVersion::Mls10Draft11);
 
     // This must panic because the two secrets have incompatible MLS versions.
     let _default_extraced = default_secret.hkdf_extract(&draft_secret);

--- a/src/config/codec.rs
+++ b/src/config/codec.rs
@@ -7,6 +7,6 @@ impl Codec for ProtocolVersion {
     }
 
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        Ok(Self::from(u8::decode(cursor)?)?)
+        Ok(Self::try_from(u8::decode(cursor)?)?)
     }
 }

--- a/src/config/errors.rs
+++ b/src/config/errors.rs
@@ -10,5 +10,7 @@ implement_error! {
         UnsupportedMlsVersion = "MLS version is not supported by this configuration.",
         UnsupportedCiphersuite = "Ciphersuite is not supported by this configuration.",
         UnsupportedSignatureScheme = "Signature scheme is not supported by this configuration.",
+        IncompatibleMlsVersion = "Operation on incompatible MLS versions.",
+        IncompatibleCiphersuite = "Operation on incompatible cipher suites.",
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -56,7 +56,7 @@ lazy_static! {
                 .map(|ciphersuite_name| Ciphersuite::new(*ciphersuite_name).unwrap())
                 .collect::<Vec<Ciphersuite>>();
             let config = PersistentConfig {
-                protocol_versions: vec![ProtocolVersion::Mls10, ProtocolVersion::Mls10Draft12],
+                protocol_versions: vec![ProtocolVersion::Mls10, ProtocolVersion::Mls10Draft11],
                 ciphersuites,
                 extensions: vec![ExtensionType::Capabilities, ExtensionType::Lifetime, ExtensionType::KeyID],
                 constants,
@@ -166,7 +166,7 @@ impl Config {
 pub enum ProtocolVersion {
     Reserved = 0,
     Mls10 = 1,
-    Mls10Draft12 = 255, // pre RFC version
+    Mls10Draft11 = 200, // pre RFC version
 }
 
 /// There's only one version right now, which is the default.
@@ -185,7 +185,7 @@ impl TryFrom<u8> for ProtocolVersion {
     fn try_from(v: u8) -> Result<Self, Self::Error> {
         match v {
             1 => Ok(ProtocolVersion::Mls10),
-            255 => Ok(ProtocolVersion::Mls10Draft12),
+            200 => Ok(ProtocolVersion::Mls10Draft11),
             _ => Err(ConfigError::UnsupportedMlsVersion),
         }
     }
@@ -196,7 +196,7 @@ impl fmt::Display for ProtocolVersion {
         match &self {
             ProtocolVersion::Reserved => Err(fmt::Error),
             ProtocolVersion::Mls10 => write!(f, "mls10"),
-            ProtocolVersion::Mls10Draft12 => write!(f, "mls10-draft12"),
+            ProtocolVersion::Mls10Draft11 => write!(f, "mls10-draft11"),
         }
     }
 }

--- a/src/extensions/capabilities_extension.rs
+++ b/src/extensions/capabilities_extension.rs
@@ -14,6 +14,8 @@
 //! } Capabilities;
 //! ```
 
+use std::convert::TryFrom;
+
 use super::{
     CapabilitiesExtensionError, Deserialize, Extension, ExtensionError, ExtensionStruct,
     ExtensionType, Serialize,
@@ -95,7 +97,7 @@ impl Extension for CapabilitiesExtension {
         let version_numbers: Vec<u8> = decode_vec(VecSize::VecU8, cursor)?;
         let mut versions = Vec::new();
         for &version_number in version_numbers.iter() {
-            versions.push(ProtocolVersion::from(version_number)?)
+            versions.push(ProtocolVersion::try_from(version_number)?)
         }
         // There must be at least one version we support.
         if versions.is_empty() {

--- a/src/extensions/test_extensions.rs
+++ b/src/extensions/test_extensions.rs
@@ -12,7 +12,9 @@ use crate::{
 #[test]
 fn capabilities() {
     // A capabilities extension with the default values for openmls.
-    let extension_bytes = [0, 1, 0, 16, 1, 1, 6, 0, 1, 0, 2, 0, 3, 6, 0, 1, 0, 2, 0, 3];
+    let extension_bytes = [
+        0, 1, 0, 17, 2, 1, 255, 6, 0, 1, 0, 2, 0, 3, 6, 0, 1, 0, 2, 0, 3,
+    ];
 
     let ext = CapabilitiesExtension::default();
     let ext_struct = ext.to_extension_struct();
@@ -103,6 +105,7 @@ ctest_ciphersuites!(ratchet_tree_extension, test(param: CiphersuiteName) {
         alice_key_package_bundle,
         config,
         None, /* Initial PSK */
+        None, /* MLS version */
     )
     .unwrap();
 
@@ -126,13 +129,15 @@ ctest_ciphersuites!(ratchet_tree_extension, test(param: CiphersuiteName) {
         .apply_commit(&mls_plaintext_commit, epoch_proposals, &[], None)
         .expect("error applying commit");
 
-    let bob_group = MlsGroup::new_from_welcome(
+    let bob_group = match MlsGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.unwrap(),
         None,
         bob_key_package_bundle,
         None,
-    )
-    .expect("Could not join group with ratchet tree extension");
+    ) {
+        Ok(g) => g,
+        Err(e) => panic!("Could not join group with ratchet tree extension {}", e),
+    };
 
     // Make sure the group state is the same
     assert_eq!(
@@ -168,6 +173,7 @@ ctest_ciphersuites!(ratchet_tree_extension, test(param: CiphersuiteName) {
         alice_key_package_bundle,
         config,
         None, /* Initial PSK */
+        None, /* MLS version */
     )
     .unwrap();
 

--- a/src/extensions/test_extensions.rs
+++ b/src/extensions/test_extensions.rs
@@ -13,7 +13,7 @@ use crate::{
 fn capabilities() {
     // A capabilities extension with the default values for openmls.
     let extension_bytes = [
-        0, 1, 0, 17, 2, 1, 255, 6, 0, 1, 0, 2, 0, 3, 6, 0, 1, 0, 2, 0, 3,
+        0, 1, 0, 17, 2, 1, 200, 6, 0, 1, 0, 2, 0, 3, 6, 0, 1, 0, 2, 0, 3,
     ];
 
     let ext = CapabilitiesExtension::default();

--- a/src/framing/codec.rs
+++ b/src/framing/codec.rs
@@ -1,5 +1,3 @@
-use crate::config::{Config, ProtocolVersion};
-
 use super::*;
 use std::convert::TryFrom;
 
@@ -39,28 +37,6 @@ impl Codec for MLSPlaintext {
             confirmation_tag,
             membership_tag,
         })
-    }
-}
-
-impl MLSPlaintext {
-    /// Decode an `MLSPlaintext` with ciphersuite and protocol version information.
-    /// This should be used instead of the raw decoding function in order to
-    /// update the `MLSPlaintext` with the missing information.
-    pub fn decode_with_context(
-        bytes: &[u8],
-        ciphersuite_name: CiphersuiteName,
-        version: ProtocolVersion,
-    ) -> Result<Self, CodecError> {
-        let cursor = &mut Cursor::new(bytes);
-        let mut plaintext = Self::decode(cursor)?;
-        let ciphersuite = Config::ciphersuite(ciphersuite_name)?;
-        if let Some(tag) = &mut plaintext.membership_tag {
-            tag.config(ciphersuite, version)
-        };
-        if let Some(tag) = &mut plaintext.confirmation_tag {
-            tag.config(ciphersuite, version);
-        };
-        Ok(plaintext)
     }
 }
 
@@ -142,22 +118,13 @@ impl MLSPlaintextContentType {
 
 impl Codec for Mac {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU8, buffer, self.mac_value.to_bytes())?;
+        encode_vec(VecSize::VecU8, buffer, &self.mac_value)?;
         Ok(())
     }
 
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
         let mac_value = decode_vec(VecSize::VecU8, cursor)?;
-        // The secret is instantiated with default values here because we don't
-        // know the correct values. They have to be set before use. Otherwise
-        // operations on the Mac will fail.
-        Ok(Self {
-            mac_value: Secret::from_slice(
-                &mac_value,
-                ProtocolVersion::default(),
-                Ciphersuite::default(),
-            ),
-        })
+        Ok(Self { mac_value })
     }
 }
 

--- a/src/framing/errors.rs
+++ b/src/framing/errors.rs
@@ -21,8 +21,8 @@ implement_error! {
         Simple {
             InvalidContentType = "The MLSCiphertext has an invalid content type.",
             GenerationOutOfBound = "Couldn't find a ratcheting secret for the given sender and generation.",
-            EncryptionError = "An error occured while encrypting.",
-            DecryptionError = "An error occured while decrypting.",
+            EncryptionError = "An error occurred while encrypting.",
+            DecryptionError = "An error occurred while decrypting.",
         }
         Complex {
             PlaintextError(MLSPlaintextError) = "MLSPlaintext error",

--- a/src/framing/plaintext.rs
+++ b/src/framing/plaintext.rs
@@ -435,7 +435,6 @@ impl MembershipTag {
         mls_version: ProtocolVersion,
     ) {
         self.0.mac_value.config(ciphersuite, mls_version);
-        // self
     }
 }
 

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -70,7 +70,8 @@ fn membership_tag() {
         let group_context =
             GroupContext::new(GroupId::random(), GroupEpoch(1), vec![], vec![], &[]).unwrap();
         let serialized_context = group_context.serialized();
-        let membership_key = MembershipKey::from_secret(Secret::random(ciphersuite.hash_length()));
+        let membership_key =
+            MembershipKey::from_secret(Secret::random(ciphersuite, None /* MLS version */));
         mls_plaintext
             .sign_from_member(&credential_bundle, serialized_context)
             .expect("Could not sign plaintext.");
@@ -169,6 +170,7 @@ fn unknown_sender() {
             alice_key_package_bundle,
             GroupConfig::default(),
             None, /* Initial PSK */
+            None, /* MLS version */
         )
         .unwrap();
 
@@ -269,7 +271,7 @@ fn unknown_sender() {
             &[1, 2, 3],
             &alice_credential_bundle,
             &group_alice.context(),
-            &MembershipKey::from_secret(Secret::default()),
+            &MembershipKey::from_secret(Secret::random(ciphersuite, None)),
         )
         .expect("Could not create new MLSPlaintext.");
 
@@ -300,12 +302,12 @@ fn unknown_sender() {
             &[1, 2, 3],
             &alice_credential_bundle,
             &group_alice.context(),
-            &MembershipKey::from_secret(Secret::default()),
+            &MembershipKey::from_secret(Secret::random(ciphersuite, None)),
         )
         .expect("Could not create new MLSPlaintext.");
 
         let mut secret_tree = SecretTree::new(
-            EncryptionSecret::from_random(ciphersuite.hash_length()),
+            EncryptionSecret::random(ciphersuite),
             LeafIndex::from(100usize),
         );
 

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -76,13 +76,12 @@ fn membership_tag() {
             .sign_from_member(&credential_bundle, serialized_context)
             .expect("Could not sign plaintext.");
         mls_plaintext
-            .add_membership_tag(ciphersuite, serialized_context, &membership_key)
+            .add_membership_tag(serialized_context, &membership_key)
             .expect("Could not mac plaintext.");
 
         println!(
             "Membership tag error: {:?}",
             mls_plaintext.verify_from_member(
-                ciphersuite,
                 serialized_context,
                 &credential_bundle.credential(),
                 &membership_key,
@@ -92,7 +91,6 @@ fn membership_tag() {
         // Verify signature & membership tag
         assert!(mls_plaintext
             .verify_from_member(
-                ciphersuite,
                 serialized_context,
                 &credential_bundle.credential(),
                 &membership_key,
@@ -105,7 +103,6 @@ fn membership_tag() {
         // Expect the signature & membership tag verification to fail
         assert!(mls_plaintext
             .verify_from_member(
-                ciphersuite,
                 serialized_context,
                 &credential_bundle.credential(),
                 &membership_key,
@@ -265,7 +262,6 @@ fn unknown_sender() {
 
         let bogus_sender = LeafIndex::from(1usize);
         let bogus_sender_message = MLSPlaintext::new_from_application(
-            ciphersuite,
             bogus_sender,
             &[],
             &[1, 2, 3],
@@ -296,7 +292,6 @@ fn unknown_sender() {
         // Expected result: MLSCiphertextError::GenerationOutOfBound
         let bogus_sender = LeafIndex::from(100usize);
         let bogus_sender_message = MLSPlaintext::new_from_application(
-            ciphersuite,
             bogus_sender,
             &[],
             &[1, 2, 3],

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -103,6 +103,7 @@ impl<'a> ManagedGroup<'a> {
             key_package_bundle,
             GroupConfig::default(),
             None, /* Initial PSK */
+            None, /* MLS version */
         )?;
 
         let resumption_secret_store =

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -110,7 +110,6 @@ impl MlsGroup {
         )?;
 
         let joiner_secret = JoinerSecret::new(
-            ciphersuite,
             provisional_tree.commit_secret(),
             self.epoch_secrets()
                 .init_secret()
@@ -179,7 +178,7 @@ impl MlsGroup {
             group_info.set_signature(group_info.sign(credential_bundle));
 
             // Encrypt GroupInfo object
-            let (welcome_key, welcome_nonce) = welcome_secret.derive_welcome_key_nonce(ciphersuite);
+            let (welcome_key, welcome_nonce) = welcome_secret.derive_welcome_key_nonce();
             let encrypted_group_info = welcome_key
                 .aead_seal(&group_info.encode_detached().unwrap(), &[], &welcome_nonce)
                 .unwrap();

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -143,17 +143,14 @@ impl MlsGroup {
         // Calculate the confirmation tag
         let confirmation_tag = provisional_epoch_secrets
             .confirmation_key()
-            .tag(&ciphersuite, &confirmed_transcript_hash);
+            .tag(&confirmed_transcript_hash);
 
         // Set the confirmation tag
         mls_plaintext.confirmation_tag = Some(confirmation_tag.clone());
 
         // Add membership tag
-        mls_plaintext.add_membership_tag(
-            ciphersuite,
-            serialized_context,
-            self.epoch_secrets().membership_key(),
-        )?;
+        mls_plaintext
+            .add_membership_tag(serialized_context, self.epoch_secrets().membership_key())?;
 
         // Check if new members were added an create welcome message
         if !plaintext_secrets.is_empty() {

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -9,7 +9,6 @@ mod test_duplicate_extension;
 #[cfg(test)]
 mod test_mls_group;
 
-use crate::ciphersuite::*;
 use crate::codec::*;
 use crate::config::Config;
 use crate::credentials::{CredentialBundle, CredentialError};
@@ -19,6 +18,7 @@ use crate::key_packages::*;
 use crate::messages::{proposals::*, *};
 use crate::schedule::*;
 use crate::tree::{index::*, node::*, secret_tree::*, *};
+use crate::{ciphersuite::*, config::ProtocolVersion};
 
 use serde::{
     de::{self, MapAccess, SeqAccess, Visitor},
@@ -49,6 +49,8 @@ pub struct MlsGroup {
     // Set to true if the ratchet tree extension is added to the `GroupInfo`.
     // Defaults to `false`.
     use_ratchet_tree_extension: bool,
+    // The MLS protocol version used in this group.
+    mls_version: ProtocolVersion,
 }
 
 implement_persistence!(
@@ -58,7 +60,8 @@ implement_persistence!(
     secret_tree,
     tree,
     interim_transcript_hash,
-    use_ratchet_tree_extension
+    use_ratchet_tree_extension,
+    mls_version
 );
 
 /// Public `MlsGroup` functions.
@@ -69,6 +72,7 @@ impl MlsGroup {
         key_package_bundle: KeyPackageBundle,
         config: GroupConfig,
         psk_option: impl Into<Option<PskSecret>>,
+        version: impl Into<Option<ProtocolVersion>>,
     ) -> Result<Self, GroupError> {
         debug!("Created group {:x?}", id);
         trace!(" >>> with {:?}, {:?}", ciphersuite_name, config);
@@ -88,11 +92,9 @@ impl MlsGroup {
         // Derive an initial joiner secret based on the commit secret.
         // Derive an epoch secret from the joiner secret.
         // We use a random `InitSecret` for initialization.
-        let joiner_secret = JoinerSecret::new(
-            ciphersuite,
-            commit_secret,
-            &InitSecret::random(ciphersuite.hash_length()),
-        );
+        let version = version.into().unwrap_or_default();
+        let joiner_secret =
+            JoinerSecret::new(commit_secret, &InitSecret::random(ciphersuite, version));
 
         let mut key_schedule = KeySchedule::init(ciphersuite, joiner_secret, psk_option);
         key_schedule.add_context(&group_context)?;
@@ -110,6 +112,7 @@ impl MlsGroup {
             tree: RefCell::new(tree),
             interim_transcript_hash,
             use_ratchet_tree_extension: config.add_ratchet_tree_extension,
+            mls_version: version,
         })
     }
 
@@ -485,7 +488,8 @@ impl MlsGroup {
 /// It gets called whenever the key schedule is advanced and references to PSKs
 /// are encountered. Since the PSKs are to be trandmitted out-of-band, they need
 /// to be fetched from wherever they are stored.
-pub type PskFetcher = fn(psks: &PreSharedKeys) -> Option<Vec<Secret>>;
+pub type PskFetcher =
+    fn(psks: &PreSharedKeys, ciphersuite: &'static Ciphersuite) -> Option<Vec<Secret>>;
 
 // Helper functions
 
@@ -508,7 +512,7 @@ pub(crate) fn update_interim_transcript_hash(
 }
 
 fn psk_output(
-    ciphersuite: &Ciphersuite,
+    ciphersuite: &'static Ciphersuite,
     psk_fetcher_option: Option<PskFetcher>,
     presharedkeys: &PreSharedKeys,
 ) -> Result<Option<PskSecret>, PskError> {
@@ -517,7 +521,7 @@ fn psk_output(
         match psk_fetcher_option {
             Some(psk_fetcher) => {
                 // Try to fetch the PSKs with the IDs
-                match psk_fetcher(&presharedkeys) {
+                match psk_fetcher(&presharedkeys, ciphersuite) {
                     Some(psks) => {
                         // Combine the PSKs in to a PskSecret
                         let psk_secret = PskSecret::new(ciphersuite, &presharedkeys.psks, &psks)?;

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -149,7 +149,6 @@ impl MlsGroup {
         };
         let proposal = Proposal::Add(add_proposal);
         MLSPlaintext::new_from_proposal_member(
-            self.ciphersuite,
             self.sender_index(),
             aad,
             proposal,
@@ -173,7 +172,6 @@ impl MlsGroup {
         let update_proposal = UpdateProposal { key_package };
         let proposal = Proposal::Update(update_proposal);
         MLSPlaintext::new_from_proposal_member(
-            self.ciphersuite,
             self.sender_index(),
             aad,
             proposal,
@@ -199,7 +197,6 @@ impl MlsGroup {
         };
         let proposal = Proposal::Remove(remove_proposal);
         MLSPlaintext::new_from_proposal_member(
-            self.ciphersuite,
             self.sender_index(),
             aad,
             proposal,
@@ -223,7 +220,6 @@ impl MlsGroup {
         let presharedkey_proposal = PreSharedKeyProposal { psk };
         let proposal = Proposal::PreSharedKey(presharedkey_proposal);
         MLSPlaintext::new_from_proposal_member(
-            self.ciphersuite,
             self.sender_index(),
             aad,
             proposal,
@@ -287,7 +283,6 @@ impl MlsGroup {
         padding_size: usize,
     ) -> Result<MLSCiphertext, GroupError> {
         let mls_plaintext = MLSPlaintext::new_from_application(
-            self.ciphersuite,
             self.sender_index(),
             aad,
             msg,

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -67,10 +67,7 @@ impl MlsGroup {
         let group_info_bytes = welcome_key
             .aead_open(welcome.encrypted_group_info(), &[], &welcome_nonce)
             .map_err(|_| WelcomeError::GroupInfoDecryptionFailure)?;
-        let mut group_info = GroupInfo::decode_detached(&group_info_bytes)?;
-        group_info
-            .confirmation_tag_mut()
-            .config(welcome.ciphersuite(), mls_version);
+        let group_info = GroupInfo::decode_detached(&group_info_bytes)?;
         let path_secret_option = group_secrets.path_secret;
 
         // Build the ratchet tree
@@ -189,7 +186,7 @@ impl MlsGroup {
 
         let confirmation_tag = epoch_secrets
             .confirmation_key()
-            .tag(&ciphersuite, &group_context.confirmed_transcript_hash);
+            .tag(&group_context.confirmed_transcript_hash);
         let interim_transcript_hash = update_interim_transcript_hash(
             &ciphersuite,
             &MLSPlaintextCommitAuthData::from(&confirmation_tag),

--- a/src/group/mls_group/test_duplicate_extension.rs
+++ b/src/group/mls_group/test_duplicate_extension.rs
@@ -55,6 +55,7 @@ ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(param: CiphersuiteNam
         alice_key_package_bundle,
         config,
         None, /* Initial PSK */
+        None, /* MLS version */
     )
     .unwrap();
 
@@ -94,7 +95,7 @@ ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(param: CiphersuiteNam
         &[],
         &[],
     ).expect("Could not decrypt group secrets");
-    let group_secrets = GroupSecrets::decode_detached(&group_secrets_bytes).expect("Could not decode GroupSecrets");
+    let group_secrets = GroupSecrets::decode_detached(&group_secrets_bytes).expect("Could not decode GroupSecrets").config(ciphersuite, ProtocolVersion::default());
     let joiner_secret = group_secrets.joiner_secret;
 
     // Create key schedule
@@ -114,7 +115,7 @@ ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(param: CiphersuiteNam
     // Derive welcome key & noce from the key schedule
     let (welcome_key, welcome_nonce) = key_schedule
         .welcome().expect("Expected a WelcomeSecret")
-        .derive_welcome_key_nonce(ciphersuite);
+        .derive_welcome_key_nonce();
 
     let group_info_bytes = welcome_key
         .aead_open(welcome.encrypted_group_info(), &[], &welcome_nonce)

--- a/src/group/mls_group/test_mls_group.rs
+++ b/src/group/mls_group/test_mls_group.rs
@@ -62,7 +62,7 @@ fn test_failed_groupinfo_decryption() {
             let confirmed_transcript_hash = vec![1, 1, 1];
             let extensions = Vec::new();
             let confirmation_tag = ConfirmationTag(Mac {
-                mac_value: Secret::random(ciphersuite, None),
+                mac_value: vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
             });
             let signer_index = LeafIndex::from(8u32);
             let group_info = GroupInfo::new(
@@ -305,11 +305,7 @@ fn test_update_path() {
             .sign_from_member(&bob_credential_bundle, serialized_context)
             .expect("Could not sign plaintext.");
         broken_plaintext
-            .add_membership_tag(
-                ciphersuite,
-                serialized_context,
-                group_bob.epoch_secrets.membership_key(),
-            )
+            .add_membership_tag(serialized_context, group_bob.epoch_secrets.membership_key())
             .expect("Could not add membership key");
 
         assert_eq!(

--- a/src/group/mls_group/test_mls_group.rs
+++ b/src/group/mls_group/test_mls_group.rs
@@ -34,6 +34,7 @@ fn test_mls_group_persistence() {
         alice_key_package_bundle,
         GroupConfig::default(),
         None, /* Initial PSK */
+        None, /* MLS version */
     )
     .unwrap();
 
@@ -60,7 +61,9 @@ fn test_failed_groupinfo_decryption() {
             let tree_hash = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
             let confirmed_transcript_hash = vec![1, 1, 1];
             let extensions = Vec::new();
-            let confirmation_tag = ConfirmationTag::from(vec![6, 6, 6]);
+            let confirmation_tag = ConfirmationTag(Mac {
+                mac_value: Secret::random(ciphersuite, None),
+            });
             let signer_index = LeafIndex::from(8u32);
             let group_info = GroupInfo::new(
                 group_id,
@@ -73,12 +76,12 @@ fn test_failed_groupinfo_decryption() {
             );
 
             // Generate key and nonce for the symmetric cipher.
-            let welcome_key = AeadKey::from_random(ciphersuite);
-            let welcome_nonce = AeadNonce::from_random();
+            let welcome_key = AeadKey::random(ciphersuite);
+            let welcome_nonce = AeadNonce::random();
 
             // Generate receiver key pair.
             let receiver_key_pair =
-                ciphersuite.derive_hpke_keypair(&Secret::from([1u8, 2u8, 3u8, 4u8].to_vec()));
+                ciphersuite.derive_hpke_keypair(&Secret::random(ciphersuite, None));
             let hpke_info = b"group info welcome test info";
             let hpke_aad = b"group info welcome test aad";
             let hpke_input = b"these should be the group secrets";
@@ -173,6 +176,7 @@ fn test_update_path() {
             alice_key_package_bundle,
             GroupConfig::default(),
             None, /* Initial PSK */
+            None, /* MLS version */
         )
         .unwrap();
 
@@ -321,9 +325,9 @@ fn test_update_path() {
 
 // Test several scenarios when PSKs are used in a group
 ctest_ciphersuites!(test_psks, test(param: CiphersuiteName) {
-    fn psk_fetcher(psks: &PreSharedKeys) -> Option<Vec<Secret>> {
+    fn psk_fetcher(psks: &PreSharedKeys, ciphersuite: &'static Ciphersuite) -> Option<Vec<Secret>> {
         let psk_id = vec![1u8, 2, 3];
-        let secret = Secret::from(vec![4u8, 5, 6]);
+        let secret = Secret::from_slice(&[6, 6, 6], ProtocolVersion::Mls10, ciphersuite);
 
         let psk = &psks.psks[0];
         if psk.psk_type == PSKType::External {
@@ -377,7 +381,7 @@ ctest_ciphersuites!(test_psks, test(param: CiphersuiteName) {
 
     let external_psk_bundle = ExternalPskBundle::new(
         ciphersuite,
-        Secret::random(ciphersuite.hash_length()),
+        Secret::random(ciphersuite, None /* MLS version */),
         psk_id,
     );
     let preshared_key_id = external_psk_bundle.to_presharedkey_id();
@@ -392,10 +396,12 @@ ctest_ciphersuites!(test_psks, test(param: CiphersuiteName) {
         alice_key_package_bundle,
         GroupConfig::default(),
         Some(initial_psk),
+        None, /* MLS version */
     )
     .unwrap();
 
     // === Alice creates a PSK proposal ===
+    log::info!(" >>> Creating psk proposal ...");
     let psk_proposal = alice_group
         .create_presharedkey_proposal(group_aad, &alice_credential_bundle, preshared_key_id)
         .expect("Could not create PSK proposal");
@@ -405,6 +411,7 @@ ctest_ciphersuites!(test_psks, test(param: CiphersuiteName) {
         .create_add_proposal(group_aad, &alice_credential_bundle, bob_key_package.clone())
         .expect("Could not create proposal");
     let epoch_proposals = &[&bob_add_proposal, &psk_proposal];
+    log::info!(" >>> Creating commit ...");
     let (mls_plaintext_commit, welcome_bundle_alice_bob_option, _kpb_option) = alice_group
         .create_commit(
             group_aad,
@@ -416,6 +423,7 @@ ctest_ciphersuites!(test_psks, test(param: CiphersuiteName) {
         )
         .expect("Error creating commit");
 
+    log::info!(" >>> Applying commit ...");
     alice_group
         .apply_commit(
             &mls_plaintext_commit,

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -1,7 +1,5 @@
 use log::error;
 
-use evercrypt::rand_util::*;
-
 use crate::ciphersuite::*;
 use crate::codec::*;
 use crate::config::{Config, ProtocolVersion};
@@ -225,7 +223,7 @@ impl KeyPackage {
     }
 
     /// Get the `Ciphersuite`.
-    pub(crate) fn ciphersuite(&self) -> &Ciphersuite {
+    pub(crate) fn ciphersuite(&self) -> &'static Ciphersuite {
         self.ciphersuite
     }
 
@@ -246,10 +244,34 @@ pub struct KeyPackageBundle {
 /// Public `KeyPackageBundle` functions.
 impl KeyPackageBundle {
     /// Create a new `KeyPackageBundle` with a fresh `HPKEKeyPair`.
+    /// See `new_with_keypair` and `new_with_version` for details.
+    /// This key package will have the default MLS version. Use `new_with_version`
+    /// to get a key package bundle for a specific MLS version.
+    ///
+    /// Returns a new `KeyPackageBundle` or a `KeyPackageError`.
+    pub fn new(
+        ciphersuites: &[CiphersuiteName],
+        credential_bundle: &CredentialBundle,
+        extensions: Vec<Box<dyn Extension>>,
+    ) -> Result<Self, KeyPackageError> {
+        Self::new_with_version(
+            ProtocolVersion::default(),
+            ciphersuites,
+            credential_bundle,
+            extensions,
+        )
+    }
+
+    /// Create a new `KeyPackageBundle` with
+    /// * a fresh `HPKEKeyPair`
+    /// * the provided MLS version
+    /// * the first cipher suite in the `ciphersuites` slice
+    /// * the provided `extensions`
     /// See `new_with_keypair` for details.
     ///
-    /// Returns a new `KeyPackageBundle`.
-    pub fn new(
+    /// Returns a new `KeyPackageBundle` or a `KeyPackageError`.
+    pub fn new_with_version(
+        version: ProtocolVersion,
         ciphersuites: &[CiphersuiteName],
         credential_bundle: &CredentialBundle,
         extensions: Vec<Box<dyn Extension>>,
@@ -261,7 +283,7 @@ impl KeyPackageBundle {
         }
         debug_assert!(!ciphersuites.is_empty());
         let ciphersuite = Config::ciphersuite(ciphersuites[0]).unwrap();
-        let leaf_secret = Secret::from(get_random_vec(ciphersuite.hash_length()));
+        let leaf_secret = Secret::random(ciphersuite, version);
         Self::new_from_leaf_secret(ciphersuites, credential_bundle, extensions, leaf_secret)
     }
 
@@ -270,8 +292,8 @@ impl KeyPackageBundle {
     pub(crate) fn from_rekeyed_key_package(key_package: &KeyPackage) -> Self {
         // Generate a new leaf secret and derive the key pair
         let ciphersuite = key_package.ciphersuite();
-        let leaf_secret = Secret::random(ciphersuite.hash_length());
-        let leaf_node_secret = Self::derive_leaf_node_secret(ciphersuite, &leaf_secret);
+        let leaf_secret = Secret::random(ciphersuite, key_package.protocol_version);
+        let leaf_node_secret = Self::derive_leaf_node_secret(&leaf_secret);
         let (private_key, public_key) = ciphersuite
             .derive_hpke_keypair(&leaf_node_secret)
             .into_keys();
@@ -397,7 +419,7 @@ impl KeyPackageBundle {
         }
 
         let ciphersuite = Config::ciphersuite(ciphersuites[0]).unwrap();
-        let leaf_node_secret = Self::derive_leaf_node_secret(ciphersuite, &leaf_secret);
+        let leaf_node_secret = Self::derive_leaf_node_secret(&leaf_secret);
         let keypair = ciphersuite.derive_hpke_keypair(&leaf_node_secret);
         Self::new_with_keypair(
             ciphersuites,
@@ -452,11 +474,8 @@ impl KeyPackageBundle {
 
     /// This function derives the leaf_node_secret from the leaf_secret as
     /// described in 5.4 Ratchet Tree Evolution
-    pub(crate) fn derive_leaf_node_secret(
-        ciphersuite: &Ciphersuite,
-        leaf_secret: &Secret,
-    ) -> Secret {
-        leaf_secret.derive_secret(ciphersuite, "node")
+    pub(crate) fn derive_leaf_node_secret(leaf_secret: &Secret) -> Secret {
+        leaf_secret.derive_secret("node")
     }
 
     /// Sign the KeyPackageBundle

--- a/src/messages/codec.rs
+++ b/src/messages/codec.rs
@@ -42,7 +42,7 @@ impl Codec for GroupInfo {
         let tree_hash = decode_vec(VecSize::VecU8, cursor)?;
         let confirmed_transcript_hash = decode_vec(VecSize::VecU8, cursor)?;
         let extensions = extensions_vec_from_cursor(cursor)?;
-        let confirmation_tag = decode_vec(VecSize::VecU8, cursor)?;
+        let confirmation_tag = ConfirmationTag::decode(cursor)?;
         let signer_index = LeafIndex::from(u32::decode(cursor)?);
         let signature = Signature::decode(cursor)?;
         Ok(GroupInfo {

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -4,7 +4,6 @@ use crate::config::Config;
 use crate::config::ProtocolVersion;
 use crate::credentials::*;
 use crate::extensions::*;
-use crate::framing::Mac;
 use crate::group::*;
 use crate::schedule::psk::PreSharedKeys;
 use crate::schedule::JoinerSecret;
@@ -121,16 +120,6 @@ impl Commit {
 /// around a `Mac`.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ConfirmationTag(pub(crate) Mac);
-
-impl ConfirmationTag {
-    pub(crate) fn config(
-        &mut self,
-        ciphersuite: &'static Ciphersuite,
-        mls_version: ProtocolVersion,
-    ) {
-        self.0.mac_value.config(ciphersuite, mls_version);
-    }
-}
 
 /// GroupInfo
 ///

--- a/src/messages/tests/test_pgs.rs
+++ b/src/messages/tests/test_pgs.rs
@@ -45,6 +45,7 @@ fn test_pgs() {
             alice_key_package_bundle,
             GroupConfig::default(),
             None, /* Initial PSK */
+            None, /* MLS version */
         )
         .expect("Could not create group.");
 

--- a/src/messages/tests/test_proposals.rs
+++ b/src/messages/tests/test_proposals.rs
@@ -100,7 +100,7 @@ fn proposal_queue_functions() {
             proposal_add_alice1,
             &alice_credential_bundle,
             &group_context,
-            &MembershipKey::from_secret(Secret::default()),
+            &MembershipKey::from_secret(Secret::random(ciphersuite, None)),
         )
         .expect("Could not create proposal.");
         let mls_plaintext_add_alice2 = MLSPlaintext::new_from_proposal_member(
@@ -110,7 +110,7 @@ fn proposal_queue_functions() {
             proposal_add_alice2,
             &alice_credential_bundle,
             &group_context,
-            &MembershipKey::from_secret(Secret::default()),
+            &MembershipKey::from_secret(Secret::random(ciphersuite, None)),
         )
         .expect("Could not create proposal.");
         let _mls_plaintext_add_bob1 = MLSPlaintext::new_from_proposal_member(
@@ -120,7 +120,7 @@ fn proposal_queue_functions() {
             proposal_add_bob1,
             &alice_credential_bundle,
             &group_context,
-            &MembershipKey::from_secret(Secret::default()),
+            &MembershipKey::from_secret(Secret::random(ciphersuite, None)),
         )
         .expect("Could not create proposal.");
 
@@ -205,7 +205,7 @@ fn proposal_queue_order() {
             proposal_add_alice1.clone(),
             &alice_credential_bundle,
             &group_context,
-            &MembershipKey::from_secret(Secret::random(ciphersuite.hash_length())),
+            &MembershipKey::from_secret(Secret::random(ciphersuite, None /* MLS version */)),
         )
         .expect("Could not create proposal.");
         let mls_plaintext_add_bob1 = MLSPlaintext::new_from_proposal_member(
@@ -215,7 +215,7 @@ fn proposal_queue_order() {
             proposal_add_bob1.clone(),
             &alice_credential_bundle,
             &group_context,
-            &MembershipKey::from_secret(Secret::random(ciphersuite.hash_length())),
+            &MembershipKey::from_secret(Secret::random(ciphersuite, None /* MLS version */)),
         )
         .expect("Could not create proposal.");
 

--- a/src/messages/tests/test_proposals.rs
+++ b/src/messages/tests/test_proposals.rs
@@ -94,7 +94,6 @@ fn proposal_queue_functions() {
 
         // Frame proposals in MLSPlaintext
         let mls_plaintext_add_alice1 = MLSPlaintext::new_from_proposal_member(
-            ciphersuite,
             LeafIndex::from(0u32),
             &[],
             proposal_add_alice1,
@@ -104,7 +103,6 @@ fn proposal_queue_functions() {
         )
         .expect("Could not create proposal.");
         let mls_plaintext_add_alice2 = MLSPlaintext::new_from_proposal_member(
-            ciphersuite,
             LeafIndex::from(1u32),
             &[],
             proposal_add_alice2,
@@ -114,7 +112,6 @@ fn proposal_queue_functions() {
         )
         .expect("Could not create proposal.");
         let _mls_plaintext_add_bob1 = MLSPlaintext::new_from_proposal_member(
-            ciphersuite,
             LeafIndex::from(1u32),
             &[],
             proposal_add_bob1,
@@ -199,7 +196,6 @@ fn proposal_queue_order() {
 
         // Frame proposals in MLSPlaintext
         let mls_plaintext_add_alice1 = MLSPlaintext::new_from_proposal_member(
-            ciphersuite,
             LeafIndex::from(0u32),
             &[],
             proposal_add_alice1.clone(),
@@ -209,7 +205,6 @@ fn proposal_queue_order() {
         )
         .expect("Could not create proposal.");
         let mls_plaintext_add_bob1 = MLSPlaintext::new_from_proposal_member(
-            ciphersuite,
             LeafIndex::from(1u32),
             &[],
             proposal_add_bob1.clone(),

--- a/src/messages/tests/test_welcome.rs
+++ b/src/messages/tests/test_welcome.rs
@@ -1,10 +1,9 @@
 #![allow(non_snake_case)]
 
 use crate::{
-    ciphersuite::{AeadKey, AeadNonce, CiphersuiteName, Secret, Signature},
+    ciphersuite::{AeadKey, AeadNonce, CiphersuiteName, Mac, Secret, Signature},
     codec::{Codec, Cursor},
     config::Config,
-    framing::plaintext::Mac,
     group::{GroupEpoch, GroupId},
     messages::{ConfirmationTag, EncryptedGroupSecrets, GroupInfo, Welcome},
     tree::index::LeafIndex,
@@ -22,7 +21,7 @@ macro_rules! test_welcome_msg {
                 confirmed_transcript_hash: vec![1, 1, 1],
                 extensions: Vec::new(),
                 confirmation_tag: ConfirmationTag(Mac {
-                    mac_value: Secret::random($ciphersuite, None),
+                    mac_value: vec![1, 2, 3, 4, 5],
                 }),
                 signer_index: LeafIndex::from(8u32),
                 signature: Signature::new_empty(),

--- a/src/messages/tests/test_welcome.rs
+++ b/src/messages/tests/test_welcome.rs
@@ -4,8 +4,9 @@ use crate::{
     ciphersuite::{AeadKey, AeadNonce, CiphersuiteName, Secret, Signature},
     codec::{Codec, Cursor},
     config::Config,
+    framing::plaintext::Mac,
     group::{GroupEpoch, GroupId},
-    messages::{EncryptedGroupSecrets, GroupInfo, Welcome},
+    messages::{ConfirmationTag, EncryptedGroupSecrets, GroupInfo, Welcome},
     tree::index::LeafIndex,
 };
 
@@ -20,18 +21,20 @@ macro_rules! test_welcome_msg {
                 tree_hash: vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
                 confirmed_transcript_hash: vec![1, 1, 1],
                 extensions: Vec::new(),
-                confirmation_tag: vec![6, 6, 6],
+                confirmation_tag: ConfirmationTag(Mac {
+                    mac_value: Secret::random($ciphersuite, None),
+                }),
                 signer_index: LeafIndex::from(8u32),
                 signature: Signature::new_empty(),
             };
 
             // Generate key and nonce for the symmetric cipher.
-            let welcome_key = AeadKey::from_random($ciphersuite);
-            let welcome_nonce = AeadNonce::from_random();
+            let welcome_key = AeadKey::random($ciphersuite);
+            let welcome_nonce = AeadNonce::random();
 
             // Generate receiver key pair.
             let receiver_key_pair =
-                $ciphersuite.derive_hpke_keypair(&Secret::from([1u8, 2u8, 3u8, 4u8].to_vec()));
+                $ciphersuite.derive_hpke_keypair(&Secret::random($ciphersuite, None));
             let hpke_info = b"group info welcome test info";
             let hpke_aad = b"group info welcome test aad";
             let hpke_input = b"these should be the group secrets";

--- a/src/schedule/kat_key_schedule.rs
+++ b/src/schedule/kat_key_schedule.rs
@@ -10,7 +10,7 @@ use std::convert::TryFrom;
 use crate::{
     ciphersuite::{Ciphersuite, CiphersuiteName},
     codec::Codec,
-    config::Config,
+    config::{Config, ProtocolVersion},
     group::{GroupContext, GroupEpoch, GroupId},
     schedule::{EpochSecrets, InitSecret, JoinerSecret, KeySchedule, WelcomeSecret},
     test_util::{bytes_to_hex, hex_to_bytes},
@@ -77,9 +77,9 @@ fn generate(
     HPKEKeyPair,
 ) {
     let tree_hash = randombytes(ciphersuite.hash_length());
-    let commit_secret = CommitSecret::random(ciphersuite.hash_length());
-    let psk_secret = PskSecret::random(ciphersuite.hash_length());
-    let joiner_secret = JoinerSecret::new(ciphersuite, &commit_secret, init_secret);
+    let commit_secret = CommitSecret::random(ciphersuite);
+    let psk_secret = PskSecret::random(ciphersuite);
+    let joiner_secret = JoinerSecret::new(&commit_secret, init_secret);
     let mut key_schedule =
         KeySchedule::init(ciphersuite, joiner_secret.clone(), Some(psk_secret.clone()));
     let welcome_secret = key_schedule.welcome().unwrap();
@@ -122,7 +122,7 @@ pub fn generate_test_vector(
     ciphersuite: &'static Ciphersuite,
 ) -> KeyScheduleTestVector {
     // Set up setting.
-    let mut init_secret = InitSecret::random(ciphersuite.hash_length());
+    let mut init_secret = InitSecret::random(ciphersuite, ProtocolVersion::default());
     let initial_init_secret = init_secret.clone();
     let group_id = randombytes(16);
 
@@ -228,7 +228,7 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KSTestV
         log::trace!("    CommitSecret from tve {:?}", epoch.commit_secret);
         let psk = hex_to_bytes(&epoch.psk_secret);
 
-        let joiner_secret = JoinerSecret::new(ciphersuite, &commit_secret, &init_secret);
+        let joiner_secret = JoinerSecret::new(&commit_secret, &init_secret);
         if hex_to_bytes(&epoch.joiner_secret) != joiner_secret.as_slice() {
             if cfg!(test) {
                 panic!("Joiner secret mismatch");

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -515,16 +515,6 @@ impl EncryptionSecret {
     }
 }
 
-// #[cfg(any(feature = "expose-test-vectors", test))]
-// #[doc(hidden)]
-// impl From<&[u8]> for EncryptionSecret {
-//     fn from(bytes: &[u8]) -> Self {
-//         Self {
-//             secret: Secret::from(bytes),
-//         }
-//     }
-// }
-
 /// A secret that we can derive secrets from, that are used outside of OpenMLS.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]

--- a/src/schedule/psk.rs
+++ b/src/schedule/psk.rs
@@ -272,7 +272,7 @@ impl PskSecret {
 
             let psk_secret =
                 psk_input.kdf_expand_label("derived psk", &psk_label, ciphersuite.hash_length());
-            secret.extend_from_slice(psk_secret.to_bytes());
+            secret.extend_from_slice(psk_secret.as_slice());
         }
         Ok(Self {
             secret: Secret::from_slice(&secret, mls_version, ciphersuite),
@@ -293,7 +293,7 @@ impl PskSecret {
 
     #[cfg(any(feature = "expose-test-vectors", test))]
     pub(crate) fn as_slice(&self) -> &[u8] {
-        self.secret.to_bytes()
+        self.secret.as_slice()
     }
 
     #[cfg(any(feature = "expose-test-vectors", test))]

--- a/src/schedule/psk.rs
+++ b/src/schedule/psk.rs
@@ -250,7 +250,7 @@ pub struct PskSecret {
 impl PskSecret {
     /// Create a new `PskSecret` from PSK IDs and PSKs
     pub fn new(
-        ciphersuite: &Ciphersuite,
+        ciphersuite: &'static Ciphersuite,
         psk_ids: &[PreSharedKeyID],
         psks: &[Secret],
     ) -> Result<Self, PskSecretError> {
@@ -261,24 +261,21 @@ impl PskSecret {
             return Err(PskSecretError::TooManyKeys);
         }
         let mut secret = vec![];
+        let mls_version = ProtocolVersion::default();
         for (index, psk) in psks.iter().enumerate() {
-            let zero_secret = Secret::from(zero(ciphersuite.hash_length()));
-            let psk_input = ciphersuite.hkdf_extract(&zero_secret, Some(psk));
+            let zero_secret = Secret::zero(ciphersuite, mls_version);
+            let psk_input = zero_secret.hkdf_extract(psk);
             let psk_label = PskLabel::new(&psk_ids[index], index as u16, psks.len() as u16)
                 .encode_detached()
                 // It is safe to unwrap here, because the struct contains no vectors
                 .unwrap();
 
-            let psk_secret = psk_input.kdf_expand_label(
-                ciphersuite,
-                "derived psk",
-                &psk_label,
-                ciphersuite.hash_length(),
-            );
+            let psk_secret =
+                psk_input.kdf_expand_label("derived psk", &psk_label, ciphersuite.hash_length());
             secret.extend_from_slice(psk_secret.to_bytes());
         }
         Ok(Self {
-            secret: Secret::from(secret),
+            secret: Secret::from_slice(&secret, mls_version, ciphersuite),
         })
     }
 
@@ -288,9 +285,9 @@ impl PskSecret {
     }
 
     #[cfg(any(feature = "expose-test-vectors", test))]
-    pub(crate) fn random(length: usize) -> Self {
+    pub(crate) fn random(ciphersuite: &'static Ciphersuite) -> Self {
         Self {
-            secret: Secret::random(length),
+            secret: Secret::random(ciphersuite, None /* MLS version */),
         }
     }
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,5 +1,5 @@
 use crate::codec::*;
-use crate::config::Config;
+use crate::config::{Config, ProtocolVersion};
 use crate::credentials::*;
 use crate::key_packages::*;
 use crate::messages::proposals::*;
@@ -348,12 +348,11 @@ impl RatchetTree {
         );
 
         // Decrypt the secret and derive path secrets
-        let secret = Secret::from(self.ciphersuite.hpke_open(
-            hpke_ciphertext,
-            &private_key,
-            group_context,
-            &[],
-        )?);
+        let secret_bytes =
+            self.ciphersuite
+                .hpke_open(hpke_ciphertext, &private_key, group_context, &[])?;
+        let secret =
+            Secret::from_slice(&secret_bytes, ProtocolVersion::default(), self.ciphersuite);
         // Derive new path secrets and generate keypairs
         let new_path_public_keys =
             self.private_tree

--- a/src/tree/private_tree.rs
+++ b/src/tree/private_tree.rs
@@ -54,7 +54,7 @@ impl PrivateTree {
     ) -> Self {
         let leaf_secret = key_package_bundle.leaf_secret();
         let ciphersuite = key_package_bundle.key_package.ciphersuite();
-        let leaf_node_secret = KeyPackageBundle::derive_leaf_node_secret(ciphersuite, &leaf_secret);
+        let leaf_node_secret = KeyPackageBundle::derive_leaf_node_secret(&leaf_secret);
         let keypair = ciphersuite.derive_hpke_keypair(&leaf_node_secret);
         let (private_key, _) = keypair.into_keys();
 
@@ -124,7 +124,7 @@ impl PrivateTree {
         let path_secrets = if path.is_empty() {
             vec![]
         } else {
-            vec![leaf_secret.kdf_expand_label(ciphersuite, "path", &[], ciphersuite.hash_length())]
+            vec![leaf_secret.kdf_expand_label("path", &[], ciphersuite.hash_length())]
         };
 
         self.derive_path_secrets(ciphersuite, path_secrets, path)
@@ -162,8 +162,7 @@ impl PrivateTree {
         let mut path_secrets = path_secrets;
 
         for i in 1..path.len() {
-            let path_secret =
-                path_secrets[i - 1].kdf_expand_label(ciphersuite, "path", &[], hash_len);
+            let path_secret = path_secrets[i - 1].kdf_expand_label("path", &[], hash_len);
             path_secrets.push(path_secret);
         }
         self.path_secrets = path_secrets;
@@ -212,7 +211,7 @@ impl PrivateTree {
 
         // Derive key pairs for all nodes in the direct path.
         for path_secret in self.path_secrets.iter() {
-            let node_secret = path_secret.kdf_expand_label(ciphersuite, "node", &[], hash_len);
+            let node_secret = path_secret.kdf_expand_label("node", &[], hash_len);
             let keypair = ciphersuite.derive_hpke_keypair(&node_secret);
             let (private_key, public_key) = keypair.into_keys();
             public_keys.push(public_key);

--- a/src/tree/secret_tree.rs
+++ b/src/tree/secret_tree.rs
@@ -52,7 +52,7 @@ pub(crate) fn derive_tree_secret(
         length
     );
     let tree_context = TreeContext { node, generation };
-    log_crypto!(trace, "Input secret {:x?}", secret.to_bytes());
+    log_crypto!(trace, "Input secret {:x?}", secret.as_slice());
     log_crypto!(trace, "Tree context {:?}", tree_context);
     let serialized_tree_context = tree_context.encode_detached().unwrap();
     secret.kdf_expand_label(label, &serialized_tree_context, length)
@@ -278,7 +278,7 @@ impl SecretTree {
             .as_ref()
             .unwrap()
             .secret;
-        log_crypto!(trace, "Node secret: {:x?}", node_secret.to_bytes());
+        log_crypto!(trace, "Node secret: {:x?}", node_secret.as_slice());
         let left_index =
             left(index_in_tree).expect("derive_down: Error while computing left child.");
         let right_index = right(index_in_tree, self.size)
@@ -291,13 +291,13 @@ impl SecretTree {
             trace,
             "Left node ({}) secret: {:x?}",
             left_index.as_u32(),
-            left_secret.to_bytes()
+            left_secret.as_slice()
         );
         log_crypto!(
             trace,
             "Right node ({}) secret: {:x?}",
             right_index.as_u32(),
-            right_secret.to_bytes()
+            right_secret.as_slice()
         );
         self.nodes[left_index.as_usize()] = Some(SecretTreeNode {
             secret: left_secret,

--- a/src/tree/sender_ratchet.rs
+++ b/src/tree/sender_ratchet.rs
@@ -90,7 +90,6 @@ impl SenderRatchet {
     /// Computes the new secret
     fn ratchet_secret(&self, ciphersuite: &Ciphersuite, secret: &Secret) -> Secret {
         derive_tree_secret(
-            ciphersuite,
             secret,
             "secret",
             NodeIndex::from(self.index).as_u32(),
@@ -107,7 +106,6 @@ impl SenderRatchet {
     ) -> RatchetSecrets {
         let tree_index = NodeIndex::from(self.index).as_u32();
         let nonce = derive_tree_secret(
-            &ciphersuite,
             secret,
             "nonce",
             tree_index,
@@ -115,17 +113,13 @@ impl SenderRatchet {
             ciphersuite.aead_nonce_length(),
         );
         let key = derive_tree_secret(
-            &ciphersuite,
             secret,
             "key",
             tree_index,
             generation,
             ciphersuite.aead_key_length(),
         );
-        (
-            AeadKey::from_secret(ciphersuite, key),
-            AeadNonce::from_secret(nonce),
-        )
+        (AeadKey::from_secret(key), AeadNonce::from_secret(nonce))
     }
     /// Gets the current generation
     #[cfg(test)]

--- a/src/tree/tests/kat_encryption.rs
+++ b/src/tree/tests/kat_encryption.rs
@@ -80,7 +80,7 @@
 use crate::{
     ciphersuite::{Ciphersuite, Signature},
     codec::*,
-    config::Config,
+    config::{Config, ProtocolVersion},
     credentials::{CredentialBundle, CredentialType},
     framing::*,
     group::*,
@@ -146,6 +146,7 @@ fn group(ciphersuite: &Ciphersuite) -> MlsGroup {
         key_package_bundle,
         GroupConfig::default(),
         None, /* Initial PSK */
+        ProtocolVersion::Mls10,
     )
     .unwrap()
 }
@@ -165,6 +166,7 @@ fn receiver_group(ciphersuite: &Ciphersuite, group_id: &GroupId) -> MlsGroup {
         key_package_bundle,
         GroupConfig::default(),
         None, /* Initial PSK */
+        ProtocolVersion::Mls10,
     )
     .unwrap()
 }
@@ -222,7 +224,7 @@ fn build_application_messages(leaf: LeafIndex, group: &mut MlsGroup) -> (Vec<u8>
         confirmation_tag: None,
         membership_tag: None,
     };
-    let ciphertext = MLSCiphertext::try_from_plaintext(
+    let ciphertext = match MLSCiphertext::try_from_plaintext(
         &plaintext,
         group.ciphersuite(),
         group.context(),
@@ -230,8 +232,10 @@ fn build_application_messages(leaf: LeafIndex, group: &mut MlsGroup) -> (Vec<u8>
         group.epoch_secrets(),
         &mut group.secret_tree_mut(),
         0,
-    )
-    .expect("Could not create MLSCiphertext");
+    ) {
+        Ok(c) => c,
+        Err(e) => panic!("Could not create MLSCiphertext {}", e),
+    };
     (
         plaintext.encode_detached().unwrap(),
         ciphertext.encode_detached().unwrap(),
@@ -242,21 +246,23 @@ fn build_application_messages(leaf: LeafIndex, group: &mut MlsGroup) -> (Vec<u8>
 pub fn generate_test_vector(
     n_generations: u32,
     n_leaves: u32,
-    ciphersuite: &Ciphersuite,
+    ciphersuite: &'static Ciphersuite,
 ) -> EncryptionTestVector {
     let ciphersuite_name = ciphersuite.name();
     let epoch_secret = randombytes(ciphersuite.hash_length());
-    let encryption_secret = EncryptionSecret::from(&epoch_secret[..]);
-    let encryption_secret_group = EncryptionSecret::from(&epoch_secret[..]);
+    let encryption_secret =
+        EncryptionSecret::from_slice(&epoch_secret[..], ProtocolVersion::default(), ciphersuite);
+    let encryption_secret_group =
+        EncryptionSecret::from_slice(&epoch_secret[..], ProtocolVersion::default(), ciphersuite);
     let encryption_secret_bytes = encryption_secret.as_slice().to_vec();
-    let sender_data_secret = SenderDataSecret::from_random(32);
+    let sender_data_secret = SenderDataSecret::random(ciphersuite);
     let sender_data_secret_bytes = sender_data_secret.as_slice();
     let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(n_leaves));
     let group_secret_tree = SecretTree::new(encryption_secret_group, LeafIndex::from(n_leaves));
 
     // Create sender_data_key/secret
     let ciphertext = randombytes(77);
-    let sender_data_key = sender_data_secret.derive_aead_key(ciphersuite, &ciphertext);
+    let sender_data_key = sender_data_secret.derive_aead_key(&ciphertext);
     // Derive initial nonce from the key schedule using the ciphertext.
     let sender_data_nonce = sender_data_secret.derive_aead_nonce(ciphersuite, &ciphertext);
     let sender_data_info = SenderDataInfo {
@@ -266,8 +272,11 @@ pub fn generate_test_vector(
     };
 
     let mut group = group(ciphersuite);
-    *group.epoch_secrets_mut().sender_data_secret_mut() =
-        SenderDataSecret::from(sender_data_secret_bytes);
+    *group.epoch_secrets_mut().sender_data_secret_mut() = SenderDataSecret::from_slice(
+        sender_data_secret_bytes,
+        ProtocolVersion::default(),
+        ciphersuite,
+    );
     *group.secret_tree_mut() = group_secret_tree;
 
     let mut leaves = Vec::new();
@@ -360,17 +369,22 @@ pub fn run_test_vector(test_vector: EncryptionTestVector) -> Result<(), EncTestV
     log::debug!("Running test vector with {:?}", ciphersuite.name());
 
     let mut secret_tree = SecretTree::new(
-        EncryptionSecret::from(hex_to_bytes(&test_vector.encryption_secret).as_slice()),
+        EncryptionSecret::from_slice(
+            hex_to_bytes(&test_vector.encryption_secret).as_slice(),
+            ProtocolVersion::default(),
+            ciphersuite,
+        ),
         LeafIndex::from(n_leaves),
     );
     log::debug!("Secret tree: {:?}", secret_tree);
-    let sender_data_secret =
-        SenderDataSecret::from(hex_to_bytes(&test_vector.sender_data_secret).as_slice());
-
-    let sender_data_key = sender_data_secret.derive_aead_key(
+    let sender_data_secret = SenderDataSecret::from_slice(
+        hex_to_bytes(&test_vector.sender_data_secret).as_slice(),
+        ProtocolVersion::default(),
         ciphersuite,
-        &hex_to_bytes(&test_vector.sender_data_info.ciphertext),
     );
+
+    let sender_data_key =
+        sender_data_secret.derive_aead_key(&hex_to_bytes(&test_vector.sender_data_info.ciphertext));
     let sender_data_nonce = sender_data_secret.derive_aead_nonce(
         ciphersuite,
         &hex_to_bytes(&test_vector.sender_data_info.ciphertext),
@@ -446,8 +460,11 @@ pub fn run_test_vector(test_vector: EncryptionTestVector) -> Result<(), EncTestV
                 MLSCiphertext::decode(&mut Cursor::new(&hex_to_bytes(&application.ciphertext)))
                     .expect("Error parsing MLSCiphertext");
             let mut group = receiver_group(ciphersuite, &mls_ciphertext_application.group_id);
-            *group.epoch_secrets_mut().sender_data_secret_mut() =
-                SenderDataSecret::from(hex_to_bytes(&test_vector.sender_data_secret).as_slice());
+            *group.epoch_secrets_mut().sender_data_secret_mut() = SenderDataSecret::from_slice(
+                hex_to_bytes(&test_vector.sender_data_secret).as_slice(),
+                ProtocolVersion::default(),
+                ciphersuite,
+            );
 
             // Decrypt and check application message
             let mls_plaintext_application = mls_ciphertext_application
@@ -491,8 +508,11 @@ pub fn run_test_vector(test_vector: EncryptionTestVector) -> Result<(), EncTestV
                 MLSCiphertext::decode(&mut Cursor::new(&hex_to_bytes(&handshake.ciphertext)))
                     .expect("Error parsing MLSCiphertext");
             let mut group = receiver_group(ciphersuite, &mls_ciphertext_handshake.group_id);
-            *group.epoch_secrets_mut().sender_data_secret_mut() =
-                SenderDataSecret::from(hex_to_bytes(&test_vector.sender_data_secret).as_slice());
+            *group.epoch_secrets_mut().sender_data_secret_mut() = SenderDataSecret::from_slice(
+                hex_to_bytes(&test_vector.sender_data_secret).as_slice(),
+                ProtocolVersion::default(),
+                ciphersuite,
+            );
 
             // Decrypt and check message
             let mls_plaintext_handshake = mls_ciphertext_handshake

--- a/src/tree/tests/test_hashes.rs
+++ b/src/tree/tests/test_hashes.rs
@@ -47,7 +47,7 @@ fn test_parent_hash() {
             // Filter out leaf nodes
             if NodeIndex::from(index).is_parent() {
                 let (_private_key, public_key) = ciphersuite
-                    .derive_hpke_keypair(&Secret::random(ciphersuite.hash_length()))
+                    .derive_hpke_keypair(&Secret::random(ciphersuite, None /* MLS version */))
                     .into_keys();
                 let parent_node = ParentNode::new(public_key, &[], &[]);
                 let node = Node {

--- a/src/tree/tests/test_resolution.rs
+++ b/src/tree/tests/test_resolution.rs
@@ -148,7 +148,7 @@ fn test_original_child_resolution() {
 
         // Add unmerged leaves to root node
         let (_private_key, public_key) = ciphersuite
-            .derive_hpke_keypair(&Secret::random(ciphersuite.hash_length()))
+            .derive_hpke_keypair(&Secret::random(ciphersuite, None /* MLS version */))
             .into_keys();
         let new_root_node = Node {
             node_type: NodeType::Parent,

--- a/src/tree/tests/test_secret_tree.rs
+++ b/src/tree/tests/test_secret_tree.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 #[test]
 fn test_boundaries() {
     for ciphersuite in Config::supported_ciphersuites() {
-        let encryption_secret = EncryptionSecret::from_random(32);
+        let encryption_secret = EncryptionSecret::random(ciphersuite);
         let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(2u32));
         let secret_type = SecretType::ApplicationSecret;
         assert!(secret_tree
@@ -48,7 +48,7 @@ fn test_boundaries() {
             secret_tree.secret_for_decryption(&ciphersuite, LeafIndex::from(2u32), secret_type, 0),
             Err(SecretTreeError::IndexOutOfBounds)
         );
-        let encryption_secret = EncryptionSecret::from_random(32);
+        let encryption_secret = EncryptionSecret::random(ciphersuite);
         let mut largetree = SecretTree::new(encryption_secret, LeafIndex::from(100_000u32));
         assert!(largetree
             .secret_for_decryption(&ciphersuite, LeafIndex::from(0u32), secret_type, 0)
@@ -80,7 +80,7 @@ fn increment_generation() {
 
     for ciphersuite in Config::supported_ciphersuites() {
         let mut unique_values: HashMap<Vec<u8>, bool> = HashMap::new();
-        let encryption_secret = EncryptionSecret::from_random(32);
+        let encryption_secret = EncryptionSecret::random(ciphersuite);
         let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(SIZE as u32));
         for i in 0..SIZE {
             assert_eq!(
@@ -129,13 +129,16 @@ fn increment_generation() {
 
 #[test]
 fn secret_tree() {
-    pretty_env_logger::init();
     let ciphersuite = &Config::supported_ciphersuites()[0];
     let leaf_index = 0u32;
     let generation = 0;
     let n_leaves = 10u32;
     let mut secret_tree = SecretTree::new(
-        EncryptionSecret::from(&crate::utils::randombytes(ciphersuite.hash_length())[..]),
+        EncryptionSecret::from_slice(
+            &crate::utils::randombytes(ciphersuite.hash_length())[..],
+            ProtocolVersion::default(),
+            ciphersuite,
+        ),
         LeafIndex::from(n_leaves),
     );
     println!("Secret tree: {:?}", secret_tree);

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -27,7 +27,10 @@ fn protocol_version() {
 
     // Make sure the supported protocol versions are what we expect them to be.
     let supported_versions = Config::supported_versions();
-    assert_eq!(vec![ProtocolVersion::Mls10], supported_versions);
+    assert_eq!(
+        vec![ProtocolVersion::Mls10, ProtocolVersion::Mls10Draft12],
+        supported_versions
+    );
 }
 
 #[test]

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -28,7 +28,7 @@ fn protocol_version() {
     // Make sure the supported protocol versions are what we expect them to be.
     let supported_versions = Config::supported_versions();
     assert_eq!(
-        vec![ProtocolVersion::Mls10, ProtocolVersion::Mls10Draft12],
+        vec![ProtocolVersion::Mls10, ProtocolVersion::Mls10Draft11],
         supported_versions
     );
 }

--- a/tests/test_encoding.rs
+++ b/tests/test_encoding.rs
@@ -116,11 +116,7 @@ fn test_update_proposal_encoding() {
         let update_encoded = update
             .encode_detached()
             .expect("Could not encode proposal.");
-        let update_decoded = match MLSPlaintext::decode_with_context(
-            &update_encoded,
-            group_state.ciphersuite().name(),
-            ProtocolVersion::default(),
-        ) {
+        let update_decoded = match MLSPlaintext::decode_detached(&update_encoded) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Update: {:?}", err),
         };
@@ -167,11 +163,7 @@ fn test_add_proposal_encoding() {
             )
             .expect("Could not create proposal.");
         let add_encoded = add.encode_detached().expect("Could not encode proposal.");
-        let add_decoded = match MLSPlaintext::decode_with_context(
-            &add_encoded,
-            group_state.ciphersuite().name(),
-            ProtocolVersion::default(),
-        ) {
+        let add_decoded = match MLSPlaintext::decode_detached(&add_encoded) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Add: {:?}", err),
         };
@@ -199,11 +191,7 @@ fn test_remove_proposal_encoding() {
         let remove_encoded = remove
             .encode_detached()
             .expect("Could not encode proposal.");
-        let remove_decoded = match MLSPlaintext::decode_with_context(
-            &remove_encoded,
-            group_state.ciphersuite().name(),
-            ProtocolVersion::default(),
-        ) {
+        let remove_decoded = match MLSPlaintext::decode_detached(&remove_encoded) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Remove: {:?}", err),
         };
@@ -274,11 +262,7 @@ fn test_commit_encoding() {
             .create_commit(&[], alice_credential_bundle, proposals, &[], true, None)
             .unwrap();
         let commit_encoded = commit.encode_detached().unwrap();
-        let commit_decoded = match MLSPlaintext::decode_with_context(
-            &commit_encoded,
-            group_state.ciphersuite().name(),
-            ProtocolVersion::default(),
-        ) {
+        let commit_decoded = match MLSPlaintext::decode_detached(&commit_encoded) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Commit: {:?}", err),
         };

--- a/tests/test_encoding.rs
+++ b/tests/test_encoding.rs
@@ -116,7 +116,11 @@ fn test_update_proposal_encoding() {
         let update_encoded = update
             .encode_detached()
             .expect("Could not encode proposal.");
-        let update_decoded = match MLSPlaintext::decode(&mut Cursor::new(&update_encoded)) {
+        let update_decoded = match MLSPlaintext::decode_with_context(
+            &update_encoded,
+            group_state.ciphersuite().name(),
+            ProtocolVersion::default(),
+        ) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Update: {:?}", err),
         };
@@ -163,7 +167,11 @@ fn test_add_proposal_encoding() {
             )
             .expect("Could not create proposal.");
         let add_encoded = add.encode_detached().expect("Could not encode proposal.");
-        let add_decoded = match MLSPlaintext::decode(&mut Cursor::new(&add_encoded)) {
+        let add_decoded = match MLSPlaintext::decode_with_context(
+            &add_encoded,
+            group_state.ciphersuite().name(),
+            ProtocolVersion::default(),
+        ) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Add: {:?}", err),
         };
@@ -191,7 +199,11 @@ fn test_remove_proposal_encoding() {
         let remove_encoded = remove
             .encode_detached()
             .expect("Could not encode proposal.");
-        let remove_decoded = match MLSPlaintext::decode(&mut Cursor::new(&remove_encoded)) {
+        let remove_decoded = match MLSPlaintext::decode_with_context(
+            &remove_encoded,
+            group_state.ciphersuite().name(),
+            ProtocolVersion::default(),
+        ) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Remove: {:?}", err),
         };
@@ -262,7 +274,11 @@ fn test_commit_encoding() {
             .create_commit(&[], alice_credential_bundle, proposals, &[], true, None)
             .unwrap();
         let commit_encoded = commit.encode_detached().unwrap();
-        let commit_decoded = match MLSPlaintext::decode(&mut Cursor::new(&commit_encoded)) {
+        let commit_decoded = match MLSPlaintext::decode_with_context(
+            &commit_encoded,
+            group_state.ciphersuite().name(),
+            ProtocolVersion::default(),
+        ) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Commit: {:?}", err),
         };

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -62,6 +62,7 @@ fn create_commit_optional_path() {
             alice_key_package_bundle,
             GroupConfig::default(),
             None, /* Initial PSK */
+            None, /* MLS version */
         )
         .unwrap();
 
@@ -217,6 +218,7 @@ fn basic_group_setup() {
             alice_key_package_bundle,
             GroupConfig::default(),
             None, /* Initial PSK */
+            None, /* MLS version */
         )
         .expect("Could not create group.");
 
@@ -303,6 +305,7 @@ fn group_operations() {
             alice_key_package_bundle,
             GroupConfig::default(),
             None, /* Initial PSK */
+            None, /* MLS version */
         )
         .expect("Could not create group.");
 

--- a/tests/utils/mls_utils/mod.rs
+++ b/tests/utils/mls_utils/mod.rs
@@ -144,6 +144,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
             initial_key_package_bundle,
             group_config.config,
             None, /* Initial PSK */
+            None, /* MLS version */
         )
         .unwrap();
         let mut proposal_list = Vec::new();


### PR DESCRIPTION
The main purpose of this patch is to make the labeled key derivation
dependent on the cipher suite and MLS version (#231).
This got a little bigger than expected ...

This patch stores the the cipher suite and MLS version of a secret
as part of the struct and enforces that it is only used with compatible
other secrets. It also removes the need to pass the ciphersuite to
many functions.
At the same time this increases the complexity of creating and parsing
secrets and other structs that don't have the necessary information.

This patch also introduces constant time comparison for secrets, in
particular for Mac values, which are now secrets as well.

Fixes #231