### PR TITLE
Refactor Managed API to accept and return individual messages

### DIFF
--- a/src/framing/plaintext.rs
+++ b/src/framing/plaintext.rs
@@ -325,15 +325,6 @@ pub enum MlsPlaintextContentType {
     Commit(Commit),
 }
 
-impl MlsPlaintextContentType {
-    pub(crate) fn to_proposal(&self) -> &Proposal {
-        match self {
-            MlsPlaintextContentType::Proposal(proposal) => proposal,
-            _ => panic!("Library error. Expected Proposal in MlsPlaintextContentType"),
-        }
-    }
-}
-
 /// 9.1 Content Authentication
 ///
 /// ```c

--- a/src/group/managed_group/errors.rs
+++ b/src/group/managed_group/errors.rs
@@ -5,7 +5,8 @@
 
 use crate::codec::CodecError;
 use crate::config::ConfigError;
-use crate::error::{ErrorPayload, ErrorString};
+use crate::error::ErrorString;
+use crate::framing::MlsCiphertextError;
 use crate::group::{ApplyCommitError, CreateCommitError, ExporterError, GroupError};
 use crate::key_store::KeyStoreError;
 
@@ -36,6 +37,7 @@ implement_error! {
             EmptyInput(EmptyInputError) =
                 "Empty input. Additional detail is provided.",
             KeyStoreError(KeyStoreError) = "See [`KeyStoreError`](`crate::key_store::KeyStoreError`) for details",
+            InvalidMessage(InvalidMessageError) = "The message could not be processed.",
         }
     }
 }
