### PR TITLE
use tls-codec for tree hash structs

### DIFF
--- a/src/ciphersuite/codec.rs
+++ b/src/ciphersuite/codec.rs
@@ -51,7 +51,7 @@ impl Codec for Signature {
 impl tls_codec::TlsSize for Signature {
     #[inline]
     fn serialized_len(&self) -> usize {
-        2 + self.value.len()
+        VecSize::VecU16.len_len() + self.value.len()
     }
 }
 

--- a/src/ciphersuite/codec.rs
+++ b/src/ciphersuite/codec.rs
@@ -48,6 +48,13 @@ impl Codec for Signature {
     }
 }
 
+impl tls_codec::TlsSize for Signature {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        2 + self.value.len()
+    }
+}
+
 impl Codec for HPKEPublicKey {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         encode_vec(VecSize::VecU16, buffer, self.as_slice())?;

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -13,6 +13,19 @@ pub enum VecSize {
     VecU32,
     VecU64,
 }
+
+impl VecSize {
+    #[inline(always)]
+    pub(crate) const fn len_len(self) -> usize {
+        match self {
+            VecSize::VecU8 => 1,
+            VecSize::VecU16 => 2,
+            VecSize::VecU32 => 4,
+            VecSize::VecU64 => 8,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Cursor {
     buffer: Vec<u8>,

--- a/src/key_packages/codec.rs
+++ b/src/key_packages/codec.rs
@@ -34,3 +34,10 @@ impl Codec for KeyPackage {
         Ok(kp)
     }
 }
+
+impl tls_codec::TlsSize for KeyPackage {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        self.encoded.len() + self.signature.serialized_len()
+    }
+}

--- a/src/tree/codec.rs
+++ b/src/tree/codec.rs
@@ -1,3 +1,5 @@
+use tls_codec::TlsSize;
+
 use crate::tree::{node::*, secret_tree::*, *};
 use std::convert::TryFrom;
 
@@ -54,6 +56,17 @@ impl Codec for ParentNode {
     }
 }
 
+impl tls_codec::TlsSize for ParentNode {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        self.public_key.serialized_len()
+            + 4
+            + self.unmerged_leaves.len() * 4
+            + 1
+            + self.parent_hash.len()
+    }
+}
+
 impl Codec for UpdatePathNode {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.public_key.encode(buffer)?;
@@ -97,30 +110,74 @@ impl Codec for SecretTreeNode {
 
 // Hash inputs
 
-impl<'a> Codec for ParentHashInput<'a> {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.public_key.encode(buffer)?;
-        encode_vec(VecSize::VecU8, buffer, &self.parent_hash)?;
-        encode_vec(VecSize::VecU32, buffer, &self.original_child_resolution)?;
+impl<'a> tls_codec::Serialize for ParentHashInput<'a> {
+    fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), tls_codec::Error> {
+        debug_assert!(buffer.capacity() == (buffer.len() + self.serialized_len()));
+        self.public_key.tls_serialize(buffer)?;
+        buffer.push(self.parent_hash.len() as u8);
+        buffer.extend_from_slice(&self.parent_hash);
+        buffer.extend_from_slice(&(self.original_child_resolution.len() as u32).to_be_bytes());
+        for &pk in self.original_child_resolution.iter() {
+            pk.tls_serialize(buffer)?;
+        }
+        debug_assert!(buffer.capacity() == buffer.len());
         Ok(())
     }
 }
 
-impl<'a> Codec for ParentNodeTreeHashInput<'a> {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.node_index.encode(buffer)?;
-        self.parent_node.encode(buffer)?;
-        encode_vec(VecSize::VecU8, buffer, &self.left_hash)?;
-        encode_vec(VecSize::VecU8, buffer, &self.right_hash)?;
+impl<'a> tls_codec::TlsSize for ParentHashInput<'a> {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        self.public_key.serialized_len()
+            + 1
+            + self.parent_hash.len()
+            + 4
+            + self
+                .original_child_resolution
+                .iter()
+                .fold(0, |acc, e| acc + e.serialized_len())
+    }
+}
+
+impl<'a> tls_codec::Serialize for ParentNodeTreeHashInput<'a> {
+    fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), tls_codec::Error> {
+        debug_assert!(buffer.capacity() == (buffer.len() + self.serialized_len()));
+        buffer.extend_from_slice(&self.node_index.to_be_bytes());
+        self.parent_node
+            .encode(buffer)
+            .map_err(|_| tls_codec::Error::EncodingError)?;
+        buffer.push(self.left_hash.len() as u8);
+        buffer.extend_from_slice(&self.left_hash);
+        buffer.push(self.right_hash.len() as u8);
+        buffer.extend_from_slice(&self.right_hash);
+        debug_assert!(buffer.capacity() == buffer.len());
         Ok(())
     }
 }
 
-impl<'a> Codec for LeafNodeHashInput<'a> {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.node_index.as_u32().encode(buffer)?;
-        self.key_package.encode(buffer)?;
+impl<'a> tls_codec::TlsSize for ParentNodeTreeHashInput<'a> {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        4 + self.parent_node.serialized_len() + 1 + self.left_hash.len() + 1 + self.right_hash.len()
+    }
+}
+
+impl<'a> tls_codec::Serialize for LeafNodeHashInput<'a> {
+    fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), tls_codec::Error> {
+        debug_assert!(buffer.capacity() == (buffer.len() + self.serialized_len()));
+        buffer.extend_from_slice(&self.node_index.as_u32().to_be_bytes());
+        self.key_package
+            .encode(buffer)
+            .map_err(|_| tls_codec::Error::EncodingError)?;
+        debug_assert!(buffer.capacity() == buffer.len());
         Ok(())
+    }
+}
+
+impl<'a> tls_codec::TlsSize for LeafNodeHashInput<'a> {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        4 + self.key_package.serialized_len()
     }
 }
 

