### PR TITLE
Refactor KeyPackageBundles to store path instead of leaf secrets

### DIFF
--- a/openmls/src/ciphersuite/mod.rs
+++ b/openmls/src/ciphersuite/mod.rs
@@ -403,11 +403,6 @@ impl Secret {
     pub(crate) fn ciphersuite(&self) -> &'static Ciphersuite {
         self.ciphersuite
     }
-
-    /// Returns the MLS version of the secret
-    pub(crate) fn version(&self) -> ProtocolVersion {
-        self.mls_version
-    }
 }
 
 #[cfg(any(feature = "expose-test-vectors", test))]

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -284,8 +284,8 @@ impl SignedStruct<GroupInfoPayload> for GroupInfo {
 ///   opaque path_secret<1..255>;
 /// } PathSecret;
 /// ```
-#[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(any(feature = "expose-test-vectors", test), derive(PartialEq, Clone))]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(any(feature = "expose-test-vectors", test), derive(PartialEq))]
 pub struct PathSecret {
     pub path_secret: Secret,
 }

--- a/openmls/src/tree/tests/test_private_tree.rs
+++ b/openmls/src/tree/tests/test_private_tree.rs
@@ -58,13 +58,12 @@ fn create_private_tree_from_secret() {
     for ciphersuite in Config::supported_ciphersuites() {
         let (key_package_bundle, own_index, direct_path) = setup(ciphersuite, PATH_LENGTH);
 
-        let mut private_tree =
-            PrivateTree::from_leaf_secret(own_index, key_package_bundle.leaf_secret());
+        let mut private_tree = PrivateTree::from_key_package_bundle(own_index, &key_package_bundle);
 
         // Compute path secrets from the leaf and generate keypairs
         let public_keys = private_tree.generate_path_secrets(
             &ciphersuite,
-            key_package_bundle.leaf_secret(),
+            key_package_bundle.path_secret(),
             &direct_path,
         );
 


### PR DESCRIPTION
This PR refactors KeyPackageBundles to store the path secret derived from the leaf secret instead of the leaf secret itself.

It also refactors the constructors for the private tree, which now rely on a KeyPackageBundle, as well as the test vector generation specific function of the KeyStore, which allows us to obtain the leaf secret which we still need to generate treekem test vectors.

TODO: 
Evaluate if we can make the `PathSecret` in the KeyPackageBundle optional so that we can remove it for processing later. Alternatively derive `Clone` for PathSecret so that it can be stored in the PrivateTree independent from the KeyPackageBundle.