@@ -64,12 +66,14 @@ implement_error! {
         Simple {
             MembershipTagMismatch =
                 "A Proposal with an invalid membership tag was received.",
+            InvalidProposal =
+                "The given proposal is invalid.",
+            CommitWithInvalidProposals =
+                "A commit contained an invalid proposal.",
         }
         Complex {
-            InvalidCiphertext(ErrorPayload) =
+            InvalidCiphertext(MlsCiphertextError) =
                 "An invalid ciphertext was provided. The error returns the associated data of the ciphertext.",
-            CommitWithInvalidProposals(ErrorString) =
-                "A commit contained an invalid proposal. Additional detail is provided.",
             CommitError(ApplyCommitError) =
                 "See [`ApplyCommitError`](`crate::group::ApplyCommitError`) for details",
             GroupError(GroupError) =

--- a/src/group/managed_group/events.rs
+++ b/src/group/managed_group/events.rs
@@ -12,7 +12,6 @@ pub enum GroupEvent {
     PskReceived(PskReceivedEvent),
     ReInit(ReInitEvent),
     ApplicationMessage(ApplicationMessageEvent),
-    InvalidMessage(InvalidMessageEvent),
     Error(ErrorEvent),
 }
 
@@ -188,26 +187,6 @@ impl ApplicationMessageEvent {
     /// Get a reference to the event's message.
     pub fn message(&self) -> &[u8] {
         &self.message
-    }
-}
-
-// Errors
-
-/// Event that occurs when an invalid message is received.
-/// `error` contains the specific error.
-#[derive(Debug, PartialEq, Clone)]
-pub struct InvalidMessageEvent {
-    error: InvalidMessageError,
-}
-
-impl InvalidMessageEvent {
-    pub(crate) fn new(error: InvalidMessageError) -> Self {
-        Self { error }
-    }
-
-    /// Get a reference to the event's error.
-    pub fn error(&self) -> &InvalidMessageError {
-        &self.error
     }
 }
 

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -434,7 +434,7 @@ impl ManagedGroup {
                 (
                     self.group
                         .decrypt(&ciphertext)
-                        .map_err(|e| InvalidMessageError::InvalidCiphertext(e))?,
+                        .map_err(InvalidMessageError::InvalidCiphertext)?,
                     Some(aad),
                 )
             }
@@ -787,9 +787,11 @@ impl ManagedGroup {
         };
 
         // Take the new KeyPackageBundle and save it for later
-        let kpb = kpb_option.ok_or(ManagedGroupError::LibraryError(
-            "We didn't get a key package for a full commit on self update.".into(),
-        ))?;
+        let kpb = kpb_option.ok_or_else(|| {
+            ManagedGroupError::LibraryError(
+                "We didn't get a key package for a full commit on self update.".into(),
+            )
+        })?;
 
         self.own_kpbs.push(kpb);
 

--- a/src/group/managed_group/test_managed_group.rs
+++ b/src/group/managed_group/test_managed_group.rs
@@ -142,7 +142,7 @@ fn remover() {
     };
 
     alice_group
-        .process_messages(queued_messages)
+        .process_message(queued_messages)
         .expect("The group is no longer active");
 
     let mut bob_group = ManagedGroup::new_from_welcome(
@@ -161,10 +161,10 @@ fn remover() {
     };
 
     alice_group
-        .process_messages(queued_messages.clone())
+        .process_message(queued_messages.clone())
         .expect("The group is no longer active");
     bob_group
-        .process_messages(queued_messages)
+        .process_message(queued_messages)
         .expect("The group is no longer active");
 
     let charlie_callbacks = ManagedGroupCallbacks::default();
@@ -180,11 +180,11 @@ fn remover() {
     // === Alice removes Bob & Charlie commits ===
 
     let queued_messages = alice_group
-        .propose_remove_members(&key_store, &[1])
+        .propose_remove_member(&key_store, 1)
         .expect("Could not propose removal");
 
     charlie_group
-        .process_messages(queued_messages)
+        .process_message(queued_messages)
         .expect("Could not process messages");
 
     let (queued_messages, _welcome) = charlie_group
@@ -192,7 +192,7 @@ fn remover() {
         .expect("Could not commit proposal");
 
     let events = charlie_group
-        .process_messages(queued_messages)
+        .process_message(queued_messages)
         .expect("Could not process messages");
 
     match events.first().expect("Expected an event to be returned") {

--- a/src/group/managed_group/test_managed_group.rs
+++ b/src/group/managed_group/test_managed_group.rs
@@ -119,7 +119,7 @@ fn remover() {
     let update_policy = UpdatePolicy::default();
     let callbacks = ManagedGroupCallbacks::default();
     let mut managed_group_config = ManagedGroupConfig::new(
-        HandshakeMessageFormat::Plaintext,
+        HandshakeMessageFormat::Ciphertext,
         update_policy,
         0, // padding_size
         0, // number_of_resumption_secrets

--- a/tests/test_managed_group.rs
+++ b/tests/test_managed_group.rs
@@ -133,7 +133,7 @@ fn managed_group_operations() {
                 };
 
             let events = alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             // Check that we received the correct event
@@ -176,7 +176,7 @@ fn managed_group_operations() {
                 .create_message(&key_store, message_alice)
                 .expect("Error creating application message");
             let events = bob_group
-                .process_messages(vec![queued_message])
+                .process_message(queued_message)
                 .expect("The group is no longer active");
 
             // Check that we received the correct event
@@ -194,10 +194,10 @@ fn managed_group_operations() {
                 Err(e) => panic!("Error performing self-update: {:?}", e),
             };
             let alice_events = alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             let bob_events = bob_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             // Check that the events are equal
@@ -235,10 +235,10 @@ fn managed_group_operations() {
                 Err(e) => panic!("Error performing self-update: {:?}", e),
             };
             alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             bob_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             let (queued_messages, _welcome_option) =
@@ -247,10 +247,10 @@ fn managed_group_operations() {
                     Err(e) => panic!("Error performing self-update: {:?}", e),
                 };
             let alice_events = alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             let bob_events = bob_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             // Check that the events are equel
@@ -291,10 +291,10 @@ fn managed_group_operations() {
                 };
 
             alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             bob_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             let mut charlie_group = ManagedGroup::new_from_welcome(
@@ -327,10 +327,10 @@ fn managed_group_operations() {
                 .create_message(&key_store, message_charlie)
                 .expect("Error creating application message");
             alice_group
-                .process_messages(vec![queued_message.clone()])
+                .process_message(queued_message.clone())
                 .expect("The group is no longer active");
             bob_group
-                .process_messages(vec![queued_message])
+                .process_message(queued_message)
                 .expect("The group is no longer active");
 
             // === Charlie updates and commits ===
@@ -340,13 +340,13 @@ fn managed_group_operations() {
                     Err(e) => panic!("Error performing self-update: {:?}", e),
                 };
             alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             bob_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             charlie_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             // Check we didn't receive a Welcome message
@@ -383,13 +383,13 @@ fn managed_group_operations() {
             assert!(bob_group.is_active());
 
             let alice_events = alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             let bob_events = bob_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             charlie_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             // Check that we receive the correct event for Alice
@@ -463,24 +463,24 @@ fn managed_group_operations() {
 
             // Create RemoveProposal and process it
             let queued_messages = alice_group
-                .propose_remove_members(&key_store, &[2])
+                .propose_remove_member(&key_store, 2)
                 .expect("Could not create proposal to remove Charlie");
             alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             charlie_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             // Create AddProposal and process it
             let queued_messages = alice_group
-                .propose_add_members(&key_store, &[bob_key_package.clone()])
+                .propose_add_member(&key_store, &bob_key_package)
                 .expect("Could not create proposal to add Bob");
             alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             charlie_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             // Commit to the proposals and process it
@@ -488,10 +488,10 @@ fn managed_group_operations() {
                 .process_pending_proposals(&key_store)
                 .expect("Could not flush proposals");
             alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             charlie_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             // Make sure the group contains two members
@@ -533,7 +533,7 @@ fn managed_group_operations() {
                 .create_message(&key_store, message_alice)
                 .expect("Error creating application message");
             bob_group
-                .process_messages(vec![queued_message.clone()])
+                .process_message(queued_message.clone())
                 .expect("The group is no longer active");
 
             // === Bob leaves the group ===
@@ -543,10 +543,10 @@ fn managed_group_operations() {
                 .expect("Could not leave group");
 
             alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             bob_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             // Should fail because you cannot remove yourself from a group
@@ -565,10 +565,10 @@ fn managed_group_operations() {
             assert!(bob_group.is_active());
 
             let alice_events = alice_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
             let bob_events = bob_group
-                .process_messages(queued_messages.clone())
+                .process_message(queued_messages.clone())
                 .expect("The group is no longer active");
 
             // Check that we receive the correct event for Bob
@@ -628,7 +628,7 @@ fn managed_group_operations() {
                 .expect("Could not add Bob");
 
             alice_group
-                .process_messages(queued_messages)
+                .process_message(queued_messages)
                 .expect("Could not process messages");
 
             let bob_group = ManagedGroup::new_from_welcome(

--- a/tests/utils/managed_utils/mod.rs
+++ b/tests/utils/managed_utils/mod.rs
@@ -198,7 +198,7 @@ impl ManagedTestSetup {
         // been removed from the group.
         sender_id: &[u8],
         group: &mut Group,
-        messages: &[MlsMessage],
+        message: &MlsMessage,
     ) -> Result<(), ClientError> {
         let clients = self.clients.borrow();
         println!("Distributing and processing messages...");
@@ -206,7 +206,7 @@ impl ManagedTestSetup {
         for (index, member_id) in &group.members {
             println!("Index: {:?}, Id: {:?}", index, member_id);
             let member = clients.get(member_id).unwrap().borrow();
-            member.receive_messages_for_group(messages)?;
+            member.receive_messages_for_group(message)?;
         }
         // Get the current tree and figure out who's still in the group.
         let sender = clients.get(sender_id).unwrap().borrow();
@@ -252,7 +252,7 @@ impl ManagedTestSetup {
         }
         drop(clients);
         for (sender_id, message) in messages {
-            self.distribute_to_members(&sender_id, group, &[message])
+            self.distribute_to_members(&sender_id, group, &message)
                 .expect("Error sending messages to clients while checking group states.");
         }
     }
@@ -420,7 +420,9 @@ impl ManagedTestSetup {
         }
         let (messages, welcome_option) =
             adder.add_members(action_type, &group.group_id, &key_packages)?;
-        self.distribute_to_members(&adder_id, group, &messages)?;
+        for message in &messages {
+            self.distribute_to_members(&adder_id, group, &message)?;
+        }
         if let Some(welcome) = welcome_option {
             self.deliver_welcome(welcome, group)?;
         }
@@ -453,7 +455,9 @@ impl ManagedTestSetup {
         }
         let (messages, welcome_option) =
             remover.remove_members(action_type, &group.group_id, &target_indices)?;
-        self.distribute_to_members(remover_id, group, &messages)?;
+        for message in &messages {
+            self.distribute_to_members(remover_id, group, &message)?;
+        }
         if let Some(welcome) = welcome_option {
             self.deliver_welcome(welcome, group)?;
         }


### PR DESCRIPTION
This PR refactors the functions in the Managed API to accept individual messages (`process_message`) and return individual messages (`propose_...`, etc).

This necessitates some refactoring of the events returned and in particular allows us to return errors if messages are invalid as opposed to just putting error events into the queue.