### PR TITLE
Enable RatchetTreeExtensions in the CLI client

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -8,3 +8,6 @@ run from the command line.
 
 While the code should compile using `cargo build`, the CLI client is neither
 very robust nor under active development.
+
+After running the client from the command line (e.g. using `cargo run`). Type
+`help` for basic usage.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # OpenMLS Proof-Of-Concept CLI Client
 
-This directory contains source code for a proof-of-concept implementation of
+This directory contains source code for a proof-of-concept implementation of a
 messaging client using OpenMLS. The client requires a running instance of our
 proof-of-concept delivery service, which can be found
 [here](https://github.com/openmls/openmls/tree/main/delivery-service) and can be

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,10 @@
+# OpenMLS Proof-Of-Concept CLI Client
+
+This directory contains source code for a proof-of-concept implementation of
+messaging client using OpenMLS. The client requires a running instance of our
+proof-of-concept delivery service, which can be found
+[here](https://github.com/openmls/openmls/tree/main/delivery-service) and can be
+run from the command line.
+
+While the code should compile using `cargo build`, the CLI client is neither
+very robust nor under active development.

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -191,7 +191,8 @@ impl User {
                             group.pending_proposals.push(msg);
                         }
                         MlsPlaintextContentType::Commit(_commit) => {
-                            match group.mls_group.borrow_mut().stage_commit(
+                            let mut mls_group = group.mls_group.borrow_mut();
+                            match mls_group.stage_commit(
                                 &msg,
                                 &(group
                                     .pending_proposals
@@ -202,7 +203,7 @@ impl User {
                                 &self.crypto,
                             ) {
                                 Ok(staged_commit) => {
-                                    group.mls_group.borrow_mut().merge_commit(staged_commit);
+                                    mls_group.merge_commit(staged_commit);
                                 }
                                 Err(e) => {
                                     let s = format!("Error applying commit: {:?}", e);

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -247,7 +247,8 @@ impl User {
         let mut group_aad = group_id.to_vec();
         group_aad.extend(b" AAD");
         let kpb = self.identity.borrow_mut().update(&self.crypto);
-        let config = MlsGroupConfig::default();
+        let mut config = MlsGroupConfig::default();
+        config.add_ratchet_tree_extension = true;
         let mls_group = MlsGroup::new(
             group_id,
             CIPHERSUITE,


### PR DESCRIPTION
This PR makes the CLI client use RatchetTreeExtensions and fixes a small bug that causes a borrow-checker panic at runtime.