### PR TITLE
Start validation tests

### DIFF
--- a/openmls/src/framing/ciphertext.rs
+++ b/openmls/src/framing/ciphertext.rs
@@ -11,7 +11,7 @@ use std::convert::TryFrom;
 /// `MlsCiphertext` is the framing struct for an encrypted `MlsPlaintext`.
 /// This message format is meant to be sent to and received from the Delivery
 /// Service.
-#[derive(Debug, PartialEq, Clone, TlsSerialize, TlsDeserialize, TlsSize)]
+#[derive(Debug, PartialEq, Clone, TlsSerialize, TlsSize)]
 pub struct MlsCiphertext {
     pub(crate) wire_format: WireFormat,
     pub(crate) group_id: GroupId,

--- a/openmls/src/framing/codec.rs
+++ b/openmls/src/framing/codec.rs
@@ -198,15 +198,6 @@ impl tls_codec::Serialize for MlsPlaintextTbs {
 
 impl tls_codec::Deserialize for MlsCiphertext {
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error> {
-        /*
-        pub(crate) wire_format: WireFormat,
-        pub(crate) group_id: GroupId,
-        pub(crate) epoch: GroupEpoch,
-        pub(crate) content_type: ContentType,
-        pub(crate) authenticated_data: TlsByteVecU32,
-        pub(crate) encrypted_sender_data: TlsByteVecU8,
-        pub(crate) ciphertext: TlsByteVecU32,
-        */
         let wire_format = WireFormat::tls_deserialize(bytes)?;
         let group_id = GroupId::tls_deserialize(bytes)?;
         let epoch = GroupEpoch::tls_deserialize(bytes)?;

--- a/openmls/src/framing/message.rs
+++ b/openmls/src/framing/message.rs
@@ -95,3 +95,10 @@ impl From<MlsMessageOut> for MlsMessageIn {
         }
     }
 }
+
+#[cfg(any(feature = "test-utils", test))]
+impl From<VerifiableMlsPlaintext> for MlsMessageIn {
+    fn from(plaintext: VerifiableMlsPlaintext) -> Self {
+        MlsMessageIn::Plaintext(plaintext)
+    }
+}

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -580,6 +580,12 @@ impl VerifiableMlsPlaintext {
         &self.tbs.group_id
     }
 
+    /// Set the group id.
+    #[cfg(test)]
+    pub(crate) fn set_group_id(&mut self, group_id: GroupId) {
+        self.tbs.group_id = group_id;
+    }
+
     /// Set the serialized context before verifying the signature.
     pub fn set_context(&mut self, serialized_context: Vec<u8>) {
         self.tbs.serialized_context = Some(serialized_context);

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -128,6 +128,7 @@ impl DecryptedMessage {
 /// Partially checked and potentially decrypted message.
 /// Use this to inspect the [Credential] of the message sender
 /// and the optional `aad` if the original message was an [MlsCiphertext].
+#[derive(Debug)]
 pub struct UnverifiedMessage {
     plaintext: VerifiableMlsPlaintext,
     credential: Option<Credential>,

--- a/openmls/src/group/managed_group/errors.rs
+++ b/openmls/src/group/managed_group/errors.rs
@@ -82,7 +82,7 @@ implement_error! {
             WrongEpoch = "The epoch does not match the group's epoch.",
             MissingConfirmationTag = "The confirmation tag is missing in the Commit message.",
             InvalidSignature = "The message's signature is invalid.",
-            WrongGroupId = "Worng group ID.",
+            WrongGroupId = "Wrong group ID.",
         }
         Complex {
             InvalidCiphertext(MlsCiphertextError) =

--- a/openmls/src/group/managed_group/errors.rs
+++ b/openmls/src/group/managed_group/errors.rs
@@ -82,6 +82,7 @@ implement_error! {
             WrongEpoch = "The epoch does not match the group's epoch.",
             MissingConfirmationTag = "The confirmation tag is missing in the Commit message.",
             InvalidSignature = "The message's signature is invalid.",
+            WrongGroupId = "Worng group ID.",
         }
         Complex {
             InvalidCiphertext(MlsCiphertextError) =

--- a/openmls/src/group/managed_group/validation.rs
+++ b/openmls/src/group/managed_group/validation.rs
@@ -30,10 +30,18 @@ impl ManagedGroup {
         if !self.active {
             return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
+
         // Check the message has the correct epoch number
         if message.epoch() != self.group.context().epoch() {
             return Err(ManagedGroupError::InvalidMessage(
                 InvalidMessageError::WrongEpoch,
+            ));
+        }
+
+        // ValSem2: Check the group ID is the right one
+        if message.group_id() != self.group_id() {
+            return Err(ManagedGroupError::InvalidMessage(
+                InvalidMessageError::WrongGroupId,
             ));
         }
 

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -465,12 +465,15 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     }
 
     // MlsPlaintextApplication
-    let tv_mls_plaintext_application = hex_to_bytes(&tv.mls_plaintext_application);
+    let mut tv_mls_plaintext_application = hex_to_bytes(&tv.mls_plaintext_application);
+    // Fake the wire format so we can deserialize
+    tv_mls_plaintext_application[0] = WireFormat::MlsPlaintext as u8;
     let my_mls_plaintext_application =
         VerifiableMlsPlaintext::tls_deserialize(&mut tv_mls_plaintext_application.as_slice())
             .unwrap()
             .tls_serialize_detached()
             .unwrap();
+
     if tv_mls_plaintext_application != my_mls_plaintext_application {
         log::error!("  MlsPlaintextApplication encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_mls_plaintext_application);
@@ -482,7 +485,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     }
 
     // MlsPlaintext(Proposal)
-    let tv_mls_plaintext_proposal = hex_to_bytes(&tv.mls_plaintext_proposal);
+    let mut tv_mls_plaintext_proposal = hex_to_bytes(&tv.mls_plaintext_proposal);
+    // Fake the wire format so we can deserialize
+    tv_mls_plaintext_proposal[0] = WireFormat::MlsPlaintext as u8;
     let my_mls_plaintext_proposal =
         VerifiableMlsPlaintext::tls_deserialize(&mut tv_mls_plaintext_proposal.as_slice())
             .unwrap()
@@ -499,7 +504,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     }
 
     // MlsPlaintext(Commit)
-    let tv_mls_plaintext_commit = hex_to_bytes(&tv.mls_plaintext_commit);
+    let mut tv_mls_plaintext_commit = hex_to_bytes(&tv.mls_plaintext_commit);
+    // Fake the wire format so we can deserialize
+    tv_mls_plaintext_commit[0] = WireFormat::MlsPlaintext as u8;
     let my_mls_plaintext_commit =
         VerifiableMlsPlaintext::tls_deserialize(&mut tv_mls_plaintext_commit.as_slice())
             .unwrap()

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -473,7 +473,6 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
             .unwrap()
             .tls_serialize_detached()
             .unwrap();
-
     if tv_mls_plaintext_application != my_mls_plaintext_application {
         log::error!("  MlsPlaintextApplication encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_mls_plaintext_application);

--- a/openmls/src/group/tests/mod.rs
+++ b/openmls/src/group/tests/mod.rs
@@ -2,3 +2,5 @@
 
 pub mod kat_messages;
 pub mod kat_transcripts;
+#[cfg(test)]
+mod test_validation;

--- a/openmls/src/group/tests/test_validation.rs
+++ b/openmls/src/group/tests/test_validation.rs
@@ -1,0 +1,213 @@
+//! This module contains all tests regarding the validation of incoming messages
+//! as defined in https://github.com/openmls/openmls/wiki/Message-validation
+
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use openmls_traits::{key_store::OpenMlsKeyStore, types::SignatureScheme, OpenMlsCryptoProvider};
+use tls_codec::{Deserialize, Serialize};
+
+use crate::{
+    ciphersuite::{Ciphersuite, CiphersuiteName},
+    credentials::{Credential, CredentialBundle, CredentialError, CredentialType},
+    extensions::Extension,
+    framing::{MlsCiphertext, MlsMessageIn, VerifiableMlsPlaintext},
+    group::{
+        GroupId, InvalidMessageError, ManagedGroup, ManagedGroupConfig, ManagedGroupError,
+        WireFormat,
+    },
+    key_packages::{KeyPackage, KeyPackageBundle, KeyPackageError},
+};
+
+fn generate_credential_bundle(
+    identity: Vec<u8>,
+    credential_type: CredentialType,
+    signature_scheme: SignatureScheme,
+    backend: &impl OpenMlsCryptoProvider,
+) -> Result<Credential, CredentialError> {
+    let cb = CredentialBundle::new(identity, credential_type, signature_scheme, backend)?;
+    let credential = cb.credential().clone();
+    backend
+        .key_store()
+        .store(credential.signature_key(), &cb)
+        .unwrap();
+    Ok(credential)
+}
+
+fn generate_key_package_bundle(
+    ciphersuites: &[CiphersuiteName],
+    credential: &Credential,
+    extensions: Vec<Extension>,
+    backend: &impl OpenMlsCryptoProvider,
+) -> Result<KeyPackage, KeyPackageError> {
+    let credential_bundle = backend
+        .key_store()
+        .read(credential.signature_key())
+        .unwrap();
+    let kpb = KeyPackageBundle::new(ciphersuites, &credential_bundle, backend, extensions)?;
+    let kp = kpb.key_package().clone();
+    backend.key_store().store(&kp.hash(backend), &kpb).unwrap();
+    Ok(kp)
+}
+
+#[cfg(test)]
+struct ValidationTestSetup {
+    backend: OpenMlsRustCrypto,
+    alice_group: ManagedGroup,
+    alice_credential: Credential,
+    bob_credential: Credential,
+    alice_key_package: KeyPackage,
+    bob_key_package: KeyPackage,
+}
+
+#[cfg(test)]
+fn validation_test_setup(wire_format: WireFormat) -> ValidationTestSetup {
+    let backend = OpenMlsRustCrypto::default();
+
+    let ciphersuite =
+        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519).unwrap();
+    let group_id = GroupId::from_slice(b"Test Group");
+
+    // Generate credential bundles
+    let alice_credential = generate_credential_bundle(
+        "Alice".into(),
+        CredentialType::Basic,
+        ciphersuite.signature_scheme(),
+        &backend,
+    )
+    .unwrap();
+
+    let bob_credential = generate_credential_bundle(
+        "Bob".into(),
+        CredentialType::Basic,
+        ciphersuite.signature_scheme(),
+        &backend,
+    )
+    .unwrap();
+
+    // Generate KeyPackages
+    let alice_key_package =
+        generate_key_package_bundle(&[ciphersuite.name()], &alice_credential, vec![], &backend)
+            .unwrap();
+
+    let bob_key_package =
+        generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![], &backend)
+            .unwrap();
+
+    // Define the managed group configuration
+
+    let managed_group_config = ManagedGroupConfig::builder()
+        .wire_format(wire_format)
+        .build();
+
+    // === Alice creates a group ===
+    let alice_group = ManagedGroup::new(
+        &backend,
+        &managed_group_config,
+        group_id,
+        &alice_key_package.hash(&backend),
+    )
+    .unwrap();
+
+    ValidationTestSetup {
+        backend,
+        alice_group,
+        alice_credential,
+        bob_credential,
+        alice_key_package,
+        bob_key_package,
+    }
+}
+
+#[test]
+fn test_valsem1() {
+    // Test with MlsPlaintext
+    let ValidationTestSetup {
+        backend,
+        mut alice_group,
+        alice_credential: _,
+        bob_credential: _,
+        alice_key_package: _,
+        bob_key_package,
+    } = validation_test_setup(WireFormat::MlsPlaintext);
+
+    let (message, _welcome) = alice_group
+        .add_members(&backend, &[bob_key_package])
+        .expect("Could not add member.");
+
+    let mut serialized_message = message
+        .tls_serialize_detached()
+        .expect("Could not serialize message.");
+
+    serialized_message[0] = WireFormat::MlsCiphertext as u8;
+
+    let err = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
+        .expect_err("Could deserialize message despite wrong wire format.");
+
+    assert_eq!(
+        err,
+        tls_codec::Error::DecodingError("Wrong wire format.".to_string())
+    );
+
+    // Test with MlsCiphertext
+    let ValidationTestSetup {
+        backend,
+        mut alice_group,
+        alice_credential: _,
+        bob_credential: _,
+        alice_key_package: _,
+        bob_key_package,
+    } = validation_test_setup(WireFormat::MlsCiphertext);
+
+    let (message, _welcome) = alice_group
+        .add_members(&backend, &[bob_key_package])
+        .expect("Could not add member.");
+
+    let mut serialized_message = message
+        .tls_serialize_detached()
+        .expect("Could not serialize message.");
+
+    serialized_message[0] = WireFormat::MlsPlaintext as u8;
+
+    let err = MlsCiphertext::tls_deserialize(&mut serialized_message.as_slice())
+        .expect_err("Could deserialize message despite wrong wire format.");
+
+    assert_eq!(
+        err,
+        tls_codec::Error::DecodingError("Wrong wire format.".to_string())
+    );
+}
+
+#[test]
+fn test_valsem2() {
+    let ValidationTestSetup {
+        backend,
+        mut alice_group,
+        alice_credential: _,
+        bob_credential: _,
+        alice_key_package: _,
+        bob_key_package,
+    } = validation_test_setup(WireFormat::MlsPlaintext);
+
+    let (message, _welcome) = alice_group
+        .add_members(&backend, &[bob_key_package])
+        .expect("Could not add member.");
+
+    let serialized_message = message
+        .tls_serialize_detached()
+        .expect("Could not serialize message.");
+
+    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
+        .expect("Could not deserialize message.");
+
+    plaintext.set_group_id(GroupId::from_slice(&[9, 9, 9]));
+
+    let message_in = MlsMessageIn::from(plaintext);
+
+    let err = alice_group
+        .parse_message(message_in, &backend)
+        .expect_err("Could parse message despite wrong group ID.");
+
+    assert_eq!(
+        err,
+        ManagedGroupError::InvalidMessage(InvalidMessageError::WrongGroupId,)
+    );
+}


### PR DESCRIPTION
This PR starts the validation testing. The tests are named after the semantic validation checks as outlined in the [wiki](https://github.com/openmls/openmls/wiki/Message-validation). This works towards #133.

This PR only contains 2 tests so far. If we agree on the structure I'll follow up with more tests.
