### PR TITLE
Change the Managed Group to accept a KeyStore ref instead of keeping a CredentialBundle ref

### DIFF
--- a/src/group/managed_group/errors.rs
+++ b/src/group/managed_group/errors.rs
@@ -7,27 +7,36 @@ use crate::codec::CodecError;
 use crate::config::ConfigError;
 use crate::error::{ErrorPayload, ErrorString};
 use crate::group::{ApplyCommitError, CreateCommitError, ExporterError, GroupError};
+use crate::key_store::KeyStoreError;
 
 implement_error! {
     pub enum ManagedGroupError {
-        LibraryError(ErrorString) =
-            "An internal library error occurred. Additional detail is provided.",
-        Codec(CodecError) =
-            "See [`CodecError`](`crate::codec::CodecError`) for details",
-        Config(ConfigError) =
-            "See [`ConfigError`](`crate::config::ConfigError`) for details",
-        Group(GroupError) =
-            "See [`GroupError`](`crate::group::GroupError`) for details",
-        CreateCommit(CreateCommitError) =
-            "See [`CreateCommitError`](`crate::group::CreateCommitError`) for details",
-        UseAfterEviction(UseAfterEviction) =
-            "See [`UseAfterEviction`](`UseAfterEviction`) for details",
-        PendingProposalsExist(PendingProposalsError) =
-            "See [`PendingProposalsError`](`PendingProposalsError`) for details",
-        Exporter(ExporterError) =
-            "See [`ExporterError`](`crate::group::ExporterError`) for details",
-        EmptyInput(EmptyInputError) =
-            "Empty input. Additional detail is provided.",
+        Simple {
+            NoMatchingCredentialBundle = "Couldn't find a `CredentialBundle` in the `KeyStore` that matches the one in my leaf.",
+            NoMatchingKeyPackageBundle = "Couldn't find a `KeyPackageBundle` in the `KeyStore` that matches the given `KeyPackage` hash.",
+            PoisonedCredentialBundle = "Tried to access a poisoned `CredentialBundle`. See [`PoisonError`](`std::sync::PoisonError`) for details.",
+        }
+        Complex {
+            LibraryError(ErrorString) =
+                "An internal library error occurred. Additional detail is provided.",
+            Codec(CodecError) =
+                "See [`CodecError`](`crate::codec::CodecError`) for details",
+            Config(ConfigError) =
+                "See [`ConfigError`](`crate::config::ConfigError`) for details",
+            Group(GroupError) =
+                "See [`GroupError`](`crate::group::GroupError`) for details",
+            CreateCommit(CreateCommitError) =
+                "See [`CreateCommitError`](`crate::group::CreateCommitError`) for details",
+            UseAfterEviction(UseAfterEviction) =
+                "See [`UseAfterEviction`](`UseAfterEviction`) for details",
+            PendingProposalsExist(PendingProposalsError) =
+                "See [`PendingProposalsError`](`PendingProposalsError`) for details",
+            Exporter(ExporterError) =
+                "See [`ExporterError`](`crate::group::ExporterError`) for details",
+            EmptyInput(EmptyInputError) =
+                "Empty input. Additional detail is provided.",
+            KeyStoreError(KeyStoreError) = "See [`KeyStoreError`](`crate::key_store::KeyStoreError`) for details",
+        }
     }
 }
 

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -757,7 +757,9 @@ impl ManagedGroup {
     }
 
     /// Returns own credential. If the group is inactive, it returns a
