### PR TITLE
Make CredentialBundle a trait

### DIFF
--- a/openmls/src/ciphersuite/signable.rs
+++ b/openmls/src/ciphersuite/signable.rs
@@ -48,7 +48,7 @@ pub trait Signable: Sized {
     /// Returns a `Signature`.
     fn sign(
         self,
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
     ) -> Result<Self::SignedOutput, CredentialError>
     where
         Self::SignedOutput: SignedStruct<Self>,

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -84,15 +84,13 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
     let group_aad = b"Alice's test group";
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = BasicCredentialBundle::new(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_scheme(),
     )
     .unwrap();
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = BasicCredentialBundle::new(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_scheme(),
     )
     .unwrap();

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -119,7 +119,7 @@ impl MlsPlaintext {
         authenticated_data: &[u8],
         payload: MlsPlaintextContentType,
         content_type: ContentType,
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         context: &GroupContext,
     ) -> Result<Self, MlsPlaintextError> {
         let serialized_context = context.tls_serialize_detached()?;
@@ -142,7 +142,7 @@ impl MlsPlaintext {
         authenticated_data: &[u8],
         payload: MlsPlaintextContentType,
         content_type: ContentType,
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         context: &GroupContext,
         membership_key: &MembershipKey,
     ) -> Result<Self, MlsPlaintextError> {
@@ -164,7 +164,7 @@ impl MlsPlaintext {
         sender_index: LeafIndex,
         authenticated_data: &[u8],
         proposal: Proposal,
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         context: &GroupContext,
         membership_key: &MembershipKey,
     ) -> Result<Self, MlsPlaintextError> {
@@ -185,7 +185,7 @@ impl MlsPlaintext {
         sender_index: LeafIndex,
         authenticated_data: &[u8],
         commit: Commit,
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         context: &GroupContext,
     ) -> Result<Self, MlsPlaintextError> {
         Self::new(
@@ -204,7 +204,7 @@ impl MlsPlaintext {
         sender_index: LeafIndex,
         authenticated_data: &[u8],
         application_message: &[u8],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         context: &GroupContext,
         membership_key: &MembershipKey,
     ) -> Result<Self, MlsPlaintextError> {

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -12,12 +12,8 @@ use crate::{
 #[test]
 fn codec() {
     for ciphersuite in Config::supported_ciphersuites() {
-        let credential_bundle = CredentialBundle::new(
-            vec![7, 8, 9],
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let credential_bundle =
+            BasicCredentialBundle::new(vec![7, 8, 9], ciphersuite.signature_scheme()).unwrap();
         let sender = Sender {
             sender_type: SenderType::Member,
             sender: LeafIndex::from(2u32),
@@ -54,12 +50,8 @@ fn codec() {
 #[test]
 fn membership_tag() {
     for ciphersuite in Config::supported_ciphersuites() {
-        let credential_bundle = CredentialBundle::new(
-            vec![7, 8, 9],
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let credential_bundle =
+            BasicCredentialBundle::new(vec![7, 8, 9], ciphersuite.signature_scheme()).unwrap();
         let group_context =
             GroupContext::new(GroupId::random(), GroupEpoch(1), vec![], vec![], &[]).unwrap();
         let membership_key =
@@ -68,7 +60,7 @@ fn membership_tag() {
             LeafIndex::from(2u32),
             &[1, 2, 3],
             &[4, 5, 6],
-            &&credential_bundle,
+            &credential_bundle,
             &group_context,
             &membership_key,
         )
@@ -102,24 +94,12 @@ fn unknown_sender() {
         let group_aad = b"Alice's test group";
 
         // Define credential bundles
-        let alice_credential_bundle = CredentialBundle::new(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
-        let bob_credential_bundle = CredentialBundle::new(
-            "Bob".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
-        let charlie_credential_bundle = CredentialBundle::new(
-            "Charlie".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let alice_credential_bundle =
+            BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme()).unwrap();
+        let bob_credential_bundle =
+            BasicCredentialBundle::new("Bob".into(), ciphersuite.signature_scheme()).unwrap();
+        let charlie_credential_bundle =
+            BasicCredentialBundle::new("Charlie".into(), ciphersuite.signature_scheme()).unwrap();
 
         // Generate KeyPackages
         let bob_key_package_bundle =
@@ -311,18 +291,10 @@ fn confirmation_tag_presence() {
         let group_aad = b"Alice's test group";
 
         // Define credential bundles
-        let alice_credential_bundle = CredentialBundle::new(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
-        let bob_credential_bundle = CredentialBundle::new(
-            "Bob".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let alice_credential_bundle =
+            BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme()).unwrap();
+        let bob_credential_bundle =
+            BasicCredentialBundle::new("Bob".into(), ciphersuite.signature_scheme()).unwrap();
 
         // Generate KeyPackages
         let bob_key_package_bundle =
@@ -381,15 +353,13 @@ ctest_ciphersuites!(invalid_plaintext_signature,test (ciphersuite_name: Ciphersu
     let group_aad = b"Alice's test group";
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = BasicCredentialBundle::new(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_scheme(),
     )
     .unwrap();
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = BasicCredentialBundle::new(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_scheme(),
     )
     .unwrap();

--- a/openmls/src/group/managed_group/mod.rs
+++ b/openmls/src/group/managed_group/mod.rs
@@ -216,7 +216,7 @@ impl ManagedGroup {
             .collect::<Vec<&MlsPlaintext>>();
 
         let credential = self.credential()?;
-        let credential_bundle = key_store
+        let credential_bundle = &**key_store
             .get_credential_bundle(credential.signature_key())
             .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
 
@@ -224,7 +224,7 @@ impl ManagedGroup {
         // TODO #141
         let (commit, welcome_option, kpb_option) = self.group.create_commit(
             &self.aad,
-            &credential_bundle,
+            credential_bundle,
             proposals_by_reference,
             proposals_by_value,
             true,
@@ -296,7 +296,7 @@ impl ManagedGroup {
             .collect::<Vec<&MlsPlaintext>>();
 
         let credential = self.credential()?;
-        let credential_bundle = key_store
+        let credential_bundle = &**key_store
             .get_credential_bundle(credential.signature_key())
             .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
 
@@ -304,7 +304,7 @@ impl ManagedGroup {
         // TODO #141
         let (commit, welcome_option, kpb_option) = self.group.create_commit(
             &self.aad,
-            &credential_bundle,
+            credential_bundle,
             proposals_by_reference,
             proposals_by_value,
             false,
@@ -341,13 +341,13 @@ impl ManagedGroup {
         }
 
         let credential = self.credential()?;
-        let credential_bundle = key_store
+        let credential_bundle = &**key_store
             .get_credential_bundle(credential.signature_key())
             .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
 
         let add_proposal =
             self.group
-                .create_add_proposal(&self.aad, &credential_bundle, key_package.clone())?;
+                .create_add_proposal(&self.aad, credential_bundle, key_package.clone())?;
 
         let mls_message = self.plaintext_to_mls_message(add_proposal)?;
 
@@ -368,13 +368,13 @@ impl ManagedGroup {
         }
 
         let credential = self.credential()?;
-        let credential_bundle = key_store
+        let credential_bundle = &**key_store
             .get_credential_bundle(credential.signature_key())
             .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
 
         let remove_proposal = self.group.create_remove_proposal(
             &self.aad,
-            &credential_bundle,
+            credential_bundle,
             LeafIndex::from(member),
         )?;
 
@@ -393,13 +393,13 @@ impl ManagedGroup {
         }
 
         let credential = self.credential()?;
-        let credential_bundle = key_store
+        let credential_bundle = &**key_store
             .get_credential_bundle(credential.signature_key())
             .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
 
         let remove_proposal = self.group.create_remove_proposal(
             &self.aad,
-            &credential_bundle,
+            credential_bundle,
             self.group.tree().own_node_index(),
         )?;
 
@@ -595,14 +595,14 @@ impl ManagedGroup {
         }
 
         let credential = self.credential()?;
-        let credential_bundle = key_store
+        let credential_bundle = &**key_store
             .get_credential_bundle(credential.signature_key())
             .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
 
         let ciphertext = self.group.create_application_message(
             &self.aad,
             message,
-            &credential_bundle,
+            credential_bundle,
             self.configuration().padding_size(),
         )?;
 
@@ -624,7 +624,7 @@ impl ManagedGroup {
         let messages_to_commit: Vec<&MlsPlaintext> = self.pending_proposals.iter().collect();
 
         let credential = self.credential()?;
-        let credential_bundle = key_store
+        let credential_bundle = &**key_store
             .get_credential_bundle(credential.signature_key())
             .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
 
@@ -632,7 +632,7 @@ impl ManagedGroup {
         // TODO #141
         let (commit, welcome_option, kpb_option) = self.group.create_commit(
             &self.aad,
-            &credential_bundle,
+            credential_bundle,
             &messages_to_commit,
             &[],
             true,
@@ -757,7 +757,7 @@ impl ManagedGroup {
         }
 
         let credential = self.credential()?;
-        let credential_bundle = key_store
+        let credential_bundle = &**key_store
             .get_credential_bundle(credential.signature_key())
             .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
 
@@ -773,7 +773,7 @@ impl ManagedGroup {
                 });
                 self.group.create_commit(
                     &self.aad,
-                    &credential_bundle,
+                    credential_bundle,
                     &messages_to_commit,
                     &[&update_proposal],
                     true, /* force_self_update */
@@ -783,7 +783,7 @@ impl ManagedGroup {
             None => {
                 self.group.create_commit(
                     &self.aad,
-                    &credential_bundle,
+                    credential_bundle,
                     &messages_to_commit,
                     &[],
                     true, /* force_self_update */
@@ -822,7 +822,7 @@ impl ManagedGroup {
         }
 
         let credential = self.credential()?;
-        let credential_bundle = key_store
+        let credential_bundle = &**key_store
             .get_credential_bundle(credential.signature_key())
             .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
 
@@ -831,12 +831,12 @@ impl ManagedGroup {
         let key_package_bundle = match key_package_bundle_option {
             Some(kpb) => kpb,
             None => KeyPackageBundlePayload::from_rekeyed_key_package(existing_key_package)
-                .sign(&credential_bundle)?,
+                .sign(credential_bundle)?,
         };
 
         let update_proposal = self.group.create_update_proposal(
             &self.aad,
-            &credential_bundle,
+            credential_bundle,
             key_package_bundle.key_package().clone(),
         )?;
         drop(tree);

--- a/openmls/src/group/managed_group/test_managed_group.rs
+++ b/openmls/src/group/managed_group/test_managed_group.rs
@@ -9,11 +9,7 @@ fn test_managed_group_persistence() {
 
     // Generate credential bundles
     let alice_credential = key_store
-        .generate_credential_bundle(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
+        .generate_basic_credential_bundle("Alice".into(), ciphersuite.signature_scheme())
         .unwrap();
 
     // Generate KeyPackages
@@ -77,27 +73,15 @@ fn remover() {
 
     // Generate credential bundles
     let alice_credential = key_store
-        .generate_credential_bundle(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
+        .generate_basic_credential_bundle("Alice".into(), ciphersuite.signature_scheme())
         .unwrap();
 
     let bob_credential = key_store
-        .generate_credential_bundle(
-            "Bob".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
+        .generate_basic_credential_bundle("Bob".into(), ciphersuite.signature_scheme())
         .unwrap();
 
     let charlie_credential = key_store
-        .generate_credential_bundle(
-            "Charly".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
+        .generate_basic_credential_bundle("Charly".into(), ciphersuite.signature_scheme())
         .unwrap();
 
     // Generate KeyPackages
@@ -218,9 +202,8 @@ ctest_ciphersuites!(export_secret, test(ciphersuite_name: CiphersuiteName) {
 
     // Generate credential bundles
     let alice_credential = key_store
-        .generate_credential_bundle(
+        .generate_basic_credential_bundle(
             "Alice".into(),
-            CredentialType::Basic,
             ciphersuite.signature_scheme(),
         )
         .unwrap();

--- a/openmls/src/group/mls_group/create_commit.rs
+++ b/openmls/src/group/mls_group/create_commit.rs
@@ -10,7 +10,7 @@ impl MlsGroup {
     pub(crate) fn create_commit_internal(
         &self,
         aad: &[u8],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         proposals_by_reference: &[&MlsPlaintext],
         proposals_by_value: &[&Proposal],
         force_self_update: bool,

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -142,7 +142,7 @@ impl MlsGroup {
     pub fn create_add_proposal(
         &self,
         aad: &[u8],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         joiner_key_package: KeyPackage,
     ) -> Result<MlsPlaintext, MlsGroupError> {
         let add_proposal = AddProposal {
@@ -167,7 +167,7 @@ impl MlsGroup {
     pub fn create_update_proposal(
         &self,
         aad: &[u8],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         key_package: KeyPackage,
     ) -> Result<MlsPlaintext, MlsGroupError> {
         let update_proposal = UpdateProposal { key_package };
@@ -190,7 +190,7 @@ impl MlsGroup {
     pub fn create_remove_proposal(
         &self,
         aad: &[u8],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         removed_index: LeafIndex,
     ) -> Result<MlsPlaintext, MlsGroupError> {
         let remove_proposal = RemoveProposal {
@@ -215,7 +215,7 @@ impl MlsGroup {
     pub fn create_presharedkey_proposal(
         &self,
         aad: &[u8],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         psk: PreSharedKeyId,
     ) -> Result<MlsPlaintext, MlsGroupError> {
         let presharedkey_proposal = PreSharedKeyProposal::new(psk);
@@ -243,7 +243,7 @@ impl MlsGroup {
     pub fn create_commit(
         &self,
         aad: &[u8],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         proposals_by_reference: &[&MlsPlaintext],
         proposals_by_value: &[&Proposal],
         force_self_update: bool,
@@ -280,7 +280,7 @@ impl MlsGroup {
         &mut self,
         aad: &[u8],
         msg: &[u8],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         padding_size: usize,
     ) -> Result<MlsCiphertext, MlsGroupError> {
         let mls_plaintext = MlsPlaintext::new_application(
@@ -431,7 +431,7 @@ impl MlsGroup {
     /// Export the `PublicGroupState`
     pub fn export_public_group_state(
         &self,
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
     ) -> Result<PublicGroupState, CredentialError> {
         PublicGroupState::new(self, credential_bundle)
     }

--- a/openmls/src/group/mls_group/test_duplicate_extension.rs
+++ b/openmls/src/group/mls_group/test_duplicate_extension.rs
@@ -14,15 +14,13 @@ ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(ciphersuite_name: Cip
     let group_aad = b"Alice's test group";
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = BasicCredentialBundle::new(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_scheme(),
     )
     .unwrap();
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = BasicCredentialBundle::new(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_scheme(),
     )
     .unwrap();

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -14,12 +14,8 @@ fn test_mls_group_persistence() {
     let ciphersuite = &Config::supported_ciphersuites()[0];
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
-        "Alice".into(),
-        CredentialType::Basic,
-        ciphersuite.signature_scheme(),
-    )
-    .unwrap();
+    let alice_credential_bundle =
+        BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme()).unwrap();
 
     // Generate KeyPackages
     let alice_key_package_bundle =
@@ -91,12 +87,8 @@ fn test_failed_groupinfo_decryption() {
                 hpke_input,
             );
 
-            let alice_credential_bundle = CredentialBundle::new(
-                "Alice".into(),
-                CredentialType::Basic,
-                ciphersuite.signature_scheme(),
-            )
-            .unwrap();
+            let alice_credential_bundle =
+                BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme()).unwrap();
             let group_info = group_info
                 .sign(&alice_credential_bundle)
                 .expect("Error signing group info");
@@ -151,18 +143,10 @@ fn test_update_path() {
         let group_aad = b"Alice's test group";
 
         // Define credential bundles
-        let alice_credential_bundle = CredentialBundle::new(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
-        let bob_credential_bundle = CredentialBundle::new(
-            "Bob".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let alice_credential_bundle =
+            BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme()).unwrap();
+        let bob_credential_bundle =
+            BasicCredentialBundle::new("Bob".into(), ciphersuite.signature_scheme()).unwrap();
 
         // Generate KeyPackages
         let alice_key_package_bundle =
@@ -353,15 +337,13 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
     let group_aad = b"Alice's test group";
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = BasicCredentialBundle::new(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_scheme(),
     )
     .unwrap();
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = BasicCredentialBundle::new(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_scheme(),
     )
     .unwrap();

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -50,9 +50,8 @@ pub struct MessagesTestVector {
 
 pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVector {
     let ciphersuite_name = ciphersuite.name();
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = BasicCredentialBundle::new(
         b"OpenMLS rocks".to_vec(),
-        CredentialType::Basic,
         SignatureScheme::from(ciphersuite_name),
     )
     .unwrap();

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -11,7 +11,7 @@ use crate::test_utils::{read, write};
 use crate::{
     ciphersuite::{signable::Verifiable, Ciphersuite, CiphersuiteName, Secret, SignatureScheme},
     config::{Config, ProtocolVersion},
-    credentials::{Credential, CredentialBundle, CredentialType},
+    credentials::{BasicCredentialBundle, Credential, CredentialBundle},
     group::{
         update_confirmed_transcript_hash, update_interim_transcript_hash, GroupContext, GroupEpoch,
         GroupId,
@@ -59,9 +59,8 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
         ConfirmationKey::from_secret(Secret::random(ciphersuite, None /* MLS version */));
 
     // Build plaintext commit message.
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = BasicCredentialBundle::new(
         b"client".to_vec(),
-        CredentialType::Basic,
         SignatureScheme::from(ciphersuite.name()),
     )
     .unwrap();

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -218,7 +218,7 @@ impl KeyPackage {
     fn new(
         ciphersuite_name: CiphersuiteName,
         hpke_init_key: HpkePublicKey,
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         extensions: Vec<Extension>,
     ) -> Result<Self, KeyPackageError> {
         if SignatureScheme::from(ciphersuite_name)
@@ -366,7 +366,7 @@ impl KeyPackageBundle {
     /// Returns a new `KeyPackageBundle` or a `KeyPackageError`.
     pub fn new(
         ciphersuites: &[CiphersuiteName],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         extensions: Vec<Extension>,
     ) -> Result<Self, KeyPackageError> {
         Self::new_with_version(
@@ -388,7 +388,7 @@ impl KeyPackageBundle {
     pub fn new_with_version(
         version: ProtocolVersion,
         ciphersuites: &[CiphersuiteName],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         extensions: Vec<Extension>,
     ) -> Result<Self, KeyPackageError> {
         if SignatureScheme::from(ciphersuites[0])
@@ -417,7 +417,7 @@ impl KeyPackageBundle {
     /// Returns a new `KeyPackageBundle`.
     pub fn new_with_keypair(
         ciphersuites: &[CiphersuiteName],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         mut extensions: Vec<Extension>,
         key_pair: HpkeKeyPair,
         leaf_secret: Secret,
@@ -508,7 +508,7 @@ impl KeyPackageBundle {
 impl KeyPackageBundle {
     fn new_from_leaf_secret(
         ciphersuites: &[CiphersuiteName],
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         extensions: Vec<Extension>,
         leaf_secret: Secret,
     ) -> Result<Self, KeyPackageError> {

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -6,12 +6,8 @@ use crate::{extensions::*, key_packages::*};
 #[test]
 fn generate_key_package() {
     for ciphersuite in Config::supported_ciphersuites() {
-        let credential_bundle = CredentialBundle::new(
-            vec![1, 2, 3],
-            CredentialType::Basic,
-            ciphersuite.name().into(),
-        )
-        .unwrap();
+        let credential_bundle =
+            BasicCredentialBundle::new(vec![1, 2, 3], ciphersuite.name().into()).unwrap();
 
         // Generate a valid KeyPackage.
         let lifetime_extension = Extension::LifeTime(LifetimeExtension::new(60));
@@ -50,8 +46,7 @@ fn generate_key_package() {
 fn test_codec() {
     for ciphersuite in Config::supported_ciphersuites() {
         let id = vec![1, 2, 3];
-        let credential_bundle =
-            CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name().into()).unwrap();
+        let credential_bundle = BasicCredentialBundle::new(id, ciphersuite.name().into()).unwrap();
         let mut kpb = KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new())
             .unwrap()
             .unsigned();
@@ -70,8 +65,7 @@ fn test_codec() {
 fn key_package_id_extension() {
     for ciphersuite in Config::supported_ciphersuites() {
         let id = vec![1, 2, 3];
-        let credential_bundle =
-            CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name().into()).unwrap();
+        let credential_bundle = BasicCredentialBundle::new(id, ciphersuite.name().into()).unwrap();
         let kpb = KeyPackageBundle::new(
             &[ciphersuite.name()],
             &credential_bundle,
@@ -101,9 +95,8 @@ fn test_mismatch() {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let signature_scheme = SignatureScheme::ECDSA_SECP256R1_SHA256;
 
-    let credential_bundle =
-        CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, signature_scheme)
-            .expect("Could not create credential bundle");
+    let credential_bundle = BasicCredentialBundle::new(vec![1, 2, 3], signature_scheme)
+        .expect("Could not create credential bundle");
 
     assert_eq!(
         KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, vec![],),
@@ -115,9 +108,8 @@ fn test_mismatch() {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let signature_scheme = SignatureScheme::ED25519;
 
-    let credential_bundle =
-        CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, signature_scheme)
-            .expect("Could not create credential bundle");
+    let credential_bundle = BasicCredentialBundle::new(vec![1, 2, 3], signature_scheme)
+        .expect("Could not create credential bundle");
 
     assert!(KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, vec![]).is_ok());
 }

--- a/openmls/src/key_store/test_key_store.rs
+++ b/openmls/src/key_store/test_key_store.rs
@@ -1,7 +1,7 @@
 use crate::config::*;
+use crate::credentials::BasicCredentialBundle;
 use crate::{ciphersuite::*, credentials::CredentialBundle};
 
-use crate::credentials::CredentialType::Basic;
 use crate::key_packages::KeyPackageBundle;
 
 use super::{KeyStore, KeyStoreError};
@@ -15,9 +15,8 @@ ctest_ciphersuites!(key_storage, test(ciphersuite_name: CiphersuiteName) {
     let ks = KeyStore::default();
 
     let credential = ks
-        .generate_credential_bundle(
+        .generate_basic_credential_bundle(
             "Alice".as_bytes().to_vec(),
-            Basic,
             ciphersuite.signature_scheme(),
         )
         .expect("Error while creating credential.");
@@ -32,9 +31,8 @@ ctest_ciphersuites!(key_storage, test(ciphersuite_name: CiphersuiteName) {
 
     // Generate a CredentialBundle externally and then try to use it to create a
     // key package bundle in the store.
-    let cb_external = CredentialBundle::new(
+    let cb_external = BasicCredentialBundle::new(
         "Bob".as_bytes().to_vec(),
-        Basic,
         ciphersuite.signature_scheme(),
     )
         .expect("Error while creating credential.");
@@ -60,9 +58,8 @@ ctest_ciphersuites!(key_storage, test(ciphersuite_name: CiphersuiteName) {
     // Let' create some errors.
 
     // Generate a CredentialBundle externally and then try to load it from the store.
-    let cb_external = CredentialBundle::new(
+    let cb_external = BasicCredentialBundle::new(
         "Bob".as_bytes().to_vec(),
-        Basic,
         ciphersuite.signature_scheme(),
     )
     .expect("Error while creating credential.");

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -419,7 +419,7 @@ impl PublicGroupState {
     /// of the group and signs it.
     pub(crate) fn new(
         mls_group: &MlsGroup,
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
     ) -> Result<Self, CredentialError> {
         let ciphersuite = mls_group.ciphersuite();
         let (_external_priv, external_pub) = mls_group

--- a/openmls/src/messages/tests/test_pgs.rs
+++ b/openmls/src/messages/tests/test_pgs.rs
@@ -3,10 +3,9 @@ use tls_codec::{Deserialize, Serialize};
 use crate::{
     ciphersuite::signable::Verifiable,
     config::Config,
+    credentials::BasicCredentialBundle,
     key_packages::KeyPackageBundle,
-    messages::{
-        CredentialBundle, CredentialType, LeafIndex, MlsGroup, MlsGroupConfig, PublicGroupState,
-    },
+    messages::{CredentialBundle, LeafIndex, MlsGroup, MlsGroupConfig, PublicGroupState},
 };
 
 /// Tests the creation of a `PublicGroupState` and verifies it was correctly
@@ -17,18 +16,10 @@ fn test_pgs() {
         let group_aad = b"Alice's test group";
 
         // Define credential bundles
-        let alice_credential_bundle = CredentialBundle::new(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
-        let bob_credential_bundle = CredentialBundle::new(
-            "Bob".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let alice_credential_bundle =
+            BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme()).unwrap();
+        let bob_credential_bundle =
+            BasicCredentialBundle::new("Bob".into(), ciphersuite.signature_scheme()).unwrap();
 
         // Generate KeyPackages
         let bob_key_package_bundle =

--- a/openmls/src/messages/tests/test_proposals.rs
+++ b/openmls/src/messages/tests/test_proposals.rs
@@ -3,7 +3,7 @@ use tls_codec::{Deserialize, Serialize};
 use crate::{
     ciphersuite::{Ciphersuite, CiphersuiteName, Secret},
     config::Config,
-    credentials::{CredentialBundle, CredentialType},
+    credentials::{BasicCredentialBundle, CredentialBundle},
     extensions::{Extension, LifetimeExtension},
     framing::sender::{Sender, SenderType},
     framing::MlsPlaintext,
@@ -24,18 +24,10 @@ use crate::{
 fn proposal_queue_functions() {
     for ciphersuite in Config::supported_ciphersuites() {
         // Define identities
-        let alice_credential_bundle = CredentialBundle::new(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
-        let bob_credential_bundle = CredentialBundle::new(
-            "Bob".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let alice_credential_bundle =
+            BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme()).unwrap();
+        let bob_credential_bundle =
+            BasicCredentialBundle::new("Bob".into(), ciphersuite.signature_scheme()).unwrap();
 
         // Mandatory extensions, will be fixed in #164
         let lifetime_extension = Extension::LifeTime(LifetimeExtension::new(60));
@@ -153,18 +145,12 @@ fn proposal_queue_functions() {
 fn proposal_queue_order() {
     for ciphersuite in Config::supported_ciphersuites() {
         // Define identities
-        let alice_credential_bundle = CredentialBundle::new(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .expect("Could not create CredentialBundle");
-        let bob_credential_bundle = CredentialBundle::new(
-            "Bob".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .expect("Could not create CredentialBundle");
+        let alice_credential_bundle =
+            BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme())
+                .expect("Could not create CredentialBundle");
+        let bob_credential_bundle =
+            BasicCredentialBundle::new("Bob".into(), ciphersuite.signature_scheme())
+                .expect("Could not create CredentialBundle");
 
         // Generate KeyPackages
         let alice_key_package_bundle =

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -3,7 +3,7 @@
 use crate::{
     ciphersuite::{signable::Signable, AeadKey, AeadNonce, CiphersuiteName, Mac, Secret},
     config::Config,
-    credentials::{CredentialBundle, CredentialType},
+    credentials::{BasicCredentialBundle, CredentialBundle},
     group::{GroupEpoch, GroupId},
     messages::{ConfirmationTag, EncryptedGroupSecrets, GroupInfoPayload, Welcome},
     tree::index::LeafIndex,
@@ -29,12 +29,8 @@ macro_rules! test_welcome_msg {
             );
 
             // We need a credential bundle to sign the group info.
-            let credential_bundle = CredentialBundle::new(
-                "XXX".into(),
-                CredentialType::Basic,
-                $ciphersuite.signature_scheme(),
-            )
-            .unwrap();
+            let credential_bundle =
+                BasicCredentialBundle::new("XXX".into(), $ciphersuite.signature_scheme()).unwrap();
             let group_info = group_info
                 .sign(&credential_bundle)
                 .expect("Error signing GroupInfo");

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -118,9 +118,8 @@ impl ManagedTestSetup {
             let mut credentials = HashMap::new();
             for ciphersuite in Config::supported_ciphersuite_names() {
                 let credential = key_store
-                    .generate_credential_bundle(
+                    .generate_basic_credential_bundle(
                         identity.clone(),
-                        CredentialType::Basic,
                         SignatureScheme::from(*ciphersuite),
                     )
                     .unwrap();

--- a/openmls/src/tree/mod.rs
+++ b/openmls/src/tree/mod.rs
@@ -411,7 +411,7 @@ impl RatchetTree {
     /// Returns the update path and an updated key package bundle.
     pub(crate) fn refresh_private_tree(
         &mut self,
-        credential_bundle: &CredentialBundle,
+        credential_bundle: &(impl CredentialBundle + ?Sized),
         group_context: &[u8],
         new_leaves_indexes: HashSet<&LeafIndex>,
     ) -> Result<(UpdatePath, KeyPackageBundle), TreeError> {

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -80,7 +80,7 @@
 use crate::{
     ciphersuite::Ciphersuite,
     config::{Config, ProtocolVersion},
-    credentials::{CredentialBundle, CredentialType},
+    credentials::CredentialBundle,
     framing::*,
     group::*,
     key_packages::KeyPackageBundle,
@@ -130,13 +130,10 @@ pub struct EncryptionTestVector {
 }
 
 #[cfg(any(feature = "test-utils", test))]
-fn group(ciphersuite: &Ciphersuite) -> (MlsGroup, CredentialBundle) {
-    let credential_bundle = CredentialBundle::new(
-        "Kreator".into(),
-        CredentialType::Basic,
-        SignatureScheme::from(ciphersuite.name()),
-    )
-    .unwrap();
+fn group(ciphersuite: &Ciphersuite) -> (MlsGroup, BasicCredentialBundle) {
+    let credential_bundle =
+        BasicCredentialBundle::new("Kreator".into(), SignatureScheme::from(ciphersuite.name()))
+            .unwrap();
     let key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new()).unwrap();
     let group_id = [1, 2, 3, 4];
@@ -156,12 +153,9 @@ fn group(ciphersuite: &Ciphersuite) -> (MlsGroup, CredentialBundle) {
 
 #[cfg(any(feature = "test-utils", test))]
 fn receiver_group(ciphersuite: &Ciphersuite, group_id: &GroupId) -> MlsGroup {
-    let credential_bundle = CredentialBundle::new(
-        "Receiver".into(),
-        CredentialType::Basic,
-        SignatureScheme::from(ciphersuite.name()),
-    )
-    .unwrap();
+    let credential_bundle =
+        BasicCredentialBundle::new("Receiver".into(), SignatureScheme::from(ciphersuite.name()))
+            .unwrap();
     let key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new()).unwrap();
     MlsGroup::new(
@@ -180,7 +174,7 @@ fn receiver_group(ciphersuite: &Ciphersuite, group_id: &GroupId) -> MlsGroup {
 fn build_handshake_messages(
     leaf: LeafIndex,
     group: &mut MlsGroup,
-    credential_bundle: &CredentialBundle,
+    credential_bundle: &(impl CredentialBundle + ?Sized),
 ) -> (Vec<u8>, Vec<u8>) {
     use tls_codec::Serialize;
 
@@ -220,7 +214,7 @@ fn build_handshake_messages(
 fn build_application_messages(
     leaf: LeafIndex,
     group: &mut MlsGroup,
-    credential_bundle: &CredentialBundle,
+    credential_bundle: &(impl CredentialBundle + ?Sized),
 ) -> (Vec<u8>, Vec<u8>) {
     use tls_codec::Serialize;
 

--- a/openmls/src/tree/tests_and_kats/kats/kat_tree_kem.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_tree_kem.rs
@@ -18,7 +18,7 @@ use crate::group::HandshakeMessageFormat;
 use crate::test_utils::{read, write};
 use crate::{
     ciphersuite::signable::Signable,
-    credentials::{CredentialBundle, CredentialType},
+    credentials::{BasicCredentialBundle, CredentialBundle},
     node::Node,
     prelude::KeyPackageBundlePayload,
     test_utils::hex_to_bytes,
@@ -93,12 +93,8 @@ pub fn run_test_vector(test_vector: TreeKemTestVector) -> Result<(), TreeKemTest
 
     // We clone the leaf secret here, because we need it later to re-create the
     // KeyPackageBundle.
-    let credential_bundle = CredentialBundle::new(
-        "username".into(),
-        CredentialType::Basic,
-        ciphersuite.signature_scheme(),
-    )
-    .unwrap();
+    let credential_bundle =
+        BasicCredentialBundle::new("username".into(), ciphersuite.signature_scheme()).unwrap();
     let my_key_package_bundle = KeyPackageBundlePayload::from_key_package_and_leaf_secret(
         my_leaf_secret.clone(),
         &my_key_package,

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_hashes.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_hashes.rs
@@ -10,12 +10,8 @@ fn test_parent_hash() {
         let mut nodes = vec![];
         let mut key_package_bundles = vec![];
         for i in 0..NODES {
-            let credential_bundle = CredentialBundle::new(
-                vec![i as u8],
-                CredentialType::Basic,
-                ciphersuite.signature_scheme(),
-            )
-            .unwrap();
+            let credential_bundle =
+                BasicCredentialBundle::new(vec![i as u8], ciphersuite.signature_scheme()).unwrap();
             let key_package_bundle =
                 KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, vec![]).unwrap();
 

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_private_tree.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_private_tree.rs
@@ -14,12 +14,8 @@ use crate::{
 
 // Common setup for tests.
 fn setup(ciphersuite: &Ciphersuite, len: usize) -> (KeyPackageBundle, LeafIndex, Vec<NodeIndex>) {
-    let credential_bundle = CredentialBundle::new(
-        "username".into(),
-        CredentialType::Basic,
-        ciphersuite.signature_scheme(),
-    )
-    .unwrap();
+    let credential_bundle =
+        BasicCredentialBundle::new("username".into(), ciphersuite.signature_scheme()).unwrap();
     let key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, vec![]).unwrap();
     let own_index = LeafIndex::from(0u32);

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_resolution.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_resolution.rs
@@ -20,12 +20,8 @@ fn test_exclusion_list() {
         let mut nodes = vec![];
         let mut key_package_bundles = vec![];
         for i in 0..NODES {
-            let credential_bundle = CredentialBundle::new(
-                vec![i as u8],
-                CredentialType::Basic,
-                ciphersuite.signature_scheme(),
-            )
-            .unwrap();
+            let credential_bundle =
+                BasicCredentialBundle::new(vec![i as u8], ciphersuite.signature_scheme()).unwrap();
             let key_package_bundle =
                 KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, vec![]).unwrap();
 
@@ -97,12 +93,8 @@ fn test_original_child_resolution() {
         let mut nodes = vec![];
         let mut key_package_bundles = vec![];
         for i in 0..NODES {
-            let credential_bundle = CredentialBundle::new(
-                vec![i as u8],
-                CredentialType::Basic,
-                ciphersuite.signature_scheme(),
-            )
-            .unwrap();
+            let credential_bundle =
+                BasicCredentialBundle::new(vec![i as u8], ciphersuite.signature_scheme()).unwrap();
             let key_package_bundle =
                 KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, vec![]).unwrap();
 

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_tree_truncation.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_tree_truncation.rs
@@ -1,6 +1,6 @@
 use crate::{
     ciphersuite::Ciphersuite,
-    credentials::{CredentialBundle, CredentialType},
+    credentials::{BasicCredentialBundle, CredentialBundle},
     group::ManagedGroupConfig,
     node::{Node, NodeType},
     prelude::{KeyPackageBundle, LeafIndex},
@@ -18,12 +18,8 @@ fn test_trim() {
     for number_of_leaves in tree_sizes {
         println!("number of leaves: {:?}", number_of_leaves);
         for i in 0..number_of_leaves {
-            let credential_bundle = CredentialBundle::new(
-                vec![i as u8],
-                CredentialType::Basic,
-                ciphersuite.signature_scheme(),
-            )
-            .unwrap();
+            let credential_bundle =
+                BasicCredentialBundle::new(vec![i as u8], ciphersuite.signature_scheme()).unwrap();
             let key_package_bundle =
                 KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, vec![]).unwrap();
 

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_treemath.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_treemath.rs
@@ -31,8 +31,7 @@ fn test_dir_path() {
 fn test_tree_hash() {
     fn create_identity(id: &[u8], ciphersuite_name: CiphersuiteName) -> KeyPackageBundle {
         let signature_scheme = SignatureScheme::from(ciphersuite_name);
-        let credential_bundle =
-            CredentialBundle::new(id.to_vec(), CredentialType::Basic, signature_scheme).unwrap();
+        let credential_bundle = BasicCredentialBundle::new(id.to_vec(), signature_scheme).unwrap();
         KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, Vec::new()).unwrap()
     }
 

--- a/openmls/tests/test_encoding.rs
+++ b/openmls/tests/test_encoding.rs
@@ -56,7 +56,7 @@ fn test_application_message_encoding() {
 
     // Create a message in each group and test the padding.
     for group_state in alice.group_states.borrow_mut().values_mut() {
-        let credential_bundle = alice
+        let credential_bundle = &**alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
             .unwrap();
@@ -65,7 +65,7 @@ fn test_application_message_encoding() {
             let message = randombytes(random_usize() % 1000);
             let aad = randombytes(random_usize() % 1000);
             let encrypted_message = group_state
-                .create_application_message(&aad, &message, &credential_bundle, 0)
+                .create_application_message(&aad, &message, credential_bundle, 0)
                 .unwrap();
             let encrypted_message_bytes = encrypted_message.tls_serialize_detached().unwrap();
             let encrypted_message_decoded =
@@ -86,7 +86,7 @@ fn test_update_proposal_encoding() {
     let alice = test_clients.get("alice").unwrap().borrow();
 
     for group_state in alice.group_states.borrow_mut().values_mut() {
-        let credential_bundle = alice
+        let credential_bundle = &**alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
             .unwrap();
@@ -137,7 +137,7 @@ fn test_add_proposal_encoding() {
     let alice = test_clients.get("alice").unwrap().borrow();
 
     for group_state in alice.group_states.borrow_mut().values_mut() {
-        let credential_bundle = alice
+        let credential_bundle = &**alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
             .unwrap();
@@ -189,7 +189,7 @@ fn test_remove_proposal_encoding() {
     let alice = test_clients.get("alice").unwrap().borrow();
 
     for group_state in alice.group_states.borrow_mut().values_mut() {
-        let credential_bundle = alice
+        let credential_bundle = &**alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
             .unwrap();
@@ -221,7 +221,7 @@ fn test_commit_encoding() {
     let alice = test_clients.get("alice").unwrap().borrow();
 
     for group_state in alice.group_states.borrow_mut().values_mut() {
-        let alice_credential_bundle = alice
+        let alice_credential_bundle = &**alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
             .unwrap();
@@ -294,7 +294,7 @@ fn test_welcome_message_encoding() {
     let alice = test_clients.get("alice").unwrap().borrow();
 
     for group_state in alice.group_states.borrow_mut().values_mut() {
-        let credential_bundle = alice
+        let credential_bundle = &**alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
             .unwrap();

--- a/openmls/tests/test_framing.rs
+++ b/openmls/tests/test_framing.rs
@@ -38,7 +38,7 @@ fn padding() {
     for padding_size in 0..50 {
         // Create a message in each group and test the padding.
         for group_state in alice.group_states.borrow_mut().values_mut() {
-            let credential_bundle = alice
+            let credential_bundle = &**alice
                 .credential_bundles
                 .get(&group_state.ciphersuite().name())
                 .unwrap();
@@ -46,7 +46,7 @@ fn padding() {
                 let message = randombytes(random_usize() % 1000);
                 let aad = randombytes(random_usize() % 1000);
                 let mls_ciphertext = group_state
-                    .create_application_message(&aad, &message, &credential_bundle, padding_size)
+                    .create_application_message(&aad, &message, credential_bundle, padding_size)
                     .unwrap();
                 let ciphertext = mls_ciphertext.ciphertext();
                 let length = ciphertext.len();

--- a/openmls/tests/test_group.rs
+++ b/openmls/tests/test_group.rs
@@ -6,18 +6,10 @@ fn create_commit_optional_path() {
         let group_aad = b"Alice's test group";
 
         // Define identities
-        let alice_credential_bundle = CredentialBundle::new(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
-        let bob_credential_bundle = CredentialBundle::new(
-            "Bob".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let alice_credential_bundle =
+            BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme()).unwrap();
+        let bob_credential_bundle =
+            BasicCredentialBundle::new("Bob".into(), ciphersuite.signature_scheme()).unwrap();
 
         // Mandatory extensions, will be fixed in #164
         let lifetime_extension = Extension::LifeTime(LifetimeExtension::new(60));
@@ -181,18 +173,10 @@ fn basic_group_setup() {
         let group_aad = b"Alice's test group";
 
         // Define credential bundles
-        let alice_credential_bundle = CredentialBundle::new(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
-        let bob_credential_bundle = CredentialBundle::new(
-            "Bob".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let alice_credential_bundle =
+            BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme()).unwrap();
+        let bob_credential_bundle =
+            BasicCredentialBundle::new("Bob".into(), ciphersuite.signature_scheme()).unwrap();
 
         // Generate KeyPackages
         let bob_key_package_bundle =
@@ -252,18 +236,10 @@ fn group_operations() {
         let group_aad = b"Alice's test group";
 
         // Define credential bundles
-        let alice_credential_bundle = CredentialBundle::new(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
-        let bob_credential_bundle = CredentialBundle::new(
-            "Bob".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let alice_credential_bundle =
+            BasicCredentialBundle::new("Alice".into(), ciphersuite.signature_scheme()).unwrap();
+        let bob_credential_bundle =
+            BasicCredentialBundle::new("Bob".into(), ciphersuite.signature_scheme()).unwrap();
 
         // Mandatory extensions
         let capabilities_extension = Extension::Capabilities(CapabilitiesExtension::new(
@@ -531,12 +507,8 @@ fn group_operations() {
         }
 
         // === Bob adds Charlie ===
-        let charlie_credential_bundle = CredentialBundle::new(
-            "Charlie".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
-        .unwrap();
+        let charlie_credential_bundle =
+            BasicCredentialBundle::new("Charlie".into(), ciphersuite.signature_scheme()).unwrap();
 
         let charlie_key_package_bundle = KeyPackageBundle::new(
             &[ciphersuite.name()],

--- a/openmls/tests/test_key_packages.rs
+++ b/openmls/tests/test_key_packages.rs
@@ -12,7 +12,7 @@ ctest_ciphersuites!(key_package_generation, test(ciphersuite_name: CiphersuiteNa
 
     let id = vec![1, 2, 3];
     let credential_bundle =
-        CredentialBundle::new(id, CredentialType::Basic, ciphersuite.signature_scheme()).unwrap();
+        BasicCredentialBundle::new(id,  ciphersuite.signature_scheme()).unwrap();
     let kpb =
         KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, Vec::new()).unwrap();
 

--- a/openmls/tests/test_managed_group.rs
+++ b/openmls/tests/test_managed_group.rs
@@ -80,27 +80,15 @@ fn managed_group_operations() {
 
             // Generate credential bundles
             let alice_credential = key_store
-                .generate_credential_bundle(
-                    "Alice".into(),
-                    CredentialType::Basic,
-                    ciphersuite.signature_scheme(),
-                )
+                .generate_basic_credential_bundle("Alice".into(), ciphersuite.signature_scheme())
                 .unwrap();
 
             let bob_credential = key_store
-                .generate_credential_bundle(
-                    "Bob".into(),
-                    CredentialType::Basic,
-                    ciphersuite.signature_scheme(),
-                )
+                .generate_basic_credential_bundle("Bob".into(), ciphersuite.signature_scheme())
                 .unwrap();
 
             let charlie_credential = key_store
-                .generate_credential_bundle(
-                    "Charlie".into(),
-                    CredentialType::Basic,
-                    ciphersuite.signature_scheme(),
-                )
+                .generate_basic_credential_bundle("Charlie".into(), ciphersuite.signature_scheme())
                 .unwrap();
 
             // Generate KeyPackages
@@ -691,11 +679,7 @@ fn test_empty_input_errors() {
 
     // Generate credential bundles
     let alice_credential = key_store
-        .generate_credential_bundle(
-            "Alice".into(),
-            CredentialType::Basic,
-            ciphersuite.signature_scheme(),
-        )
+        .generate_basic_credential_bundle("Alice".into(), ciphersuite.signature_scheme())
         .unwrap();
 
     // Generate KeyPackages
@@ -760,19 +744,11 @@ fn managed_group_ratchet_tree_extension() {
 
             // Generate credential bundles
             let alice_credential = key_store
-                .generate_credential_bundle(
-                    "Alice".into(),
-                    CredentialType::Basic,
-                    ciphersuite.signature_scheme(),
-                )
+                .generate_basic_credential_bundle("Alice".into(), ciphersuite.signature_scheme())
                 .unwrap();
 
             let bob_credential = key_store
-                .generate_credential_bundle(
-                    "Bob".into(),
-                    CredentialType::Basic,
-                    ciphersuite.signature_scheme(),
-                )
+                .generate_basic_credential_bundle("Bob".into(), ciphersuite.signature_scheme())
                 .unwrap();
 
             // Generate KeyPackages
@@ -820,19 +796,11 @@ fn managed_group_ratchet_tree_extension() {
 
             // Generate credential bundles
             let alice_credential = key_store
-                .generate_credential_bundle(
-                    "Alice".into(),
-                    CredentialType::Basic,
-                    ciphersuite.signature_scheme(),
-                )
+                .generate_basic_credential_bundle("Alice".into(), ciphersuite.signature_scheme())
                 .unwrap();
 
             let bob_credential = key_store
-                .generate_credential_bundle(
-                    "Bob".into(),
-                    CredentialType::Basic,
-                    ciphersuite.signature_scheme(),
-                )
+                .generate_basic_credential_bundle("Bob".into(), ciphersuite.signature_scheme())
                 .unwrap();
 
             // Generate KeyPackages


### PR DESCRIPTION
This PR makes `CredentialBundle` a trait. This allows consumers to implement their own `CredentialBundle`, in particular managing where the private key material is stored (e.g. in a secure enclave).

This might be irrelevant depending on how the key store refactoring goes, but I thought it would be a meaning full exercise for now.

This does not fully address #163, but it fixes #461.