### PR TITLE
Create CredentialBundle from existing keys

### DIFF
--- a/openmls/src/ciphersuite/signature.rs
+++ b/openmls/src/ciphersuite/signature.rs
@@ -43,6 +43,14 @@ impl<T> SignedStruct<T> for Signature {
 }
 
 impl SignatureKeypair {
+    /// Construct new [SignatureKeypair] from a private and a public key
+    pub fn from_keys(private_key: SignaturePrivateKey, public_key: SignaturePublicKey) -> Self {
+        Self {
+            private_key,
+            public_key,
+        }
+    }
+
     /// Get the private and public key objects
     pub fn into_tuple(self) -> (SignaturePrivateKey, SignaturePublicKey) {
         (self.private_key, self.public_key)

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -177,7 +177,7 @@ impl CredentialBundle {
     }
 
     /// Creates a new [CredentialBundle] from an identity, a [SignatureScheme] and a [SignatureKeypair].
-    /// Note that only BasicCredentials are cuurently supported.
+    /// Note that only [BasicCredential] is currently supported.
     pub fn from_parts(
         identity: Vec<u8>,
         signature_scheme: SignatureScheme,

--- a/openmls/src/credentials/tests.rs
+++ b/openmls/src/credentials/tests.rs
@@ -1,0 +1,30 @@
+use openmls_rust_crypto::OpenMlsRustCrypto;
+
+use super::*;
+
+#[test]
+fn test_protocol_version() {
+    use crate::config::ProtocolVersion;
+    let mls10_version = ProtocolVersion::Mls10;
+    let default_version = ProtocolVersion::default();
+    let mls10_e = mls10_version.tls_serialize_detached().unwrap();
+    assert_eq!(mls10_e[0], mls10_version as u8);
+    let default_e = default_version.tls_serialize_detached().unwrap();
+    assert_eq!(default_e[0], default_version as u8);
+    assert_eq!(mls10_e[0], 1);
+    assert_eq!(default_e[0], 1);
+}
+
+#[test]
+fn test_credential_bundle_from_parts() {
+    let backend = OpenMlsRustCrypto::default();
+    let signature_scheme = SignatureScheme::ED25519;
+    let keypair = SignatureKeypair::new(signature_scheme, &backend)
+        .expect("Could not create signature keypair.");
+
+    // Test decomposing the SignatureKeypair
+    let (private_key, public_key) = keypair.into_tuple();
+    let keypair = SignatureKeypair::from_keys(private_key, public_key);
+
+    let _credential_bundle = CredentialBundle::from_parts(vec![1, 2, 3], signature_scheme, keypair);
+}


### PR DESCRIPTION
This PR adds a function to `CredentialBundle` to create it from existing keys. This feature was requested by OpenMLS users.