-    /// `UseAfterEviction` error.
+    /// `UseAfterEviction` error. This function currently returns a full
+    /// `Credential` rather than just a reference. This issue is tracked in
+    /// issue #387.
     pub fn credential(&self) -> Result<Credential, ManagedGroupError> {
         if !self.is_active() {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -8,11 +8,12 @@ mod ser;
 mod test_managed_group;
 
 use crate::{
-    credentials::{Credential, CredentialBundle},
+    credentials::Credential,
     error::ErrorString,
     framing::*,
     group::*,
     key_packages::{KeyPackage, KeyPackageBundle},
+    key_store::KeyStore,
     messages::{proposals::*, Welcome},
     schedule::ResumptionSecret,
     tree::{index::LeafIndex, node::Node},
@@ -60,10 +61,7 @@ use ser::*;
 /// Changes to the group state are dispatched as events through callback
 /// functions (see [`ManagedGroupCallbacks`]).
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
-pub struct ManagedGroup<'a> {
-    // CredentialBundle used to sign messages
-    credential_bundle: &'a CredentialBundle,
+pub struct ManagedGroup {
     // The group configuration. See `ManagedGroupCongig` for more information.
     managed_group_config: ManagedGroupConfig,
     // the internal `MlsGroup` used for lower level operations. See `MlsGroup` for more
@@ -86,17 +84,23 @@ pub struct ManagedGroup<'a> {
     active: bool,
 }
 
-impl<'a> ManagedGroup<'a> {
+impl ManagedGroup {
     // === Group creation ===
 
-    /// Creates a new group from scratch with only the creator as a member.
+    /// Creates a new group from scratch with only the creator as a member. This
+    /// function removes the `KeyPackageBundle` corresponding to the
+    /// `key_package_hash` from the `key_store`. Throws an error if no
+    /// `KeyPackageBundle` can be found.
     pub fn new(
-        credential_bundle: &'a CredentialBundle,
+        key_store: &KeyStore,
         managed_group_config: &ManagedGroupConfig,
         group_id: GroupId,
-        key_package_bundle: KeyPackageBundle,
+        key_package_hash: &[u8],
     ) -> Result<Self, ManagedGroupError> {
         // TODO #141
+        let key_package_bundle = key_store
+            .take_key_package_bundle(key_package_hash)
+            .ok_or(ManagedGroupError::NoMatchingKeyPackageBundle)?;
         let group = MlsGroup::new(
             &group_id.as_slice(),
             key_package_bundle.key_package().ciphersuite_name(),
@@ -109,7 +113,6 @@ impl<'a> ManagedGroup<'a> {
             ResumptionSecretStore::new(managed_group_config.number_of_resumption_secrets);
 
         let managed_group = ManagedGroup {
-            credential_bundle,
             managed_group_config: managed_group_config.clone(),
             group,
             pending_proposals: vec![],
@@ -127,20 +130,22 @@ impl<'a> ManagedGroup<'a> {
 
     /// Creates a new group from a `Welcome` message
     pub fn new_from_welcome(
-        credential_bundle: &'a CredentialBundle,
+        key_store: &KeyStore,
         managed_group_config: &ManagedGroupConfig,
         welcome: Welcome,
         ratchet_tree: Option<Vec<Option<Node>>>,
-        key_package_bundle: KeyPackageBundle,
-    ) -> Result<Self, GroupError> {
+    ) -> Result<Self, ManagedGroupError> {
+        let resumption_secret_store =
+            ResumptionSecretStore::new(managed_group_config.number_of_resumption_secrets);
+        let key_package_bundle = welcome
+            .secrets()
+            .iter()
+            .find_map(|egs| key_store.take_key_package_bundle(&egs.key_package_hash))
+            .ok_or(ManagedGroupError::NoMatchingKeyPackageBundle)?;
         // TODO #141
         let group = MlsGroup::new_from_welcome(welcome, ratchet_tree, key_package_bundle, None)?;
 
-        let resumption_secret_store =
-            ResumptionSecretStore::new(managed_group_config.number_of_resumption_secrets);
-
         let managed_group = ManagedGroup {
-            credential_bundle,
             managed_group_config: managed_group_config.clone(),
             group,
             pending_proposals: vec![],
@@ -167,6 +172,7 @@ impl<'a> ManagedGroup<'a> {
     /// [`Welcome`](crate::prelude::Welcome) message.
     pub fn add_members(
         &mut self,
+        key_store: &KeyStore,
         key_packages: &[KeyPackage],
     ) -> Result<(Vec<MLSMessage>, Welcome), ManagedGroupError> {
         if !self.active {
@@ -194,16 +200,22 @@ impl<'a> ManagedGroup<'a> {
             .iter()
             .collect::<Vec<&MLSPlaintext>>();
 
+        let credential = self.credential()?;
+        let credential_bundle = key_store
+            .get_credential_bundle(credential.signature_key())
+            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+
         // Create Commit over all proposals
         // TODO #141
         let (commit, welcome_option, kpb_option) = self.group.create_commit(
             &self.aad,
-            &self.credential_bundle,
+            &credential_bundle,
             proposals_by_reference,
             proposals_by_value,
             false,
             None,
         )?;
+
         let welcome = match welcome_option {
             Some(welcome) => welcome,
             None => {
@@ -238,6 +250,7 @@ impl<'a> ManagedGroup<'a> {
     /// in the queue of pending proposals.
     pub fn remove_members(
         &mut self,
+        key_store: &KeyStore,
         members: &[usize],
     ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ManagedGroupError> {
         if !self.active {
@@ -267,11 +280,16 @@ impl<'a> ManagedGroup<'a> {
             .iter()
             .collect::<Vec<&MLSPlaintext>>();
 
+        let credential = self.credential()?;
+        let credential_bundle = key_store
+            .get_credential_bundle(credential.signature_key())
+            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+
         // Create Commit over all proposals
         // TODO #141
         let (commit, welcome_option, kpb_option) = self.group.create_commit(
             &self.aad,
-            &self.credential_bundle,
+            &credential_bundle,
             proposals_by_reference,
             proposals_by_value,
             false,
@@ -300,17 +318,24 @@ impl<'a> ManagedGroup<'a> {
     /// Creates proposals to add members to the group
     pub fn propose_add_members(
         &mut self,
+        key_store: &KeyStore,
         key_packages: &[KeyPackage],
     ) -> Result<Vec<MLSMessage>, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
+
+        let credential = self.credential()?;
+        let credential_bundle = key_store
+            .get_credential_bundle(credential.signature_key())
+            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+
         let plaintext_messages: Vec<MLSPlaintext> = {
             let mut messages = vec![];
             for key_package in key_packages.iter() {
                 let add_proposal = self.group.create_add_proposal(
                     &self.aad,
-                    &self.credential_bundle,
+                    &credential_bundle,
                     key_package.clone(),
                 )?;
                 messages.push(add_proposal);
@@ -329,17 +354,24 @@ impl<'a> ManagedGroup<'a> {
     /// Creates proposals to remove members from the group
     pub fn propose_remove_members(
         &mut self,
+        key_store: &KeyStore,
         members: &[usize],
     ) -> Result<Vec<MLSMessage>, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
+
+        let credential = self.credential()?;
+        let credential_bundle = key_store
+            .get_credential_bundle(credential.signature_key())
+            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+
         let plaintext_messages: Vec<MLSPlaintext> = {
             let mut messages = vec![];
             for member in members.iter() {
                 let remove_proposal = self.group.create_remove_proposal(
                     &self.aad,
-                    &self.credential_bundle,
+                    &credential_bundle,
                     LeafIndex::from(*member),
                 )?;
                 messages.push(remove_proposal);
@@ -356,13 +388,22 @@ impl<'a> ManagedGroup<'a> {
     }
 
     /// Leave the group
-    pub fn leave_group(&mut self) -> Result<Vec<MLSMessage>, ManagedGroupError> {
+    pub fn leave_group(
+        &mut self,
+        key_store: &KeyStore,
+    ) -> Result<Vec<MLSMessage>, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
+
+        let credential = self.credential()?;
+        let credential_bundle = key_store
+            .get_credential_bundle(credential.signature_key())
+            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+
         let remove_proposal = self.group.create_remove_proposal(
             &self.aad,
-            &self.credential_bundle,
+            &credential_bundle,
             self.group.tree().own_node_index(),
         )?;
 
@@ -569,7 +610,11 @@ impl<'a> ManagedGroup<'a> {
     /// Returns `ManagedGroupError::PendingProposalsExist` if pending proposals
     /// exist. In that case `.process_pending_proposals()` must be called first
     /// and incoming messages from the DS must be processed afterwards.
-    pub fn create_message(&mut self, message: &[u8]) -> Result<MLSMessage, ManagedGroupError> {
+    pub fn create_message(
+        &mut self,
+        key_store: &KeyStore,
+        message: &[u8],
+    ) -> Result<MLSMessage, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
@@ -578,10 +623,16 @@ impl<'a> ManagedGroup<'a> {
                 PendingProposalsError::Exists,
             ));
         }
+
+        let credential = self.credential()?;
+        let credential_bundle = key_store
+            .get_credential_bundle(credential.signature_key())
+            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+
         let ciphertext = self.group.create_application_message(
             &self.aad,
             message,
-            &self.credential_bundle,
+            &credential_bundle,
             self.configuration().padding_size(),
         )?;
 
@@ -594,6 +645,7 @@ impl<'a> ManagedGroup<'a> {
     /// Process pending proposals
     pub fn process_pending_proposals(
         &mut self,
+        key_store: &KeyStore,
     ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
@@ -601,11 +653,16 @@ impl<'a> ManagedGroup<'a> {
         // Include pending proposals into Commit
         let messages_to_commit: Vec<&MLSPlaintext> = self.pending_proposals.iter().collect();
 
+        let credential = self.credential()?;
+        let credential_bundle = key_store
+            .get_credential_bundle(credential.signature_key())
+            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+
         // Create Commit over all pending proposals
         // TODO #141
         let (commit, welcome_option, kpb_option) = self.group.create_commit(
             &self.aad,
-            &self.credential_bundle,
+            &credential_bundle,
             &messages_to_commit,
             &[],
             true,
@@ -698,14 +755,14 @@ impl<'a> ManagedGroup<'a> {
         self.active
     }
 
-    /// Sets a different `CredentialBundle`
-    pub fn set_credential_bundle(&mut self, credential_bundle: &'a CredentialBundle) {
-        self.credential_bundle = credential_bundle;
-    }
-
-    /// Returns own credential
-    pub fn credential(&self) -> &Credential {
-        &self.credential_bundle.credential()
+    /// Returns own credential. If the group is inactive, it returns a
+    /// `UseAfterEviction` error.
+    pub fn credential(&self) -> Result<Credential, ManagedGroupError> {
+        if !self.is_active() {
+            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+        }
+        let tree = self.group.tree();
+        Ok(tree.own_key_package().credential().clone())
     }
 
     /// Get group ID
@@ -724,17 +781,23 @@ impl<'a> ManagedGroup<'a> {
     /// in the queue of pending proposals.
     pub fn self_update(
         &mut self,
+        key_store: &KeyStore,
         key_package_bundle_option: Option<KeyPackageBundle>,
     ) -> Result<(Vec<MLSMessage>, Option<Welcome>), ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
+        let credential = self.credential()?;
+        let credential_bundle = key_store
+            .get_credential_bundle(credential.signature_key())
+            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+
         // If a KeyPackageBundle was provided, create an UpdateProposal
         let mut plaintext_messages = if let Some(key_package_bundle) = key_package_bundle_option {
             let update_proposal = self.group.create_update_proposal(
                 &self.aad,
-                &self.credential_bundle,
+                &credential_bundle,
                 key_package_bundle.key_package().clone(),
             )?;
             self.own_kpbs.push(key_package_bundle);
@@ -754,7 +817,7 @@ impl<'a> ManagedGroup<'a> {
         // TODO #141
         let (commit, welcome_option, kpb_option) = self.group.create_commit(
             &self.aad,
-            &self.credential_bundle,
+            &credential_bundle,
             &messages_to_commit,
             &[],
             true, /* force_self_update */
@@ -788,11 +851,18 @@ impl<'a> ManagedGroup<'a> {
     /// Creates a proposal to update the own leaf node
     pub fn propose_self_update(
         &mut self,
+        key_store: &KeyStore,
         key_package_bundle_option: Option<KeyPackageBundle>,
     ) -> Result<Vec<MLSMessage>, ManagedGroupError> {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
+
+        let credential = self.credential()?;
+        let credential_bundle = key_store
+            .get_credential_bundle(credential.signature_key())
+            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+
         let tree = self.group.tree();
         let existing_key_package = tree.own_key_package();
         let key_package_bundle = match key_package_bundle_option {
@@ -800,14 +870,14 @@ impl<'a> ManagedGroup<'a> {
             None => {
                 let mut key_package_bundle =
                     KeyPackageBundle::from_rekeyed_key_package(existing_key_package);
-                key_package_bundle.sign(self.credential_bundle);
+                key_package_bundle.sign(&credential_bundle);
                 key_package_bundle
             }
         };
 
         let plaintext_messages = vec![self.group.create_update_proposal(
             &self.aad,
-            &self.credential_bundle,
+            &credential_bundle,
             key_package_bundle.key_package().clone(),
         )?];
         drop(tree);
@@ -832,11 +902,10 @@ impl<'a> ManagedGroup<'a> {
     /// Loads the state from persisted state
     pub fn load<R: Read>(
         reader: R,
-        credential_bundle: &'a CredentialBundle,
         callbacks: &ManagedGroupCallbacks,
-    ) -> Result<ManagedGroup<'a>, Error> {
+    ) -> Result<ManagedGroup, Error> {
         let serialized_managed_group: SerializedManagedGroup = serde_json::from_reader(reader)?;
-        Ok(serialized_managed_group.into_managed_group(credential_bundle, callbacks))
+        Ok(serialized_managed_group.into_managed_group(callbacks))
     }
 
     /// Persists the state
@@ -854,7 +923,7 @@ impl<'a> ManagedGroup<'a> {
 }
 
 // Private methods of ManagedGroup
-impl<'a> ManagedGroup<'a> {
+impl ManagedGroup {
     /// Converts MLSPlaintext to MLSMessage. Depending on whether handshake
     /// message should be encrypted, MLSPlaintext messages are encrypted to
     /// MLSCiphertext first.
@@ -999,7 +1068,7 @@ impl<'a> ManagedGroup<'a> {
             // Remove proposals
             Proposal::Remove(remove_proposal) => {
                 let removal = Removal::new(
-                    self.credential_bundle.credential().clone(),
+                    indexed_members[&self.group.tree().own_node_index()].clone(),
                     sender_credential.clone(),
                     indexed_members[&LeafIndex::from(remove_proposal.removed)].clone(),
                 );

--- a/src/group/managed_group/ser.rs
+++ b/src/group/managed_group/ser.rs
@@ -15,7 +15,7 @@ pub struct SerializedManagedGroup {
     active: bool,
 }
 
-impl<'a> SerializedManagedGroup {
+impl SerializedManagedGroup {
     pub(crate) fn into_managed_group(self, callbacks: &ManagedGroupCallbacks) -> ManagedGroup {
         let mut managed_group = ManagedGroup {
             managed_group_config: self.managed_group_config,
@@ -31,7 +31,7 @@ impl<'a> SerializedManagedGroup {
     }
 }
 
-impl<'a> Serialize for ManagedGroup {
+impl Serialize for ManagedGroup {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/group/managed_group/ser.rs
+++ b/src/group/managed_group/ser.rs
@@ -16,13 +16,8 @@ pub struct SerializedManagedGroup {
 }
 
 impl<'a> SerializedManagedGroup {
-    pub(crate) fn into_managed_group(
-        self,
-        credential_bundle: &'a CredentialBundle,
-        callbacks: &ManagedGroupCallbacks,
-    ) -> ManagedGroup<'a> {
+    pub(crate) fn into_managed_group(self, callbacks: &ManagedGroupCallbacks) -> ManagedGroup {
         let mut managed_group = ManagedGroup {
-            credential_bundle,
             managed_group_config: self.managed_group_config,
             group: self.group,
             pending_proposals: self.pending_proposals,
@@ -36,7 +31,7 @@ impl<'a> SerializedManagedGroup {
     }
 }
 
-impl<'a> Serialize for ManagedGroup<'a> {
+impl<'a> Serialize for ManagedGroup {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/group/managed_group/test_managed_group.rs
+++ b/src/group/managed_group/test_managed_group.rs
@@ -11,7 +11,7 @@ fn test_managed_group_persistence() {
 
     // Generate credential bundles
     let alice_credential = key_store
-        .generate_credential(
+        .generate_credential_bundle(
             "Alice".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
@@ -20,7 +20,7 @@ fn test_managed_group_persistence() {
 
     // Generate KeyPackages
     let alice_key_package = key_store
-        .generate_key_package(&[ciphersuite.name()], &alice_credential, vec![])
+        .generate_key_package_bundle(&[ciphersuite.name()], &alice_credential, vec![])
         .unwrap();
 
     // Define the managed group configuration
@@ -78,7 +78,7 @@ fn remover() {
 
     // Generate credential bundles
     let alice_credential = key_store
-        .generate_credential(
+        .generate_credential_bundle(
             "Alice".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
@@ -86,7 +86,7 @@ fn remover() {
         .unwrap();
 
     let bob_credential = key_store
-        .generate_credential(
+        .generate_credential_bundle(
             "Bob".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
@@ -94,7 +94,7 @@ fn remover() {
         .unwrap();
 
     let charlie_credential = key_store
-        .generate_credential(
+        .generate_credential_bundle(
             "Charly".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
@@ -103,15 +103,15 @@ fn remover() {
 
     // Generate KeyPackages
     let alice_key_package = key_store
-        .generate_key_package(&[ciphersuite.name()], &alice_credential, vec![])
+        .generate_key_package_bundle(&[ciphersuite.name()], &alice_credential, vec![])
         .unwrap();
 
     let bob_key_package = key_store
-        .generate_key_package(&[ciphersuite.name()], &bob_credential, vec![])
+        .generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![])
         .unwrap();
 
     let charlie_key_package = key_store
-        .generate_key_package(&[ciphersuite.name()], &charlie_credential, vec![])
+        .generate_key_package_bundle(&[ciphersuite.name()], &charlie_credential, vec![])
         .unwrap();
 
     // Define the managed group configuration

--- a/src/group/managed_group/test_managed_group.rs
+++ b/src/group/managed_group/test_managed_group.rs
@@ -218,7 +218,7 @@ ctest_ciphersuites!(export_secret, test(ciphersuite_name: CiphersuiteName) {
 
     // Generate credential bundles
     let alice_credential = key_store
-        .generate_credential(
+        .generate_credential_bundle(
             "Alice".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
@@ -227,7 +227,7 @@ ctest_ciphersuites!(export_secret, test(ciphersuite_name: CiphersuiteName) {
 
     // Generate KeyPackages
     let alice_key_package = key_store
-        .generate_key_package(&[ciphersuite.name()], &alice_credential, vec![])
+        .generate_key_package_bundle(&[ciphersuite.name()], &alice_credential, vec![])
         .unwrap();
 
     // Define the managed group configuration

--- a/src/key_store/errors.rs
+++ b/src/key_store/errors.rs
@@ -1,0 +1,14 @@
+use crate::{credentials::CredentialError, key_packages::KeyPackageError};
+
+implement_error! {
+   pub enum KeyStoreError {
+       Simple {
+           NoMatchingCredentialBundle = "No `CredentialBundle` found for the given `Credential`.",
+           NoMatchingKeyPackageBundle = "No `KeyPackageBundle` found for the given `KeyPackage` hash.",
+       }
+       Complex {
+           KeyPackageError(KeyPackageError) = "Error while creating `KeyPackageBundle`. See [`KeyPackageError`](`crate::key_packages::KeyPackageError`) for details.",
+           CredentialError(CredentialError) = "Error while creating `CredentialBundle`. See [`CredentialError`](`crate::credentials::CredentialError`) for details.",
+       }
+    }
+}

--- a/src/key_store/mod.rs
+++ b/src/key_store/mod.rs
@@ -14,7 +14,7 @@
 //! ## `CredentialBundle` Instances
 //!
 //! The API of the `KeyStore` allows the generation of `Credential` instances
-//! via `generate_credential`, such that it stores the corresponding
+//! via `generate_credential_bundle`, such that it stores the corresponding
 //! `CredentialBundle`. After storing them, references to `CredentialBundle`
 //! instances can be retrieved via `get_credential_bundle` using the
 //! `SignaturePublicKey` of the corresponding `Credential` as index.
@@ -22,7 +22,7 @@
 //! ## Init `KeyPackageBundle` Instances
 //!
 //! Similarly, the `KeyStore` can generate "init" `KeyPackage` instances via
-//! `generate_key_package` and store the corresponding `KeyPackageBundle`. Init
+//! `generate_key_package_bundle` and store the corresponding `KeyPackageBundle`. Init
 //! `KeyPackage` instances are meant to be published so other parties can use
 //! them to add the publishing party to groups.
 //!
@@ -57,7 +57,7 @@
 //!
 //! // Generate a credential bundle with the matching signature scheme.
 //! let alice_credential = key_store
-//!     .generate_credential(
+//!     .generate_credential_bundle(
 //!         "Alice".into(),
 //!         CredentialType::Basic,
 //!         SignatureScheme::from(ciphersuite_name),
@@ -66,7 +66,7 @@
 //!
 //! // Generate a key package bundle.
 //! let alice_key_package = key_store
-//!     .generate_key_package(&[ciphersuite_name], &alice_credential, vec![])
+//!     .generate_key_package_bundle(&[ciphersuite_name], &alice_credential, vec![])
 //!     .unwrap();
 //!
 //! // Create a group with the previously generated credential and key package.
@@ -153,7 +153,7 @@ impl KeyStore {
     /// corresponding to the given `KeyPackage` hash.
     pub fn take_key_package_bundle(&self, kp_hash: &[u8]) -> Option<KeyPackageBundle> {
         // We unwrap here, because the two functions claiming a write lock on
-        // `init_key_package_bundles` (this one and `generate_key_package`) only
+        // `init_key_package_bundles` (this one and `generate_key_package_bundle`) only
         // hold the lock very briefly and should not panic during that period.
         let mut kpbs = self.init_key_package_bundles.write().unwrap();
         kpbs.remove(kp_hash)
@@ -183,7 +183,7 @@ impl KeyStore {
     /// error if no `CredentialBundle` can be found in the `KeyStore`
     /// corresponding to the given `Credential` or if an error occurred during
     /// the creation of the `KeyPackageBundle`.
-    pub fn generate_key_package(
+    pub fn generate_key_package_bundle(
         &self,
         ciphersuites: &[CiphersuiteName],
         credential: &Credential,
@@ -206,7 +206,7 @@ impl KeyStore {
     /// Generate a fresh `CredentialBundle` with the given parameters and store
     /// it in the `KeyStore`. Returns the corresponding `Credential` or an error
     /// if the creation of the `CredentialBundle` fails.
-    pub fn generate_credential(
+    pub fn generate_credential_bundle(
         &self,
         identity: Vec<u8>,
         credential_type: CredentialType,

--- a/src/key_store/mod.rs
+++ b/src/key_store/mod.rs
@@ -198,7 +198,7 @@ impl KeyStore {
         // only hold the lock very briefly and should not panic during that
         // period.
         let mut kpbs = self.init_key_package_bundles.write().unwrap();
-        kpbs.insert(kp.hash().clone(), kpb);
+        kpbs.insert(kp.hash(), kpb);
         Ok(kp)
     }
 

--- a/src/key_store/mod.rs
+++ b/src/key_store/mod.rs
@@ -127,14 +127,14 @@ pub struct KeyStore {
 /// This guard struct for a `CredentialBundle` implements `Deref`, such that the
 /// underlying `RwLock<CredentialBundle>` can be obtained for read or write
 /// access to the credential.
-pub struct CBGuard<'a> {
+pub struct CbGuard<'a> {
     cbs: RwLockReadGuard<'a, HashMap<SignaturePublicKey, CredentialBundle>>,
     index: &'a SignaturePublicKey,
 }
 
 use std::ops::Deref;
 
-impl<'b> Deref for CBGuard<'b> {
+impl<'b> Deref for CbGuard<'b> {
     type Target = CredentialBundle;
 
     fn deref(&self) -> &CredentialBundle {
@@ -166,12 +166,12 @@ impl KeyStore {
     pub(crate) fn get_credential_bundle<'key_store>(
         &'key_store self,
         signature_public_key: &'key_store SignaturePublicKey,
-    ) -> Option<CBGuard> {
+    ) -> Option<CbGuard> {
         let cbs = self.credential_bundles.read().unwrap();
         if !cbs.contains_key(signature_public_key) {
             return None;
         }
-        Some(CBGuard {
+        Some(CbGuard {
             cbs,
             index: signature_public_key,
         })

--- a/src/key_store/mod.rs
+++ b/src/key_store/mod.rs
@@ -1,0 +1,224 @@
+//! A storage solution for cryptographic key material used in OpenMLS groups.
+//!
+//! This module provides access to the `KeyStore` struct, which manages the
+//! storage of `CredentialBundle` and `KeyPackageBundle` instances for use in
+//! one or more `ManagedGroup` instances. The development of this module is
+//! tracked in #337, which also includes a roadmap.
+//!
+//! # Key Store API
+//!
+//! All functions accessible via the `KeyStore` API are thread safe, allowing
+//! multiple concurrent read locks, on any category of stored key material (e.g.
+//! `CredentialBundle` instances, "init" `KeyPackageBundle` instance).
+//!
+//! ## `CredentialBundle` Instances
+//!
+//! The API of the `KeyStore` allows the generation of `Credential` instances
+//! via `generate_credential`, such that it stores the corresponding
+//! `CredentialBundle`. After storing them, references to `CredentialBundle`
+//! instances can be retrieved via `get_credential_bundle` using the
+//! `SignaturePublicKey` of the corresponding `Credential` as index.
+//!
+//! ## Init `KeyPackageBundle` Instances
+//!
+//! Similarly, the `KeyStore` can generate "init" `KeyPackage` instances via
+//! `generate_key_package` and store the corresponding `KeyPackageBundle`. Init
+//! `KeyPackage` instances are meant to be published so other parties can use
+//! them to add the publishing party to groups.
+//!
+//! ### `KeyPackageBundle` Ownership
+//!
+//! In contrast to the functions providing access to `CredentialBundle`
+//! instances, the function to retrieve `KeyPackageBundle` instances deletes
+//! them from the `KeyStore`. This is because each `ManagedGroup` currently owns
+//! the `KeyPackageBundle` in its leaf, so upon creation of the group, it needs
+//! to consume a `KeyPackageBundle` instance. Note, that in contrast to
+//! `CredentialBundle` instances, `KeyPackageBundle` instances should not be
+//! used across groups.
+//!
+//! This design is temporary and only until the `ManagedGroup` is refactored to
+//! access its `KeyPackageBundle` via the `KeyStore`. Once this is the case, the
+//! `take_key_package_bundle` will be deprecated in favor of a
+//! `get_key_package_bundle`, which only returns a reference to the
+//! `KeyPackageBundle`.
+//!
+//! # Example
+//!
+//! A simple example for the generation and the retrieval of a
+//! `CredentialBundle` and a `KeyPackageBundle`.
+//!
+//! ```
+//! use openmls::prelude::*;
+//!
+//! let key_store = KeyStore::default();
+//!
+//! let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+//!
+//! // Generate a credential bundle with the matching signature scheme.
+//! let alice_credential = key_store
+//!     .generate_credential(
+//!         "Alice".into(),
+//!         CredentialType::Basic,
+//!         SignatureScheme::from(ciphersuite_name),
+//!     )
+//!     .unwrap();
+//!
+//! // Generate a key package bundle.
+//! let alice_key_package = key_store
+//!     .generate_key_package(&[ciphersuite_name], &alice_credential, vec![])
+//!     .unwrap();
+//!
+//! // Create a group with the previously generated credential and key package.
+//! let managed_group_config = ManagedGroupConfig::new(
+//!     HandshakeMessageFormat::Plaintext,
+//!     UpdatePolicy::default(),
+//!     0,
+//!     0,
+//!     ManagedGroupCallbacks::default(),
+//! );
+//!
+//! let alice_group = ManagedGroup::new(
+//!     &key_store,
+//!     &managed_group_config,
+//!     GroupId::from_slice(b"Test Group"),
+//!     &alice_key_package.hash(),
+//! )
+//! .unwrap();
+//! ```
+//!
+//! # Future Work
+//!
+//! A more detailed roadmap can be found in issue #337, but generally the plan is to
+//! * move ownership of all `KeyPackageBundle` instances into the `KeyStore` and
+//!   change the API from `take_` to `get_`
+//! * keep track of which key material is (still) in use and where, as well as if it expires and when
+//! * extend the API to allow for deletion of unused key material, expired or otherwise
+//! * add a persistence layer
+
+use std::{
+    collections::HashMap,
+    sync::{RwLock, RwLockReadGuard},
+};
+
+use crate::{
+    ciphersuite::{CiphersuiteName, SignaturePublicKey, SignatureScheme},
+    credentials::{Credential, CredentialBundle, CredentialType},
+    extensions::Extension,
+    key_packages::{KeyPackage, KeyPackageBundle},
+};
+
+pub mod errors;
+
+#[cfg(test)]
+mod test_key_store;
+
+pub use errors::KeyStoreError;
+
+#[derive(Debug, Default)]
+/// The `KeyStore` contains `CredentialBundle`s and `KeyPackageBundle`s and
+/// makes them available via information in the corresponding `Credential` and
+/// `KeyPackage` instances.
+pub struct KeyStore {
+    // Map from signature public keys to credential bundles
+    credential_bundles: RwLock<HashMap<SignaturePublicKey, CredentialBundle>>,
+    init_key_package_bundles: RwLock<HashMap<Vec<u8>, KeyPackageBundle>>,
+}
+
+/// This guard struct for a `CredentialBundle` implements `Deref`, such that the
+/// underlying `RwLock<CredentialBundle>` can be obtained for read or write
+/// access to the credential.
+pub struct CBGuard<'a> {
+    cbs: RwLockReadGuard<'a, HashMap<SignaturePublicKey, CredentialBundle>>,
+    index: &'a SignaturePublicKey,
+}
+
+use std::ops::Deref;
+
+impl<'b> Deref for CBGuard<'b> {
+    type Target = CredentialBundle;
+
+    fn deref(&self) -> &CredentialBundle {
+        // We can unwrap here, as we checked if the entry is present before
+        // creating the guard. Also, since we hold a read lock on the `HashMap`,
+        // the entry can't have been removed in the meantime.
+        self.cbs.get(self.index).unwrap()
+    }
+}
+
+impl KeyStore {
+    /// Retrieve a `KeyPackageBundle` from the key store given the hash of the
+    /// corresponding `KeyPackage`. This removes the `KeyPackageBundle` from the
+    /// store. Returns an error if no `KeyPackageBundle` can be found
+    /// corresponding to the given `KeyPackage` hash.
+    pub fn take_key_package_bundle(&self, kp_hash: &[u8]) -> Option<KeyPackageBundle> {
+        // We unwrap here, because the two functions claiming a write lock on
+        // `init_key_package_bundles` (this one and `generate_key_package`) only
+        // hold the lock very briefly and should not panic during that period.
+        let mut kpbs = self.init_key_package_bundles.write().unwrap();
+        kpbs.remove(kp_hash)
+    }
+
+    /// Retrieve a `CBGuard` from the key store given the `SignaturePublicKey`
+    /// of the corresponding `Credential`. The `CBGuard` can be dereferenced to
+    /// obtain an `RwLock` on the desired `CredentialBundle`. Returns an error
+    /// if no `CredentialBundle` can be found corresponding to the given
+    /// `SignaturePublicKey`.
+    pub(crate) fn get_credential_bundle<'key_store>(
+        &'key_store self,
+        signature_public_key: &'key_store SignaturePublicKey,
+    ) -> Option<CBGuard> {
+        let cbs = self.credential_bundles.read().unwrap();
+        if !cbs.contains_key(signature_public_key) {
+            return None;
+        }
+        Some(CBGuard {
+            cbs,
+            index: signature_public_key,
+        })
+    }
+
+    /// Generate a fresh `KeyPackageBundle` with the given parameters, store it
+    /// in the `KeyStore` and return the corresponding `KeyPackage`. Throws an
+    /// error if no `CredentialBundle` can be found in the `KeyStore`
+    /// corresponding to the given `Credential` or if an error occurred during
+    /// the creation of the `KeyPackageBundle`.
+    pub fn generate_key_package(
+        &self,
+        ciphersuites: &[CiphersuiteName],
+        credential: &Credential,
+        extensions: Vec<Box<dyn Extension>>,
+    ) -> Result<KeyPackage, KeyStoreError> {
+        let credential_bundle = self
+            .get_credential_bundle(credential.signature_key())
+            .ok_or(KeyStoreError::NoMatchingCredentialBundle)?;
+        let kpb = KeyPackageBundle::new(ciphersuites, &credential_bundle, extensions)?;
+        let kp_hash = kpb.key_package().hash();
+        // We unwrap here, because the two functions claiming write locks on
+        // `init_key_package_bundles` (this one and `take_key_package_bundle`)
+        // only hold the lock very briefly and should not panic during that
+        // period.
+        let mut kpbs = self.init_key_package_bundles.write().unwrap();
+        kpbs.insert(kp_hash.clone(), kpb);
+        let kp = kpbs.get(&kp_hash).unwrap().key_package().clone();
+        Ok(kp)
+    }
+
+    /// Generate a fresh `CredentialBundle` with the given parameters and store
+    /// it in the `KeyStore`. Returns the corresponding `Credential` or an error
+    /// if the creation of the `CredentialBundle` fails.
+    pub fn generate_credential(
+        &self,
+        identity: Vec<u8>,
+        credential_type: CredentialType,
+        signature_scheme: SignatureScheme,
+    ) -> Result<Credential, KeyStoreError> {
+        let cb = CredentialBundle::new(identity, credential_type, signature_scheme)?;
+        let credential = cb.credential().clone();
+        // We unwrap here, because this is the only function claiming a write
+        // lock on `credential_bundles`. It only holds the lock very briefly and
+        // should not panic during that period.
+        let mut cbs = self.credential_bundles.write().unwrap();
+        cbs.insert(credential.signature_key().clone(), cb);
+        Ok(credential)
+    }
+}

--- a/src/key_store/mod.rs
+++ b/src/key_store/mod.rs
@@ -26,7 +26,7 @@
 //! `KeyPackage` instances are meant to be published so other parties can use
 //! them to add the publishing party to groups.
 //!
-//! ### `KeyPackageBundle` Ownership
+//! ### `KeyPackageBundle` vs. `CredentialBundle` Ownership
 //!
 //! In contrast to the functions providing access to `CredentialBundle`
 //! instances, the function to retrieve `KeyPackageBundle` instances deletes
@@ -40,7 +40,8 @@
 //! access its `KeyPackageBundle` via the `KeyStore`. Once this is the case, the
 //! `take_key_package_bundle` will be deprecated in favor of a
 //! `get_key_package_bundle`, which only returns a reference to the
-//! `KeyPackageBundle`.
+//! `KeyPackageBundle`. The issue is tracked as part of the KeyStore roadmap in
+//! issue #337.
 //!
 //! # Example
 //!

--- a/src/key_store/mod.rs
+++ b/src/key_store/mod.rs
@@ -158,8 +158,8 @@ impl KeyStore {
         kpbs.remove(kp_hash)
     }
 
-    /// Retrieve a `CBGuard` from the key store given the `SignaturePublicKey`
-    /// of the corresponding `Credential`. The `CBGuard` can be dereferenced to
+    /// Retrieve a `CbGuard` from the key store given the `SignaturePublicKey`
+    /// of the corresponding `Credential`. The `CbGuard` can be dereferenced to
     /// obtain an `RwLock` on the desired `CredentialBundle`. Returns an error
     /// if no `CredentialBundle` can be found corresponding to the given
     /// `SignaturePublicKey`.

--- a/src/key_store/mod.rs
+++ b/src/key_store/mod.rs
@@ -192,14 +192,13 @@ impl KeyStore {
             .get_credential_bundle(credential.signature_key())
             .ok_or(KeyStoreError::NoMatchingCredentialBundle)?;
         let kpb = KeyPackageBundle::new(ciphersuites, &credential_bundle, extensions)?;
-        let kp_hash = kpb.key_package().hash();
+        let kp = kpb.key_package().clone();
         // We unwrap here, because the two functions claiming write locks on
         // `init_key_package_bundles` (this one and `take_key_package_bundle`)
         // only hold the lock very briefly and should not panic during that
         // period.
         let mut kpbs = self.init_key_package_bundles.write().unwrap();
-        kpbs.insert(kp_hash.clone(), kpb);
-        let kp = kpbs.get(&kp_hash).unwrap().key_package().clone();
+        kpbs.insert(kp.hash().clone(), kpb);
         Ok(kp)
     }
 

--- a/src/key_store/test_key_store.rs
+++ b/src/key_store/test_key_store.rs
@@ -1,0 +1,79 @@
+use crate::config::*;
+use crate::{ciphersuite::*, credentials::CredentialBundle};
+use std::convert::TryFrom;
+
+use crate::credentials::CredentialType::Basic;
+use crate::key_packages::KeyPackageBundle;
+
+use super::{KeyStore, KeyStoreError};
+
+ctest_ciphersuites!(key_storage, test(param: CiphersuiteName) {
+    let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
+    println!("Testing ciphersuite {:?}", ciphersuite_name);
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+
+    let ks = KeyStore::default();
+
+    let credential = ks
+        .generate_credential(
+            "Alice".as_bytes().to_vec(),
+            Basic,
+            ciphersuite.signature_scheme(),
+        )
+        .expect("Error while creating credential.")
+        .clone();
+
+    let key_package = ks
+        .generate_key_package(&[ciphersuite.name()], &credential, Vec::new())
+        .expect("Error while generating key package.")
+        .clone();
+
+    assert_eq!(&credential, key_package.credential());
+
+    // Let's cause an error.
+
+    // Generate a CredentialBundle externally and then try to use it to create a
+    // key package bundle in the store.
+    let cb_external = CredentialBundle::new(
+        "Bob".as_bytes().to_vec(),
+        Basic,
+        ciphersuite.signature_scheme(),
+    )
+        .expect("Error while creating credential.");
+
+    let kpb_external_cred_err = ks
+        .generate_key_package(&[ciphersuite.name()], cb_external.credential(), Vec::new()).expect_err("No error while trying to generate a key package with unavailable credential bundle.");
+
+    assert_eq!(kpb_external_cred_err, KeyStoreError::NoMatchingCredentialBundle);
+
+    // Let's load the bundles
+    let cb = ks
+        .get_credential_bundle(credential.signature_key())
+        .expect("Error while getting CredentialBundle from the store.");
+
+    assert_eq!(cb.credential(), &credential);
+
+    let kpb = ks
+        .take_key_package_bundle(&key_package.hash())
+        .expect("Error while getting KeyPackageBundle from the store.");
+
+    assert_eq!(kpb.key_package(), &key_package);
+
+    // Let' create some errors.
+
+    // Generate a CredentialBundle externally and then try to load it from the store.
+    let cb_external = CredentialBundle::new(
+        "Bob".as_bytes().to_vec(),
+        Basic,
+        ciphersuite.signature_scheme(),
+    )
+    .expect("Error while creating credential.");
+
+    assert_eq!(ks.get_credential_bundle(cb_external.credential().signature_key()).is_none(), true);
+
+    let kpb_external = KeyPackageBundle::new(&[ciphersuite.name()], &cb_external, Vec::new())
+        .expect("Error while generating key package.");
+
+    assert_eq!(ks.take_key_package_bundle(&kpb_external.key_package().hash()).is_none(), true);
+
+});

--- a/src/key_store/test_key_store.rs
+++ b/src/key_store/test_key_store.rs
@@ -7,6 +7,8 @@ use crate::key_packages::KeyPackageBundle;
 
 use super::{KeyStore, KeyStoreError};
 
+// This test tests the basic functions of the key store, i.e. generation and
+// retrieval of key packages and credential bundles, including error cases.
 ctest_ciphersuites!(key_storage, test(param: CiphersuiteName) {
     let ciphersuite_name = CiphersuiteName::try_from(param).unwrap();
     println!("Testing ciphersuite {:?}", ciphersuite_name);

--- a/src/key_store/test_key_store.rs
+++ b/src/key_store/test_key_store.rs
@@ -17,7 +17,7 @@ ctest_ciphersuites!(key_storage, test(param: CiphersuiteName) {
     let ks = KeyStore::default();
 
     let credential = ks
-        .generate_credential(
+        .generate_credential_bundle(
             "Alice".as_bytes().to_vec(),
             Basic,
             ciphersuite.signature_scheme(),
@@ -26,7 +26,7 @@ ctest_ciphersuites!(key_storage, test(param: CiphersuiteName) {
         .clone();
 
     let key_package = ks
-        .generate_key_package(&[ciphersuite.name()], &credential, Vec::new())
+        .generate_key_package_bundle(&[ciphersuite.name()], &credential, Vec::new())
         .expect("Error while generating key package.")
         .clone();
 
@@ -44,7 +44,7 @@ ctest_ciphersuites!(key_storage, test(param: CiphersuiteName) {
         .expect("Error while creating credential.");
 
     let kpb_external_cred_err = ks
-        .generate_key_package(&[ciphersuite.name()], cb_external.credential(), Vec::new()).expect_err("No error while trying to generate a key package with unavailable credential bundle.");
+        .generate_key_package_bundle(&[ciphersuite.name()], cb_external.credential(), Vec::new()).expect_err("No error while trying to generate a key package with unavailable credential bundle.");
 
     assert_eq!(kpb_external_cred_err, KeyStoreError::NoMatchingCredentialBundle);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ mod extensions;
 pub mod framing;
 pub mod group;
 mod key_packages;
-mod key_store;
+pub mod key_store;
 pub mod messages;
 mod schedule;
 pub mod tree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod extensions;
 pub mod framing;
 pub mod group;
 mod key_packages;
+mod key_store;
 pub mod messages;
 mod schedule;
 pub mod tree;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,6 +25,7 @@ pub use crate::extensions::*;
 pub use crate::framing::{errors::*, sender::Sender, *};
 pub use crate::group::GroupId;
 pub use crate::key_packages::*;
+pub use crate::key_store::*;
 pub use crate::messages::{
     proposals::{
         AddProposal, PreSharedKeyProposal, ReInitProposal, RemoveProposal, UpdateProposal,

--- a/tests/test_decryption_key_index.rs
+++ b/tests/test_decryption_key_index.rs
@@ -20,45 +20,45 @@ ctest_ciphersuites!(decryption_key_index_computation, test(param: CiphersuiteNam
         ManagedGroupConfig::new(handshake_message_format, update_policy, 10, 0, callbacks);
     let number_of_clients = 20;
     let setup = ManagedTestSetup::new(managed_group_config, number_of_clients);
-        // Create a basic group with more than 4 members to create a tree with intermediate nodes.
-        let group_id = setup.create_random_group(10, ciphersuite).unwrap();
-        let mut groups = setup.groups.borrow_mut();
-        let group = groups.get_mut(&group_id).unwrap();
+    // Create a basic group with more than 4 members to create a tree with intermediate nodes.
+    let group_id = setup.create_random_group(10, ciphersuite).unwrap();
+    let mut groups = setup.groups.borrow_mut();
+    let group = groups.get_mut(&group_id).unwrap();
 
-        // Now we have to create a situation, where the resolution is neither
-        // the leaf, nor the common ancestor closest to the root. To do that, we
-        // first have the member at index 0 remove the one at index 2, thus
-        // populating its own parent node.
+    // Now we have to create a situation, where the resolution is neither
+    // the leaf, nor the common ancestor closest to the root. To do that, we
+    // first have the member at index 0 remove the one at index 2, thus
+    // populating its own parent node.
 
-        // Find the identity of the member with leaf index 0.
-        let (_, remover_id) = &group
-            .members
-            .iter()
-            .find(|(index, _)| index == &0)
-            .unwrap()
-            .clone();
-        setup
-            .remove_clients_by_index(ActionType::Commit, group, &remover_id, &[2])
-            .unwrap();
+    // Find the identity of the member with leaf index 0.
+    let (_, remover_id) = &group
+        .members
+        .iter()
+        .find(|(index, _)| index == &0)
+        .unwrap()
+        .clone();
+    setup
+        .remove_clients_by_index(ActionType::Commit, group, &remover_id, &[2])
+        .unwrap();
 
-        // Then we have the member at index 7 remove the one at index 3. This
-        // causes a secret to be encrypted to the parent node of index 0, which
-        // fails if the index of the decryption key is computed incorrectly.
-        // Find the member with index 0.
+    // Then we have the member at index 7 remove the one at index 3. This
+    // causes a secret to be encrypted to the parent node of index 0, which
+    // fails if the index of the decryption key is computed incorrectly.
+    // Find the member with index 0.
 
-        // Find the identity of the member with leaf index 7.
-        let (_, remover_id) = &group
-            .members
-            .iter()
-            .find(|(index, _)| index == &7)
-            .unwrap()
-            .clone();
-        setup
-            .remove_clients_by_index(ActionType::Commit, group, &remover_id, &[3])
-            .unwrap();
+    // Find the identity of the member with leaf index 7.
+    let (_, remover_id) = &group
+        .members
+        .iter()
+        .find(|(index, _)| index == &7)
+        .unwrap()
+        .clone();
+    setup
+        .remove_clients_by_index(ActionType::Commit, group, &remover_id, &[3])
+        .unwrap();
 
-        // Since the decryption failure doesn't cause a panic, but only an error
-        // message in the callback, we also have to check that the group states
-        // match for all group members.
-        setup.check_group_states(group);
+    // Since the decryption failure doesn't cause a panic, but only an error
+    // message in the callback, we also have to check that the group states
+    // match for all group members.
+    setup.check_group_states(group);
 });

--- a/tests/test_decryption_key_index.rs
+++ b/tests/test_decryption_key_index.rs
@@ -20,7 +20,6 @@ ctest_ciphersuites!(decryption_key_index_computation, test(param: CiphersuiteNam
         ManagedGroupConfig::new(handshake_message_format, update_policy, 10, 0, callbacks);
     let number_of_clients = 20;
     let setup = ManagedTestSetup::new(managed_group_config, number_of_clients);
-    setup.create_clients();
         // Create a basic group with more than 4 members to create a tree with intermediate nodes.
         let group_id = setup.create_random_group(10, ciphersuite).unwrap();
         let mut groups = setup.groups.borrow_mut();

--- a/tests/test_interop_scenarios.rs
+++ b/tests/test_interop_scenarios.rs
@@ -29,7 +29,6 @@ ctest_ciphersuites!(one_to_one_join, test(param: CiphersuiteName) {
     let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
     let number_of_clients = 2;
     let setup = ManagedTestSetup::new(default_managed_group_config(), number_of_clients);
-    setup.create_clients();
 
     // Create a group with a random creator.
     let group_id = setup
@@ -66,7 +65,6 @@ ctest_ciphersuites!(three_party_join, test(param: CiphersuiteName) {
 
     let number_of_clients = 3;
     let setup = ManagedTestSetup::new(default_managed_group_config(), number_of_clients);
-    setup.create_clients();
 
     // Create a group with a random creator.
     let group_id = setup
@@ -110,7 +108,6 @@ ctest_ciphersuites!(multiple_joins, test(param: CiphersuiteName) {
 
     let number_of_clients = 3;
     let setup = ManagedTestSetup::new(default_managed_group_config(), number_of_clients);
-    setup.create_clients();
 
     // Create a group with a random creator.
     let group_id = setup
@@ -148,7 +145,6 @@ ctest_ciphersuites!(update, test(param: CiphersuiteName) {
 
     let number_of_clients = 2;
     let setup = ManagedTestSetup::new(default_managed_group_config(), number_of_clients);
-    setup.create_clients();
 
     // Create a group with two members. Includes the process of adding Bob.
     let group_id = setup
@@ -183,7 +179,6 @@ ctest_ciphersuites!(remove, test(param: CiphersuiteName) {
 
     let number_of_clients = 2;
     let setup = ManagedTestSetup::new(default_managed_group_config(), number_of_clients);
-    setup.create_clients();
 
     // Create a group with two members. Includes the process of adding Bob.
     let group_id = setup
@@ -223,7 +218,6 @@ ctest_ciphersuites!(large_group_lifecycle, test(param: CiphersuiteName) {
     // "Large" is 20 for now.
     let number_of_clients = 20;
     let setup = ManagedTestSetup::new(default_managed_group_config(), number_of_clients);
-    setup.create_clients();
 
     // Create a group with all available clients. The process includes creating
     // a one-person group and then adding new members in bunches of up to 5,

--- a/tests/test_managed_api.rs
+++ b/tests/test_managed_api.rs
@@ -14,7 +14,6 @@ fn test_managed_api() {
         ManagedGroupConfig::new(handshake_message_format, update_policy, 0, 0, callbacks);
     let number_of_clients = 20;
     let setup = ManagedTestSetup::new(managed_group_config, number_of_clients);
-    setup.create_clients();
 
     for ciphersuite in Config::supported_ciphersuites() {
         let group_id = setup.create_random_group(3, ciphersuite).unwrap();

--- a/tests/test_managed_group.rs
+++ b/tests/test_managed_group.rs
@@ -74,7 +74,7 @@ fn managed_group_operations() {
 
             // Generate credential bundles
             let alice_credential = key_store
-                .generate_credential(
+                .generate_credential_bundle(
                     "Alice".into(),
                     CredentialType::Basic,
                     ciphersuite.signature_scheme(),
@@ -82,7 +82,7 @@ fn managed_group_operations() {
                 .unwrap();
 
             let bob_credential = key_store
-                .generate_credential(
+                .generate_credential_bundle(
                     "Bob".into(),
                     CredentialType::Basic,
                     ciphersuite.signature_scheme(),
@@ -90,7 +90,7 @@ fn managed_group_operations() {
                 .unwrap();
 
             let charlie_credential = key_store
-                .generate_credential(
+                .generate_credential_bundle(
                     "Charlie".into(),
                     CredentialType::Basic,
                     ciphersuite.signature_scheme(),
@@ -99,11 +99,11 @@ fn managed_group_operations() {
 
             // Generate KeyPackages
             let alice_key_package = key_store
-                .generate_key_package(&[ciphersuite.name()], &alice_credential, vec![])
+                .generate_key_package_bundle(&[ciphersuite.name()], &alice_credential, vec![])
                 .unwrap();
 
             let bob_key_package = key_store
-                .generate_key_package(&[ciphersuite.name()], &bob_credential, vec![])
+                .generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![])
                 .unwrap();
 
             // Define the managed group configuration
@@ -281,7 +281,7 @@ fn managed_group_operations() {
 
             // === Bob adds Charlie ===
             let charlie_key_package = key_store
-                .generate_key_package(&[ciphersuite.name()], &charlie_credential, vec![])
+                .generate_key_package_bundle(&[ciphersuite.name()], &charlie_credential, vec![])
                 .unwrap();
 
             let (queued_messages, welcome) =
@@ -458,7 +458,7 @@ fn managed_group_operations() {
 
             // Create a new KeyPackageBundle for Bob
             let bob_key_package = key_store
-                .generate_key_package(&[ciphersuite.name()], &bob_credential, vec![])
+                .generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![])
                 .unwrap();
 
             // Create RemoveProposal and process it
@@ -619,7 +619,7 @@ fn managed_group_operations() {
 
             // Create a new KeyPackageBundle for Bob
             let bob_key_package = key_store
-                .generate_key_package(&[ciphersuite.name()], &bob_credential, vec![])
+                .generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![])
                 .unwrap();
 
             // Add Bob to the group
@@ -668,7 +668,7 @@ fn test_empty_input_errors() {
 
     // Generate credential bundles
     let alice_credential = key_store
-        .generate_credential(
+        .generate_credential_bundle(
             "Alice".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
@@ -677,7 +677,7 @@ fn test_empty_input_errors() {
 
     // Generate KeyPackages
     let alice_key_package = key_store
-        .generate_key_package(&[ciphersuite.name()], &alice_credential, vec![])
+        .generate_key_package_bundle(&[ciphersuite.name()], &alice_credential, vec![])
         .unwrap();
 
     // Define the managed group configuration

--- a/tests/utils/managed_utils/client.rs
+++ b/tests/utils/managed_utils/client.rs
@@ -5,24 +5,23 @@ use std::{cell::RefCell, collections::HashMap};
 
 use openmls::{node::Node, prelude::*};
 
-use super::{errors::ClientError, ActionType, KeyStore};
+use super::{errors::ClientError, ActionType};
 
 #[derive(Debug)]
 /// The client contains the necessary state for a client in the context of MLS.
 /// It contains the group states, as well as a reference to a `KeyStore`
 /// containing its `CredentialBundle`s. The `key_package_bundles` field contains
 /// generated `KeyPackageBundle`s that are waiting to be used for new groups.
-pub struct Client<'key_store_lifetime> {
+pub struct Client {
     /// Name of the client.
     pub(crate) identity: Vec<u8>,
     /// Ciphersuites supported by the client.
-    pub(crate) key_store: &'key_store_lifetime KeyStore,
-    // Map from key package hash to the corresponding bundle.
-    pub(crate) key_package_bundles: RefCell<HashMap<Vec<u8>, KeyPackageBundle>>,
-    pub(crate) groups: RefCell<HashMap<GroupId, ManagedGroup<'key_store_lifetime>>>,
+    pub(crate) credentials: HashMap<CiphersuiteName, Credential>,
+    pub(crate) key_store: KeyStore,
+    pub(crate) groups: RefCell<HashMap<GroupId, ManagedGroup>>,
 }
 
-impl<'key_store_lifetime> Client<'key_store_lifetime> {
+impl Client {
     /// Generate a fresh key package bundle and store it in
     /// `self.key_package_bundles`. The first ciphersuite determines the
     /// credential used to generate the `KeyPackageBundle`. Returns the
@@ -34,17 +33,15 @@ impl<'key_store_lifetime> Client<'key_store_lifetime> {
         if ciphersuites.is_empty() {
             return Err(ClientError::NoCiphersuite);
         }
-        let credential_bundle = self
-            .key_store
-            .get_credential(&(self.identity.clone(), ciphersuites[0]))
+        let credential = self
+            .credentials
+            .get(&ciphersuites[0])
             .ok_or(ClientError::CiphersuiteNotSupported)?;
         let mandatory_extensions = Vec::new();
-        let key_package_bundle: KeyPackageBundle =
-            KeyPackageBundle::new(ciphersuites, &credential_bundle, mandatory_extensions).unwrap();
-        let key_package = key_package_bundle.key_package().clone();
-        self.key_package_bundles
-            .borrow_mut()
-            .insert(key_package_bundle.key_package().hash(), key_package_bundle);
+        let key_package: KeyPackage = self
+            .key_store
+            .generate_key_package(ciphersuites, credential, mandatory_extensions)
+            .unwrap();
         Ok(key_package)
     }
 
@@ -57,22 +54,20 @@ impl<'key_store_lifetime> Client<'key_store_lifetime> {
         managed_group_config: ManagedGroupConfig,
         ciphersuite: &Ciphersuite,
     ) -> Result<(), ClientError> {
-        let credential_bundle = self
-            .key_store
-            .get_credential(&(self.identity.clone(), ciphersuite.name()))
+        let credential = self
+            .credentials
+            .get(&ciphersuite.name())
             .ok_or(ClientError::CiphersuiteNotSupported)?;
         let mandatory_extensions = Vec::new();
-        let key_package_bundle: KeyPackageBundle = KeyPackageBundle::new(
-            &[ciphersuite.name()],
-            &credential_bundle,
-            mandatory_extensions,
-        )
-        .unwrap();
+        let key_package: KeyPackage = self
+            .key_store
+            .generate_key_package(&[ciphersuite.name()], credential, mandatory_extensions)
+            .unwrap();
         let group_state = ManagedGroup::new(
-            credential_bundle,
+            &self.key_store,
             &managed_group_config,
             group_id.clone(),
-            key_package_bundle,
+            &key_package.hash(),
         )?;
         self.groups.borrow_mut().insert(group_id, group_state);
         Ok(())
@@ -88,34 +83,11 @@ impl<'key_store_lifetime> Client<'key_store_lifetime> {
         welcome: Welcome,
         ratchet_tree: Option<Vec<Option<Node>>>,
     ) -> Result<(), ClientError> {
-        let encrypted_group_secret = welcome
-            .secrets()
-            .iter()
-            .find(|egs| {
-                self.key_package_bundles
-                    .borrow()
-                    .contains_key(&egs.key_package_hash)
-            })
-            .ok_or(ClientError::NoMatchingKeyPackage)?;
-        // We can unwrap here, because we just checked that this kpb exists.
-        // Also, we should be fine just removing the KeyPackageBundle here,
-        // because it shouldn't be used again anyway.
-        let key_package_bundle = self
-            .key_package_bundles
-            .borrow_mut()
-            .remove(&encrypted_group_secret.key_package_hash)
-            .unwrap();
-        let ciphersuite = key_package_bundle.key_package().ciphersuite_name();
-        let credential_bundle = self
-            .key_store
-            .get_credential(&(self.identity.clone(), ciphersuite))
-            .ok_or(ClientError::CiphersuiteNotSupported)?;
-        let new_group: ManagedGroup<'key_store_lifetime> = ManagedGroup::new_from_welcome(
-            credential_bundle,
+        let new_group: ManagedGroup = ManagedGroup::new_from_welcome(
+            &self.key_store,
             &managed_group_config,
             welcome,
             ratchet_tree,
-            key_package_bundle,
         )?;
         self.groups
             .borrow_mut()
@@ -176,8 +148,11 @@ impl<'key_store_lifetime> Client<'key_store_lifetime> {
             .get_mut(group_id)
             .ok_or(ClientError::NoMatchingGroup)?;
         let action_results = match action_type {
-            ActionType::Commit => group.self_update(key_package_bundle_option)?,
-            ActionType::Proposal => (group.propose_self_update(key_package_bundle_option)?, None),
+            ActionType::Commit => group.self_update(&self.key_store, key_package_bundle_option)?,
+            ActionType::Proposal => (
+                group.propose_self_update(&self.key_store, key_package_bundle_option)?,
+                None,
+            ),
         };
         Ok(action_results)
     }
@@ -199,10 +174,13 @@ impl<'key_store_lifetime> Client<'key_store_lifetime> {
             .ok_or(ClientError::NoMatchingGroup)?;
         let action_results = match action_type {
             ActionType::Commit => {
-                let (messages, welcome) = group.add_members(key_packages)?;
+                let (messages, welcome) = group.add_members(&self.key_store, key_packages)?;
                 (messages, Some(welcome))
             }
-            ActionType::Proposal => (group.propose_add_members(key_packages)?, None),
+            ActionType::Proposal => (
+                group.propose_add_members(&self.key_store, key_packages)?,
+                None,
+            ),
         };
         Ok(action_results)
     }
@@ -223,8 +201,11 @@ impl<'key_store_lifetime> Client<'key_store_lifetime> {
             .get_mut(group_id)
             .ok_or(ClientError::NoMatchingGroup)?;
         let action_results = match action_type {
-            ActionType::Commit => group.remove_members(target_indices)?,
-            ActionType::Proposal => (group.propose_remove_members(target_indices)?, None),
+            ActionType::Commit => group.remove_members(&self.key_store, target_indices)?,
+            ActionType::Proposal => (
+                group.propose_remove_members(&self.key_store, target_indices)?,
+                None,
+            ),
         };
         Ok(action_results)
     }

--- a/tests/utils/managed_utils/client.rs
+++ b/tests/utils/managed_utils/client.rs
@@ -40,7 +40,7 @@ impl Client {
         let mandatory_extensions = Vec::new();
         let key_package: KeyPackage = self
             .key_store
-            .generate_key_package(ciphersuites, credential, mandatory_extensions)
+            .generate_key_package_bundle(ciphersuites, credential, mandatory_extensions)
             .unwrap();
         Ok(key_package)
     }
@@ -61,7 +61,7 @@ impl Client {
         let mandatory_extensions = Vec::new();
         let key_package: KeyPackage = self
             .key_store
-            .generate_key_package(&[ciphersuite.name()], credential, mandatory_extensions)
+            .generate_key_package_bundle(&[ciphersuite.name()], credential, mandatory_extensions)
             .unwrap();
         let group_state = ManagedGroup::new(
             &self.key_store,

--- a/tests/utils/managed_utils/mod.rs
+++ b/tests/utils/managed_utils/mod.rs
@@ -118,7 +118,7 @@ impl ManagedTestSetup {
             let mut credentials = HashMap::new();
             for ciphersuite in Config::supported_ciphersuite_names() {
                 let credential = key_store
-                    .generate_credential(
+                    .generate_credential_bundle(
                         identity.clone(),
                         CredentialType::Basic,
                         SignatureScheme::from(*ciphersuite),


### PR DESCRIPTION
This PR replaces #334, as it goes a step further and doesn't keep the KeyStore reference in the ManagedGroup struct, but instead passes a KeyStore reference into every call into the Managed Group API. This allows us to avoid lifetime issues, as Rust doesn't allow struct-internal references.

One caveat in this PR that might be worth discussing:
* We currently ignore (i.e. `unwrap`) PoisonErrors when accessing KeyPackageBundles and CredentialBundles. The argument being that there is (to my knowledge) no way that the code can panic while it holds a write lock. In particular while holding a write lock, we only interact with the HashMap using `get`, `insert` or `remove`, which should be safe.

The PR is rather large, but should be easy to review, as a lot of the changes are due to the change of API, so function calls will look different, but in most places, there are no changes in terms of functionality.