--- a/src/tree/codec.rs
+++ b/src/tree/codec.rs
@@ -60,9 +60,9 @@ impl tls_codec::TlsSize for ParentNode {
     #[inline]
     fn serialized_len(&self) -> usize {
         self.public_key.serialized_len()
-            + 4
+            + VecSize::VecU32.len_len()
             + self.unmerged_leaves.len() * 4
-            + 1
+            + VecSize::VecU8.len_len()
             + self.parent_hash.len()
     }
 }
@@ -129,9 +129,9 @@ impl<'a> tls_codec::TlsSize for ParentHashInput<'a> {
     #[inline]
     fn serialized_len(&self) -> usize {
         self.public_key.serialized_len()
-            + 1
+            + VecSize::VecU8.len_len()
             + self.parent_hash.len()
-            + 4
+            + VecSize::VecU32.len_len()
             + self
                 .original_child_resolution
                 .iter()
@@ -158,7 +158,12 @@ impl<'a> tls_codec::Serialize for ParentNodeTreeHashInput<'a> {
 impl<'a> tls_codec::TlsSize for ParentNodeTreeHashInput<'a> {
     #[inline]
     fn serialized_len(&self) -> usize {
-        4 + self.parent_node.serialized_len() + 1 + self.left_hash.len() + 1 + self.right_hash.len()
+        VecSize::VecU32.len_len()
+            + self.parent_node.serialized_len()
+            + VecSize::VecU8.len_len()
+            + self.left_hash.len()
+            + VecSize::VecU8.len_len()
+            + self.right_hash.len()
     }
 }
 
@@ -177,7 +182,7 @@ impl<'a> tls_codec::Serialize for LeafNodeHashInput<'a> {
 impl<'a> tls_codec::TlsSize for LeafNodeHashInput<'a> {
     #[inline]
     fn serialized_len(&self) -> usize {
-        4 + self.key_package.serialized_len()
+        VecSize::VecU32.len_len() + self.key_package.serialized_len()
     }
 }
 

--- a/src/tree/hashes.rs
+++ b/src/tree/hashes.rs
@@ -36,10 +36,11 @@
 //! } ParentNodeTreeHashInput;
 //! ```
 
+use tls_codec::Serialize;
+
 use super::node::ParentNode;
 use super::*;
 use crate::ciphersuite::{Ciphersuite, HPKEPublicKey};
-use crate::codec::Codec;
 use crate::key_packages::KeyPackage;
 
 pub(crate) struct ParentHashInput<'a> {
@@ -67,7 +68,7 @@ impl<'a> ParentHashInput<'a> {
         })
     }
     pub(crate) fn hash(&self, ciphersuite: &Ciphersuite) -> Vec<u8> {
-        let payload = self.encode_detached().unwrap();
+        let payload = self.tls_serialize_detached().unwrap();
         ciphersuite.hash(&payload)
     }
 }
@@ -84,7 +85,7 @@ impl<'a> LeafNodeHashInput<'a> {
         }
     }
     pub fn hash(&self, ciphersuite: &Ciphersuite) -> Vec<u8> {
-        let payload = self.encode_detached().unwrap();
+        let payload = self.tls_serialize_detached().unwrap();
         ciphersuite.hash(&payload)
     }
 }
@@ -110,7 +111,7 @@ impl<'a> ParentNodeTreeHashInput<'a> {
         }
     }
     pub(crate) fn hash(&self, ciphersuite: &Ciphersuite) -> Vec<u8> {
-        let payload = self.encode_detached().unwrap();
+        let payload = self.tls_serialize_detached().unwrap();
         ciphersuite.hash(&payload)
     }
 }

--- a/tls-codec/src/arrays.rs
+++ b/tls-codec/src/arrays.rs
@@ -1,15 +1,13 @@
 //! Implement the TLS codec for some byte arrays.
 
