### PR TITLE
Rename add only commit to partial commit

### DIFF
--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -237,8 +237,8 @@ pub(crate) struct JoinerSecret {
 impl JoinerSecret {
     /// Derive a `JoinerSecret` from an optional `CommitSecret` and an
     /// `EpochSecrets` object, which contains the necessary `InitSecret`. The
-    /// `CommitSecret` needs to be present if the current commit is not an
-    /// Add-only commit. TODO: For now, this takes a reference to a
+    /// `CommitSecret` needs to be present if the current commit is not a
+    /// partial commit. TODO: For now, this takes a reference to a
     /// `CommitSecret` as input. This should change with #224.
     pub(crate) fn new<'a>(
         commit_secret_option: impl Into<Option<&'a CommitSecret>>,


### PR DESCRIPTION
Fixes #421.

We don't have the notion of an explicit "add only" commit. The mechanics are there, though. So on the level of the MLS Group API, one can not have any remove/update propsals and don't flip the "force self update" bit, which will result in an "add only"/"partial" commit.