### PR TITLE
Store encoded key_pacakge

### DIFF
--- a/src/key_packages/errors.rs
+++ b/src/key_packages/errors.rs
@@ -3,7 +3,7 @@
 //! `KeyPackageError` are thrown on errors handling `KeyPackage`s and
 //! `KeyPackageBundle`s.
 
-use crate::{config::ConfigError, extensions::ExtensionError};
+use crate::{codec::CodecError, config::ConfigError, extensions::ExtensionError};
 
 implement_error! {
     pub enum KeyPackageError {
@@ -24,6 +24,8 @@ implement_error! {
                 "See [`ExtensionError`](crate::extensions::ExtensionError`) for details.",
             ConfigError(ConfigError) =
                 "See [`ConfigError`](crate::config::ConfigError`) for details.",
+            CodecError(CodecError) =
+                "See [`CodecError`](crate::codec::CodecError`) for details.",
         }
     }
 }


### PR DESCRIPTION
Encoding of key packages is a performance bottleneck.
In order to speed up things like tree hashes this PR
serializes the key package on creation and every update
and stores the serialized value in the key package itself.