### PR TITLE
Work on clippy warnings

### DIFF
--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -139,7 +139,7 @@ impl User {
                                 Ok(msg) => msg,
                                 Err(e) => {
                                     log::error!(
-                                        "Error decrypting MLSCiphertext: {:?} -  Dropping message.",
+                                        "Error decrypting MlsCiphertext: {:?} -  Dropping message.",
                                         e
                                     );
                                     continue;

--- a/delivery-service/ds-lib/src/lib.rs
+++ b/delivery-service/ds-lib/src/lib.rs
@@ -15,7 +15,7 @@ pub struct ClientInfo {
     pub client_name: String,
     pub key_packages: ClientKeyPackages,
     pub id: Vec<u8>,
-    pub msgs: Vec<MLSMessage>,
+    pub msgs: Vec<MlsMessage>,
     pub welcome_queue: Vec<Welcome>,
 }
 
@@ -52,7 +52,7 @@ impl ClientInfo {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Message {
     /// An `MLSMessage` is either an OpenMLS `MLSCiphertext` or `MLSPlaintext`.
-    MLSMessage(MLSMessage),
+    MlsMessage(MlsMessage),
 
     /// An OpenMLS `Welcome` message.
     Welcome(Welcome),
@@ -63,10 +63,10 @@ pub enum Message {
 #[repr(u8)]
 pub enum MessageType {
     /// An MLSCiphertext message.
-    MLSCiphertext = 0,
+    MlsCiphertext = 0,
 
     /// An MLSPlaintext message.
-    MLSPlaintext = 1,
+    MlsPlaintext = 1,
 
     /// A Welcome message.
     Welcome = 2,
@@ -77,14 +77,14 @@ pub enum MessageType {
 /// names.
 #[derive(Debug)]
 pub struct GroupMessage {
-    pub msg: MLSMessage,
+    pub msg: MlsMessage,
     pub recipients: Vec<Vec<u8>>,
 }
 
 impl GroupMessage {
     /// Create a new `GroupMessage` taking an `MLSMessage` and slice of
     /// recipient names.
-    pub fn new(msg: MLSMessage, recipients: &[Vec<u8>]) -> Self {
+    pub fn new(msg: MlsMessage, recipients: &[Vec<u8>]) -> Self {
         Self {
             msg,
             recipients: recipients.to_vec(),
@@ -138,8 +138,8 @@ impl Codec for MessageType {
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
         let value = u8::decode(cursor)?;
         match value {
-            0 => Ok(Self::MLSCiphertext),
-            1 => Ok(Self::MLSPlaintext),
+            0 => Ok(Self::MlsCiphertext),
+            1 => Ok(Self::MlsPlaintext),
             2 => Ok(Self::Welcome),
             _ => Err(CodecError::DecodingError),
         }
@@ -149,13 +149,13 @@ impl Codec for MessageType {
 impl Codec for Message {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         match self {
-            Message::MLSMessage(m) => match m {
-                MLSMessage::Ciphertext(m) => {
-                    MessageType::MLSCiphertext.encode(buffer)?;
+            Message::MlsMessage(m) => match m {
+                MlsMessage::Ciphertext(m) => {
+                    MessageType::MlsCiphertext.encode(buffer)?;
                     m.encode(buffer)?;
                 }
-                MLSMessage::Plaintext(m) => {
-                    MessageType::MLSPlaintext.encode(buffer)?;
+                MlsMessage::Plaintext(m) => {
+                    MessageType::MlsPlaintext.encode(buffer)?;
                     m.encode(buffer)?;
                 }
             },
@@ -170,11 +170,11 @@ impl Codec for Message {
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
         let msg_type = MessageType::decode(cursor)?;
         let msg = match msg_type {
-            MessageType::MLSCiphertext => {
-                Message::MLSMessage(MLSMessage::Ciphertext(MLSCiphertext::decode(cursor)?))
+            MessageType::MlsCiphertext => {
+                Message::MlsMessage(MlsMessage::Ciphertext(MlsCiphertext::decode(cursor)?))
             }
-            MessageType::MLSPlaintext => {
-                Message::MLSMessage(MLSMessage::Plaintext(MLSPlaintext::decode(cursor)?))
+            MessageType::MlsPlaintext => {
+                Message::MlsMessage(MlsMessage::Plaintext(MlsPlaintext::decode(cursor)?))
             }
             MessageType::Welcome => Message::Welcome(Welcome::decode(cursor)?),
         };
@@ -185,12 +185,12 @@ impl Codec for Message {
 impl Codec for GroupMessage {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         match &self.msg {
-            MLSMessage::Ciphertext(m) => {
-                MessageType::MLSCiphertext.encode(buffer)?;
+            MlsMessage::Ciphertext(m) => {
+                MessageType::MlsCiphertext.encode(buffer)?;
                 m.encode(buffer)?;
             }
-            MLSMessage::Plaintext(m) => {
-                MessageType::MLSPlaintext.encode(buffer)?;
+            MlsMessage::Plaintext(m) => {
+                MessageType::MlsPlaintext.encode(buffer)?;
                 m.encode(buffer)?;
             }
         }
@@ -200,8 +200,8 @@ impl Codec for GroupMessage {
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
         let msg_type = MessageType::decode(cursor)?;
         let msg = match msg_type {
-            MessageType::MLSCiphertext => MLSMessage::Ciphertext(MLSCiphertext::decode(cursor)?),
-            MessageType::MLSPlaintext => MLSMessage::Plaintext(MLSPlaintext::decode(cursor)?),
+            MessageType::MlsCiphertext => MlsMessage::Ciphertext(MlsCiphertext::decode(cursor)?),
+            MessageType::MlsPlaintext => MlsMessage::Plaintext(MlsPlaintext::decode(cursor)?),
             _ => return Err(CodecError::DecodingError),
         };
 

--- a/delivery-service/ds-lib/src/lib.rs
+++ b/delivery-service/ds-lib/src/lib.rs
@@ -51,7 +51,7 @@ impl ClientInfo {
 /// (see OpenMLS) for details.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Message {
-    /// An `MLSMessage` is either an OpenMLS `MLSCiphertext` or `MLSPlaintext`.
+    /// An `MLSMessage` is either an OpenMLS `MlsCiphertext` or `MlsPlaintext`.
     MlsMessage(MlsMessage),
 
     /// An OpenMLS `Welcome` message.
@@ -62,10 +62,10 @@ pub enum Message {
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum MessageType {
-    /// An MLSCiphertext message.
+    /// An MlsCiphertext message.
     MlsCiphertext = 0,
 
-    /// An MLSPlaintext message.
+    /// An MlsPlaintext message.
     MlsPlaintext = 1,
 
     /// A Welcome message.

--- a/delivery-service/ds/src/main.rs
+++ b/delivery-service/ds/src/main.rs
@@ -264,7 +264,7 @@ async fn msg_recv(
         .map(Message::Welcome)
         .collect();
     out.append(&mut welcomes);
-    let mut msgs: Vec<Message> = client.msgs.drain(..).map(Message::MLSMessage).collect();
+    let mut msgs: Vec<Message> = client.msgs.drain(..).map(Message::MlsMessage).collect();
     out.append(&mut msgs);
 
     let mut out_bytes = Vec::new();

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -296,7 +296,7 @@ async fn test_group() {
     let mls_ciphertext = match messages.remove(mls_ciphertext) {
         Message::MlsMessage(m) => match m {
             MlsMessage::Ciphertext(m) => m,
-            _ => panic!("This is not an MLSCiphertext but an MLSPlaintext (or something else)."),
+            _ => panic!("This is not an MlsCiphertext but an MlsPlaintext (or something else)."),
         },
         _ => panic!("This is not an MLS message."),
     };
@@ -305,7 +305,7 @@ async fn test_group() {
     // Decrypt the message on Client1
     let mls_plaintext = group
         .decrypt(&mls_ciphertext)
-        .expect("Error decrypting MLSCiphertext");
+        .expect("Error decrypting MlsCiphertext");
     assert_eq!(
         client2_message,
         mls_plaintext.as_application_message().unwrap()

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -265,7 +265,7 @@ async fn test_group() {
         .unwrap();
 
     // Send mls_ciphertext to the group
-    let msg = GroupMessage::new(MLSMessage::Ciphertext(mls_ciphertext), &client_ids);
+    let msg = GroupMessage::new(MlsMessage::Ciphertext(mls_ciphertext), &client_ids);
     let req = test::TestRequest::post()
         .uri("/send/message")
         .set_payload(Bytes::copy_from_slice(&msg.encode_detached().unwrap()))
@@ -290,11 +290,11 @@ async fn test_group() {
 
     let mls_ciphertext = messages
         .iter()
-        .position(|m| matches!(m, Message::MLSMessage(_)))
+        .position(|m| matches!(m, Message::MlsMessage(_)))
         .expect("Didn't get an MLS application message from the server.");
     let mls_ciphertext = match messages.remove(mls_ciphertext) {
-        Message::MLSMessage(m) => match m {
-            MLSMessage::Ciphertext(m) => m,
+        Message::MlsMessage(m) => match m {
+            MlsMessage::Ciphertext(m) => m,
             _ => panic!("This is not an MLSCiphertext but an MLSPlaintext (or something else)."),
         },
         _ => panic!("This is not an MLS message."),

--- a/fuzz/fuzz_targets/mls_ciphertext_decode.rs
+++ b/fuzz/fuzz_targets/mls_ciphertext_decode.rs
@@ -5,5 +5,5 @@ use openmls::prelude::*;
 
 fuzz_target!(|data: &[u8]| {
     let mut cursor = Cursor::new(data);
-    let _ = MLSCiphertext::decode(&mut cursor);
+    let _ = MlsCiphertext::decode(&mut cursor);
 });

--- a/fuzz/fuzz_targets/mls_plaintext_decode.rs
+++ b/fuzz/fuzz_targets/mls_plaintext_decode.rs
@@ -5,5 +5,5 @@ use openmls::prelude::*;
 
 fuzz_target!(|data: &[u8]| {
     let mut cursor = Cursor::new(data);
-    let _ = MLSPlaintext::decode(&mut cursor);
+    let _ = MlsPlaintext::decode(&mut cursor);
 });

--- a/src/ciphersuite/errors.rs
+++ b/src/ciphersuite/errors.rs
@@ -3,7 +3,7 @@
 //! This file defines a set of errors thrown by crypto operations.
 
 implement_error! {
-    pub(crate) enum HKDFError {
+    pub(crate) enum HkdfError {
         InvalidLength = "The HKDF output is empty.",
     }
 }

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -39,6 +39,7 @@ pub(crate) const NONCE_BYTES: usize = 12;
 pub(crate) const REUSE_GUARD_BYTES: usize = 4;
 
 #[allow(non_camel_case_types)]
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u16)]
 pub enum CiphersuiteName {
@@ -53,8 +54,9 @@ pub enum CiphersuiteName {
 implement_enum_display!(CiphersuiteName);
 
 /// SignatureScheme according to IANA TLS parameters
-#[derive(Copy, Hash, Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Copy, Hash, Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 #[repr(u16)]
 pub enum SignatureScheme {
     /// ECDSA_SECP256R1_SHA256
@@ -443,10 +445,10 @@ impl Ciphersuite {
         prk: &Secret,
         info: &[u8],
         okm_len: usize,
-    ) -> Result<Secret, HKDFError> {
+    ) -> Result<Secret, HkdfError> {
         let key = hkdf_expand(self.hmac, &prk.value, info, okm_len);
         if key.is_empty() {
-            return Err(HKDFError::InvalidLength);
+            return Err(HkdfError::InvalidLength);
         }
         Ok(Secret { value: key })
     }
@@ -610,6 +612,7 @@ impl AeadNonce {
 
     /// Get a slice to the nonce value.
     #[cfg(any(feature = "expose-test-vectors", test))]
+    #[allow(dead_code)]
     pub(crate) fn as_slice(&self) -> &[u8] {
         &self.value
     }

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -612,7 +612,6 @@ impl AeadNonce {
 
     /// Get a slice to the nonce value.
     #[cfg(any(feature = "expose-test-vectors", test))]
-    #[allow(dead_code)]
     pub(crate) fn as_slice(&self) -> &[u8] {
         &self.value
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -58,7 +58,7 @@ lazy_static! {
             let config = PersistentConfig {
                 protocol_versions: vec![ProtocolVersion::Mls10],
                 ciphersuites,
-                extensions: vec![ExtensionType::Capabilities, ExtensionType::Lifetime, ExtensionType::KeyID],
+                extensions: vec![ExtensionType::Capabilities, ExtensionType::Lifetime, ExtensionType::KeyId],
                 constants,
             };
             config.into()

--- a/src/credentials/codec.rs
+++ b/src/credentials/codec.rs
@@ -17,12 +17,12 @@ impl Codec for CredentialType {
 impl Codec for Credential {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         match &self.credential {
-            MLSCredentialType::Basic(basic_credential) => {
+            MlsCredentialType::Basic(basic_credential) => {
                 CredentialType::Basic.encode(buffer)?;
                 basic_credential.encode(buffer)?;
             }
             // TODO #134: implement encoding for X509 certificates
-            MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
         Ok(())
     }
@@ -32,7 +32,7 @@ impl Codec for Credential {
             Err(_) => return Err(CodecError::DecodingError),
         };
         match credential_type {
-            CredentialType::Basic => Ok(Credential::from(MLSCredentialType::Basic(
+            CredentialType::Basic => Ok(Credential::from(MlsCredentialType::Basic(
                 BasicCredential::decode(cursor)?,
             ))),
             _ => Err(CodecError::DecodingError),

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -38,7 +38,7 @@ pub struct Certificate {
 
 /// This enum contains the different available credentials.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub enum MLSCredentialType {
+pub enum MlsCredentialType {
     Basic(BasicCredential),
     X509(Certificate),
 }
@@ -47,7 +47,7 @@ pub enum MLSCredentialType {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Credential {
     credential_type: CredentialType,
-    credential: MLSCredentialType,
+    credential: MlsCredentialType,
 }
 
 impl Credential {
@@ -55,45 +55,45 @@ impl Credential {
     /// in a credential.
     pub fn verify(&self, payload: &[u8], signature: &Signature) -> Result<(), CredentialError> {
         match &self.credential {
-            MLSCredentialType::Basic(basic_credential) => basic_credential
+            MlsCredentialType::Basic(basic_credential) => basic_credential
                 .public_key
                 .verify(signature, payload)
                 .map_err(|_| CredentialError::InvalidSignature),
             // TODO: implement verification for X509 certificates. See issue #134.
-            MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }
     /// Get the identity of a given credential.
     pub fn identity(&self) -> &Vec<u8> {
         match &self.credential {
-            MLSCredentialType::Basic(basic_credential) => &basic_credential.identity,
+            MlsCredentialType::Basic(basic_credential) => &basic_credential.identity,
             // TODO: implement getter for identity for X509 certificates. See issue #134.
-            MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }
     /// Get the signature scheme used by the credential.
     pub fn signature_scheme(&self) -> SignatureScheme {
         match &self.credential {
-            MLSCredentialType::Basic(basic_credential) => basic_credential.signature_scheme,
+            MlsCredentialType::Basic(basic_credential) => basic_credential.signature_scheme,
             // TODO: implement getter for signature scheme for X509 certificates. See issue #134.
-            MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }
     /// Get the public key contained in the credential.
     pub fn signature_key(&self) -> &SignaturePublicKey {
         match &self.credential {
-            MLSCredentialType::Basic(basic_credential) => &basic_credential.public_key,
-            MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+            MlsCredentialType::Basic(basic_credential) => &basic_credential.public_key,
+            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }
 }
 
-impl From<MLSCredentialType> for Credential {
-    fn from(mls_credential_type: MLSCredentialType) -> Self {
+impl From<MlsCredentialType> for Credential {
+    fn from(mls_credential_type: MlsCredentialType) -> Self {
         Credential {
             credential_type: match mls_credential_type {
-                MLSCredentialType::Basic(_) => CredentialType::Basic,
-                MLSCredentialType::X509(_) => CredentialType::X509,
+                MlsCredentialType::Basic(_) => CredentialType::Basic,
+                MlsCredentialType::X509(_) => CredentialType::X509,
             },
             credential: mls_credential_type,
         }
@@ -162,7 +162,7 @@ impl CredentialBundle {
         };
         let credential = Credential {
             credential_type,
-            credential: MLSCredentialType::Basic(mls_credential),
+            credential: MlsCredentialType::Basic(mls_credential),
         };
         Ok(CredentialBundle {
             credential,

--- a/src/extensions/key_package_id_extension.rs
+++ b/src/extensions/key_package_id_extension.rs
@@ -19,11 +19,11 @@ use super::{
 use crate::codec::{decode_vec, encode_vec, Cursor, VecSize};
 
 #[derive(PartialEq, Clone, Debug, Default, Serialize, Deserialize)]
-pub struct KeyIDExtension {
+pub struct KeyIdExtension {
     key_id: Vec<u8>,
 }
 
-impl KeyIDExtension {
+impl KeyIdExtension {
     /// Create a new key identifier extension from a byte slice.
     pub fn new(id: &[u8]) -> Self {
         Self {
@@ -38,9 +38,9 @@ impl KeyIDExtension {
 }
 
 #[typetag::serde]
-impl Extension for KeyIDExtension {
+impl Extension for KeyIdExtension {
     fn extension_type(&self) -> ExtensionType {
-        ExtensionType::KeyID
+        ExtensionType::KeyId
     }
 
     /// Build a new KeyIDExtension from a byte slice.
@@ -58,7 +58,7 @@ impl Extension for KeyIDExtension {
     fn to_extension_struct(&self) -> ExtensionStruct {
         let mut extension_data: Vec<u8> = vec![];
         encode_vec(VecSize::VecU16, &mut extension_data, &self.key_id).unwrap();
-        let extension_type = ExtensionType::KeyID;
+        let extension_type = ExtensionType::KeyId;
         ExtensionStruct::new(extension_type, extension_data)
     }
 

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -12,7 +12,7 @@ mod ratchet_tree_extension;
 
 pub use capabilities_extension::CapabilitiesExtension;
 pub use errors::*;
-pub use key_package_id_extension::KeyIDExtension;
+pub use key_package_id_extension::KeyIdExtension;
 pub use life_time_extension::LifetimeExtension;
 pub(crate) use parent_hash_extension::ParentHashExtension;
 pub(crate) use ratchet_tree_extension::RatchetTreeExtension;
@@ -29,7 +29,7 @@ pub enum ExtensionType {
     Reserved = 0,
     Capabilities = 1,
     Lifetime = 2,
-    KeyID = 3,
+    KeyId = 3,
     ParentHash = 4,
     RatchetTree = 5,
 }
@@ -53,7 +53,7 @@ impl TryFrom<u16> for ExtensionType {
             0 => Ok(ExtensionType::Reserved),
             1 => Ok(ExtensionType::Capabilities),
             2 => Ok(ExtensionType::Lifetime),
-            3 => Ok(ExtensionType::KeyID),
+            3 => Ok(ExtensionType::KeyId),
             4 => Ok(ExtensionType::ParentHash),
             5 => Ok(ExtensionType::RatchetTree),
             _ => Err(CodecError::DecodingError),
@@ -131,7 +131,7 @@ impl Codec for ExtensionStruct {
 fn from_bytes(ext_type: ExtensionType, bytes: &[u8]) -> Result<Box<dyn Extension>, ExtensionError> {
     match ext_type {
         ExtensionType::Capabilities => Ok(Box::new(CapabilitiesExtension::new_from_bytes(bytes)?)),
-        ExtensionType::KeyID => Ok(Box::new(KeyIDExtension::new_from_bytes(bytes)?)),
+        ExtensionType::KeyId => Ok(Box::new(KeyIdExtension::new_from_bytes(bytes)?)),
         ExtensionType::Lifetime => Ok(Box::new(LifetimeExtension::new_from_bytes(bytes)?)),
         ExtensionType::ParentHash => Ok(Box::new(ParentHashExtension::new_from_bytes(bytes)?)),
         ExtensionType::RatchetTree => Ok(Box::new(RatchetTreeExtension::new_from_bytes(bytes)?)),
@@ -246,8 +246,8 @@ pub trait Extension: Debug + ExtensionHelper + Send + Sync {
     /// Get a reference to the `KeyIDExtension`.
     /// Returns an `InvalidExtensionType` error if called on an `Extension`
     /// that's not a `KeyIDExtension`.
-    fn to_key_id_extension(&self) -> Result<&KeyIDExtension, ExtensionError> {
-        match self.as_any().downcast_ref::<KeyIDExtension>() {
+    fn to_key_id_extension(&self) -> Result<&KeyIdExtension, ExtensionError> {
+        match self.as_any().downcast_ref::<KeyIdExtension>() {
             Some(e) => Ok(e),
             None => Err(ExtensionError::InvalidExtensionType(
                 "This is not a KeyIDExtension".into(),

--- a/src/extensions/test_extensions.rs
+++ b/src/extensions/test_extensions.rs
@@ -33,14 +33,14 @@ fn capabilities() {
 fn key_package_id() {
     // A key package extension with the default values for openmls.
     let data = [0, 8, 1, 2, 3, 4, 5, 6, 6, 6];
-    let kpi = KeyIDExtension::new(&data[2..]);
-    assert_eq!(ExtensionType::KeyID, kpi.extension_type());
+    let kpi = KeyIdExtension::new(&data[2..]);
+    assert_eq!(ExtensionType::KeyId, kpi.extension_type());
 
-    let kpi_from_bytes = KeyIDExtension::new_from_bytes(&data).unwrap();
+    let kpi_from_bytes = KeyIdExtension::new_from_bytes(&data).unwrap();
     assert_eq!(kpi, kpi_from_bytes);
 
     let extension_struct = kpi.to_extension_struct();
-    assert_eq!(ExtensionType::KeyID, extension_struct.extension_type);
+    assert_eq!(ExtensionType::KeyId, extension_struct.extension_type);
     assert_eq!(&data[..], &extension_struct.extension_data[..]);
 }
 
@@ -58,8 +58,7 @@ fn lifetime() {
 
 // This tests the ratchet tree extension to deliver the public ratcheting tree
 // in-band
-ctest_ciphersuites!(ratchet_tree_extension, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 

--- a/src/framing/ciphertext.rs
+++ b/src/framing/ciphertext.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use std::convert::TryFrom;
 
-/// `MLSCiphertext` is the framing struct for an encrypted `MLSPlaintext`.
+/// `MlsCiphertext` is the framing struct for an encrypted `MlsPlaintext`.
 /// This message format is meant to be sent to and received from the Delivery
 /// Service.
 #[derive(Debug, PartialEq, Clone)]
@@ -16,7 +16,7 @@ pub struct MlsCiphertext {
 }
 
 impl MlsCiphertext {
-    /// Try to create a new `MLSCiphertext` from an `MLSPlaintext`
+    /// Try to create a new `MlsCiphertext` from an `MlsPlaintext`
     pub(crate) fn try_from_plaintext(
         mls_plaintext: &MlsPlaintext,
         ciphersuite: &Ciphersuite,
@@ -26,7 +26,7 @@ impl MlsCiphertext {
         secret_tree: &mut SecretTree,
         padding_size: usize,
     ) -> Result<MlsCiphertext, MlsCiphertextError> {
-        log::debug!("MLSCiphertext::try_from_plaintext");
+        log::debug!("MlsCiphertext::try_from_plaintext");
         log::trace!("  ciphersuite: {}", ciphersuite);
         // Serialize the content AAD
         let mls_ciphertext_content_aad = MlsCiphertextContentAad {
@@ -57,7 +57,7 @@ impl MlsCiphertext {
                 &ratchet_nonce,
             )
             .map_err(|e| {
-                log::error!("MLSCiphertext::try_from_plaintext encryption error {:?}", e);
+                log::error!("MlsCiphertext::try_from_plaintext encryption error {:?}", e);
                 MlsCiphertextError::EncryptionError
             })?;
         // Derive the sender data key from the key schedule using the ciphertext.
@@ -86,7 +86,7 @@ impl MlsCiphertext {
                 &sender_data_nonce,
             )
             .map_err(|e| {
-                log::error!("MLSCiphertext::try_from_plaintext encryption error {:?}", e);
+                log::error!("MlsCiphertext::try_from_plaintext encryption error {:?}", e);
                 MlsCiphertextError::EncryptionError
             })?;
         Ok(MlsCiphertext {
@@ -105,7 +105,7 @@ impl MlsCiphertext {
         epoch_secrets: &EpochSecrets,
         secret_tree: &mut SecretTree,
     ) -> Result<MlsPlaintext, MlsCiphertextError> {
-        log::debug!("Decrypting MLSCiphertext");
+        log::debug!("Decrypting MlsCiphertext");
         // Derive key from the key schedule using the ciphertext.
         let sender_data_key = epoch_secrets
             .sender_data_secret()
@@ -167,23 +167,23 @@ impl MlsCiphertext {
                 MlsCiphertextError::DecryptionError
             })?;
         log::trace!(
-            "  Successfully decrypted MLSPlaintext bytes: {:x?}",
+            "  Successfully decrypted MlsPlaintext bytes: {:x?}",
             mls_ciphertext_content_bytes
         );
         let mls_ciphertext_content = MlsCiphertextContent::decode(
             self.content_type,
             &mut Cursor::new(&mls_ciphertext_content_bytes),
         )?;
-        // Extract sender. The sender type is always of type Member for MLSCiphertext.
+        // Extract sender. The sender type is always of type Member for MlsCiphertext.
         let sender = Sender {
             sender_type: SenderType::Member,
             sender: sender_data.sender,
         };
         log::trace!(
-            "  Successfully decoded MLSPlaintext with: {:x?}",
+            "  Successfully decoded MlsPlaintext with: {:x?}",
             mls_ciphertext_content.content
         );
-        // Return the MLSPlaintext
+        // Return the MlsPlaintext
         Ok(MlsPlaintext {
             group_id: self.group_id.clone(),
             epoch: self.epoch,

--- a/src/framing/codec.rs
+++ b/src/framing/codec.rs
@@ -1,7 +1,7 @@
 use super::*;
 use std::convert::TryFrom;
 
-impl Codec for MLSPlaintext {
+impl Codec for MlsPlaintext {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.group_id.encode(buffer)?;
         self.epoch.encode(buffer)?;
@@ -21,12 +21,12 @@ impl Codec for MLSPlaintext {
         let sender = Sender::decode(cursor)?;
         let authenticated_data = decode_vec(VecSize::VecU32, cursor)?;
         let content_type = ContentType::decode(cursor)?;
-        let content = MLSPlaintextContentType::decode(content_type, cursor)?;
+        let content = MlsPlaintextContentType::decode(content_type, cursor)?;
         let signature = Signature::decode(cursor)?;
         let confirmation_tag = Option::<ConfirmationTag>::decode(cursor)?;
         let membership_tag = Option::<MembershipTag>::decode(cursor)?;
 
-        Ok(MLSPlaintext {
+        Ok(MlsPlaintext {
             group_id,
             epoch,
             sender,
@@ -40,7 +40,7 @@ impl Codec for MLSPlaintext {
     }
 }
 
-impl Codec for MLSCiphertext {
+impl Codec for MlsCiphertext {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.group_id.encode(buffer)?;
         self.epoch.encode(buffer)?;
@@ -59,7 +59,7 @@ impl Codec for MLSCiphertext {
         let authenticated_data = decode_vec(VecSize::VecU32, cursor)?;
         let encrypted_sender_data = decode_vec(VecSize::VecU8, cursor)?;
         let ciphertext = decode_vec(VecSize::VecU32, cursor)?;
-        Ok(MLSCiphertext {
+        Ok(MlsCiphertext {
             group_id,
             epoch,
             content_type,
@@ -80,16 +80,16 @@ impl Codec for ContentType {
     }
 }
 
-impl Codec for MLSPlaintextContentType {
+impl Codec for MlsPlaintextContentType {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         match self {
-            MLSPlaintextContentType::Application(application_data) => {
+            MlsPlaintextContentType::Application(application_data) => {
                 encode_vec(VecSize::VecU32, buffer, application_data)?;
             }
-            MLSPlaintextContentType::Proposal(proposal) => {
+            MlsPlaintextContentType::Proposal(proposal) => {
                 proposal.encode(buffer)?;
             }
-            MLSPlaintextContentType::Commit(commit) => {
+            MlsPlaintextContentType::Commit(commit) => {
                 commit.encode(buffer)?;
             }
         }
@@ -97,20 +97,20 @@ impl Codec for MLSPlaintextContentType {
     }
 }
 
-impl MLSPlaintextContentType {
+impl MlsPlaintextContentType {
     fn decode(content_type: ContentType, cursor: &mut Cursor) -> Result<Self, CodecError> {
         match content_type {
             ContentType::Application => {
                 let application_data = decode_vec(VecSize::VecU32, cursor)?;
-                Ok(MLSPlaintextContentType::Application(application_data))
+                Ok(MlsPlaintextContentType::Application(application_data))
             }
             ContentType::Proposal => {
                 let proposal = Proposal::decode(cursor)?;
-                Ok(MLSPlaintextContentType::Proposal(proposal))
+                Ok(MlsPlaintextContentType::Proposal(proposal))
             }
             ContentType::Commit => {
                 let commit = Commit::decode(cursor)?;
-                Ok(MLSPlaintextContentType::Commit(commit))
+                Ok(MlsPlaintextContentType::Commit(commit))
             }
         }
     }
@@ -140,7 +140,7 @@ impl Codec for MembershipTag {
     }
 }
 
-impl<'a> Codec for MLSPlaintextTBS<'a> {
+impl<'a> Codec for MlsPlaintextTbs<'a> {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         if let Some(ref serialized_context) = self.serialized_context_option {
             buffer.extend_from_slice(serialized_context);
@@ -155,7 +155,7 @@ impl<'a> Codec for MLSPlaintextTBS<'a> {
     }
 }
 
-impl Codec for MLSSenderData {
+impl Codec for MlsSenderData {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.sender.encode(buffer)?;
         self.generation.encode(buffer)?;
@@ -168,7 +168,7 @@ impl Codec for MLSSenderData {
         let generation = u32::decode(cursor)?;
         let reuse_guard = ReuseGuard::decode(cursor)?;
 
-        Ok(MLSSenderData {
+        Ok(MlsSenderData {
             sender,
             generation,
             reuse_guard,
@@ -176,7 +176,7 @@ impl Codec for MLSSenderData {
     }
 }
 
-impl Codec for MLSSenderDataAAD {
+impl Codec for MlsSenderDataAad {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.group_id.encode(buffer)?;
         self.epoch.encode(buffer)?;
@@ -196,7 +196,7 @@ impl Codec for MLSSenderDataAAD {
     }
 }
 
-impl MLSCiphertextContent {
+impl MlsCiphertextContent {
     pub(crate) fn decode(
         content_type: ContentType,
         cursor: &mut Cursor,
@@ -205,21 +205,21 @@ impl MLSCiphertextContent {
         let content = match content_type {
             ContentType::Application => {
                 let application_data = decode_vec(VecSize::VecU32, cursor)?;
-                MLSPlaintextContentType::Application(application_data)
+                MlsPlaintextContentType::Application(application_data)
             }
             ContentType::Proposal => {
                 let proposal = Proposal::decode(cursor)?;
-                MLSPlaintextContentType::Proposal(proposal)
+                MlsPlaintextContentType::Proposal(proposal)
             }
             ContentType::Commit => {
                 let commit = Commit::decode(cursor)?;
-                MLSPlaintextContentType::Commit(commit)
+                MlsPlaintextContentType::Commit(commit)
             }
         };
         let signature = Signature::decode(cursor)?;
         let confirmation_tag = Option::<ConfirmationTag>::decode(cursor)?;
         let padding = decode_vec(VecSize::VecU16, cursor)?;
-        Ok(MLSCiphertextContent {
+        Ok(MlsCiphertextContent {
             content,
             signature,
             confirmation_tag,
@@ -228,7 +228,7 @@ impl MLSCiphertextContent {
     }
 }
 
-impl Codec for MLSCiphertextContentAAD {
+impl Codec for MlsCiphertextContentAad {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.group_id.encode(buffer)?;
         self.epoch.encode(buffer)?;
@@ -242,7 +242,7 @@ impl Codec for MLSCiphertextContentAAD {
         let epoch = GroupEpoch::decode(cursor)?;
         let content_type = ContentType::decode(cursor)?;
         let authenticated_data = decode_vec(VecSize::VecU32, cursor)?;
-        Ok(MLSCiphertextContentAAD {
+        Ok(MlsCiphertextContentAad {
             group_id,
             epoch,
             content_type,
@@ -251,7 +251,7 @@ impl Codec for MLSCiphertextContentAAD {
     }
 }
 
-impl<'a> Codec for MLSPlaintextCommitContent<'a> {
+impl<'a> Codec for MlsPlaintextCommitContent<'a> {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.group_id.encode(buffer)?;
         self.epoch.encode(buffer)?;
@@ -263,7 +263,7 @@ impl<'a> Codec for MLSPlaintextCommitContent<'a> {
     }
 }
 
-impl<'a> Codec for MLSPlaintextCommitAuthData<'a> {
+impl<'a> Codec for MlsPlaintextCommitAuthData<'a> {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.confirmation_tag.encode(buffer)?;
         Ok(())

--- a/src/framing/codec.rs
+++ b/src/framing/codec.rs
@@ -15,7 +15,7 @@ impl Codec for MlsPlaintext {
         Ok(())
     }
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        log_content!(debug, "Decoding MLSPlaintext {:x?}", cursor.raw());
+        log_content!(debug, "Decoding MlsPlaintext {:x?}", cursor.raw());
         let group_id = GroupId::decode(cursor)?;
         let epoch = GroupEpoch::decode(cursor)?;
         let sender = Sender::decode(cursor)?;
@@ -52,7 +52,7 @@ impl Codec for MlsCiphertext {
     }
 
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        log::debug!("Decoding MLSCiphertext {:x?}", cursor.raw());
+        log::debug!("Decoding MlsCiphertext {:x?}", cursor.raw());
         let group_id = GroupId::decode(cursor)?;
         let epoch = GroupEpoch::decode(cursor)?;
         let content_type = ContentType::decode(cursor)?;
@@ -201,7 +201,7 @@ impl MlsCiphertextContent {
         content_type: ContentType,
         cursor: &mut Cursor,
     ) -> Result<Self, CodecError> {
-        log_content!(debug, "Decoding MLSCiphertextContent {:x?}", cursor.raw());
+        log_content!(debug, "Decoding MlsCiphertextContent {:x?}", cursor.raw());
         let content = match content_type {
             ContentType::Application => {
                 let application_data = decode_vec(VecSize::VecU32, cursor)?;

--- a/src/framing/errors.rs
+++ b/src/framing/errors.rs
@@ -1,7 +1,7 @@
 //! # Framing errors.
 //!
-//! `MLSPlaintextError` and `MLSCiphertextError` are thrown on errors
-//! handling `MLSPlaintext` and `MLSCiphertext`.
+//! `MlsPlaintextError` and `MlsCiphertextError` are thrown on errors
+//! handling `MlsPlaintext` and `MlsCiphertext`.
 
 use crate::codec::CodecError;
 use crate::credentials::CredentialError;
@@ -9,23 +9,23 @@ use crate::tree::secret_tree::SecretTreeError;
 
 implement_error! {
     pub enum MlsPlaintextError {
-        NotAnApplicationMessage = "The MLSPlaintext message is not an application message.",
+        NotAnApplicationMessage = "The MlsPlaintext message is not an application message.",
         UnknownSender = "Sender is not part of the group",
-        InvalidSignature = "The MLSPlaintext signature is invalid",
-        InvalidMembershipTag = "The MLSPlaintext membership tag is invalid",
+        InvalidSignature = "The MlsPlaintext signature is invalid",
+        InvalidMembershipTag = "The MlsPlaintext membership tag is invalid",
     }
 }
 
 implement_error! {
     pub enum MlsCiphertextError {
         Simple {
-            InvalidContentType = "The MLSCiphertext has an invalid content type.",
+            InvalidContentType = "The MlsCiphertext has an invalid content type.",
             GenerationOutOfBound = "Couldn't find a ratcheting secret for the given sender and generation.",
             EncryptionError = "An error occurred while encrypting.",
             DecryptionError = "An error occurred while decrypting.",
         }
         Complex {
-            PlaintextError(MlsPlaintextError) = "MLSPlaintext error",
+            PlaintextError(MlsPlaintextError) = "MlsPlaintext error",
             SecretTreeError(SecretTreeError) = "SecretTree error",
             CodecError(CodecError) = "Codec error",
         }
@@ -35,8 +35,8 @@ implement_error! {
 implement_error! {
     pub enum VerificationError {
         Simple {
-            MissingMembershipTag = "The MLSPlaintext membership tag is missing",
-            InvalidMembershipTag = "The MLSPlaintext membership tag is invalid",
+            MissingMembershipTag = "The MlsPlaintext membership tag is missing",
+            InvalidMembershipTag = "The MlsPlaintext membership tag is invalid",
         }
         Complex {
             CodecError(CodecError) = "Codec error",

--- a/src/framing/errors.rs
+++ b/src/framing/errors.rs
@@ -8,7 +8,7 @@ use crate::credentials::CredentialError;
 use crate::tree::secret_tree::SecretTreeError;
 
 implement_error! {
-    pub enum MLSPlaintextError {
+    pub enum MlsPlaintextError {
         NotAnApplicationMessage = "The MLSPlaintext message is not an application message.",
         UnknownSender = "Sender is not part of the group",
         InvalidSignature = "The MLSPlaintext signature is invalid",
@@ -17,7 +17,7 @@ implement_error! {
 }
 
 implement_error! {
-    pub enum MLSCiphertextError {
+    pub enum MlsCiphertextError {
         Simple {
             InvalidContentType = "The MLSCiphertext has an invalid content type.",
             GenerationOutOfBound = "Couldn't find a ratcheting secret for the given sender and generation.",
@@ -25,7 +25,7 @@ implement_error! {
             DecryptionError = "An error occured while decrypting.",
         }
         Complex {
-            PlaintextError(MLSPlaintextError) = "MLSPlaintext error",
+            PlaintextError(MlsPlaintextError) = "MLSPlaintext error",
             SecretTreeError(SecretTreeError) = "SecretTree error",
             CodecError(CodecError) = "Codec error",
         }

--- a/src/framing/plaintext.rs
+++ b/src/framing/plaintext.rs
@@ -44,7 +44,7 @@ pub struct MlsPlaintext {
 }
 
 impl MlsPlaintext {
-    /// This constructor builds a new `MLSPlaintext` from the parameters
+    /// This constructor builds a new `MlsPlaintext` from the parameters
     /// provided. It is only used internally.
     pub(crate) fn new_from_member(
         sender_index: LeafIndex,
@@ -72,7 +72,7 @@ impl MlsPlaintext {
         Ok(mls_plaintext)
     }
 
-    /// This constructor builds an `MLSPlaintext` containing a Proposal.
+    /// This constructor builds an `MlsPlaintext` containing a Proposal.
     /// The sender type is always `SenderType::Member`.
     pub fn new_from_proposal_member(
         sender_index: LeafIndex,
@@ -94,7 +94,7 @@ impl MlsPlaintext {
         Ok(mls_plaintext)
     }
 
-    /// This constructor builds an `MLSPlaintext` containing an application
+    /// This constructor builds an `MlsPlaintext` containing an application
     /// message. The sender type is always `SenderType::Member`.
     pub fn new_from_application(
         sender_index: LeafIndex,
@@ -126,7 +126,7 @@ impl MlsPlaintext {
         self.sender.to_leaf_index()
     }
 
-    /// Sign this `MLSPlaintext`. This populates the
+    /// Sign this `MlsPlaintext`. This populates the
     /// `signature` field. The signature is produced from
     /// the private key conatined in the credential bundle.
     ///
@@ -136,7 +136,7 @@ impl MlsPlaintext {
         self.signature = tbs_payload.sign(credential_bundle);
     }
 
-    /// Sign this `MLSPlaintext` and add a membership tag. This populates the
+    /// Sign this `MlsPlaintext` and add a membership tag. This populates the
     /// `signature` and `membership_tag` fields. The signature is produced from
     /// the private key conatined in the credential bundle, and the
     /// membership_tag is produced using the the membership secret.
@@ -152,7 +152,7 @@ impl MlsPlaintext {
         Ok(())
     }
 
-    /// Adds a membership tag to this `MLSPlaintext`. The membership_tag is
+    /// Adds a membership tag to this `MlsPlaintext`. The membership_tag is
     /// produced using the the membership secret.
     ///
     /// This should be used after signing messages from group members.
@@ -171,7 +171,7 @@ impl MlsPlaintext {
         Ok(())
     }
 
-    /// Verify the signature of an `MLSPlaintext` sent from an external party.
+    /// Verify the signature of an `MlsPlaintext` sent from an external party.
     /// Returns `Ok(())` if successful or `VerificationError` otherwise.
     pub fn verify_signature(
         &self,
@@ -182,7 +182,7 @@ impl MlsPlaintext {
         tbs_payload.verify(credential, &self.signature)
     }
 
-    /// Verify the membership tag of an `MLSPlaintext` sent from member.
+    /// Verify the membership tag of an `MlsPlaintext` sent from member.
     /// Returns `Ok(())` if successful or `VerificationError` otherwise.
     // TODO #133: Include this in the validation
     pub fn verify_membership_tag(
@@ -212,7 +212,7 @@ impl MlsPlaintext {
         }
     }
 
-    /// Verify the signature and the membership tag of an `MLSPlaintext` sent
+    /// Verify the signature and the membership tag of an `MlsPlaintext` sent
     /// from a group member. Returns `Ok(())` if successful or
     /// `VerificationError` otherwise.
     // TODO #133: Include this in the validation
@@ -245,8 +245,8 @@ impl MlsPlaintext {
         }
     }
 
-    /// Tries to extract an application messages from an `MLSPlaintext`. Returns
-    /// `MLSPlaintextError::NotAnApplicationMessage` if the `MLSPlaintext`
+    /// Tries to extract an application messages from an `MlsPlaintext`. Returns
+    /// `MlsPlaintextError::NotAnApplicationMessage` if the `MlsPlaintext`
     /// contained something other than an application message.
     pub fn as_application_message(&self) -> Result<&[u8], MlsPlaintextError> {
         match &self.content {
@@ -329,7 +329,7 @@ impl MlsPlaintextContentType {
     pub(crate) fn to_proposal(&self) -> &Proposal {
         match self {
             MlsPlaintextContentType::Proposal(proposal) => proposal,
-            _ => panic!("Library error. Expected Proposal in MLSPlaintextContentType"),
+            _ => panic!("Library error. Expected Proposal in MlsPlaintextContentType"),
         }
     }
 }
@@ -455,7 +455,7 @@ impl<'a> TryFrom<&'a MlsPlaintext> for MlsPlaintextCommitContent<'a> {
     fn try_from(mls_plaintext: &'a MlsPlaintext) -> Result<Self, Self::Error> {
         let commit = match &mls_plaintext.content {
             MlsPlaintextContentType::Commit(commit) => commit,
-            _ => return Err("MLSPlaintext needs to contain a Commit."),
+            _ => return Err("MlsPlaintext needs to contain a Commit."),
         };
         Ok(MlsPlaintextCommitContent {
             group_id: &mls_plaintext.group_id,
@@ -478,7 +478,7 @@ impl<'a> TryFrom<&'a MlsPlaintext> for MlsPlaintextCommitAuthData<'a> {
     fn try_from(mls_plaintext: &'a MlsPlaintext) -> Result<Self, Self::Error> {
         let confirmation_tag = match &mls_plaintext.confirmation_tag {
             Some(confirmation_tag) => confirmation_tag,
-            None => return Err("MLSPlaintext needs to contain a confirmation tag."),
+            None => return Err("MlsPlaintext needs to contain a confirmation tag."),
         };
         Ok(MlsPlaintextCommitAuthData { confirmation_tag })
     }

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -15,13 +15,13 @@ fn codec() {
             sender_type: SenderType::Member,
             sender: LeafIndex::from(2u32),
         };
-        let mut orig = MLSPlaintext {
+        let mut orig = MlsPlaintext {
             group_id: GroupId::random(),
             epoch: GroupEpoch(1u64),
             sender,
             authenticated_data: vec![1, 2, 3],
             content_type: ContentType::Application,
-            content: MLSPlaintextContentType::Application(vec![4, 5, 6]),
+            content: MlsPlaintextContentType::Application(vec![4, 5, 6]),
             signature: Signature::new_empty(),
             confirmation_tag: None,
             membership_tag: None,
@@ -30,13 +30,13 @@ fn codec() {
         let group_context =
             GroupContext::new(GroupId::random(), GroupEpoch(1), vec![], vec![], &[]).unwrap();
         let serialized_context = group_context.serialized();
-        let signature_input = MLSPlaintextTBS::new_from(&orig, Some(serialized_context));
+        let signature_input = MlsPlaintextTbs::new_from(&orig, Some(serialized_context));
         orig.signature = signature_input
             .sign(&credential_bundle)
             .expect("Signing failed.");
 
         let enc = orig.encode_detached().unwrap();
-        let copy = MLSPlaintext::decode(&mut Cursor::new(&enc)).unwrap();
+        let copy = MlsPlaintext::decode(&mut Cursor::new(&enc)).unwrap();
         assert_eq!(orig, copy);
         assert!(!orig.is_handshake_message());
     }
@@ -55,13 +55,13 @@ fn membership_tag() {
             sender_type: SenderType::Member,
             sender: LeafIndex::from(2u32),
         };
-        let mut mls_plaintext = MLSPlaintext {
+        let mut mls_plaintext = MlsPlaintext {
             group_id: GroupId::random(),
             epoch: GroupEpoch(1u64),
             sender,
             authenticated_data: vec![1, 2, 3],
             content_type: ContentType::Application,
-            content: MLSPlaintextContentType::Application(vec![4, 5, 6]),
+            content: MlsPlaintextContentType::Application(vec![4, 5, 6]),
             signature: Signature::new_empty(),
             confirmation_tag: None,
             membership_tag: None,
@@ -99,7 +99,7 @@ fn membership_tag() {
             .is_ok());
 
         // Change the content of the plaintext message
-        mls_plaintext.content = MLSPlaintextContentType::Application(vec![7, 8, 9]);
+        mls_plaintext.content = MlsPlaintextContentType::Application(vec![7, 8, 9]);
 
         // Expect the signature & membership tag verification to fail
         assert!(mls_plaintext
@@ -262,7 +262,7 @@ fn unknown_sender() {
         // Expected result: MLSCiphertextError::UnknownSender
 
         let bogus_sender = LeafIndex::from(1usize);
-        let bogus_sender_message = MLSPlaintext::new_from_application(
+        let bogus_sender_message = MlsPlaintext::new_from_application(
             ciphersuite,
             bogus_sender,
             &[],
@@ -273,7 +273,7 @@ fn unknown_sender() {
         )
         .expect("Could not create new MLSPlaintext.");
 
-        let enc_message = MLSCiphertext::try_from_plaintext(
+        let enc_message = MlsCiphertext::try_from_plaintext(
             &bogus_sender_message,
             ciphersuite,
             group_alice.context(),
@@ -287,13 +287,13 @@ fn unknown_sender() {
         let received_message = group_charlie.decrypt(&enc_message);
         assert_eq!(
             received_message.unwrap_err(),
-            MLSCiphertextError::PlaintextError(MLSPlaintextError::UnknownSender)
+            MlsCiphertextError::PlaintextError(MlsPlaintextError::UnknownSender)
         );
 
         // Alice sends a message with a sender that is outside of the group
         // Expected result: MLSCiphertextError::GenerationOutOfBound
         let bogus_sender = LeafIndex::from(100usize);
-        let bogus_sender_message = MLSPlaintext::new_from_application(
+        let bogus_sender_message = MlsPlaintext::new_from_application(
             ciphersuite,
             bogus_sender,
             &[],
@@ -309,7 +309,7 @@ fn unknown_sender() {
             LeafIndex::from(100usize),
         );
 
-        let enc_message = MLSCiphertext::try_from_plaintext(
+        let enc_message = MlsCiphertext::try_from_plaintext(
             &bogus_sender_message,
             ciphersuite,
             group_alice.context(),
@@ -323,7 +323,7 @@ fn unknown_sender() {
         let received_message = group_charlie.decrypt(&enc_message);
         assert_eq!(
             received_message.unwrap_err(),
-            MLSCiphertextError::GenerationOutOfBound
+            MlsCiphertextError::GenerationOutOfBound
         );
     }
 }

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -1,7 +1,7 @@
 use crate::config::*;
 use crate::framing::*;
 
-/// This tests serializing/deserializing MLSPlaintext
+/// This tests serializing/deserializing MlsPlaintext
 #[test]
 fn codec() {
     for ciphersuite in Config::supported_ciphersuites() {
@@ -258,7 +258,7 @@ fn unknown_sender() {
         _print_tree(&group_charlie.tree(), "Charlie tree");
 
         // Alice sends a message with a sender that points to a blank leaf
-        // Expected result: MLSCiphertextError::UnknownSender
+        // Expected result: MlsCiphertextError::UnknownSender
 
         let bogus_sender = LeafIndex::from(1usize);
         let bogus_sender_message = MlsPlaintext::new_from_application(
@@ -269,7 +269,7 @@ fn unknown_sender() {
             &group_alice.context(),
             &MembershipKey::from_secret(Secret::random(ciphersuite, None)),
         )
-        .expect("Could not create new MLSPlaintext.");
+        .expect("Could not create new MlsPlaintext.");
 
         let enc_message = MlsCiphertext::try_from_plaintext(
             &bogus_sender_message,
@@ -289,7 +289,7 @@ fn unknown_sender() {
         );
 
         // Alice sends a message with a sender that is outside of the group
-        // Expected result: MLSCiphertextError::GenerationOutOfBound
+        // Expected result: MlsCiphertextError::GenerationOutOfBound
         let bogus_sender = LeafIndex::from(100usize);
         let bogus_sender_message = MlsPlaintext::new_from_application(
             bogus_sender,
@@ -299,7 +299,7 @@ fn unknown_sender() {
             &group_alice.context(),
             &MembershipKey::from_secret(Secret::random(ciphersuite, None)),
         )
-        .expect("Could not create new MLSPlaintext.");
+        .expect("Could not create new MlsPlaintext.");
 
         let mut secret_tree = SecretTree::new(
             EncryptionSecret::random(ciphersuite),

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -19,7 +19,7 @@ implement_error! {
         }
         Complex {
             MlsCiphertextError(MlsCiphertextError) =
-                "See [`MLSCiphertextError`](`crate::framing::errors::MLSCiphertextError`) for details.",
+                "See [`MlsCiphertextError`](`crate::framing::errors::MlsCiphertextError`) for details.",
             WelcomeError(WelcomeError) =
                 "See [`WelcomeError`](`WelcomeError`) for details.",
             ApplyCommitError(ApplyCommitError) =
@@ -89,9 +89,9 @@ implement_error! {
     pub enum ApplyCommitError {
         Simple {
             EpochMismatch =
-                "Couldn't apply Commit. The epoch of the group context and MLSPlaintext didn't match.",
+                "Couldn't apply Commit. The epoch of the group context and MlsPlaintext didn't match.",
             WrongPlaintextContentType =
-                "apply_commit_internal was called with an MLSPlaintext that is not a Commit.",
+                "apply_commit_internal was called with an MlsPlaintext that is not a Commit.",
             SelfRemoved =
                 "Tried to apply a commit to a group we are not a part of.",
             PathKeyPackageVerificationFailure =
@@ -117,7 +117,7 @@ implement_error! {
         }
         Complex {
             PlaintextSignatureFailure(VerificationError) =
-                "MLSPlaintext signature is invalid.",
+                "MlsPlaintext signature is invalid.",
             DecryptionFailure(TreeError) =
                 "A matching EncryptedPathSecret failed to decrypt.",
             CodecError(CodecError) =

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -6,7 +6,7 @@
 use crate::ciphersuite::CryptoError;
 use crate::codec::CodecError;
 use crate::config::ConfigError;
-use crate::framing::errors::{MLSCiphertextError, VerificationError};
+use crate::framing::errors::{MlsCiphertextError, VerificationError};
 use crate::messages::errors::ProposalQueueError;
 use crate::schedule::errors::{KeyScheduleError, PskSecretError};
 use crate::tree::{treemath::TreeMathError, ParentHashError, TreeError};
@@ -18,7 +18,7 @@ implement_error! {
                 "Missing init secret when creating commit.",
         }
         Complex {
-            MLSCiphertextError(MLSCiphertextError) =
+            MlsCiphertextError(MlsCiphertextError) =
                 "See [`MLSCiphertextError`](`crate::framing::errors::MLSCiphertextError`) for details.",
             WelcomeError(WelcomeError) =
                 "See [`WelcomeError`](`WelcomeError`) for details.",

--- a/src/group/managed_group/config.rs
+++ b/src/group/managed_group/config.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 /// Defines whether handshake messages (Proposals & Commits) are encrypted.
 /// Application are always encrypted regardless. `Plaintext`: Handshake messages
-/// are returned as MLSPlaintext messages `Ciphertext`: Handshake messages are
-/// returned as MLSCiphertext messages
+/// are returned as MlsPlaintext messages `Ciphertext`: Handshake messages are
+/// returned as MlsCiphertext messages
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum HandshakeMessageFormat {
     Plaintext,

--- a/src/group/managed_group/events.rs
+++ b/src/group/managed_group/events.rs
@@ -108,11 +108,11 @@ impl MemberUpdatedEvent {
 #[derive(Debug, PartialEq, Clone)]
 pub struct PskReceivedEvent {
     aad: Vec<u8>,
-    psk_id: PreSharedKeyID,
+    psk_id: PreSharedKeyId,
 }
 
 impl PskReceivedEvent {
-    pub(crate) fn new(aad: Vec<u8>, psk_id: PreSharedKeyID) -> Self {
+    pub(crate) fn new(aad: Vec<u8>, psk_id: PreSharedKeyId) -> Self {
         Self { aad, psk_id }
     }
 
@@ -122,7 +122,7 @@ impl PskReceivedEvent {
     }
 
     /// Get a reference to the event's psk id.
-    pub fn psk_id(&self) -> &PreSharedKeyID {
+    pub fn psk_id(&self) -> &PreSharedKeyId {
         &self.psk_id
     }
 }

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -71,7 +71,7 @@ pub struct ManagedGroup<'a> {
     group: MlsGroup,
     // A queue of incoming proposals from the DS for a given epoch. New proposals are added to the
     // queue through `process_messages()`. The queue is emptied after every epoch change.
-    pending_proposals: Vec<MLSPlaintext>,
+    pending_proposals: Vec<MlsPlaintext>,
     // Own `KeyPackageBundle`s that were created for update proposals or commits. The vector is
     // emptied after every epoch change.
     own_kpbs: Vec<KeyPackageBundle>,
@@ -168,7 +168,7 @@ impl<'a> ManagedGroup<'a> {
     pub fn add_members(
         &mut self,
         key_packages: &[KeyPackage],
-    ) -> Result<(Vec<MLSMessage>, Welcome), ManagedGroupError> {
+    ) -> Result<(Vec<MlsMessage>, Welcome), ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
@@ -192,7 +192,7 @@ impl<'a> ManagedGroup<'a> {
         let proposals_by_reference = &self
             .pending_proposals
             .iter()
-            .collect::<Vec<&MLSPlaintext>>();
+            .collect::<Vec<&MlsPlaintext>>();
 
         // Create Commit over all proposals
         // TODO #141
@@ -239,7 +239,7 @@ impl<'a> ManagedGroup<'a> {
     pub fn remove_members(
         &mut self,
         members: &[usize],
-    ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ManagedGroupError> {
+    ) -> Result<(Vec<MlsMessage>, Option<Welcome>), ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
@@ -265,7 +265,7 @@ impl<'a> ManagedGroup<'a> {
         let proposals_by_reference = &self
             .pending_proposals
             .iter()
-            .collect::<Vec<&MLSPlaintext>>();
+            .collect::<Vec<&MlsPlaintext>>();
 
         // Create Commit over all proposals
         // TODO #141
@@ -301,11 +301,11 @@ impl<'a> ManagedGroup<'a> {
     pub fn propose_add_members(
         &mut self,
         key_packages: &[KeyPackage],
-    ) -> Result<Vec<MLSMessage>, ManagedGroupError> {
+    ) -> Result<Vec<MlsMessage>, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
-        let plaintext_messages: Vec<MLSPlaintext> = {
+        let plaintext_messages: Vec<MlsPlaintext> = {
             let mut messages = vec![];
             for key_package in key_packages.iter() {
                 let add_proposal = self.group.create_add_proposal(
@@ -330,11 +330,11 @@ impl<'a> ManagedGroup<'a> {
     pub fn propose_remove_members(
         &mut self,
         members: &[usize],
-    ) -> Result<Vec<MLSMessage>, ManagedGroupError> {
+    ) -> Result<Vec<MlsMessage>, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
-        let plaintext_messages: Vec<MLSPlaintext> = {
+        let plaintext_messages: Vec<MlsPlaintext> = {
             let mut messages = vec![];
             for member in members.iter() {
                 let remove_proposal = self.group.create_remove_proposal(
@@ -356,7 +356,7 @@ impl<'a> ManagedGroup<'a> {
     }
 
     /// Leave the group
-    pub fn leave_group(&mut self) -> Result<Vec<MLSMessage>, ManagedGroupError> {
+    pub fn leave_group(&mut self) -> Result<Vec<MlsMessage>, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
@@ -391,7 +391,7 @@ impl<'a> ManagedGroup<'a> {
     /// occurred while processing messages.
     pub fn process_messages(
         &mut self,
-        messages: Vec<MLSMessage>,
+        messages: Vec<MlsMessage>,
     ) -> Result<Vec<GroupEvent>, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
@@ -402,7 +402,7 @@ impl<'a> ManagedGroup<'a> {
             // Check the type of message we received
             let (plaintext, aad_option) = match message {
                 // If it is a ciphertext we decrypt it and return the plaintext message
-                MLSMessage::Ciphertext(ciphertext) => {
+                MlsMessage::Ciphertext(ciphertext) => {
                     let aad = ciphertext.authenticated_data.clone();
                     match self.group.decrypt(&ciphertext) {
                         Ok(plaintext) => (plaintext, Some(aad)),
@@ -417,7 +417,7 @@ impl<'a> ManagedGroup<'a> {
                     }
                 }
                 // If it is a plaintext message we just return it
-                MLSMessage::Plaintext(plaintext) => {
+                MlsMessage::Plaintext(plaintext) => {
                     // Verify signature & membership tag
                     // TODO #106: Support external senders
                     if plaintext.is_proposal()
@@ -438,7 +438,7 @@ impl<'a> ManagedGroup<'a> {
             let indexed_members = self.indexed_members();
             // See what kind of message it is
             match plaintext.content {
-                MLSPlaintextContentType::Proposal(_) => {
+                MlsPlaintextContentType::Proposal(_) => {
                     // Incoming proposals are validated against the application validation
                     // policy and then appended to the internal `pending_proposal` list.
                     // TODO #133: Semantic validation of proposals
@@ -457,7 +457,7 @@ impl<'a> ManagedGroup<'a> {
                         )));
                     }
                 }
-                MLSPlaintextContentType::Commit(ref commit) => {
+                MlsPlaintextContentType::Commit(ref commit) => {
                     // Validate inline proposals
                     if !self.validate_inline_proposals(
                         &commit.proposals,
@@ -478,7 +478,7 @@ impl<'a> ManagedGroup<'a> {
                     let proposals = &self
                         .pending_proposals
                         .iter()
-                        .collect::<Vec<&MLSPlaintext>>();
+                        .collect::<Vec<&MlsPlaintext>>();
                     // TODO #141
                     match self
                         .group
@@ -542,7 +542,7 @@ impl<'a> ManagedGroup<'a> {
                         },
                     }
                 }
-                MLSPlaintextContentType::Application(ref app_message) => {
+                MlsPlaintextContentType::Application(ref app_message) => {
                     // Save the application message as an event
                     events.push(GroupEvent::ApplicationMessage(
                         ApplicationMessageEvent::new(
@@ -569,7 +569,7 @@ impl<'a> ManagedGroup<'a> {
     /// Returns `ManagedGroupError::PendingProposalsExist` if pending proposals
     /// exist. In that case `.process_pending_proposals()` must be called first
     /// and incoming messages from the DS must be processed afterwards.
-    pub fn create_message(&mut self, message: &[u8]) -> Result<MLSMessage, ManagedGroupError> {
+    pub fn create_message(&mut self, message: &[u8]) -> Result<MlsMessage, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
@@ -588,18 +588,18 @@ impl<'a> ManagedGroup<'a> {
         // Since the state of the group was changed, call the auto-save function
         self.auto_save();
 
-        Ok(MLSMessage::Ciphertext(ciphertext))
+        Ok(MlsMessage::Ciphertext(ciphertext))
     }
 
     /// Process pending proposals
     pub fn process_pending_proposals(
         &mut self,
-    ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ManagedGroupError> {
+    ) -> Result<(Vec<MlsMessage>, Option<Welcome>), ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
         // Include pending proposals into Commit
-        let messages_to_commit: Vec<&MLSPlaintext> = self.pending_proposals.iter().collect();
+        let messages_to_commit: Vec<&MlsPlaintext> = self.pending_proposals.iter().collect();
 
         // Create Commit over all pending proposals
         // TODO #141
@@ -725,7 +725,7 @@ impl<'a> ManagedGroup<'a> {
     pub fn self_update(
         &mut self,
         key_package_bundle_option: Option<KeyPackageBundle>,
-    ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ManagedGroupError> {
+    ) -> Result<(Vec<MlsMessage>, Option<Welcome>), ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
@@ -744,7 +744,7 @@ impl<'a> ManagedGroup<'a> {
         };
 
         // Include pending proposals into Commit
-        let messages_to_commit: Vec<&MLSPlaintext> = self
+        let messages_to_commit: Vec<&MlsPlaintext> = self
             .pending_proposals
             .iter()
             .chain(plaintext_messages.iter())
@@ -789,7 +789,7 @@ impl<'a> ManagedGroup<'a> {
     pub fn propose_self_update(
         &mut self,
         key_package_bundle_option: Option<KeyPackageBundle>,
-    ) -> Result<Vec<MLSMessage>, ManagedGroupError> {
+    ) -> Result<Vec<MlsMessage>, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
@@ -823,7 +823,7 @@ impl<'a> ManagedGroup<'a> {
     }
 
     /// Returns a list of proposal
-    pub fn pending_proposals(&self) -> &[MLSPlaintext] {
+    pub fn pending_proposals(&self) -> &[MlsPlaintext] {
         &self.pending_proposals
     }
 
@@ -860,17 +860,17 @@ impl<'a> ManagedGroup<'a> {
     /// MLSCiphertext first.
     fn plaintext_to_mls_messages(
         &mut self,
-        mut plaintext_messages: Vec<MLSPlaintext>,
-    ) -> Result<Vec<MLSMessage>, ManagedGroupError> {
+        mut plaintext_messages: Vec<MlsPlaintext>,
+    ) -> Result<Vec<MlsMessage>, ManagedGroupError> {
         let mut out = Vec::with_capacity(plaintext_messages.len());
         for plaintext in plaintext_messages.drain(..) {
             let msg = match self.configuration().handshake_message_format {
-                HandshakeMessageFormat::Plaintext => MLSMessage::Plaintext(plaintext),
+                HandshakeMessageFormat::Plaintext => MlsMessage::Plaintext(plaintext),
                 HandshakeMessageFormat::Ciphertext => {
                     let ciphertext = self
                         .group
                         .encrypt(plaintext, self.configuration().padding_size())?;
-                    MLSMessage::Ciphertext(ciphertext)
+                    MlsMessage::Ciphertext(ciphertext)
                 }
             };
             out.push(msg);
@@ -951,7 +951,7 @@ impl<'a> ManagedGroup<'a> {
         let pending_proposals_list = self
             .pending_proposals
             .iter()
-            .collect::<Vec<&MLSPlaintext>>();
+            .collect::<Vec<&MlsPlaintext>>();
         // Build a proposal queue for easier searching
         let pending_proposals_queue =
             ProposalQueue::from_proposals_by_reference(ciphersuite, &pending_proposals_list);
@@ -1044,48 +1044,48 @@ impl<'a> ManagedGroup<'a> {
 
 /// Unified message type
 #[derive(PartialEq, Debug, Clone)]
-pub enum MLSMessage {
+pub enum MlsMessage {
     /// An OpenMLS `MLSPlaintext`.
-    Plaintext(MLSPlaintext),
+    Plaintext(MlsPlaintext),
 
     /// An OpenMLS `MLSCiphertext`.
-    Ciphertext(MLSCiphertext),
+    Ciphertext(MlsCiphertext),
 }
 
-impl From<MLSPlaintext> for MLSMessage {
-    fn from(mls_plaintext: MLSPlaintext) -> Self {
-        MLSMessage::Plaintext(mls_plaintext)
+impl From<MlsPlaintext> for MlsMessage {
+    fn from(mls_plaintext: MlsPlaintext) -> Self {
+        MlsMessage::Plaintext(mls_plaintext)
     }
 }
 
-impl From<MLSCiphertext> for MLSMessage {
-    fn from(mls_ciphertext: MLSCiphertext) -> Self {
-        MLSMessage::Ciphertext(mls_ciphertext)
+impl From<MlsCiphertext> for MlsMessage {
+    fn from(mls_ciphertext: MlsCiphertext) -> Self {
+        MlsMessage::Ciphertext(mls_ciphertext)
     }
 }
 
-impl MLSMessage {
+impl MlsMessage {
     /// Get the group ID as plain byte vector.
     pub fn group_id(&self) -> Vec<u8> {
         match self {
-            MLSMessage::Ciphertext(m) => m.group_id.as_slice(),
-            MLSMessage::Plaintext(m) => m.group_id().as_slice(),
+            MlsMessage::Ciphertext(m) => m.group_id.as_slice(),
+            MlsMessage::Plaintext(m) => m.group_id().as_slice(),
         }
     }
 
     /// Get the epoch as plain u64.
     pub fn epoch(&self) -> u64 {
         match self {
-            MLSMessage::Ciphertext(m) => m.epoch.0,
-            MLSMessage::Plaintext(m) => m.epoch().0,
+            MlsMessage::Ciphertext(m) => m.epoch.0,
+            MlsMessage::Plaintext(m) => m.epoch().0,
         }
     }
 
     /// Returns `true` if this is a handshake message and `false` otherwise.
     pub fn is_handshake_message(&self) -> bool {
         match self {
-            MLSMessage::Ciphertext(m) => m.is_handshake_message(),
-            MLSMessage::Plaintext(m) => m.is_handshake_message(),
+            MlsMessage::Ciphertext(m) => m.is_handshake_message(),
+            MlsMessage::Plaintext(m) => m.is_handshake_message(),
         }
     }
 }

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -219,7 +219,7 @@ impl<'a> ManagedGroup<'a> {
             self.own_kpbs.push(kpb);
         }
 
-        // Convert MLSPlaintext messages to MLSMessage and encrypt them if required by
+        // Convert MlsPlaintext messages to MLSMessage and encrypt them if required by
         // the configuration
         let mls_messages = self.plaintext_to_mls_messages(vec![commit])?;
 
@@ -288,7 +288,7 @@ impl<'a> ManagedGroup<'a> {
             ));
         }
 
-        // Convert MLSPlaintext messages to MLSMessage and encrypt them if required by
+        // Convert MlsPlaintext messages to MLSMessage and encrypt them if required by
         // the configuration
         let mls_messages = self.plaintext_to_mls_messages(vec![commit])?;
 
@@ -386,8 +386,8 @@ impl<'a> ManagedGroup<'a> {
 
     // === Process messages ===
 
-    /// Processes any incoming messages from the DS (MLSPlaintext &
-    /// MLSCiphertext) and triggers the corresponding callback functions.
+    /// Processes any incoming messages from the DS (MlsPlaintext &
+    /// MlsCiphertext) and triggers the corresponding callback functions.
     /// Return a list of `GroupEvent` that contain the individual events that
     /// occurred while processing messages.
     pub fn process_messages(
@@ -411,7 +411,7 @@ impl<'a> ManagedGroup<'a> {
                             events.push(GroupEvent::InvalidMessage(InvalidMessageEvent::new(
                                 InvalidMessageError::InvalidCiphertext(aad.into()),
                             )));
-                            // Since we cannot decrypt the MLSCiphertext to a MLSPlaintext we move
+                            // Since we cannot decrypt the MlsCiphertext to a MlsPlaintext we move
                             // to the next message
                             continue;
                         }
@@ -621,7 +621,7 @@ impl<'a> ManagedGroup<'a> {
             self.own_kpbs.push(kpb);
         }
 
-        // Convert MLSPlaintext messages to MLSMessage and encrypt them if required by
+        // Convert MlsPlaintext messages to MLSMessage and encrypt them if required by
         // the configuration
         let mls_messages = self.plaintext_to_mls_messages(plaintext_messages)?;
 
@@ -776,7 +776,7 @@ impl<'a> ManagedGroup<'a> {
         };
         self.own_kpbs.push(kpb);
 
-        // Convert MLSPlaintext messages to MLSMessage and encrypt them if required by
+        // Convert MlsPlaintext messages to MLSMessage and encrypt them if required by
         // the configuration
         let mls_messages = self.plaintext_to_mls_messages(plaintext_messages)?;
 
@@ -856,9 +856,9 @@ impl<'a> ManagedGroup<'a> {
 
 // Private methods of ManagedGroup
 impl<'a> ManagedGroup<'a> {
-    /// Converts MLSPlaintext to MLSMessage. Depending on whether handshake
-    /// message should be encrypted, MLSPlaintext messages are encrypted to
-    /// MLSCiphertext first.
+    /// Converts MlsPlaintext to MLSMessage. Depending on whether handshake
+    /// message should be encrypted, MlsPlaintext messages are encrypted to
+    /// MlsCiphertext first.
     fn plaintext_to_mls_messages(
         &mut self,
         mut plaintext_messages: Vec<MlsPlaintext>,
@@ -1046,10 +1046,10 @@ impl<'a> ManagedGroup<'a> {
 /// Unified message type
 #[derive(PartialEq, Debug, Clone)]
 pub enum MlsMessage {
-    /// An OpenMLS `MLSPlaintext`.
+    /// An OpenMLS `MlsPlaintext`.
     Plaintext(MlsPlaintext),
 
-    /// An OpenMLS `MLSCiphertext`.
+    /// An OpenMLS `MlsCiphertext`.
     Ciphertext(MlsCiphertext),
 }
 

--- a/src/group/managed_group/ser.rs
+++ b/src/group/managed_group/ser.rs
@@ -8,7 +8,7 @@ use serde::{
 pub struct SerializedManagedGroup {
     managed_group_config: ManagedGroupConfig,
     group: MlsGroup,
-    pending_proposals: Vec<MLSPlaintext>,
+    pending_proposals: Vec<MlsPlaintext>,
     own_kpbs: Vec<KeyPackageBundle>,
     aad: Vec<u8>,
     resumption_secret_store: ResumptionSecretStore,

--- a/src/group/managed_group/test_managed_group.rs
+++ b/src/group/managed_group/test_managed_group.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use std::convert::TryFrom;
 
 #[test]
 fn test_managed_group_persistence() {
@@ -193,8 +192,7 @@ fn remover() {
     }
 }
 
-ctest_ciphersuites!(export_secret, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(export_secret, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
     let group_id = GroupId::from_slice(b"Test Group");

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -20,7 +20,7 @@ impl MlsGroup {
             return Err(ApplyCommitError::EpochMismatch);
         }
 
-        // Extract Commit & Confirmation Tag from MLSPlaintext
+        // Extract Commit & Confirmation Tag from MlsPlaintext
         let commit = match &mls_plaintext.content {
             MlsPlaintextContentType::Commit(commit) => commit,
             _ => return Err(ApplyCommitError::WrongPlaintextContentType),
@@ -63,7 +63,7 @@ impl MlsGroup {
         let zero_commit_secret = CommitSecret::zero_secret(ciphersuite, self.mls_version);
         // Determine if Commit has a path
         let commit_secret = if let Some(path) = commit.path.clone() {
-            // Verify KeyPackage and MLSPlaintext signature & membership tag
+            // Verify KeyPackage and MlsPlaintext signature & membership tag
             // TODO #106: Support external members
             let kp = &path.leaf_key_package;
             if kp.verify().is_err() {
@@ -116,7 +116,7 @@ impl MlsGroup {
 
         let confirmed_transcript_hash = update_confirmed_transcript_hash(
             ciphersuite,
-            // It is ok to use `unwrap()` here, because we know the MLSPlaintext contains a Commit
+            // It is ok to use `unwrap()` here, because we know the MlsPlaintext contains a Commit
             &MlsPlaintextCommitContent::try_from(mls_plaintext).unwrap(),
             &self.interim_transcript_hash,
         )?;

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -8,8 +8,8 @@ use crate::schedule::CommitSecret;
 impl MlsGroup {
     pub(crate) fn apply_commit_internal(
         &mut self,
-        mls_plaintext: &MLSPlaintext,
-        proposals_by_reference: &[&MLSPlaintext],
+        mls_plaintext: &MlsPlaintext,
+        proposals_by_reference: &[&MlsPlaintext],
         own_key_packages: &[KeyPackageBundle],
         psk_fetcher_option: Option<PskFetcher>,
     ) -> Result<(), ApplyCommitError> {
@@ -22,7 +22,7 @@ impl MlsGroup {
 
         // Extract Commit & Confirmation Tag from MLSPlaintext
         let commit = match &mls_plaintext.content {
-            MLSPlaintextContentType::Commit(commit) => commit,
+            MlsPlaintextContentType::Commit(commit) => commit,
             _ => return Err(ApplyCommitError::WrongPlaintextContentType),
         };
         let received_confirmation_tag = match &mls_plaintext.confirmation_tag {
@@ -118,7 +118,7 @@ impl MlsGroup {
         let confirmed_transcript_hash = update_confirmed_transcript_hash(
             ciphersuite,
             // It is ok to use `unwrap()` here, because we know the MLSPlaintext contains a Commit
-            &MLSPlaintextCommitContent::try_from(mls_plaintext).unwrap(),
+            &MlsPlaintextCommitContent::try_from(mls_plaintext).unwrap(),
             &self.interim_transcript_hash,
         )?;
 
@@ -147,7 +147,7 @@ impl MlsGroup {
         let provisional_epoch_secrets = key_schedule.epoch_secrets(true)?;
 
         let mls_plaintext_commit_auth_data =
-            match MLSPlaintextCommitAuthData::try_from(mls_plaintext) {
+            match MlsPlaintextCommitAuthData::try_from(mls_plaintext) {
                 Ok(mpcad) => mpcad,
                 Err(_) => return Err(ApplyCommitError::ConfirmationTagMissing),
             };

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -66,7 +66,7 @@ impl MlsGroup {
         let mut provisional_epoch = self.group_context.epoch;
         provisional_epoch.increment();
 
-        // Build MLSPlaintext
+        // Build MlsPlaintext
         let content = MlsPlaintextContentType::Commit(commit);
         let sender = Sender::member(sender_index);
         let mut mls_plaintext = MlsPlaintext {
@@ -81,14 +81,14 @@ impl MlsGroup {
             membership_tag: None,
         };
 
-        // Add signature and membership tag to the MLSPlaintext
+        // Add signature and membership tag to the MlsPlaintext
         let serialized_context = self.group_context.serialized();
         mls_plaintext.sign_from_member(credential_bundle, serialized_context)?;
 
         // Calculate the confirmed transcript hash
         let confirmed_transcript_hash = update_confirmed_transcript_hash(
             &ciphersuite,
-            // It is ok to use `unwrap()` here, because we know the MLSPlaintext contains a
+            // It is ok to use `unwrap()` here, because we know the MlsPlaintext contains a
             // Commit
             &MlsPlaintextCommitContent::try_from(&mls_plaintext).unwrap(),
             &self.interim_transcript_hash,

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -12,7 +12,7 @@ impl MlsGroup {
         &self,
         aad: &[u8],
         credential_bundle: &CredentialBundle,
-        proposals_by_reference: &[&MLSPlaintext],
+        proposals_by_reference: &[&MlsPlaintext],
         proposals_by_value: &[&Proposal],
         force_self_update: bool,
         psk_fetcher_option: Option<PskFetcher>,
@@ -67,9 +67,9 @@ impl MlsGroup {
         provisional_epoch.increment();
 
         // Build MLSPlaintext
-        let content = MLSPlaintextContentType::Commit(commit);
+        let content = MlsPlaintextContentType::Commit(commit);
         let sender = Sender::member(sender_index);
-        let mut mls_plaintext = MLSPlaintext {
+        let mut mls_plaintext = MlsPlaintext {
             group_id: self.context().group_id.clone(),
             epoch: self.context().epoch,
             sender,
@@ -90,7 +90,7 @@ impl MlsGroup {
             &ciphersuite,
             // It is ok to use `unwrap()` here, because we know the MLSPlaintext contains a
             // Commit
-            &MLSPlaintextCommitContent::try_from(&mls_plaintext).unwrap(),
+            &MlsPlaintextCommitContent::try_from(&mls_plaintext).unwrap(),
             &self.interim_transcript_hash,
         )?;
 

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -469,13 +469,11 @@ impl MlsGroup {
     }
 
     #[cfg(any(feature = "expose-test-vectors", test))]
-    #[allow(dead_code)]
     pub(crate) fn epoch_secrets_mut(&mut self) -> &mut EpochSecrets {
         &mut self.epoch_secrets
     }
 
     #[cfg(any(feature = "expose-test-vectors", test))]
-    #[allow(dead_code)]
     pub(crate) fn context_mut(&mut self) -> &mut GroupContext {
         &mut self.group_context
     }

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -185,7 +185,7 @@ impl MlsGroup {
             .tag(&ciphersuite, &group_context.confirmed_transcript_hash);
         let interim_transcript_hash = update_interim_transcript_hash(
             &ciphersuite,
-            &MLSPlaintextCommitAuthData::from(&confirmation_tag),
+            &MlsPlaintextCommitAuthData::from(&confirmation_tag),
             &group_context.confirmed_transcript_hash,
         )?;
 

--- a/src/group/mls_group/test_duplicate_extension.rs
+++ b/src/group/mls_group/test_duplicate_extension.rs
@@ -11,8 +11,7 @@ use crate::{
 };
 
 // This tests the ratchet tree extension to test if the duplicate detection works
-ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 

--- a/src/group/mls_group/test_mls_group.rs
+++ b/src/group/mls_group/test_mls_group.rs
@@ -6,8 +6,6 @@ use crate::{
     tree::{TreeError, UpdatePath, UpdatePathNode},
 };
 
-use std::convert::TryFrom;
-
 #[test]
 fn test_mls_group_persistence() {
     use std::fs::File;
@@ -193,7 +191,7 @@ fn test_update_path() {
             .expect("Error creating commit");
 
         let commit = match mls_plaintext_commit.content() {
-            MLSPlaintextContentType::Commit(commit) => commit,
+            MlsPlaintextContentType::Commit(commit) => commit,
             _ => panic!("Wrong content type"),
         };
         assert!(!commit.has_path() && kpb_option.is_none());
@@ -245,7 +243,7 @@ fn test_update_path() {
         // apart the commit, manipulating the ciphertexts and the piecing it
         // back together.
         let commit = match &mls_plaintext_commit.content {
-            MLSPlaintextContentType::Commit(commit) => commit,
+            MlsPlaintextContentType::Commit(commit) => commit,
             _ => panic!("Bob created a commit, which does not contain an actual commit."),
         };
 
@@ -280,9 +278,9 @@ fn test_update_path() {
             path: Some(broken_path),
         };
 
-        let broken_commit_content = MLSPlaintextContentType::Commit(broken_commit);
+        let broken_commit_content = MlsPlaintextContentType::Commit(broken_commit);
 
-        let mut broken_plaintext = MLSPlaintext::new_from_member(
+        let mut broken_plaintext = MlsPlaintext::new_from_member(
             mls_plaintext_commit.sender.to_leaf_index(),
             &mls_plaintext_commit.authenticated_data,
             broken_commit_content,
@@ -320,13 +318,13 @@ fn test_update_path() {
 }
 
 // Test several scenarios when PSKs are used in a group
-ctest_ciphersuites!(test_psks, test(param: CiphersuiteName) {
+ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
     fn psk_fetcher(psks: &PreSharedKeys) -> Option<Vec<Secret>> {
         let psk_id = vec![1u8, 2, 3];
         let secret = Secret::from(vec![4u8, 5, 6]);
 
         let psk = &psks.psks[0];
-        if psk.psk_type == PSKType::External {
+        if psk.psk_type == PskType::External {
             if let Psk::External(external_psk) = &psk.psk {
                 if external_psk.psk_id() == psk_id {
                     Some(vec![secret])
@@ -341,7 +339,6 @@ ctest_ciphersuites!(test_psks, test(param: CiphersuiteName) {
         }
     }
 
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
     // Basic group setup.

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -69,6 +69,7 @@ pub struct GroupContext {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
+#[allow(dead_code)]
 impl GroupContext {
     pub(crate) fn set_epoch(&mut self, epoch: GroupEpoch) {
         self.epoch = epoch;

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -69,7 +69,6 @@ pub struct GroupContext {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 impl GroupContext {
     pub(crate) fn set_epoch(&mut self, epoch: GroupEpoch) {
         self.epoch = epoch;

--- a/src/group/tests/kat_transcripts.rs
+++ b/src/group/tests/kat_transcripts.rs
@@ -45,7 +45,6 @@ pub struct TranscriptTestVector {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 pub fn generate_test_vector(ciphersuite: &Ciphersuite) -> TranscriptTestVector {
     // Generate random values.
     let group_id = GroupId::random();
@@ -135,7 +134,6 @@ fn write_test_vectors() {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 pub fn run_test_vector(test_vector: TranscriptTestVector) -> Result<(), TranscriptTestVectorError> {
     let ciphersuite =
         CiphersuiteName::try_from(test_vector.cipher_suite).expect("Invalid ciphersuite");

--- a/src/group/tests/kat_transcripts.rs
+++ b/src/group/tests/kat_transcripts.rs
@@ -38,7 +38,7 @@ pub struct TranscriptTestVector {
     interim_transcript_hash_before: String,
     membership_key: String,
     confirmation_key: String,
-    commit: String, // TLS serialized MLSPlaintext(Commit)
+    commit: String, // TLS serialized MlsPlaintext(Commit)
 
     confirmed_transcript_hash_after: String,
     interim_transcript_hash_after: String,

--- a/src/group/tests/mod.rs
+++ b/src/group/tests/mod.rs
@@ -1,3 +1,3 @@
 //! Unit tests for the MLS group
 
-mod kat_transcripts;
+pub mod kat_transcripts;

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -106,7 +106,7 @@ impl KeyPackage {
     /// Get the ID of this key package as byte slice.
     /// Returns an error if no Key ID extension is present.
     pub fn key_id(&self) -> Result<&[u8], KeyPackageError> {
-        if let Some(key_id_ext) = self.extension_with_type(ExtensionType::KeyID) {
+        if let Some(key_id_ext) = self.extension_with_type(ExtensionType::KeyId) {
             return Ok(key_id_ext.to_key_id_extension()?.as_slice());
         }
         Err(KeyPackageError::ExtensionError(

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -81,7 +81,7 @@ fn key_package_id_extension() {
         // Add an ID to the key package.
         let id = [1, 2, 3, 4];
         kpb.key_package_mut()
-            .add_extension(Box::new(KeyIDExtension::new(&id)));
+            .add_extension(Box::new(KeyIdExtension::new(&id)));
 
         // This is invalid now.
         assert!(kpb.key_package().verify().is_err());
@@ -91,7 +91,7 @@ fn key_package_id_extension() {
         assert!(kpb.key_package().verify().is_ok());
 
         // Check ID
-        assert_eq!(&id[..], &kpb.key_package().key_id().expect("No key ID")[..]);
+        assert_eq!(&id[..], kpb.key_package().key_id().expect("No key ID"));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod key_packages;
 pub mod messages;
 #[cfg(any(feature = "expose-test-vectors", test))]
 pub mod schedule;
-#[cfg(not(feature = "expose-test-vectors"))]
+#[cfg(not(any(feature = "expose-test-vectors", test)))]
 mod schedule;
 pub mod tree;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@ pub mod framing;
 pub mod group;
 mod key_packages;
 pub mod messages;
+#[cfg(any(feature = "expose-test-vectors", test))]
+pub mod schedule;
+#[cfg(not(feature = "expose-test-vectors"))]
 mod schedule;
 pub mod tree;
 

--- a/src/messages/codec.rs
+++ b/src/messages/codec.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::codec::Codec;
-use crate::{key_packages::KeyPackage, schedule::psk::PreSharedKeyID};
+use crate::{key_packages::KeyPackage, schedule::psk::PreSharedKeyId};
 
 use std::convert::TryFrom;
 
@@ -252,7 +252,7 @@ impl Codec for PreSharedKeyProposal {
         Ok(())
     }
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let psk = PreSharedKeyID::decode(cursor)?;
+        let psk = PreSharedKeyId::decode(cursor)?;
         Ok(Self { psk })
     }
 }
@@ -316,7 +316,7 @@ impl Codec for PublicGroupState {
     }
 }
 
-impl<'a> Codec for PublicGroupStateTBS<'a> {
+impl<'a> Codec for PublicGroupStateTbs<'a> {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.group_id.encode(buffer)?;
         self.epoch.encode(buffer)?;

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -338,7 +338,7 @@ impl PublicGroupState {
         let interim_transcript_hash = mls_group.interim_transcript_hash().to_vec();
         let extensions = mls_group.extensions();
 
-        let pgstbs = PublicGroupStateTBS {
+        let pgstbs = PublicGroupStateTbs {
             group_id: &group_id,
             epoch: &epoch,
             tree_hash: &tree_hash,
@@ -363,7 +363,7 @@ impl PublicGroupState {
     /// Verifies the signature of the `PublicGroupState`.
     /// Returns `Ok(())` in case of success and `CredentialError` otherwise.
     pub fn verify(&self, credential_bundle: &CredentialBundle) -> Result<(), CredentialError> {
-        let pgstbs = PublicGroupStateTBS {
+        let pgstbs = PublicGroupStateTbs {
             group_id: &self.group_id,
             epoch: &self.epoch,
             tree_hash: &self.tree_hash,
@@ -392,7 +392,7 @@ impl PublicGroupState {
 ///     HPKEPublicKey external_pub;
 /// } PublicGroupStateTBS;
 /// ```
-pub(crate) struct PublicGroupStateTBS<'a> {
+pub(crate) struct PublicGroupStateTbs<'a> {
     pub(crate) group_id: &'a GroupId,
     pub(crate) epoch: &'a GroupEpoch,
     pub(crate) tree_hash: &'a [u8],
@@ -401,7 +401,7 @@ pub(crate) struct PublicGroupStateTBS<'a> {
     pub(crate) external_pub: &'a HPKEPublicKey,
 }
 
-impl<'a> PublicGroupStateTBS<'a> {
+impl<'a> PublicGroupStateTbs<'a> {
     /// Signs the `PublicGroupStateTBS` with a `CredentialBundle`.
     fn sign(&self, credential_bundle: &CredentialBundle) -> Result<Signature, CredentialError> {
         let payload = self

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -116,7 +116,7 @@ impl Commit {
     }
 }
 
-/// Confirmation tag field of MLSPlaintext. For type saftey this is a wrapper
+/// Confirmation tag field of MlsPlaintext. For type saftey this is a wrapper
 /// around a `Mac`.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ConfirmationTag(pub(crate) Mac);

--- a/src/messages/proposals.rs
+++ b/src/messages/proposals.rs
@@ -157,7 +157,7 @@ impl ProposalReference {
 }
 
 /// Alternative representation of a Proposal, where the sender is extracted from
-/// the encapsulating MLSPlaintext and the ProposalReference is attached.
+/// the encapsulating MlsPlaintext and the ProposalReference is attached.
 #[derive(Clone)]
 pub(crate) struct QueuedProposal<'a> {
     proposal: &'a Proposal,
@@ -167,7 +167,7 @@ pub(crate) struct QueuedProposal<'a> {
 }
 
 impl<'a> QueuedProposal<'a> {
-    /// Creates a new `QueuedProposal` from an `MLSPlaintext`
+    /// Creates a new `QueuedProposal` from an `MlsPlaintext`
     pub(crate) fn from_mls_plaintext(
         ciphersuite: &Ciphersuite,
         mls_plaintext: &'a MlsPlaintext,

--- a/src/messages/proposals.rs
+++ b/src/messages/proposals.rs
@@ -170,11 +170,11 @@ impl<'a> QueuedProposal<'a> {
     /// Creates a new `QueuedProposal` from an `MLSPlaintext`
     pub(crate) fn from_mls_plaintext(
         ciphersuite: &Ciphersuite,
-        mls_plaintext: &'a MLSPlaintext,
+        mls_plaintext: &'a MlsPlaintext,
     ) -> Result<Self, QueuedProposalError> {
         debug_assert!(mls_plaintext.content_type == ContentType::Proposal);
         let proposal = match &mls_plaintext.content {
-            MLSPlaintextContentType::Proposal(p) => p,
+            MlsPlaintextContentType::Proposal(p) => p,
             _ => return Err(QueuedProposalError::WrongContentType),
         };
         let proposal_reference = ProposalReference::from_proposal(ciphersuite, &proposal);
@@ -233,7 +233,7 @@ impl<'a> ProposalQueue<'a> {
     /// don't need filtering
     pub(crate) fn from_proposals_by_reference(
         ciphersuite: &Ciphersuite,
-        proposals: &'a [&MLSPlaintext],
+        proposals: &'a [&MlsPlaintext],
     ) -> Self {
         let mut proposal_queue = ProposalQueue::default();
         for mls_plaintext in proposals {
@@ -250,7 +250,7 @@ impl<'a> ProposalQueue<'a> {
     pub(crate) fn from_committed_proposals(
         ciphersuite: &Ciphersuite,
         committed_proposals: &'a [ProposalOrRef],
-        proposals_by_reference: &[&'a MLSPlaintext],
+        proposals_by_reference: &[&'a MlsPlaintext],
         sender: Sender,
     ) -> Result<Self, ProposalQueueError> {
         // Feed the `proposals_by_reference` in a `HashMap` so that we can easily
@@ -306,7 +306,7 @@ impl<'a> ProposalQueue<'a> {
     /// own node were included
     pub(crate) fn filter_proposals(
         ciphersuite: &Ciphersuite,
-        proposals_by_reference: &'a [&MLSPlaintext],
+        proposals_by_reference: &'a [&MlsPlaintext],
         proposals_by_value: &'a [&Proposal],
         own_index: LeafIndex,
         tree_size: LeafIndex,
@@ -496,7 +496,7 @@ pub struct RemoveProposal {
 /// } PreSharedKey;
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct PreSharedKeyProposal {
-    pub psk: PreSharedKeyID,
+    pub psk: PreSharedKeyId,
 }
 
 /// ReInit proposal

--- a/src/messages/tests/test_codec.rs
+++ b/src/messages/tests/test_codec.rs
@@ -1,7 +1,7 @@
 use crate::{
     group::{GroupEpoch, GroupId},
     messages::{Codec, Config, PreSharedKeyProposal, ProtocolVersion, ReInitProposal},
-    schedule::psk::{BranchPsk, ExternalPsk, PSKType, PreSharedKeyID, Psk, ReinitPsk},
+    schedule::psk::{BranchPsk, ExternalPsk, PreSharedKeyId, Psk, PskType, ReinitPsk},
 };
 
 /// Test the encoding for PreSharedKeyProposal, that also covers some of the
@@ -10,8 +10,8 @@ use crate::{
 fn test_pre_shared_key_proposal_codec() {
     // ReInit
     let orig = PreSharedKeyProposal {
-        psk: PreSharedKeyID {
-            psk_type: PSKType::Reinit,
+        psk: PreSharedKeyId {
+            psk_type: PskType::Reinit,
             psk: Psk::Reinit(ReinitPsk {
                 psk_group_id: GroupId::random(),
                 psk_epoch: GroupEpoch(1234),
@@ -25,8 +25,8 @@ fn test_pre_shared_key_proposal_codec() {
 
     // External
     let orig = PreSharedKeyProposal {
-        psk: PreSharedKeyID {
-            psk_type: PSKType::External,
+        psk: PreSharedKeyId {
+            psk_type: PskType::External,
             psk: Psk::External(ExternalPsk::new(vec![4, 5, 6])),
             psk_nonce: vec![1, 2, 3],
         },
@@ -37,8 +37,8 @@ fn test_pre_shared_key_proposal_codec() {
 
     // Branch
     let orig = PreSharedKeyProposal {
-        psk: PreSharedKeyID {
-            psk_type: PSKType::Branch,
+        psk: PreSharedKeyId {
+            psk_type: PskType::Branch,
             psk: Psk::Branch(BranchPsk {
                 psk_group_id: GroupId::random(),
                 psk_epoch: GroupEpoch(1234),

--- a/src/messages/tests/test_proposals.rs
+++ b/src/messages/tests/test_proposals.rs
@@ -92,7 +92,7 @@ fn proposal_queue_functions() {
         assert!(!proposal_add_alice1.is_type(ProposalType::Update));
         assert!(!proposal_add_alice1.is_type(ProposalType::Remove));
 
-        // Frame proposals in MLSPlaintext
+        // Frame proposals in MlsPlaintext
         let mls_plaintext_add_alice1 = MlsPlaintext::new_from_proposal_member(
             LeafIndex::from(0u32),
             &[],
@@ -194,7 +194,7 @@ fn proposal_queue_order() {
             ProposalReference::from_proposal(ciphersuite, &proposal_add_alice1);
         let proposal_add_bob1 = Proposal::Add(add_proposal_bob1);
 
-        // Frame proposals in MLSPlaintext
+        // Frame proposals in MlsPlaintext
         let mls_plaintext_add_alice1 = MlsPlaintext::new_from_proposal_member(
             LeafIndex::from(0u32),
             &[],

--- a/src/messages/tests/test_proposals.rs
+++ b/src/messages/tests/test_proposals.rs
@@ -4,7 +4,7 @@ use crate::{
     credentials::{CredentialBundle, CredentialType},
     extensions::{Extension, LifetimeExtension},
     framing::sender::{Sender, SenderType},
-    framing::MLSPlaintext,
+    framing::MlsPlaintext,
     group::{GroupContext, GroupEpoch, GroupId},
     key_packages::KeyPackageBundle,
     messages::proposals::{
@@ -93,7 +93,7 @@ fn proposal_queue_functions() {
         assert!(!proposal_add_alice1.is_type(ProposalType::Remove));
 
         // Frame proposals in MLSPlaintext
-        let mls_plaintext_add_alice1 = MLSPlaintext::new_from_proposal_member(
+        let mls_plaintext_add_alice1 = MlsPlaintext::new_from_proposal_member(
             ciphersuite,
             LeafIndex::from(0u32),
             &[],
@@ -103,7 +103,7 @@ fn proposal_queue_functions() {
             &MembershipKey::from_secret(Secret::default()),
         )
         .expect("Could not create proposal.");
-        let mls_plaintext_add_alice2 = MLSPlaintext::new_from_proposal_member(
+        let mls_plaintext_add_alice2 = MlsPlaintext::new_from_proposal_member(
             ciphersuite,
             LeafIndex::from(1u32),
             &[],
@@ -113,7 +113,7 @@ fn proposal_queue_functions() {
             &MembershipKey::from_secret(Secret::default()),
         )
         .expect("Could not create proposal.");
-        let _mls_plaintext_add_bob1 = MLSPlaintext::new_from_proposal_member(
+        let _mls_plaintext_add_bob1 = MlsPlaintext::new_from_proposal_member(
             ciphersuite,
             LeafIndex::from(1u32),
             &[],
@@ -198,7 +198,7 @@ fn proposal_queue_order() {
         let proposal_add_bob1 = Proposal::Add(add_proposal_bob1);
 
         // Frame proposals in MLSPlaintext
-        let mls_plaintext_add_alice1 = MLSPlaintext::new_from_proposal_member(
+        let mls_plaintext_add_alice1 = MlsPlaintext::new_from_proposal_member(
             ciphersuite,
             LeafIndex::from(0u32),
             &[],
@@ -208,7 +208,7 @@ fn proposal_queue_order() {
             &MembershipKey::from_secret(Secret::random(ciphersuite.hash_length())),
         )
         .expect("Could not create proposal.");
-        let mls_plaintext_add_bob1 = MLSPlaintext::new_from_proposal_member(
+        let mls_plaintext_add_bob1 = MlsPlaintext::new_from_proposal_member(
             ciphersuite,
             LeafIndex::from(1u32),
             &[],

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,8 +4,8 @@
 pub use crate::group::GroupConfig;
 pub use crate::group::MlsGroup;
 pub use crate::group::{
-    GroupEvent, HandshakeMessageFormat, InvalidMessageError, MLSMessage, ManagedGroup,
-    ManagedGroupCallbacks, ManagedGroupConfig, ManagedGroupError, Removal, UpdatePolicy,
+    GroupEvent, HandshakeMessageFormat, InvalidMessageError, ManagedGroup, ManagedGroupCallbacks,
+    ManagedGroupConfig, ManagedGroupError, MlsMessage, Removal, UpdatePolicy,
 };
 // Errors
 pub use crate::error::ErrorString;
@@ -32,7 +32,7 @@ pub use crate::messages::{
     Welcome,
 };
 pub use crate::schedule::psk::{
-    BranchPsk, ExternalPsk, PSKType, PreSharedKeyID, PreSharedKeys, Psk, ReinitPsk,
+    BranchPsk, ExternalPsk, PreSharedKeyId, PreSharedKeys, Psk, PskType, ReinitPsk,
 };
 pub use crate::utils::*;
 

--- a/src/schedule/codec.rs
+++ b/src/schedule/codec.rs
@@ -5,14 +5,14 @@ use crate::group::{GroupEpoch, GroupId};
 
 use std::convert::TryFrom;
 
-impl Codec for PSKType {
+impl Codec for PskType {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         (*self as u8).encode(buffer)?;
         Ok(())
     }
 
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        match PSKType::try_from(u8::decode(cursor)?) {
+        match PskType::try_from(u8::decode(cursor)?) {
             Ok(psk_type) => Ok(psk_type),
             Err(_) => Err(CodecError::DecodingError),
         }
@@ -65,7 +65,7 @@ impl Codec for BranchPsk {
     }
 }
 
-impl Codec for PreSharedKeyID {
+impl Codec for PreSharedKeyId {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.psk_type.encode(buffer)?;
         match &self.psk {
@@ -78,11 +78,11 @@ impl Codec for PreSharedKeyID {
     }
 
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let psktype = PSKType::decode(cursor)?;
+        let psktype = PskType::decode(cursor)?;
         let psk = match psktype {
-            PSKType::External => Psk::External(ExternalPsk::decode(cursor)?),
-            PSKType::Reinit => Psk::Reinit(ReinitPsk::decode(cursor)?),
-            PSKType::Branch => Psk::Branch(BranchPsk::decode(cursor)?),
+            PskType::External => Psk::External(ExternalPsk::decode(cursor)?),
+            PskType::Reinit => Psk::Reinit(ReinitPsk::decode(cursor)?),
+            PskType::Branch => Psk::Branch(BranchPsk::decode(cursor)?),
         };
         let psk_nonce = decode_vec(VecSize::VecU8, cursor)?;
         Ok(Self {

--- a/src/schedule/errors.rs
+++ b/src/schedule/errors.rs
@@ -22,7 +22,7 @@ implement_error! {
 
 #[cfg(any(feature = "expose-test-vectors", test))]
 implement_error! {
-    pub enum KSTestVectorError {
+    pub enum KsTestVectorError {
         JoinerSecretMismatch = "The computed joiner secret doesn't match the one in the test vector.",
         WelcomeSecretMismatch = "The computed welcome secret doesn't match the one in the test vector.",
         InitSecretMismatch = "The computed init secret doesn't match the one in the test vector.",

--- a/src/schedule/kat_key_schedule.rs
+++ b/src/schedule/kat_key_schedule.rs
@@ -24,7 +24,7 @@ use hpke::HPKEKeyPair;
 use serde::{self, Deserialize, Serialize};
 
 use super::CommitSecret;
-use super::{errors::KSTestVectorError, PskSecret};
+use super::{errors::KsTestVectorError, PskSecret};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 struct Epoch {
@@ -117,6 +117,7 @@ fn generate(
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
+#[allow(dead_code)]
 pub fn generate_test_vector(
     n_epochs: u64,
     ciphersuite: &'static Ciphersuite,
@@ -196,7 +197,8 @@ fn read_test_vectors() {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KSTestVectorError> {
+#[allow(dead_code)]
+pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestVectorError> {
     let ciphersuite =
         CiphersuiteName::try_from(test_vector.cipher_suite).expect("Invalid ciphersuite");
     let ciphersuite = match Config::ciphersuite(ciphersuite) {
@@ -233,7 +235,7 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KSTestV
             if cfg!(test) {
                 panic!("Joiner secret mismatch");
             }
-            return Err(KSTestVectorError::JoinerSecretMismatch);
+            return Err(KsTestVectorError::JoinerSecretMismatch);
         }
 
         let mut key_schedule = KeySchedule::init(
@@ -247,7 +249,7 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KSTestV
             if cfg!(test) {
                 panic!("Welcome secret mismatch");
             }
-            return Err(KSTestVectorError::WelcomeSecretMismatch);
+            return Err(KsTestVectorError::WelcomeSecretMismatch);
         }
 
         let confirmed_transcript_hash = hex_to_bytes(&epoch.confirmed_transcript_hash);
@@ -269,7 +271,7 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KSTestV
             if cfg!(test) {
                 panic!("Group context mismatch");
             }
-            return Err(KSTestVectorError::GroupContextMismatch);
+            return Err(KsTestVectorError::GroupContextMismatch);
         }
 
         key_schedule.add_context(&group_context).unwrap();
@@ -287,26 +289,26 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KSTestV
             if cfg!(test) {
                 panic!("Init secret mismatch");
             }
-            return Err(KSTestVectorError::InitSecretMismatch);
+            return Err(KsTestVectorError::InitSecretMismatch);
         }
         if hex_to_bytes(&epoch.sender_data_secret) != epoch_secrets.sender_data_secret().as_slice()
         {
             if cfg!(test) {
                 panic!("Sender data secret mismatch");
             }
-            return Err(KSTestVectorError::SenderDataSecretMismatch);
+            return Err(KsTestVectorError::SenderDataSecretMismatch);
         }
         if hex_to_bytes(&epoch.encryption_secret) != epoch_secrets.encryption_secret().as_slice() {
             if cfg!(test) {
                 panic!("Encryption secret mismatch");
             }
-            return Err(KSTestVectorError::EncryptionSecretMismatch);
+            return Err(KsTestVectorError::EncryptionSecretMismatch);
         }
         if hex_to_bytes(&epoch.exporter_secret) != epoch_secrets.exporter_secret().as_slice() {
             if cfg!(test) {
                 panic!("Exporter secret mismatch");
             }
-            return Err(KSTestVectorError::ExporterSecretMismatch);
+            return Err(KsTestVectorError::ExporterSecretMismatch);
         }
         if hex_to_bytes(&epoch.authentication_secret)
             != epoch_secrets.authentication_secret().as_slice()
@@ -314,31 +316,31 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KSTestV
             if cfg!(test) {
                 panic!("Authentication secret mismatch");
             }
-            return Err(KSTestVectorError::AuthenticationSecretMismatch);
+            return Err(KsTestVectorError::AuthenticationSecretMismatch);
         }
         if hex_to_bytes(&epoch.external_secret) != epoch_secrets.external_secret().as_slice() {
             if cfg!(test) {
                 panic!("External secret mismatch");
             }
-            return Err(KSTestVectorError::ExternalSecretMismatch);
+            return Err(KsTestVectorError::ExternalSecretMismatch);
         }
         if hex_to_bytes(&epoch.confirmation_key) != epoch_secrets.confirmation_key().as_slice() {
             if cfg!(test) {
                 panic!("Confirmation key mismatch");
             }
-            return Err(KSTestVectorError::ConfirmationKeyMismatch);
+            return Err(KsTestVectorError::ConfirmationKeyMismatch);
         }
         if hex_to_bytes(&epoch.membership_key) != epoch_secrets.membership_key().as_slice() {
             if cfg!(test) {
                 panic!("Membership key mismatch");
             }
-            return Err(KSTestVectorError::MembershipKeyMismatch);
+            return Err(KsTestVectorError::MembershipKeyMismatch);
         }
         if hex_to_bytes(&epoch.resumption_secret) != epoch_secrets.resumption_secret().as_slice() {
             if cfg!(test) {
                 panic!("Resumption secret mismatch");
             }
-            return Err(KSTestVectorError::ResumptionSecretMismatch);
+            return Err(KsTestVectorError::ResumptionSecretMismatch);
         }
 
         // Calculate external HPKE key pair
@@ -357,7 +359,7 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KSTestV
             if cfg!(test) {
                 panic!("External pub mismatch");
             }
-            return Err(KSTestVectorError::ExternalPubMismatch);
+            return Err(KsTestVectorError::ExternalPubMismatch);
         }
     }
     Ok(())

--- a/src/schedule/kat_key_schedule.rs
+++ b/src/schedule/kat_key_schedule.rs
@@ -117,7 +117,6 @@ fn generate(
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 pub fn generate_test_vector(
     n_epochs: u64,
     ciphersuite: &'static Ciphersuite,
@@ -197,7 +196,6 @@ fn read_test_vectors() {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestVectorError> {
     let ciphersuite =
         CiphersuiteName::try_from(test_vector.cipher_suite).expect("Invalid ciphersuite");

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -132,7 +132,7 @@ pub mod errors;
 pub(crate) mod psk;
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-mod kat_key_schedule;
+pub mod kat_key_schedule;
 
 pub use errors::{ErrorState, KeyScheduleError, PskSecretError};
 pub use psk::{PreSharedKeyId, PreSharedKeys, PskSecret};
@@ -762,7 +762,6 @@ impl SenderDataSecret {
     }
 
     #[cfg(any(feature = "expose-test-vectors", test))]
-    #[allow(dead_code)]
     #[doc(hidden)]
     pub fn from_random(length: usize) -> Self {
         Self {
@@ -933,7 +932,6 @@ impl EpochSecrets {
     }
 
     #[cfg(any(feature = "expose-test-vectors", test))]
-    #[allow(dead_code)]
     #[doc(hidden)]
     pub(crate) fn sender_data_secret_mut(&mut self) -> &mut SenderDataSecret {
         &mut self.sender_data_secret

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -135,7 +135,7 @@ pub(crate) mod psk;
 mod kat_key_schedule;
 
 pub use errors::{ErrorState, KeyScheduleError, PskSecretError};
-pub use psk::{PreSharedKeyID, PreSharedKeys, PskSecret};
+pub use psk::{PreSharedKeyId, PreSharedKeys, PskSecret};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
@@ -762,6 +762,7 @@ impl SenderDataSecret {
     }
 
     #[cfg(any(feature = "expose-test-vectors", test))]
+    #[allow(dead_code)]
     #[doc(hidden)]
     pub fn from_random(length: usize) -> Self {
         Self {
@@ -932,6 +933,7 @@ impl EpochSecrets {
     }
 
     #[cfg(any(feature = "expose-test-vectors", test))]
+    #[allow(dead_code)]
     #[doc(hidden)]
     pub(crate) fn sender_data_secret_mut(&mut self) -> &mut SenderDataSecret {
         &mut self.sender_data_secret

--- a/src/schedule/psk.rs
+++ b/src/schedule/psk.rs
@@ -48,19 +48,19 @@ use std::convert::TryFrom;
 /// ```
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 #[repr(u8)]
-pub enum PSKType {
+pub enum PskType {
     External = 1,
     Reinit = 2,
     Branch = 3,
 }
 
-impl TryFrom<u8> for PSKType {
+impl TryFrom<u8> for PskType {
     type Error = &'static str;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            1 => Ok(PSKType::External),
-            2 => Ok(PSKType::Reinit),
-            3 => Ok(PSKType::Branch),
+            1 => Ok(PskType::External),
+            2 => Ok(PskType::Reinit),
+            3 => Ok(PskType::Branch),
             _ => Err("Unknown PSK type."),
         }
     }
@@ -101,9 +101,9 @@ impl ExternalPskBundle {
         }
     }
     /// Return the `PreSharedKeyID`
-    pub fn to_presharedkey_id(&self) -> PreSharedKeyID {
-        PreSharedKeyID {
-            psk_type: PSKType::External,
+    pub fn to_presharedkey_id(&self) -> PreSharedKeyId {
+        PreSharedKeyId {
+            psk_type: PskType::External,
             psk: Psk::External(self.external_psk.clone()),
             psk_nonce: self.nonce.clone(),
         }
@@ -178,15 +178,15 @@ pub enum Psk {
 /// } PreSharedKeyID;
 /// ```
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct PreSharedKeyID {
-    pub(crate) psk_type: PSKType,
+pub struct PreSharedKeyId {
+    pub(crate) psk_type: PskType,
     pub(crate) psk: Psk,
     pub(crate) psk_nonce: Vec<u8>,
 }
 
-impl PreSharedKeyID {
+impl PreSharedKeyId {
     /// Create a new `PreSharedKeyID`
-    pub fn new(psk_type: PSKType, psk: Psk, psk_nonce: Vec<u8>) -> Self {
+    pub fn new(psk_type: PskType, psk: Psk, psk_nonce: Vec<u8>) -> Self {
         Self {
             psk_type,
             psk,
@@ -194,7 +194,7 @@ impl PreSharedKeyID {
         }
     }
     /// Return the type of the PSK
-    pub fn psktype(&self) -> &PSKType {
+    pub fn psktype(&self) -> &PskType {
         &self.psk_type
     }
     /// Return the PSK
@@ -212,12 +212,12 @@ impl PreSharedKeyID {
 ///     PreSharedKeyID psks<0..2^16-1>;
 /// } PreSharedKeys;
 pub struct PreSharedKeys {
-    pub(crate) psks: Vec<PreSharedKeyID>,
+    pub(crate) psks: Vec<PreSharedKeyId>,
 }
 
 impl PreSharedKeys {
     /// Return the `PreSharedKeyID`s
-    pub fn psks(&self) -> &Vec<PreSharedKeyID> {
+    pub fn psks(&self) -> &Vec<PreSharedKeyId> {
         &self.psks
     }
 }
@@ -229,14 +229,14 @@ impl PreSharedKeys {
 ///     uint16 count;
 /// } PSKLabel;
 pub(crate) struct PskLabel<'a> {
-    pub(crate) id: &'a PreSharedKeyID,
+    pub(crate) id: &'a PreSharedKeyId,
     pub(crate) index: u16,
     pub(crate) count: u16,
 }
 
 impl<'a> PskLabel<'a> {
     /// Create a new `PskLabel`
-    fn new(id: &'a PreSharedKeyID, index: u16, count: u16) -> Self {
+    fn new(id: &'a PreSharedKeyId, index: u16, count: u16) -> Self {
         Self { id, index, count }
     }
 }
@@ -251,7 +251,7 @@ impl PskSecret {
     /// Create a new `PskSecret` from PSK IDs and PSKs
     pub fn new(
         ciphersuite: &Ciphersuite,
-        psk_ids: &[PreSharedKeyID],
+        psk_ids: &[PreSharedKeyId],
         psks: &[Secret],
     ) -> Result<Self, PskSecretError> {
         if psk_ids.len() != psks.len() {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -34,7 +34,7 @@ use std::collections::HashSet;
 use std::convert::TryInto;
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-mod tests;
+pub mod tests;
 
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -3,7 +3,7 @@ use crate::config::Config;
 use crate::credentials::*;
 use crate::key_packages::*;
 use crate::messages::proposals::*;
-use crate::{ciphersuite::*, prelude::PreSharedKeyID};
+use crate::{ciphersuite::*, prelude::PreSharedKeyId};
 
 // Tree modules
 pub(crate) mod codec;
@@ -718,7 +718,7 @@ impl RatchetTree {
         }
 
         // Process PSK proposals
-        let psks: Vec<PreSharedKeyID> = proposal_queue
+        let psks: Vec<PreSharedKeyId> = proposal_queue
             .filtered_by_type(ProposalType::Presharedkey)
             .map(|queued_proposal| {
                 // Unwrapping here is safe because we know the proposal type

--- a/src/tree/secret_tree.rs
+++ b/src/tree/secret_tree.rs
@@ -192,7 +192,7 @@ impl SecretTree {
     }
 
     /// Return RatchetSecrets for a given index and generation. This should be
-    /// called when decrypting an MLSCiphertext received from another member.
+    /// called when decrypting an MlsCiphertext received from another member.
     /// Returns an error if index or generation are out of bound.
     pub(crate) fn secret_for_decryption(
         &mut self,

--- a/src/tree/secret_tree.rs
+++ b/src/tree/secret_tree.rs
@@ -30,8 +30,8 @@ impl From<&ContentType> for SecretType {
     }
 }
 
-impl From<&MLSPlaintext> for SecretType {
-    fn from(mls_plaintext: &MLSPlaintext) -> SecretType {
+impl From<&MlsPlaintext> for SecretType {
+    fn from(mls_plaintext: &MlsPlaintext) -> SecretType {
         SecretType::from(&mls_plaintext.content_type)
     }
 }

--- a/src/tree/tests/kat_encryption.rs
+++ b/src/tree/tests/kat_encryption.rs
@@ -52,18 +52,18 @@
 //! For all `N` entries in the `leaves` and all generations `j`
 //! * `leaves[N].handshake[j].key = handshake_ratchet_key_[2*N]_[j]`
 //! * `leaves[N].handshake[j].nonce = handshake_ratchet_nonce_[2*N]_[j]`
-//! * `leaves[N].handshake[j].plaintext` represents an MLSPlaintext containing a
+//! * `leaves[N].handshake[j].plaintext` represents an MlsPlaintext containing a
 //!   handshake message (Proposal or Commit) from leaf `N`
-//! * `leaves[N].handshake[j].ciphertext` represents an MLSCiphertext object
-//!   that successfully decrypts to an MLSPlaintext equivalent to
+//! * `leaves[N].handshake[j].ciphertext` represents an MlsCiphertext object
+//!   that successfully decrypts to an MlsPlaintext equivalent to
 //!   `leaves[N].handshake[j].plaintext` using the keys for leaf `N` and
 //!   generation `j`.
 //! * `leaves[N].application[j].key = application_ratchet_key_[2*N]_[j]`
 //! * `leaves[N].application[j].nonce = application_ratchet_nonce_[2*N]_[j]`
-//! * `leaves[N].application[j].plaintext` represents an MLSPlaintext containing
+//! * `leaves[N].application[j].plaintext` represents an MlsPlaintext containing
 //!   application data from leaf `N`
-//! * `leaves[N].application[j].ciphertext` represents an MLSCiphertext object
-//!   that successfully decrypts to an MLSPlaintext equivalent to
+//! * `leaves[N].application[j].ciphertext` represents an MlsCiphertext object
+//!   that successfully decrypts to an MlsPlaintext equivalent to
 //!   `leaves[N].handshake[j].plaintext` using the keys for leaf `N` and
 //!   generation `j`.
 //! * `sender_data_info.secret.key = sender_data_key(sender_data_secret,
@@ -202,7 +202,7 @@ fn build_handshake_messages(leaf: LeafIndex, group: &mut MlsGroup) -> (Vec<u8>, 
         &mut group.secret_tree_mut(),
         0,
     )
-    .expect("Could not create MLSCiphertext");
+    .expect("Could not create MlsCiphertext");
     (
         plaintext.encode_detached().unwrap(),
         ciphertext.encode_detached().unwrap(),
@@ -238,7 +238,7 @@ fn build_application_messages(leaf: LeafIndex, group: &mut MlsGroup) -> (Vec<u8>
         0,
     ) {
         Ok(c) => c,
-        Err(e) => panic!("Could not create MLSCiphertext {}", e),
+        Err(e) => panic!("Could not create MlsCiphertext {}", e),
     };
     (
         plaintext.encode_detached().unwrap(),
@@ -462,7 +462,7 @@ pub fn run_test_vector(test_vector: EncryptionTestVector) -> Result<(), EncTestV
             // Setup group
             let mls_ciphertext_application =
                 MlsCiphertext::decode(&mut Cursor::new(&hex_to_bytes(&application.ciphertext)))
-                    .expect("Error parsing MLSCiphertext");
+                    .expect("Error parsing MlsCiphertext");
             let mut group = receiver_group(ciphersuite, &mls_ciphertext_application.group_id);
             *group.epoch_secrets_mut().sender_data_secret_mut() = SenderDataSecret::from_slice(
                 hex_to_bytes(&test_vector.sender_data_secret).as_slice(),
@@ -473,11 +473,11 @@ pub fn run_test_vector(test_vector: EncryptionTestVector) -> Result<(), EncTestV
             // Decrypt and check application message
             let mls_plaintext_application = mls_ciphertext_application
                 .to_plaintext(ciphersuite, group.epoch_secrets(), &mut secret_tree)
-                .expect("Error decrypting MLSCiphertext");
+                .expect("Error decrypting MlsCiphertext");
             if hex_to_bytes(&application.plaintext)
                 != mls_plaintext_application
                     .encode_detached()
-                    .expect("Error encoding MLSPlaintext")
+                    .expect("Error encoding MlsPlaintext")
             {
                 if cfg!(test) {
                     panic!("Decrypted application message mismatch");
@@ -510,7 +510,7 @@ pub fn run_test_vector(test_vector: EncryptionTestVector) -> Result<(), EncTestV
             // Setup group
             let mls_ciphertext_handshake =
                 MlsCiphertext::decode(&mut Cursor::new(&hex_to_bytes(&handshake.ciphertext)))
-                    .expect("Error parsing MLSCiphertext");
+                    .expect("Error parsing MlsCiphertext");
             let mut group = receiver_group(ciphersuite, &mls_ciphertext_handshake.group_id);
             *group.epoch_secrets_mut().sender_data_secret_mut() = SenderDataSecret::from_slice(
                 hex_to_bytes(&test_vector.sender_data_secret).as_slice(),
@@ -521,11 +521,11 @@ pub fn run_test_vector(test_vector: EncryptionTestVector) -> Result<(), EncTestV
             // Decrypt and check message
             let mls_plaintext_handshake = mls_ciphertext_handshake
                 .to_plaintext(ciphersuite, group.epoch_secrets(), &mut secret_tree)
-                .expect("Error decrypting MLSCiphertext");
+                .expect("Error decrypting MlsCiphertext");
             if hex_to_bytes(&handshake.plaintext)
                 != mls_plaintext_handshake
                     .encode_detached()
-                    .expect("Error encoding MLSPlaintext")
+                    .expect("Error encoding MlsPlaintext")
             {
                 if cfg!(test) {
                     panic!("Decrypted handshake message mismatch");

--- a/src/tree/tests/kat_encryption.rs
+++ b/src/tree/tests/kat_encryption.rs
@@ -131,7 +131,6 @@ pub struct EncryptionTestVector {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 fn group(ciphersuite: &Ciphersuite) -> MlsGroup {
     let credential_bundle = CredentialBundle::new(
         "Kreator".into(),
@@ -153,7 +152,6 @@ fn group(ciphersuite: &Ciphersuite) -> MlsGroup {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 fn receiver_group(ciphersuite: &Ciphersuite, group_id: &GroupId) -> MlsGroup {
     let credential_bundle = CredentialBundle::new(
         "Receiver".into(),
@@ -175,7 +173,6 @@ fn receiver_group(ciphersuite: &Ciphersuite, group_id: &GroupId) -> MlsGroup {
 
 // XXX: we could be more creative in generating these messages.
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 fn build_handshake_messages(leaf: LeafIndex, group: &mut MlsGroup) -> (Vec<u8>, Vec<u8>) {
     let sender = Sender {
         sender_type: SenderType::Member,
@@ -211,7 +208,6 @@ fn build_handshake_messages(leaf: LeafIndex, group: &mut MlsGroup) -> (Vec<u8>, 
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 fn build_application_messages(leaf: LeafIndex, group: &mut MlsGroup) -> (Vec<u8>, Vec<u8>) {
     let sender = Sender {
         sender_type: SenderType::Member,
@@ -247,7 +243,6 @@ fn build_application_messages(leaf: LeafIndex, group: &mut MlsGroup) -> (Vec<u8>
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 pub fn generate_test_vector(
     n_generations: u32,
     n_leaves: u32,
@@ -349,7 +344,6 @@ fn write_test_vectors() {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 pub fn run_test_vector(test_vector: EncryptionTestVector) -> Result<(), EncTestVectorError> {
     let n_leaves = test_vector.n_leaves;
     if n_leaves != test_vector.leaves.len() as u32 {

--- a/src/tree/tests/kat_treemath.rs
+++ b/src/tree/tests/kat_treemath.rs
@@ -61,6 +61,7 @@ macro_rules! convert {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
+#[allow(dead_code)]
 pub fn generate_test_vector(n_leaves: u32) -> TreeMathTestVector {
     let leaves = LeafIndex::from(n_leaves);
     let n_nodes = node_width(leaves.as_usize()) as u32;
@@ -106,31 +107,32 @@ fn write_test_vectors() {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-pub fn run_test_vector(test_vector: TreeMathTestVector) -> Result<(), TMTestVectorError> {
+#[allow(dead_code)]
+pub fn run_test_vector(test_vector: TreeMathTestVector) -> Result<(), TmTestVectorError> {
     let n_leaves = test_vector.n_leaves as usize;
     let n_nodes = node_width(n_leaves);
     let leaves = LeafIndex::from(n_leaves);
     if test_vector.n_nodes != node_width(leaves.as_usize()) as u32 {
-        return Err(TMTestVectorError::TreeSizeMismatch);
+        return Err(TmTestVectorError::TreeSizeMismatch);
     }
     for i in 0..n_leaves {
         if test_vector.root[i] != root(LeafIndex::from(i + 1)).as_u32() {
-            return Err(TMTestVectorError::RootIndexMismatch);
+            return Err(TmTestVectorError::RootIndexMismatch);
         }
     }
 
     for i in 0..n_nodes {
         if test_vector.left[i] != convert!(left(NodeIndex::from(i))) {
-            return Err(TMTestVectorError::LeftIndexMismatch);
+            return Err(TmTestVectorError::LeftIndexMismatch);
         }
         if test_vector.right[i] != convert!(right(NodeIndex::from(i), leaves)) {
-            return Err(TMTestVectorError::RightIndexMismatch);
+            return Err(TmTestVectorError::RightIndexMismatch);
         }
         if test_vector.parent[i] != convert!(parent(NodeIndex::from(i), leaves)) {
-            return Err(TMTestVectorError::ParentIndexMismatch);
+            return Err(TmTestVectorError::ParentIndexMismatch);
         }
         if test_vector.sibling[i] != convert!(sibling(NodeIndex::from(i), leaves)) {
-            return Err(TMTestVectorError::SiblingIndexMismatch);
+            return Err(TmTestVectorError::SiblingIndexMismatch);
         }
     }
     Ok(())
@@ -149,7 +151,7 @@ fn read_test_vectors() {
 
 #[cfg(any(feature = "expose-test-vectors", test))]
 implement_error! {
-    pub enum TMTestVectorError {
+    pub enum TmTestVectorError {
         TreeSizeMismatch = "The computed tree size doesn't match the one in the test vector.",
         RootIndexMismatch = "The computed root index doesn't match the one in the test vector.",
         LeftIndexMismatch = "A computed left child index doesn't match the one in the test vector.",

--- a/src/tree/tests/kat_treemath.rs
+++ b/src/tree/tests/kat_treemath.rs
@@ -61,7 +61,6 @@ macro_rules! convert {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 pub fn generate_test_vector(n_leaves: u32) -> TreeMathTestVector {
     let leaves = LeafIndex::from(n_leaves);
     let n_nodes = node_width(leaves.as_usize()) as u32;
@@ -107,7 +106,6 @@ fn write_test_vectors() {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 pub fn run_test_vector(test_vector: TreeMathTestVector) -> Result<(), TmTestVectorError> {
     let n_leaves = test_vector.n_leaves as usize;
     let n_nodes = node_width(n_leaves);

--- a/src/tree/tests/mod.rs
+++ b/src/tree/tests/mod.rs
@@ -1,9 +1,9 @@
 //! Tree unit tests.
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-mod kat_encryption;
+pub mod kat_encryption;
 #[cfg(any(feature = "expose-test-vectors", test))]
-mod kat_treemath;
+pub mod kat_treemath;
 
 #[cfg(test)]
 mod test_hashes;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,11 +11,13 @@ pub(crate) fn randombytes(n: usize) -> Vec<u8> {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
+#[allow(dead_code)]
 pub(crate) fn random_u32() -> u32 {
     OsRng.next_u32()
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
+#[allow(dead_code)]
 pub(crate) fn random_u64() -> u64 {
     OsRng.next_u64()
 }
@@ -190,6 +192,7 @@ macro_rules! implement_persistence {
         }
 
         impl Serialize for $name {
+            #[allow(clippy::vec_init_then_push)]
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: Serializer,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,13 +11,11 @@ pub(crate) fn randombytes(n: usize) -> Vec<u8> {
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 pub(crate) fn random_u32() -> u32 {
     OsRng.next_u32()
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]
-#[allow(dead_code)]
 pub(crate) fn random_u64() -> u64 {
     OsRng.next_u64()
 }

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -38,7 +38,7 @@ fn default_extensions() {
         vec![
             ExtensionType::Capabilities,
             ExtensionType::Lifetime,
-            ExtensionType::KeyID
+            ExtensionType::KeyId
         ],
         supported_extensions
     );

--- a/tests/test_decryption_key_index.rs
+++ b/tests/test_decryption_key_index.rs
@@ -4,11 +4,9 @@ use openmls::prelude::*;
 #[macro_use]
 mod utils;
 
-use std::convert::TryFrom;
 use utils::managed_utils::*;
 
-ctest_ciphersuites!(decryption_key_index_computation, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(decryption_key_index_computation, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 

--- a/tests/test_encoding.rs
+++ b/tests/test_encoding.rs
@@ -1,5 +1,5 @@
 use openmls::prelude::*;
-mod utils;
+pub mod utils;
 use utils::mls_utils::*;
 
 /// Creates a simple test setup for various encoding tests.

--- a/tests/test_encoding.rs
+++ b/tests/test_encoding.rs
@@ -70,7 +70,7 @@ fn test_application_message_encoding() {
             let encrypted_message_decoded =
                 match MlsCiphertext::decode(&mut Cursor::new(&encrypted_message_bytes)) {
                     Ok(a) => a,
-                    Err(err) => panic!("Error decoding MLSCiphertext: {:?}", err),
+                    Err(err) => panic!("Error decoding MlsCiphertext: {:?}", err),
                 };
             assert_eq!(encrypted_message, encrypted_message_decoded);
         }

--- a/tests/test_encoding.rs
+++ b/tests/test_encoding.rs
@@ -68,7 +68,7 @@ fn test_application_message_encoding() {
                 .unwrap();
             let encrypted_message_bytes = encrypted_message.encode_detached().unwrap();
             let encrypted_message_decoded =
-                match MLSCiphertext::decode(&mut Cursor::new(&encrypted_message_bytes)) {
+                match MlsCiphertext::decode(&mut Cursor::new(&encrypted_message_bytes)) {
                     Ok(a) => a,
                     Err(err) => panic!("Error decoding MLSCiphertext: {:?}", err),
                 };
@@ -116,7 +116,7 @@ fn test_update_proposal_encoding() {
         let update_encoded = update
             .encode_detached()
             .expect("Could not encode proposal.");
-        let update_decoded = match MLSPlaintext::decode(&mut Cursor::new(&update_encoded)) {
+        let update_decoded = match MlsPlaintext::decode(&mut Cursor::new(&update_encoded)) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Update: {:?}", err),
         };
@@ -163,7 +163,7 @@ fn test_add_proposal_encoding() {
             )
             .expect("Could not create proposal.");
         let add_encoded = add.encode_detached().expect("Could not encode proposal.");
-        let add_decoded = match MLSPlaintext::decode(&mut Cursor::new(&add_encoded)) {
+        let add_decoded = match MlsPlaintext::decode(&mut Cursor::new(&add_encoded)) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Add: {:?}", err),
         };
@@ -191,7 +191,7 @@ fn test_remove_proposal_encoding() {
         let remove_encoded = remove
             .encode_detached()
             .expect("Could not encode proposal.");
-        let remove_decoded = match MLSPlaintext::decode(&mut Cursor::new(&remove_encoded)) {
+        let remove_decoded = match MlsPlaintext::decode(&mut Cursor::new(&remove_encoded)) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Remove: {:?}", err),
         };
@@ -262,7 +262,7 @@ fn test_commit_encoding() {
             .create_commit(&[], alice_credential_bundle, proposals, &[], true, None)
             .unwrap();
         let commit_encoded = commit.encode_detached().unwrap();
-        let commit_decoded = match MLSPlaintext::decode(&mut Cursor::new(&commit_encoded)) {
+        let commit_decoded = match MlsPlaintext::decode(&mut Cursor::new(&commit_encoded)) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding MPLSPlaintext Commit: {:?}", err),
         };

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -369,7 +369,7 @@ fn group_operations() {
             .unwrap();
         let mls_plaintext_bob = match group_bob.decrypt(&mls_ciphertext_alice) {
             Ok(mls_plaintext) => mls_plaintext,
-            Err(e) => panic!("Error decrypting MLSCiphertext: {:?}", e),
+            Err(e) => panic!("Error decrypting MlsCiphertext: {:?}", e),
         };
         assert_eq!(
             message_alice,
@@ -621,11 +621,11 @@ fn group_operations() {
             .unwrap();
         let mls_plaintext_alice = match group_alice.decrypt(&mls_ciphertext_charlie.clone()) {
             Ok(mls_plaintext) => mls_plaintext,
-            Err(e) => panic!("Error decrypting MLSCiphertext: {:?}", e),
+            Err(e) => panic!("Error decrypting MlsCiphertext: {:?}", e),
         };
         let mls_plaintext_bob = match group_bob.decrypt(&mls_ciphertext_charlie) {
             Ok(mls_plaintext) => mls_plaintext,
-            Err(e) => panic!("Error decrypting MLSCiphertext: {:?}", e),
+            Err(e) => panic!("Error decrypting MlsCiphertext: {:?}", e),
         };
         assert_eq!(
             message_charlie,

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -76,7 +76,7 @@ fn create_commit_optional_path() {
             .create_commit(
                 group_aad,
                 &alice_credential_bundle,
-                &(epoch_proposals.iter().collect::<Vec<&MLSPlaintext>>()),
+                &(epoch_proposals.iter().collect::<Vec<&MlsPlaintext>>()),
                 &[],
                 true, /* force self-update */
                 None, /* No PSK fetcher */
@@ -85,7 +85,7 @@ fn create_commit_optional_path() {
             Err(e) => panic!("Error creating commit: {:?}", e),
         };
         let commit = match mls_plaintext_commit.content() {
-            MLSPlaintextContentType::Commit(commit) => commit,
+            MlsPlaintextContentType::Commit(commit) => commit,
             _ => panic!(),
         };
         assert!(commit.has_path());
@@ -112,7 +112,7 @@ fn create_commit_optional_path() {
             Err(e) => panic!("Error creating commit: {:?}", e),
         };
         let commit = match mls_plaintext_commit.content() {
-            MLSPlaintextContentType::Commit(commit) => commit,
+            MlsPlaintextContentType::Commit(commit) => commit,
             _ => panic!(),
         };
         assert!(!commit.has_path() && kpb_option.is_none());
@@ -163,7 +163,7 @@ fn create_commit_optional_path() {
             Err(e) => panic!("Error creating commit: {:?}", e),
         };
         let commit = match commit_mls_plaintext.content() {
-            MLSPlaintextContentType::Commit(commit) => commit,
+            MlsPlaintextContentType::Commit(commit) => commit,
             _ => panic!(),
         };
         assert!(commit.has_path() && kpb_option.is_some());
@@ -322,7 +322,7 @@ fn group_operations() {
             )
             .expect("Error creating commit");
         let commit = match mls_plaintext_commit.content() {
-            MLSPlaintextContentType::Commit(commit) => commit,
+            MlsPlaintextContentType::Commit(commit) => commit,
             _ => panic!("Wrong content type"),
         };
         assert!(!commit.has_path() && kpb_option.is_none());

--- a/tests/test_interop_scenarios.rs
+++ b/tests/test_interop_scenarios.rs
@@ -1,5 +1,4 @@
 use openmls::prelude::*;
-use std::convert::TryFrom;
 
 #[macro_use]
 mod utils;
@@ -23,8 +22,7 @@ fn default_managed_group_config() -> ManagedGroupConfig {
 // B->A: KeyPackage
 // A->B: Welcome
 // ***:  Verify group state
-ctest_ciphersuites!(one_to_one_join, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(one_to_one_join, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
     let number_of_clients = 2;
@@ -59,8 +57,7 @@ ctest_ciphersuites!(one_to_one_join, test(param: CiphersuiteName) {
 // A->B: Add(C), Commit
 // A->C: Welcome
 // ***:  Verify group state
-ctest_ciphersuites!(three_party_join, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(three_party_join, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
@@ -103,8 +100,7 @@ ctest_ciphersuites!(three_party_join, test(param: CiphersuiteName) {
 // A->B: Welcome
 // A->C: Welcome
 // ***:  Verify group state
-ctest_ciphersuites!(multiple_joins, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(multiple_joins, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
@@ -141,8 +137,7 @@ ctest_ciphersuites!(multiple_joins, test(param: CiphersuiteName) {
 // A->B: Welcome
 // A->B: Update, Commit
 // ***:  Verify group state
-ctest_ciphersuites!(update, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(update, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
@@ -176,8 +171,7 @@ ctest_ciphersuites!(update, test(param: CiphersuiteName) {
 // A->C: Welcome
 // A->B: Remove(B), Commit
 // ***:  Verify group state
-ctest_ciphersuites!(remove, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(remove, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
@@ -215,8 +209,7 @@ ctest_ciphersuites!(remove, test(param: CiphersuiteName) {
 // * All members update
 // * While the group size is >1, a randomly-chosen group member removes a
 //   randomly-chosen other group member
-ctest_ciphersuites!(large_group_lifecycle, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(large_group_lifecycle, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -1,13 +1,11 @@
 //! # Key package tests
 
 use openmls::prelude::*;
-use std::convert::TryFrom;
 
 #[macro_use]
 mod utils;
 
-ctest_ciphersuites!(key_package_generation, test(param: CiphersuiteName) {
-    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+ctest_ciphersuites!(key_package_generation, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
 
@@ -58,7 +56,7 @@ ctest_ciphersuites!(key_package_generation, test(param: CiphersuiteName) {
     // Add and retrieve a key package ID.
     let key_id = [1, 2, 3, 4, 5, 6, 7];
     kpb.key_package_mut()
-        .add_extension(Box::new(KeyIDExtension::new(&key_id)));
+        .add_extension(Box::new(KeyIdExtension::new(&key_id)));
 
     // The key package is invalid because the signature is invalid now.
     assert!(kpb.key_package().verify().is_err());
@@ -71,7 +69,7 @@ ctest_ciphersuites!(key_package_generation, test(param: CiphersuiteName) {
     let extensions = kpb.key_package().extensions();
     let key_id_extension = extensions
         .iter()
-        .find(|e| e.extension_type() == ExtensionType::KeyID)
+        .find(|e| e.extension_type() == ExtensionType::KeyId)
         .expect("Key ID extension is missing in key package");
     let key_id_extension = key_id_extension.to_key_id_extension().unwrap();
     assert_eq!(&key_id, key_id_extension.as_slice());

--- a/tests/utils/managed_utils/client.rs
+++ b/tests/utils/managed_utils/client.rs
@@ -126,7 +126,7 @@ impl<'key_store_lifetime> Client<'key_store_lifetime> {
     /// Have the client process the given messages. Returns an error if an error
     /// occurs during message processing or if no group exists for one of the
     /// messages.
-    pub fn receive_messages_for_group(&self, messages: &[MLSMessage]) -> Result<(), ClientError> {
+    pub fn receive_messages_for_group(&self, messages: &[MlsMessage]) -> Result<(), ClientError> {
         let mut group_states = self.groups.borrow_mut();
         for message in messages {
             let group_id = GroupId::from_slice(&message.group_id());
@@ -170,7 +170,7 @@ impl<'key_store_lifetime> Client<'key_store_lifetime> {
         action_type: ActionType,
         group_id: &GroupId,
         key_package_bundle_option: Option<KeyPackageBundle>,
-    ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ClientError> {
+    ) -> Result<(Vec<MlsMessage>, Option<Welcome>), ClientError> {
         let mut groups = self.groups.borrow_mut();
         let group = groups
             .get_mut(group_id)
@@ -192,7 +192,7 @@ impl<'key_store_lifetime> Client<'key_store_lifetime> {
         action_type: ActionType,
         group_id: &GroupId,
         key_packages: &[KeyPackage],
-    ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ClientError> {
+    ) -> Result<(Vec<MlsMessage>, Option<Welcome>), ClientError> {
         let mut groups = self.groups.borrow_mut();
         let group = groups
             .get_mut(group_id)
@@ -217,7 +217,7 @@ impl<'key_store_lifetime> Client<'key_store_lifetime> {
         action_type: ActionType,
         group_id: &GroupId,
         target_indices: &[usize],
-    ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ClientError> {
+    ) -> Result<(Vec<MlsMessage>, Option<Welcome>), ClientError> {
         let mut groups = self.groups.borrow_mut();
         let group = groups
             .get_mut(group_id)

--- a/tests/utils/managed_utils/mod.rs
+++ b/tests/utils/managed_utils/mod.rs
@@ -250,7 +250,7 @@ impl<'ks> ManagedTestSetup<'ks> {
         // been removed from the group.
         sender_id: &[u8],
         group: &mut Group,
-        messages: &[MLSMessage],
+        messages: &[MlsMessage],
     ) -> Result<(), ClientError> {
         let clients = self.clients.borrow();
         println!("Distributing and processing messages...");
@@ -371,8 +371,7 @@ impl<'ks> ManagedTestSetup<'ks> {
         let group = creator_groups.get(&group_id).unwrap();
         let public_tree = group.export_ratchet_tree();
         let exporter_secret = group.export_secret("test", &[], 32)?;
-        let mut member_ids = Vec::new();
-        member_ids.push((0, group_creator_id));
+        let member_ids = vec![(0, group_creator_id)];
         let group = Group {
             group_id: group_id.clone(),
             members: member_ids,

--- a/tests/utils/mls_utils/mod.rs
+++ b/tests/utils/mls_utils/mod.rs
@@ -187,7 +187,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                 .create_commit(
                     group_aad,
                     &initial_credential_bundle,
-                    &(proposal_list.iter().collect::<Vec<&MLSPlaintext>>()),
+                    &(proposal_list.iter().collect::<Vec<&MlsPlaintext>>()),
                     &[],
                     true, /* Set this to true to populate the tree a little bit. */
                     None, /* PSKs are not supported here */
@@ -199,7 +199,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
             // the key package bundle returned by the create_commit earlier.
             match mls_group.apply_commit(
                 &commit_mls_plaintext,
-                &(proposal_list.iter().collect::<Vec<&MLSPlaintext>>()),
+                &(proposal_list.iter().collect::<Vec<&MlsPlaintext>>()),
                 &[key_package_bundle],
                 None,
             ) {

--- a/tests/utils/mls_utils/mod.rs
+++ b/tests/utils/mls_utils/mod.rs
@@ -260,25 +260,19 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
     }
 }
 
-#[allow(dead_code)]
 pub fn random_usize() -> usize {
     OsRng.next_u64() as usize
 }
 
-#[allow(dead_code)]
 pub fn randombytes(n: usize) -> Vec<u8> {
     get_random_vec(n)
 }
 
-// Not currently used.
-//pub(crate) fn hex_to_bytes(hex: &str) -> Vec<u8> {
-//    let mut bytes = Vec::new();
-//    for i in 0..(hex.len() / 2) {
-//        let b = u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).unwrap();
-//        bytes.push(b);
-//    }
-//    bytes
-//}
+#[test]
+fn test_random() {
+    random_usize();
+    randombytes(0);
+}
 
 #[test]
 fn test_setup() {

--- a/tls-codec-derive/tests/decode.rs
+++ b/tls-codec-derive/tests/decode.rs
@@ -8,7 +8,7 @@ pub enum ExtensionType {
     Reserved = 0,
     Capabilities = 1,
     Lifetime = 2,
-    KeyID = 3,
+    KeyId = 3,
     ParentHash = 4,
     RatchetTree = 5,
     SomethingElse = 500,
@@ -53,7 +53,7 @@ fn simple_enum() {
 fn simple_struct() {
     let b = [0, 3, 0, 5, 1, 2, 3, 4, 5];
     let extension = ExtensionStruct {
-        extension_type: ExtensionType::KeyID,
+        extension_type: ExtensionType::KeyId,
         extension_data: TlsVecU16::from_slice(&[1, 2, 3, 4, 5]),
     };
     let deserialized = ExtensionStruct::tls_deserialize_detached(&b).unwrap();
@@ -64,7 +64,7 @@ fn simple_struct() {
         data: TlsVecU8::from_slice(&[
             ExtensionType::Capabilities,
             ExtensionType::Lifetime,
-            ExtensionType::KeyID,
+            ExtensionType::KeyId,
             ExtensionType::SomethingElse,
         ]),
     };

--- a/tls-codec-derive/tests/decode.rs
+++ b/tls-codec-derive/tests/decode.rs
@@ -2,7 +2,6 @@ use tls_codec::{Cursor, Deserialize, Serialize, TlsVecU16, TlsVecU8};
 use tls_codec_derive::{TlsDeserialize, TlsSerialize};
 
 #[derive(TlsDeserialize, Debug, PartialEq, Clone, Copy, TlsSerialize)]
-#[allow(dead_code)]
 #[repr(u16)]
 pub enum ExtensionType {
     Reserved = 0,

--- a/tls-codec-derive/tests/encode.rs
+++ b/tls-codec-derive/tests/encode.rs
@@ -2,7 +2,6 @@ use tls_codec::{Serialize, TlsVecU16};
 use tls_codec_derive::TlsSerialize;
 
 #[derive(TlsSerialize, Debug)]
-#[allow(dead_code)]
 #[repr(u16)]
 pub enum ExtensionType {
     Reserved = 0,

--- a/tls-codec-derive/tests/encode.rs
+++ b/tls-codec-derive/tests/encode.rs
@@ -8,7 +8,7 @@ pub enum ExtensionType {
     Reserved = 0,
     Capabilities = 1,
     Lifetime = 2,
-    KeyID = 3,
+    KeyId = 3,
     ParentHash = 4,
     RatchetTree = 5,
     SomethingElse = 500,
@@ -22,7 +22,7 @@ pub struct ExtensionStruct {
 
 #[test]
 fn simple_enum() {
-    let serialized = ExtensionType::KeyID.tls_serialize_detached().unwrap();
+    let serialized = ExtensionType::KeyId.tls_serialize_detached().unwrap();
     assert_eq!(vec![0, 3], serialized);
     let serialized = ExtensionType::SomethingElse
         .tls_serialize_detached()
@@ -33,7 +33,7 @@ fn simple_enum() {
 #[test]
 fn simple_struct() {
     let extension = ExtensionStruct {
-        extension_type: ExtensionType::KeyID,
+        extension_type: ExtensionType::KeyId,
         extension_data: TlsVecU16::from_slice(&[1, 2, 3, 4, 5]),
     };
     let serialized = extension.tls_serialize_detached().unwrap();


### PR DESCRIPTION
This PR tries to get rid of the clippy warnings that were introduced in past PRs.

No other code changes were made, except for the ones strictly necessary to get rid of the warnings.