### PR TITLE
Refactor group info extensions for MlsGroup

### DIFF
--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -156,9 +156,9 @@ async fn test_group() {
         group_id,
         group_ciphersuite,
         key_package_bundles.remove(0),
-        GroupConfig::default(),
-        None, /* Initial PSK */
-        None, /* MLS version */
+        false, /* use ratchet tree extension */
+        None,  /* Initial PSK */
+        None,  /* MLS version */
     )
     .unwrap();
 
@@ -202,6 +202,7 @@ async fn test_group() {
             &[],
             false,
             None,
+            vec![], /* Extensions */
         )
         .expect("Error creating commit");
     let welcome_msg = welcome_msg.expect("Welcome message wasn't created by create_commit.");
@@ -246,7 +247,7 @@ async fn test_group() {
     assert_eq!(welcome_msg, welcome_message);
     assert!(messages.is_empty());
 
-    let mut group_on_client2 = MlsGroup::new_from_welcome(
+    let (mut group_on_client2, _extensions) = MlsGroup::new_from_welcome(
         welcome_message,
         Some(group.tree().public_key_tree_copy()), // delivered out of band
         key_package_bundles.remove(0),

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -69,12 +69,15 @@ impl<'a> Cursor {
     }
 }
 
-pub trait Codec: Sized {
+pub trait Codec {
     fn encode(&self, _buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         unimplemented!();
     }
 
-    fn decode(_cursor: &mut Cursor) -> Result<Self, CodecError> {
+    fn decode(_cursor: &mut Cursor) -> Result<Self, CodecError>
+    where
+        Self: Sized,
+    {
         unimplemented!();
     }
 
@@ -84,7 +87,10 @@ pub trait Codec: Sized {
         Ok(buffer)
     }
 
-    fn decode_detached(bytes: &[u8]) -> Result<Self, CodecError> {
+    fn decode_detached(bytes: &[u8]) -> Result<Self, CodecError>
+    where
+        Self: Sized,
+    {
         let cursor = &mut Cursor::new(bytes);
         Self::decode(cursor)
     }

--- a/src/extensions/group_info_extension.rs
+++ b/src/extensions/group_info_extension.rs
@@ -1,0 +1,24 @@
+use super::*;
+
+pub trait GroupInfoExtension: Codec {
+    fn extension_type(&self) -> ExtensionType
+    where
+        Self: Sized;
+
+    fn to_extension_struct(&self) -> Result<ExtensionStruct, CodecError>
+    where
+        Self: Sized,
+    {
+        Ok(ExtensionStruct::new(
+            self.extension_type(),
+            self.encode_detached()?,
+        ))
+    }
+
+    fn from_extension_struct(extension_struct: ExtensionStruct) -> Result<Self, CodecError>
+    where
+        Self: Sized,
+    {
+        Self::decode_detached(extension_struct.extension_data())
+    }
+}

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -125,13 +125,12 @@ impl<'a> ExtensionStruct {
         }
     }
 
-    /// Get the extension type
+    /// Get the extension type.
     pub fn extension_type(&self) -> ExtensionType {
         self.extension_type
     }
 
     /// Get the data of this extension struct.
-    #[cfg(any(feature = "expose-test-vectors", test))]
     pub fn extension_data(&'a self) -> &'a [u8] {
         &self.extension_data
     }

--- a/src/extensions/test_extensions.rs
+++ b/src/extensions/test_extensions.rs
@@ -109,18 +109,13 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
             .unwrap();
     let bob_key_package = bob_key_package_bundle.key_package();
 
-    let config = GroupConfig {
-        add_ratchet_tree_extension: true,
-        ..GroupConfig::default()
-    };
-
     // === Alice creates a group with the ratchet tree extension ===
     let group_id = [1, 2, 3, 4];
     let mut alice_group = MlsGroup::new(
         &group_id,
         ciphersuite.name(),
         alice_key_package_bundle,
-        config,
+        true, /* use ratchet tree extension */
         None, /* Initial PSK */
         None, /* MLS version */
     )
@@ -139,6 +134,7 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
             &[],
             false,
             None,
+            vec![], /* Extensions */
         )
         .expect("Error creating commit");
 
@@ -146,7 +142,7 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
         .apply_commit(&mls_plaintext_commit, epoch_proposals, &[], None)
         .expect("error applying commit");
 
-    let bob_group = match MlsGroup::new_from_welcome(
+    let (bob_group, _extensions) = match MlsGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.unwrap(),
         None,
         bob_key_package_bundle,
@@ -162,10 +158,6 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
         bob_group.authentication_secret()
     );
 
-    // Make sure both groups have set the flag correctly
-    assert!(alice_group.use_ratchet_tree_extension());
-    assert!(bob_group.use_ratchet_tree_extension());
-
     // === Alice creates a group without the ratchet tree extension ===
 
     // Generate KeyPackages
@@ -178,17 +170,12 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
             .unwrap();
     let bob_key_package = bob_key_package_bundle.key_package();
 
-    let config = GroupConfig {
-        add_ratchet_tree_extension: false,
-        ..GroupConfig::default()
-    };
-
     let group_id = [5, 6, 7, 8];
     let mut alice_group = MlsGroup::new(
         &group_id,
         ciphersuite.name(),
         alice_key_package_bundle,
-        config,
+        false, /* use ratchet tree extension */
         None, /* Initial PSK */
         None, /* MLS version */
     )
@@ -207,6 +194,7 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
             &[],
             false,
             None,
+            vec![], /* Extensions */
         )
         .expect("Error creating commit");
 

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -165,9 +165,9 @@ fn unknown_sender() {
             &group_id,
             ciphersuite.name(),
             alice_key_package_bundle,
-            GroupConfig::default(),
-            None, /* Initial PSK */
-            None, /* MLS version */
+            false, /* use ratchet tree extension */
+            None,  /* Initial PSK */
+            None,  /* MLS version */
         )
         .unwrap();
 
@@ -184,6 +184,7 @@ fn unknown_sender() {
                 &[],
                 false,
                 None,
+                vec![], /* Extensions */
             )
             .expect("Error creating Commit");
 
@@ -209,6 +210,7 @@ fn unknown_sender() {
                 &[],
                 false,
                 None,
+                vec![], /* Extensions */
             )
             .expect("Error creating Commit");
 
@@ -216,7 +218,7 @@ fn unknown_sender() {
             .apply_commit(&commit, &[&charlie_add_proposal], &[], None)
             .expect("Could not apply Commit");
 
-        let mut group_charlie = MlsGroup::new_from_welcome(
+        let (mut group_charlie, _extensions) = MlsGroup::new_from_welcome(
             welcome_option.unwrap(),
             Some(group_alice.tree().public_key_tree_copy()),
             charlie_key_package_bundle,
@@ -236,6 +238,7 @@ fn unknown_sender() {
                 &[],
                 false,
                 None,
+                vec![], /* Extensions */
             )
             .expect("Error creating Commit");
 

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -61,8 +61,8 @@ implement_error! {
                 "The signature on the GroupInfo is not valid.",
             GroupInfoDecryptionFailure =
                 "Unable to decrypt the GroupInfo.",
-            DuplicateRatchetTreeExtension =
-                "Found a duplicate ratchet tree extension in the Welcome message.",
+            DuplicateGroupInfoExtension =
+                "Found a duplicate group info extension in the Welcome message.",
             UnsupportedMlsVersion =
                 "The Welcome message uses an unsupported MLS version.",
             UnknownError =

--- a/src/group/managed_group/mod.rs
+++ b/src/group/managed_group/mod.rs
@@ -111,7 +111,7 @@ impl ManagedGroup {
             &group_id.as_slice(),
             key_package_bundle.key_package().ciphersuite_name(),
             key_package_bundle,
-            GroupConfig::default(),
+            false,
             None, /* Initial PSK */
             None, /* MLS version */
         )?;
@@ -150,7 +150,8 @@ impl ManagedGroup {
             .find_map(|egs| key_store.take_key_package_bundle(&egs.key_package_hash))
             .ok_or(ManagedGroupError::NoMatchingKeyPackageBundle)?;
         // TODO #141
-        let group = MlsGroup::new_from_welcome(welcome, ratchet_tree, key_package_bundle, None)?;
+        let (group, _extensions) =
+            MlsGroup::new_from_welcome(welcome, ratchet_tree, key_package_bundle, None)?;
 
         let managed_group = ManagedGroup {
             managed_group_config: managed_group_config.clone(),
@@ -224,6 +225,7 @@ impl ManagedGroup {
             proposals_by_value,
             true,
             None,
+            vec![], /* Extensions */
         )?;
 
         let welcome = match welcome_option {
@@ -304,6 +306,7 @@ impl ManagedGroup {
             proposals_by_value,
             false,
             None,
+            vec![], /* Extensions */
         )?;
 
         // It has to be a full Commit and we have to save the KeyPackageBundle for later
@@ -633,6 +636,7 @@ impl ManagedGroup {
             &[],
             true,
             None,
+            vec![], /* Extensions */
         )?;
 
         // If it was a full Commit, we have to save the KeyPackageBundle for later
@@ -775,6 +779,7 @@ impl ManagedGroup {
                     &[&update_proposal],
                     true, /* force_self_update */
                     None,
+                    vec![], /* Extensions */
                 )?
             }
             None => {
@@ -785,6 +790,7 @@ impl ManagedGroup {
                     &[],
                     true, /* force_self_update */
                     None,
+                    vec![], /* Extensions */
                 )?
             }
         };

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -17,7 +17,7 @@ impl MlsGroup {
         proposals_by_value: &[&Proposal],
         force_self_update: bool,
         psk_fetcher_option: Option<PskFetcher>,
-        group_info_extensions: Vec<Box<dyn Extension>>,
+        group_info_extensions: Vec<ExtensionStruct>,
     ) -> CreateCommitResult {
         let ciphersuite = self.ciphersuite();
         // Filter proposals
@@ -159,9 +159,8 @@ impl MlsGroup {
             // Create the ratchet tree extension if necessary
             let mut extensions = group_info_extensions;
             if self.use_ratchet_tree_extension {
-                extensions.push(Box::new(RatchetTreeExtension::new(
-                    provisional_tree.public_key_tree_copy(),
-                )));
+                let rte = RatchetTreeExtension::new(provisional_tree.public_key_tree_copy());
+                extensions.push(rte.to_extension_struct());
             }
             // Create GroupInfo object
             let mut group_info = GroupInfo::new(

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -7,6 +7,8 @@ mod new_from_welcome;
 #[cfg(test)]
 mod test_duplicate_extension;
 #[cfg(test)]
+mod test_group_info_extensions;
+#[cfg(test)]
 mod test_mls_group;
 
 use crate::codec::*;
@@ -122,7 +124,7 @@ impl MlsGroup {
         nodes_option: Option<Vec<Option<Node>>>,
         kpb: KeyPackageBundle,
         psk_fetcher_option: Option<PskFetcher>,
-    ) -> Result<(Self, Vec<Box<dyn Extension>>), GroupError> {
+    ) -> Result<(Self, Vec<ExtensionStruct>), GroupError> {
         Ok(Self::new_from_welcome_internal(
             welcome,
             nodes_option,
@@ -248,7 +250,7 @@ impl MlsGroup {
         proposals_by_value: &[&Proposal],
         force_self_update: bool,
         psk_fetcher_option: Option<PskFetcher>,
-        extensions: Vec<Box<dyn Extension>>,
+        extensions: Vec<ExtensionStruct>,
     ) -> CreateCommitResult {
         self.create_commit_internal(
             aad,

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -1,6 +1,5 @@
 use log::debug;
 
-use crate::extensions::ExtensionType;
 use crate::group::{mls_group::*, *};
 use crate::key_packages::*;
 use crate::messages::*;
@@ -14,7 +13,7 @@ impl MlsGroup {
         nodes_option: Option<Vec<Option<Node>>>,
         key_package_bundle: KeyPackageBundle,
         psk_fetcher_option: Option<PskFetcher>,
-    ) -> Result<(Self, Vec<Box<dyn Extension>>), WelcomeError> {
+    ) -> Result<(Self, Vec<ExtensionStruct>), WelcomeError> {
         log::debug!("MlsGroup::new_from_welcome_internal");
         let mls_version = *welcome.version();
         if !Config::supported_versions().contains(&mls_version) {
@@ -70,36 +69,20 @@ impl MlsGroup {
         let mut group_info = GroupInfo::decode_detached(&group_info_bytes)?;
         let path_secret_option = group_secrets.path_secret;
 
-        // Build the ratchet tree
-        // First check the extensions to see if the tree is in there.
-        let mut ratchet_tree_extensions = group_info
-            .extensions()
-            .iter()
-            .filter(|e| e.extension_type() == ExtensionType::RatchetTree)
-            .collect::<Vec<&Box<dyn Extension>>>();
+        // Throw an error if there is more than one ratchet tree extension.
+        // This shouldn't be the case anyway, because extensions are checked
+        // for uniqueness anyway when decoding them.
+        // We have to see if this makes problems later as it's not something
+        // required by the spec right now.
+        if !group_info.extensions_are_unique() {
+            return Err(WelcomeError::DuplicateGroupInfoExtension);
+        }
 
-        let ratchet_tree_extension = if ratchet_tree_extensions.is_empty() {
-            None
-        } else if ratchet_tree_extensions.len() == 1 {
-            let extension = ratchet_tree_extensions
-                .pop()
-                // Unwrappig here is safe because we know we only have one element
-                .unwrap()
-                .as_ratchet_tree_extension()
-                // Unwrapping here is safe, because we know the extension type already
-                .unwrap()
-                // We clone the nodes here upon extraction, so that we don't have to clone
-                // them later when we build the tree
-                .clone();
-            Some(extension)
-        } else {
-            // Throw an error if there is more than one ratchet tree extension.
-            // This shouldn't be the case anyway, because extensions are checked
-            // for uniqueness anyway when decoding them.
-            // We have to see if this makes problems later as it's not something
-            // required by the spec right now.
-            return Err(WelcomeError::DuplicateRatchetTreeExtension);
-        };
+        // Save the group info payload for later
+        let group_info_payload = group_info.unsigned_payload().unwrap();
+
+        // If the group info contains a ratchet tree extension, we extract it
+        let ratchet_tree_extension = group_info.take_ratchet_tree_extension();
 
         // Set nodes either from the extension or from the `nodes_option`.
         // If we got a ratchet tree extension in the welcome, we enable it for
@@ -130,11 +113,10 @@ impl MlsGroup {
         // Verify GroupInfo signature
         let signer_node = tree.nodes[group_info.signer_index()].clone();
         let signer_key_package = signer_node.key_package.unwrap();
-        let payload = group_info.unsigned_payload().unwrap();
 
         signer_key_package
             .credential()
-            .verify(&payload, group_info.signature())
+            .verify(&group_info_payload, group_info.signature())
             .map_err(|_| WelcomeError::InvalidGroupInfoSignature)?;
 
         // Compute path secrets
@@ -190,12 +172,6 @@ impl MlsGroup {
             &group_context.confirmed_transcript_hash,
         )?;
 
-        // Strip the ratchet tree extensions from the group info extensions
-        group_info
-            .extensions_mut()
-            .retain(|e| e.extension_type() != ExtensionType::RatchetTree);
-        let group_info_extensions = Clone::clone(group_info.extensions_mut());
-
         // Verify confirmation tag
         if &confirmation_tag != group_info.confirmation_tag() {
             log::error!("Confirmation tag mismatch");
@@ -214,7 +190,7 @@ impl MlsGroup {
                     use_ratchet_tree_extension,
                     mls_version,
                 },
-                group_info_extensions,
+                group_info.into_extensions(),
             ))
         }
     }

--- a/src/group/mls_group/test_duplicate_extension.rs
+++ b/src/group/mls_group/test_duplicate_extension.rs
@@ -42,17 +42,12 @@ ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(ciphersuite_name: Cip
             .unwrap();
     let bob_key_package = bob_key_package_bundle.key_package();
 
-    let config = GroupConfig {
-        add_ratchet_tree_extension: true,
-        ..GroupConfig::default()
-    };
-
     let group_id = [5, 6, 7, 8];
     let mut alice_group = MlsGroup::new(
         &group_id,
         ciphersuite.name(),
         alice_key_package_bundle,
-        config,
+        true, /* use ratchet tree extension */
         None, /* Initial PSK */
         None, /* MLS version */
     )
@@ -71,6 +66,7 @@ ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(ciphersuite_name: Cip
             &[],
             false,
             None,
+            vec![], /* Extensions */
         )
         .expect("Error creating commit");
 

--- a/src/group/mls_group/test_group_info_extensions.rs
+++ b/src/group/mls_group/test_group_info_extensions.rs
@@ -1,0 +1,167 @@
+use super::*;
+
+use crate::prelude::*;
+
+// === Custom Extension ===
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+struct AnswerToLifeExtension {
+    answer: u8,
+}
+
+impl Default for AnswerToLifeExtension {
+    fn default() -> Self {
+        AnswerToLifeExtension { answer: 42 }
+    }
+}
+
+impl GroupInfoExtension for AnswerToLifeExtension {
+    fn extension_type(&self) -> ExtensionType {
+        ExtensionType::Custom(0xff01)
+    }
+}
+
+impl Codec for AnswerToLifeExtension {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), crate::codec::CodecError> {
+        self.answer.encode(buffer).unwrap();
+        Ok(())
+    }
+
+    fn decode(mut cursor: &mut Cursor) -> Result<Self, crate::codec::CodecError> {
+        let answer = u8::decode(&mut cursor)?;
+        Ok(Self { answer })
+    }
+}
+
+#[test]
+fn custom_extension_group_info_extension_serialization() {
+    let answer_to_life_extension = AnswerToLifeExtension::default();
+    let encoded = answer_to_life_extension
+        .encode_detached()
+        .expect("Could not encode AnswerToLifeExtension");
+    let decoded = AnswerToLifeExtension::decode_detached(&encoded)
+        .expect("Could not decode AnswerToLifeExtension");
+    assert_eq!(decoded, answer_to_life_extension);
+}
+
+// Test several scenarios when PSKs are used in a group
+ctest_ciphersuites!(test_custom_group_info_extension, test(ciphersuite_name: CiphersuiteName) {
+
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+
+    // Basic group setup.
+    let group_aad = b"Alice's test group";
+
+    // Define credential bundles
+    let alice_credential_bundle = CredentialBundle::new(
+        "Alice".into(),
+        CredentialType::Basic,
+        ciphersuite.signature_scheme(),
+    )
+    .unwrap();
+    let bob_credential_bundle = CredentialBundle::new(
+        "Bob".into(),
+        CredentialType::Basic,
+        ciphersuite.signature_scheme(),
+    )
+    .unwrap();
+
+    // Generate KeyPackages
+    let alice_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite.name()], &alice_credential_bundle, Vec::new())
+            .unwrap();
+
+    let bob_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle, Vec::new())
+            .unwrap();
+    let bob_key_package = bob_key_package_bundle.key_package();
+
+    // === Alice creates a group ===
+    let group_id = [1, 2, 3, 4];
+
+    let mut alice_group = MlsGroup::new(
+        &group_id,
+        ciphersuite.name(),
+        alice_key_package_bundle,
+        false, /* use ratchet tree extension */
+        None, /* PSK fetcher */
+        None, /* MLS version */
+    )
+    .unwrap();
+
+    // === Custom extension ===
+
+    let answer_to_life = AnswerToLifeExtension::default();
+
+    // === Alice adds Bob ===
+    let bob_add_proposal = alice_group
+        .create_add_proposal(group_aad, &alice_credential_bundle, bob_key_package.clone())
+        .expect("Could not create proposal");
+    let epoch_proposals = &[&bob_add_proposal];
+    log::info!(" >>> Creating commit ...");
+    let (mls_plaintext_commit, welcome_bundle_alice_bob_option, _kpb_option) = alice_group
+        .create_commit(
+            group_aad,
+            &alice_credential_bundle,
+            epoch_proposals,
+            &[],
+            false,
+            None, /* PSK fetcher */
+            vec![answer_to_life.to_extension_struct().expect("Could not convert extension to ExtensionStruct")], /* Extensions */
+        )
+        .expect("Error creating commit");
+
+    log::info!(" >>> Applying commit ...");
+    alice_group
+        .apply_commit(
+            &mls_plaintext_commit,
+            epoch_proposals,
+            &[],
+            None,
+        )
+        .expect("error applying commit");
+    let ratchet_tree = alice_group.tree().public_key_tree_copy();
+
+    // === Bob joins ===
+
+    let (group_bob, extensions) = MlsGroup::new_from_welcome(
+        welcome_bundle_alice_bob_option.unwrap(),
+        Some(ratchet_tree),
+        bob_key_package_bundle,
+        None,
+    )
+    .expect("Could not create new group from Welcome");
+
+    // Make sure only one extension was returned
+    assert_eq!(extensions.len(), 1);
+
+    // Make sure we received the right extension
+    let extension = AnswerToLifeExtension::from_extension_struct(extensions[0].clone())
+        .expect("Could not convert extension from ExtensionStruct");
+    assert_eq!(extension.answer, 42);
+
+    // === Bob updates and commits ===
+    let bob_update_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle, Vec::new())
+            .unwrap();
+
+    let update_proposal_bob = group_bob
+        .create_update_proposal(
+            &[],
+            &bob_credential_bundle,
+            bob_update_key_package_bundle.key_package().clone(),
+        )
+        .expect("Could not create proposal.");
+    let (_mls_plaintext_commit, _welcome_option, _kpb_option) = group_bob
+        .create_commit(
+            &[],
+            &bob_credential_bundle,
+            &[&update_proposal_bob],
+            &[],
+            false, /* force self update */
+            None,
+            vec![], /* Extensions */
+        )
+        .unwrap();
+
+});

--- a/src/group/mls_group/test_mls_group.rs
+++ b/src/group/mls_group/test_mls_group.rs
@@ -30,7 +30,7 @@ fn test_mls_group_persistence() {
         &group_id,
         ciphersuite.name(),
         alice_key_package_bundle,
-        GroupConfig::default(),
+        true, /* use ratchet tree extension */
         None, /* Initial PSK */
         None, /* MLS version */
     )
@@ -172,9 +172,9 @@ fn test_update_path() {
             &group_id,
             ciphersuite.name(),
             alice_key_package_bundle,
-            GroupConfig::default(),
-            None, /* Initial PSK */
-            None, /* MLS version */
+            false, /* use ratchet tree extension */
+            None,  /* Initial PSK */
+            None,  /* MLS version */
         )
         .unwrap();
 
@@ -191,6 +191,7 @@ fn test_update_path() {
                 &[],
                 false,
                 None,
+                vec![], /* Extensions */
             )
             .expect("Error creating commit");
 
@@ -212,7 +213,7 @@ fn test_update_path() {
             .expect("error applying commit");
         let ratchet_tree = alice_group.tree().public_key_tree_copy();
 
-        let group_bob = MlsGroup::new_from_welcome(
+        let (group_bob, _extensions) = MlsGroup::new_from_welcome(
             welcome_bundle_alice_bob_option.unwrap(),
             Some(ratchet_tree),
             bob_key_package_bundle,
@@ -240,6 +241,7 @@ fn test_update_path() {
                 &[],
                 false, /* force self update */
                 None,
+                vec![], /* Extensions */
             )
             .unwrap();
 
@@ -387,7 +389,7 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
         &group_id,
         ciphersuite.name(),
         alice_key_package_bundle,
-        GroupConfig::default(),
+        false, /* use ratchet tree extension */
         Some(initial_psk),
         None, /* MLS version */
     )
@@ -413,6 +415,7 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
             &[],
             false,
             Some(psk_fetcher),
+            vec![], /* Extensions */
         )
         .expect("Error creating commit");
 
@@ -427,7 +430,7 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
         .expect("error applying commit");
     let ratchet_tree = alice_group.tree().public_key_tree_copy();
 
-    let group_bob = MlsGroup::new_from_welcome(
+    let (group_bob, _extensions) = MlsGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.unwrap(),
         Some(ratchet_tree),
         bob_key_package_bundle,
@@ -455,6 +458,7 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
             &[],
             false, /* force self update */
             None,
+            vec![], /* Extensions */
         )
         .unwrap();
 

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -74,30 +74,3 @@ impl GroupContext {
         self.epoch = epoch;
     }
 }
-
-/// Configuration for an MLS group.
-#[derive(Clone, Copy, Debug)]
-pub struct GroupConfig {
-    /// Flag whether to send the ratchet tree along with the `GroupInfo` or not.
-    /// Defaults to false.
-    pub add_ratchet_tree_extension: bool,
-    pub padding_block_size: u32,
-    pub additional_as_epochs: u32,
-}
-
-impl GroupConfig {
-    /// Get the padding block size used in this config.
-    pub fn padding_block_size(&self) -> u32 {
-        self.padding_block_size
-    }
-}
-
-impl Default for GroupConfig {
-    fn default() -> Self {
-        Self {
-            add_ratchet_tree_extension: false,
-            padding_block_size: 10,
-            additional_as_epochs: 0,
-        }
-    }
-}

--- a/src/group/tests/kat_messages.rs
+++ b/src/group/tests/kat_messages.rs
@@ -79,7 +79,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
         GroupEpoch(0),
         get_random_vec(ciphersuite.hash_length()),
         get_random_vec(ciphersuite.hash_length()),
-        vec![Box::new(RatchetTreeExtension::new(ratchet_tree.clone()))],
+        vec![RatchetTreeExtension::new(ratchet_tree.clone()).to_extension_struct()],
         ConfirmationTag(Mac {
             mac_value: get_random_vec(ciphersuite.hash_length()),
         }),

--- a/src/group/tests/kat_messages.rs
+++ b/src/group/tests/kat_messages.rs
@@ -61,12 +61,11 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
 
     // Let's create a group
     let group_id = GroupId::random();
-    let config = GroupConfig::default();
     let mut group = MlsGroup::new(
         &group_id.as_slice(),
         ciphersuite_name,
         key_package_bundle,
-        config,
+        false,
         None,
         ProtocolVersion::default(),
     )
@@ -87,7 +86,9 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
         LeafIndex::from(random_u32()),
     );
     let group_secrets = GroupSecrets::random_encoded(ciphersuite, ProtocolVersion::default());
-    let public_group_state = group.export_public_group_state(&credential_bundle).unwrap();
+    let public_group_state = group
+        .export_public_group_state(&credential_bundle, vec![])
+        .unwrap();
 
     // Create some proposals
     let key_package_bundle =
@@ -139,6 +140,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
             &[],
             true,
             None,
+            vec![],
         )
         .unwrap();
     let commit = if let MlsPlaintextContentType::Commit(commit) = commit_pt.content() {

--- a/src/messages/codec.rs
+++ b/src/messages/codec.rs
@@ -41,7 +41,7 @@ impl Codec for GroupInfo {
         let epoch = GroupEpoch::decode(cursor)?;
         let tree_hash = decode_vec(VecSize::VecU8, cursor)?;
         let confirmed_transcript_hash = decode_vec(VecSize::VecU8, cursor)?;
-        let extensions = extensions_vec_from_cursor(cursor)?;
+        let extensions: Vec<ExtensionStruct> = decode_vec(VecSize::VecU32, cursor)?;
         let confirmation_tag = ConfirmationTag::decode(cursor)?;
         let signer_index = LeafIndex::from(u32::decode(cursor)?);
         let signature = Signature::decode(cursor)?;

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -228,6 +228,11 @@ impl GroupInfo {
         &self.extensions
     }
 
+    /// Get a mutable reference to the extensions.
+    pub(crate) fn extensions_mut(&mut self) -> &mut Vec<Box<dyn Extension>> {
+        &mut self.extensions
+    }
+
     /// Set the group info's extensions.
     #[cfg(test)]
     pub(crate) fn set_extensions(&mut self, extensions: Vec<Box<dyn Extension>>) {
@@ -370,6 +375,7 @@ impl PublicGroupState {
     pub(crate) fn new(
         mls_group: &MlsGroup,
         credential_bundle: &CredentialBundle,
+        extensions: Vec<Box<dyn Extension>>,
     ) -> Result<Self, CredentialError> {
         let ciphersuite = mls_group.ciphersuite();
         let (_external_priv, external_pub) = mls_group
@@ -382,7 +388,6 @@ impl PublicGroupState {
         let epoch = mls_group.context().epoch();
         let tree_hash = mls_group.tree().tree_hash();
         let interim_transcript_hash = mls_group.interim_transcript_hash().to_vec();
-        let extensions = mls_group.extensions();
 
         let pgstbs = PublicGroupStateTbs {
             group_id: &group_id,

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -225,7 +225,7 @@ impl GroupInfo {
         &self.confirmation_tag
     }
 
-    /// Get the extensions.
+    /// Consume the group info and return the extensions.
     pub(crate) fn into_extensions(self) -> Vec<ExtensionStruct> {
         self.extensions
     }
@@ -269,7 +269,7 @@ impl GroupInfo {
     pub(crate) fn extensions_are_unique(&self) -> bool {
         let mut ehs = HashSet::new();
         for e in &self.extensions {
-            if !ehs.insert(e) {
+            if !ehs.insert(e.extension_type()) {
                 return false;
             }
         }

--- a/src/messages/tests/test_pgs.rs
+++ b/src/messages/tests/test_pgs.rs
@@ -1,8 +1,7 @@
 use crate::{
     key_packages::KeyPackageBundle,
     messages::{
-        Codec, Config, CredentialBundle, CredentialType, GroupConfig, LeafIndex, MlsGroup,
-        PublicGroupState,
+        Codec, Config, CredentialBundle, CredentialType, LeafIndex, MlsGroup, PublicGroupState,
     },
 };
 
@@ -43,9 +42,9 @@ fn test_pgs() {
             &group_id,
             ciphersuite.name(),
             alice_key_package_bundle,
-            GroupConfig::default(),
-            None, /* Initial PSK */
-            None, /* MLS version */
+            false, /* use ratchet tree extension */
+            None,  /* Initial PSK */
+            None,  /* MLS version */
         )
         .expect("Could not create group.");
 
@@ -60,6 +59,7 @@ fn test_pgs() {
             &[],
             true,
             None,
+            vec![], /* Extensions */
         ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
@@ -75,7 +75,7 @@ fn test_pgs() {
             .expect("Could not apply Commit");
 
         let pgs = group_alice
-            .export_public_group_state(&alice_credential_bundle)
+            .export_public_group_state(&alice_credential_bundle, vec![] /* Extensions */)
             .expect("Could not export the public group state");
 
         // Make sure Alice is the signer

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,6 @@
 //! Prelude for OpenMLS.
 //! Include this to get access to all the public functions of OpenMLS.
 
-pub use crate::group::GroupConfig;
 pub use crate::group::MlsGroup;
 pub use crate::group::{
     GroupEvent, HandshakeMessageFormat, InvalidMessageError, ManagedGroup, ManagedGroupCallbacks,

--- a/src/tree/tests/kat_encryption.rs
+++ b/src/tree/tests/kat_encryption.rs
@@ -145,7 +145,7 @@ fn group(ciphersuite: &Ciphersuite) -> MlsGroup {
         &group_id,
         ciphersuite.name(),
         key_package_bundle,
-        GroupConfig::default(),
+        false,
         None, /* Initial PSK */
         ProtocolVersion::Mls10,
     )
@@ -166,7 +166,7 @@ fn receiver_group(ciphersuite: &Ciphersuite, group_id: &GroupId) -> MlsGroup {
         &group_id.as_slice(),
         ciphersuite.name(),
         key_package_bundle,
-        GroupConfig::default(),
+        false,
         None, /* Initial PSK */
         ProtocolVersion::Mls10,
     )

--- a/tests/test_encoding.rs
+++ b/tests/test_encoding.rs
@@ -26,11 +26,7 @@ fn create_encoding_test_setup() -> TestSetup {
     for ciphersuite_name in Config::supported_ciphersuite_names() {
         let test_group = TestGroupConfig {
             ciphersuite: *ciphersuite_name,
-            config: GroupConfig {
-                add_ratchet_tree_extension: true,
-                padding_block_size: 10,
-                additional_as_epochs: 0,
-            },
+            use_ratchet_tree_extension: true,
             members: vec![alice_config.clone(), bob_config.clone()],
         };
         test_group_configs.push(test_group);
@@ -259,7 +255,15 @@ fn test_commit_encoding() {
 
         let proposals = &[&add, &remove, &update];
         let (commit, _welcome_option, _key_package_bundle_option) = group_state
-            .create_commit(&[], alice_credential_bundle, proposals, &[], true, None)
+            .create_commit(
+                &[],
+                alice_credential_bundle,
+                proposals,
+                &[],
+                true,
+                None,
+                vec![], /* Extensions */
+            )
             .unwrap();
         let commit_encoded = commit.encode_detached().unwrap();
         let commit_decoded = match MlsPlaintext::decode_detached(&commit_encoded) {
@@ -299,7 +303,7 @@ fn test_welcome_message_encoding() {
 
         let proposals = &[&add];
         let (commit, welcome_option, key_package_bundle_option) = group_state
-            .create_commit(&[], credential_bundle, proposals, &[], true, None)
+            .create_commit(&[], credential_bundle, proposals, &[], true, None, vec![])
             .unwrap();
         // Alice applies the commit
         assert!(group_state

--- a/tests/test_framing.rs
+++ b/tests/test_framing.rs
@@ -19,7 +19,7 @@ fn padding() {
     for ciphersuite_name in Config::supported_ciphersuite_names() {
         let test_group = TestGroupConfig {
             ciphersuite: *ciphersuite_name,
-            config: GroupConfig::default(),
+            use_ratchet_tree_extension: false,
             members: vec![alice_config.clone()],
         };
         test_group_configs.push(test_group);

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -60,9 +60,9 @@ fn create_commit_optional_path() {
             &group_id,
             ciphersuite.name(),
             alice_key_package_bundle,
-            GroupConfig::default(),
-            None, /* Initial PSK */
-            None, /* MLS version */
+            false, /* use ratchet tree extension */
+            None,  /* Initial PSK */
+            None,  /* MLS version */
         )
         .unwrap();
 
@@ -79,8 +79,9 @@ fn create_commit_optional_path() {
                 &alice_credential_bundle,
                 &(epoch_proposals.iter().collect::<Vec<&MlsPlaintext>>()),
                 &[],
-                true, /* force self-update */
-                None, /* No PSK fetcher */
+                true,   /* force self-update */
+                None,   /* No PSK fetcher */
+                vec![], /* Extensions */
             ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
@@ -106,8 +107,9 @@ fn create_commit_optional_path() {
                 &alice_credential_bundle,
                 epoch_proposals,
                 &[],
-                false, /* don't force selfupdate */
-                None,  /* PSK fetcher */
+                false,  /* don't force selfupdate */
+                None,   /* PSK fetcher */
+                vec![], /* Extensions */
             ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
@@ -126,7 +128,7 @@ fn create_commit_optional_path() {
         let ratchet_tree = group_alice.tree().public_key_tree_copy();
 
         // Bob creates group from Welcome
-        let group_bob = match MlsGroup::new_from_welcome(
+        let (group_bob, _extensions) = match MlsGroup::new_from_welcome(
             welcome_bundle_alice_bob_option.unwrap(),
             Some(ratchet_tree),
             bob_key_package_bundle,
@@ -157,8 +159,9 @@ fn create_commit_optional_path() {
             &alice_credential_bundle,
             proposals,
             &[],
-            false, /* force self update */
-            None,  /* PSK fetcher */
+            false,  /* force self update */
+            None,   /* PSK fetcher */
+            vec![], /* Extensions */
         ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
@@ -216,9 +219,9 @@ fn basic_group_setup() {
             &group_id,
             ciphersuite.name(),
             alice_key_package_bundle,
-            GroupConfig::default(),
-            None, /* Initial PSK */
-            None, /* MLS version */
+            false, /* use ratchet tree extension */
+            None,  /* Initial PSK */
+            None,  /* MLS version */
         )
         .expect("Could not create group.");
 
@@ -232,7 +235,8 @@ fn basic_group_setup() {
             &[&bob_add_proposal],
             &[],
             true,
-            None, /* PSK fetcher */
+            None,   /* PSK fetcher */
+            vec![], /* Extensions */
         ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
@@ -303,9 +307,9 @@ fn group_operations() {
             &group_id,
             ciphersuite.name(),
             alice_key_package_bundle,
-            GroupConfig::default(),
-            None, /* Initial PSK */
-            None, /* MLS version */
+            false, /* use ratchet tree extension */
+            None,  /* Initial PSK */
+            None,  /* MLS version */
         )
         .expect("Could not create group.");
 
@@ -321,7 +325,8 @@ fn group_operations() {
                 epoch_proposals,
                 &[],
                 false,
-                None, /* PSK fetcher */
+                None,   /* PSK fetcher */
+                vec![], /* Extensions */
             )
             .expect("Error creating commit");
         let commit = match mls_plaintext_commit.content() {
@@ -342,7 +347,7 @@ fn group_operations() {
             .expect("error applying commit");
         let ratchet_tree = group_alice.tree().public_key_tree_copy();
 
-        let mut group_bob = match MlsGroup::new_from_welcome(
+        let (mut group_bob, _extensions) = match MlsGroup::new_from_welcome(
             welcome_bundle_alice_bob_option.unwrap(),
             Some(ratchet_tree),
             bob_key_package_bundle,
@@ -396,8 +401,9 @@ fn group_operations() {
             &bob_credential_bundle,
             &[&update_proposal_bob],
             &[],
-            false, /* force self update */
-            None,  /* PSK fetcher */
+            false,  /* force self update */
+            None,   /* PSK fetcher */
+            vec![], /* Extensions */
         ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
@@ -451,8 +457,9 @@ fn group_operations() {
             &alice_credential_bundle,
             &[&update_proposal_alice],
             &[],
-            false, /* force self update */
-            None,  /* PSK fetcher */
+            false,  /* force self update */
+            None,   /* PSK fetcher */
+            vec![], /* Extensions */
         ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
@@ -504,8 +511,9 @@ fn group_operations() {
             &alice_credential_bundle,
             &[&update_proposal_bob],
             &[],
-            false, /* force self update */
-            None,  /* PSK fetcher */
+            false,  /* force self update */
+            None,   /* PSK fetcher */
+            vec![], /* Extensions */
         ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
@@ -563,8 +571,9 @@ fn group_operations() {
                 &bob_credential_bundle,
                 &[&add_charlie_proposal_bob],
                 &[],
-                false, /* force self update */
-                None,  /* PSK fetcher */
+                false,  /* force self update */
+                None,   /* PSK fetcher */
+                vec![], /* Extensions */
             ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
@@ -594,7 +603,7 @@ fn group_operations() {
             .expect("Error applying commit (Bob)");
 
         let ratchet_tree = group_alice.tree().public_key_tree_copy();
-        let mut group_charlie = match MlsGroup::new_from_welcome(
+        let (mut group_charlie, _extensions) = match MlsGroup::new_from_welcome(
             welcome_for_charlie_option.unwrap(),
             Some(ratchet_tree),
             charlie_key_package_bundle,
@@ -656,8 +665,9 @@ fn group_operations() {
             &charlie_credential_bundle,
             &[&update_proposal_charlie],
             &[],
-            false, /* force self update */
-            None,  /* PSK fetcher */
+            false,  /* force self update */
+            None,   /* PSK fetcher */
+            vec![], /* Extensions */
         ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),
@@ -710,8 +720,9 @@ fn group_operations() {
             &charlie_credential_bundle,
             &[&remove_bob_proposal_charlie],
             &[],
-            false, /* force self update */
-            None,  /* PSK fetcher */
+            false,  /* force self update */
+            None,   /* PSK fetcher */
+            vec![], /* Extensions */
         ) {
             Ok(c) => c,
             Err(e) => panic!("Error creating commit: {:?}", e),

--- a/tests/utils/mls_utils/mod.rs
+++ b/tests/utils/mls_utils/mod.rs
@@ -23,7 +23,7 @@ pub(crate) struct TestClientConfig {
 /// Configuration of a group meant to be used in a test setup.
 pub(crate) struct TestGroupConfig {
     pub(crate) ciphersuite: CiphersuiteName,
-    pub(crate) config: GroupConfig,
+    pub(crate) use_ratchet_tree_extension: bool,
     pub(crate) members: Vec<TestClientConfig>,
 }
 
@@ -142,7 +142,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
             &group_id.to_be_bytes(),
             group_config.ciphersuite,
             initial_key_package_bundle,
-            group_config.config,
+            group_config.use_ratchet_tree_extension,
             None, /* Initial PSK */
             None, /* MLS version */
         )
@@ -190,8 +190,9 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                     &initial_credential_bundle,
                     &(proposal_list.iter().collect::<Vec<&MlsPlaintext>>()),
                     &[],
-                    true, /* Set this to true to populate the tree a little bit. */
-                    None, /* PSKs are not supported here */
+                    true,   /* Set this to true to populate the tree a little bit. */
+                    None,   /* PSKs are not supported here */
+                    vec![], /* Extensions */
                 )
                 .unwrap();
             let welcome = welcome_option.unwrap();
@@ -238,7 +239,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                     .remove(kpb_position);
                 // Create the local group state of the new member based on the
                 // Welcome.
-                let new_group = match MlsGroup::new_from_welcome(
+                let (new_group, _extensions) = match MlsGroup::new_from_welcome(
                     welcome.clone(),
                     Some(mls_group.tree().public_key_tree_copy()),
                     key_package_bundle,
@@ -285,10 +286,9 @@ fn test_setup() {
         name: "TestClientConfigB",
         ciphersuites: vec![CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519],
     };
-    let group_config = GroupConfig::default();
     let test_group_config = TestGroupConfig {
         ciphersuite: CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
-        config: group_config,
+        use_ratchet_tree_extension: false,
         members: vec![test_client_config_a.clone(), test_client_config_b.clone()],
     };
     let test_setup_config = TestSetupConfig {


### PR DESCRIPTION
This PR prepares `MlsGroup` for custom group info extensions.
Details:

 - I got rid of `GroupConfig`, because it was only used for the ratchet tree extension
 - `MlsGroup` still has an internal state `bool` to track whether to use the ratchet tree extension. The reason for that is that it is not possible to treat the ratchet tree extension like any other group info extension. When a `Commit` is created, the corresponding `Welcome` message needs the ratchet tree of the provisional state. Since the provisional state is ephemeral (for now), it is not possible to generate the ratchet tree extension from outside the group. Long story short, this part hasn't changed. The alternative would be to not store the state in the group and instead pass a `bool` for every `create_commit` call, but this might get harder to track.
  - `create_commit` now accepts a `Vec` of group info extensions that are to be included in the `Welcome` message. Conversely, `new_from_welcome` now also return all group info extensions, except for the ratchet tree extension.
  - A new trait for group info extensions is introduced: `GroupInfoExtension`. The idea behind it is that it can be used by consumer code easily by only implementing `Codec` and attributing an extension number.
  - There is a test with a custom extension that implements `GroupInfoExtension`.
  - None of this affects the `ManagedGroup` so far, that will follow in another PR.