-use super::{Cursor, Deserialize, Error, Serialize};
+use super::{Cursor, Deserialize, Error, Serialize, TlsSize};
 use std::convert::TryInto;
 
 macro_rules! impl_array {
     ($len:literal) => {
         impl Serialize for [u8; $len] {
             fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error> {
-                for b in self {
-                    buffer.push(*b);
-                }
+                buffer.extend_from_slice(self);
                 Ok(())
             }
         }
@@ -17,6 +15,13 @@ macro_rules! impl_array {
         impl Deserialize for [u8; $len] {
             fn tls_deserialize(cursor: &Cursor) -> Result<Self, Error> {
                 Ok(cursor.read($len)?.try_into()?)
+            }
+        }
+
+        impl TlsSize for [u8; $len] {
+            #[inline]
+            fn serialized_len(&self) -> usize {
+                $len
             }
         }
     };

--- a/tls-codec/src/hpke.rs
+++ b/tls-codec/src/hpke.rs
@@ -16,3 +16,10 @@ impl Deserialize for HPKEPublicKey {
         Ok(Self::new(value.as_slice().to_vec()))
     }
 }
+
+impl TlsSize for HPKEPublicKey {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        2 + self.as_slice().len()
+    }
+}

--- a/tls-codec/src/hpke.rs
+++ b/tls-codec/src/hpke.rs
@@ -20,6 +20,6 @@ impl Deserialize for HPKEPublicKey {
 impl TlsSize for HPKEPublicKey {
     #[inline]
     fn serialized_len(&self) -> usize {
-        2 + self.as_slice().len()
+        TlsVecU16::<u8>::len_len() + self.as_slice().len()
     }
 }

--- a/tls-codec/src/lib.rs
+++ b/tls-codec/src/lib.rs
@@ -42,16 +42,24 @@ pub enum Error {
     DecodingError,
 }
 
+/// The `TlsSize` trait needs to be implemented by any struct that should be
+/// efficiently serialized.
+/// This allows to collect the length of a serialized structure before allocating
+/// memory.
+pub trait TlsSize {
+    fn serialized_len(&self) -> usize;
+}
+
 /// The `Serialize` trait provides functions to serialize a struct or enum.
 ///
 /// The trait provides two functions:
 /// * `tls_serialize` that takes a buffer to write the serialization to
 /// * `tls_serialize_detached` that returns a byte vector
-pub trait Serialize {
+pub trait Serialize: TlsSize {
     fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error>;
 
     fn tls_serialize_detached(&self) -> Result<Vec<u8>, Error> {
-        let mut buffer = Vec::new();
+        let mut buffer = Vec::with_capacity(self.serialized_len());
         self.tls_serialize(&mut buffer)?;
         Ok(buffer)
     }

--- a/tls-codec/src/primitives.rs
+++ b/tls-codec/src/primitives.rs
@@ -1,6 +1,6 @@
 //! Codec implementations for unsigned integer primitives.
 
-use super::{Cursor, Deserialize, Error, Serialize};
+use super::{Cursor, Deserialize, Error, Serialize, TlsSize};
 
 use std::convert::TryInto;
 
@@ -11,10 +11,24 @@ impl Serialize for u8 {
     }
 }
 
+impl TlsSize for u8 {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        1
+    }
+}
+
 impl Serialize for u16 {
     fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error> {
         buffer.extend_from_slice(&self.to_be_bytes());
         Ok(())
+    }
+}
+
+impl TlsSize for u16 {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        2
     }
 }
 
@@ -25,10 +39,34 @@ impl Serialize for u32 {
     }
 }
 
+impl TlsSize for u32 {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        4
+    }
+}
+
 impl Serialize for u64 {
     fn tls_serialize(&self, buffer: &mut Vec<u8>) -> Result<(), Error> {
         buffer.extend_from_slice(&self.to_be_bytes());
         Ok(())
+    }
+}
+
+impl TlsSize for u64 {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        8
+    }
+}
+
+impl<T: TlsSize> TlsSize for Option<T> {
+    #[inline]
+    fn serialized_len(&self) -> usize {
+        1 + match self {
+            Some(v) => v.serialized_len(),
+            None => 0,
+        }
     }
 }
 

--- a/tls-codec/src/tls_vec.rs
+++ b/tls-codec/src/tls_vec.rs
@@ -45,6 +45,12 @@ macro_rules! impl_tls_vec {
             pub fn pop(&mut self) -> Option<T> {
                 self.vec.pop()
             }
+
+            /// Get the number of bytes used for the length encoding.
+            #[inline(always)]
+            pub fn len_len() -> usize {
+                $len_len
+            }
         }
 
         impl<T: Serialize + Deserialize + Clone + PartialEq> From<Vec<T>> for $name<T> {


### PR DESCRIPTION
This PR starts using the tls-codec for OpenMLS TLS encoding, starting
with the tree hash structs. Note that this is a mix now, but the tree
hash inputs are pretty self contained and therefore a good starting
point. Some of the encoding is a little more manual than before. This
should be improved later on when more structs use the tls-codec crate.

The tls-codec crate now offers a way to pre-allocate memory for
serializing. The `TlsSize` trait must be implemented for any struct
that want to implement `Serialize` and provides a `serialized_len`
method to get the length of the struct before serializing.

This reduces the tree_hash time by about 30%. There's a lot more to
do here, but this is an easy start to improve performance.