### PR TITLE
Use tls_codec 0.2.0-pre.2

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "0.13"
 log = "0.4"
 pretty_env_logger = "0.4"
 termion = "1.5"
-tls_codec = "0.1.4"
+tls_codec = "0.2.0-pre.1"
 
 openmls = { path = "../openmls" }
 ds-lib = { path = "../delivery-service/ds-lib" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "0.13"
 log = "0.4"
 pretty_env_logger = "0.4"
 termion = "1.5"
-tls_codec = "0.2.0-pre.1"
+tls_codec = "0.2.0-pre.2"
 
 openmls = { path = "../openmls" }
 ds-lib = { path = "../delivery-service/ds-lib" }

--- a/delivery-service/ds-lib/Cargo.toml
+++ b/delivery-service/ds-lib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Types to interact with the OpenMLS DS."
 
 [dependencies]
+tls_codec = "0.2.0-pre.1"
 openmls = { path = "../../openmls" }
-tls_codec = "0.1.4"
 openmls_traits = { version = "0.1", path = "../../traits" }
 openmls_rust_crypto = { path = "../../openmls_rust_crypto" }

--- a/delivery-service/ds-lib/Cargo.toml
+++ b/delivery-service/ds-lib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Types to interact with the OpenMLS DS."
 
 [dependencies]
-tls_codec = "0.2.0-pre.1"
+tls_codec = "0.2.0-pre.2"
 openmls = { path = "../../openmls" }
 openmls_traits = { version = "0.1", path = "../../traits" }
 openmls_rust_crypto = { path = "../../openmls_rust_crypto" }

--- a/delivery-service/ds-lib/src/lib.rs
+++ b/delivery-service/ds-lib/src/lib.rs
@@ -7,7 +7,7 @@
 
 use openmls::{framing::VerifiableMlsPlaintext, prelude::*};
 use tls_codec::{
-    Size, TlsByteSliceU16, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8, TlsDeserialize,
+    TlsByteSliceU16, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8, TlsDeserialize,
     TlsSerialize, TlsSize, TlsVecU32,
 };
 

--- a/delivery-service/ds/Cargo.toml
+++ b/delivery-service/ds/Cargo.toml
@@ -18,7 +18,7 @@ serde = {version = "1.0", features = ["derive"]}
 uuid = { version = "0.8", features = ["serde", "v4"] }
 clap = "2.33"
 base64 = "0.13"
-tls_codec = "0.1.4"
+tls_codec = "0.2.0-pre.1"
 
 openmls = { path = "../../openmls" }
 ds-lib = { path = "../ds-lib/" }

--- a/delivery-service/ds/Cargo.toml
+++ b/delivery-service/ds/Cargo.toml
@@ -18,7 +18,7 @@ serde = {version = "1.0", features = ["derive"]}
 uuid = { version = "0.8", features = ["serde", "v4"] }
 clap = "2.33"
 base64 = "0.13"
-tls_codec = "0.2.0-pre.1"
+tls_codec = "0.2.0-pre.2"
 
 openmls = { path = "../../openmls" }
 ds-lib = { path = "../ds-lib/" }

--- a/evercrypt_backend/Cargo.toml
+++ b/evercrypt_backend/Cargo.toml
@@ -10,7 +10,7 @@ evercrypt = { version = "0.0.10", features = ["serialization"] }
 memory_keystore = { version = "0.1", path = "../memory_keystore" }
 rand = "0.8"
 rand_chacha = { version = "0.3" }
-hpke = { version = "0.0.12", package = "hpke-rs", features = ["hazmat", "serialization"] }
+hpke = { version = "0.1.0-pre.1", package = "hpke-rs", features = ["hazmat", "serialization"] }
 log = { version = "0.4", features = ["std"] }
-hpke-rs-crypto = { version = "0.1.0" }
-hpke-rs-evercrypt = { version = "0.1.0" }
+hpke-rs-crypto = { version = "0.1.1-pre.1" }
+hpke-rs-evercrypt = { version = "0.1.1-pre.1" }

--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "0.2", features = ["macros",  "net"] }
 clap = "3.0.0-beta.4"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-tls_codec = { version = "0.2.0-pre.1", features = ["derive", "serde_serialize"] }
+tls_codec = { version = "0.2.0-pre.2", features = ["derive", "serde_serialize"] }
 pretty_env_logger = "0.4"
 openmls_rust_crypto = { path = "../openmls_rust_crypto" }
 openmls_traits = { version = "0.1", path = "../traits" }

--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "0.2", features = ["macros",  "net"] }
 clap = "3.0.0-beta.4"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-tls_codec = { version = "0.1", features = ["derive", "serde_serialize"] }
+tls_codec = { version = "0.2.0-pre.1", features = ["derive", "serde_serialize"] }
 pretty_env_logger = "0.4"
 openmls_rust_crypto = { path = "../openmls_rust_crypto" }
 openmls_traits = { version = "0.1", path = "../traits" }

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 log = { version = "0.4", features = ["std"] }
 typetag = "0.1"
-tls_codec = { version = "0.2.0-pre.1", features = ["derive", "serde_serialize"] }
+tls_codec = { version = "0.2.0-pre.2", features = ["derive", "serde_serialize"] }
 # Only required for tests.
 rand = { version = "0.8", optional = true }
 # The js feature is required for wasm.

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 log = { version = "0.4", features = ["std"] }
 typetag = "0.1"
-tls_codec = { version = "0.1.4", features = ["derive", "serde_serialize"] }
+tls_codec = { version = "0.2.0-pre.1", features = ["derive", "serde_serialize"] }
 # Only required for tests.
 rand = { version = "0.8", optional = true }
 # The js feature is required for wasm.

--- a/openmls/fuzz/Cargo.toml
+++ b/openmls/fuzz/Cargo.toml
@@ -47,8 +47,3 @@ name = "proposal_decode"
 path = "fuzz_targets/proposal_decode.rs"
 test = false
 doc = false
-
-# Override these dependencies as they might not be up to date.
-[patch.crates-io]
-tls_codec = { git = "https://github.com/openmls/tls-codec" }
-tls_codec_derive = { git = "https://github.com/openmls/tls-codec" }

--- a/openmls/src/ciphersuite/codec.rs
+++ b/openmls/src/ciphersuite/codec.rs
@@ -7,13 +7,13 @@ use std::io::{Read, Write};
 
 use tls_codec::{TlsSliceU16, TlsSliceU8, TlsVecU8};
 
-impl tls_codec::Size for Ciphersuite {
+impl tls_codec::Size for &Ciphersuite {
     fn tls_serialized_len(&self) -> usize {
         CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256.tls_serialized_len()
     }
 }
 
-impl tls_codec::Serialize for Ciphersuite {
+impl tls_codec::Serialize for &Ciphersuite {
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, ::tls_codec::Error> {
         self.name.tls_serialize(writer)
     }

--- a/openmls/src/ciphersuite/mod.rs
+++ b/openmls/src/ciphersuite/mod.rs
@@ -4,7 +4,7 @@
 //! See `codec.rs` and `ciphersuites.rs` for internals.
 
 use crate::config::{Config, ConfigError, ProtocolVersion};
-use ::tls_codec::{Size, TlsDeserialize, TlsSerialize, TlsSize};
+use ::tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 use openmls_traits::types::{HpkeAeadType, HpkeConfig, HpkeKdfType, HpkeKemType};
 use openmls_traits::{
     crypto::OpenMlsCrypto,

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 #[cfg(test)]
 use tls_codec::Serialize as TlsSerializeTrait;
-use tls_codec::{Size, TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize};
 
 use crate::ciphersuite::*;
 

--- a/openmls/src/extensions/capabilities_extension.rs
+++ b/openmls/src/extensions/capabilities_extension.rs
@@ -16,7 +16,7 @@
 
 use std::io::Read;
 
-use tls_codec::{Size, TlsSerialize, TlsSize, TlsVecU8};
+use tls_codec::{TlsSerialize, TlsSize, TlsVecU8};
 
 use super::{CapabilitiesExtensionError, Deserialize, ExtensionType, Serialize};
 use crate::ciphersuite::CiphersuiteName;

--- a/openmls/src/extensions/key_package_id_extension.rs
+++ b/openmls/src/extensions/key_package_id_extension.rs
@@ -12,7 +12,7 @@
 //! opaque key_id<0..2^16-1>;
 //! ```
 
-use tls_codec::{Size, TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize};
 
 use super::{Deserialize, Serialize};
 

--- a/openmls/src/extensions/life_time_extension.rs
+++ b/openmls/src/extensions/life_time_extension.rs
@@ -18,7 +18,7 @@
 //! uint64 not_before;
 //! uint64 not_after;
 //! ```
-use tls_codec::{Size, TlsSerialize, TlsSize};
+use tls_codec::{TlsSerialize, TlsSize};
 
 use super::{Deserialize, LifetimeExtensionError, Serialize};
 use crate::config::Config;

--- a/openmls/src/extensions/parent_hash_extension.rs
+++ b/openmls/src/extensions/parent_hash_extension.rs
@@ -18,7 +18,7 @@
 //! parent_hash matches the hash of the leaf's parent node when represented as a
 //! ParentNode struct.
 
-use tls_codec::{Size, TlsByteVecU8, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsByteVecU8, TlsDeserialize, TlsSerialize, TlsSize};
 
 use super::{Deserialize, Serialize};
 

--- a/openmls/src/extensions/ratchet_tree_extension.rs
+++ b/openmls/src/extensions/ratchet_tree_extension.rs
@@ -22,7 +22,7 @@
 //!
 //! optional<Node> ratchet_tree<1..2^32-1>;
 //! ```
-use tls_codec::{Size, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
 
 use super::{Deserialize, Serialize};
 use crate::tree::node::*;

--- a/openmls/src/extensions/required_capabilities.rs
+++ b/openmls/src/extensions/required_capabilities.rs
@@ -20,7 +20,7 @@
 //! contains a `required_capabilities` extension that requires capabililities not
 //! supported by all current members.
 
-use tls_codec::{Size, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU8};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, TlsVecU8};
 
 use crate::messages::proposals::ProposalType;
 

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -26,7 +26,7 @@ use crate::ciphersuite::signable::{Signable, SignedStruct, Verifiable, VerifiedS
 use super::*;
 use openmls_traits::OpenMlsCryptoProvider;
 use std::convert::TryFrom;
-use tls_codec::{Serialize, Size, TlsByteVecU32, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{Serialize, TlsByteVecU32, TlsDeserialize, TlsSerialize, TlsSize};
 
 /// `MLSPlaintext` is a framing structure for MLS messages. It can contain
 /// Proposals, Commits and application messages.

--- a/openmls/src/framing/sender.rs
+++ b/openmls/src/framing/sender.rs
@@ -27,7 +27,7 @@
 
 use super::*;
 use std::convert::TryFrom;
-use tls_codec::{Size, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 
 #[derive(
     PartialEq, Clone, Copy, Debug, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -27,7 +27,7 @@ pub use managed_group::*;
 pub use mls_group::*;
 
 use tls_codec::TlsVecU32;
-use tls_codec::{Size, TlsByteVecU8, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsByteVecU8, TlsDeserialize, TlsSerialize, TlsSize};
 
 #[derive(
     Hash, Eq, Debug, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -23,8 +23,8 @@ pub use codec::*;
 pub use errors::*;
 use proposals::*;
 use tls_codec::{
-    Serialize as TlsSerializeTrait, Size, TlsByteVecU32, TlsByteVecU8, TlsDeserialize,
-    TlsSerialize, TlsSize, TlsVecU32,
+    Serialize as TlsSerializeTrait, TlsByteVecU32, TlsByteVecU8, TlsDeserialize, TlsSerialize,
+    TlsSize, TlsVecU32,
 };
 
 #[cfg(test)]

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -7,8 +7,7 @@ use openmls_traits::OpenMlsCryptoProvider;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use tls_codec::{
-    Serialize as TlsSerializeTrait, Size, TlsByteVecU8, TlsDeserialize, TlsSerialize, TlsSize,
-    TlsVecU32,
+    Serialize as TlsSerializeTrait, TlsByteVecU8, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32,
 };
 
 use super::errors::*;

--- a/openmls/src/messages/public_group_state.rs
+++ b/openmls/src/messages/public_group_state.rs
@@ -5,7 +5,7 @@
 //!
 //! [`OpenMLS Wiki`]: https://github.com/openmls/openmls/wiki/Signable
 use openmls_traits::OpenMlsCryptoProvider;
-use tls_codec::{Serialize, Size, TlsByteVecU8, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
+use tls_codec::{Serialize, TlsByteVecU8, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
 
 use crate::{
     ciphersuite::{

--- a/openmls/src/schedule/codec.rs
+++ b/openmls/src/schedule/codec.rs
@@ -5,6 +5,13 @@ use super::*;
 
 use std::io::{Read, Write};
 
+impl tls_codec::Size for &PreSharedKeyId {
+    #[inline]
+    fn tls_serialized_len(&self) -> usize {
+        (*self).tls_serialized_len()
+    }
+}
+
 impl tls_codec::Size for PreSharedKeyId {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
@@ -19,6 +26,7 @@ impl tls_codec::Size for PreSharedKeyId {
 }
 
 impl tls_codec::Serialize for PreSharedKeyId {
+    #[inline]
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, ::tls_codec::Error> {
         let mut written = self.psk_type.tls_serialize(writer)?;
         written += match &self.psk {
@@ -27,6 +35,13 @@ impl tls_codec::Serialize for PreSharedKeyId {
             Psk::Branch(branch_psk) => branch_psk.tls_serialize(writer)?,
         };
         self.psk_nonce.tls_serialize(writer).map(|l| l + written)
+    }
+}
+
+impl tls_codec::Serialize for &PreSharedKeyId {
+    #[inline]
+    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, ::tls_codec::Error> {
+        (*self).tls_serialize(writer)
     }
 }
 

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -129,7 +129,7 @@ use openmls_traits::types::HpkeKeyPair;
 use openmls_traits::OpenMlsCryptoProvider;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
-use tls_codec::{Serialize as TlsSerializeTrait, Size, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{Serialize as TlsSerializeTrait, TlsDeserialize, TlsSerialize, TlsSize};
 
 pub mod codec;
 pub mod errors;

--- a/openmls/src/tree/index.rs
+++ b/openmls/src/tree/index.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 use std::ops::{Index, IndexMut};
-use tls_codec::{Size, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 
 use super::*;
 

--- a/openmls/src/tree/mod.rs
+++ b/openmls/src/tree/mod.rs
@@ -26,7 +26,7 @@ use openmls_traits::crypto::OpenMlsCrypto;
 use openmls_traits::types::HpkeCiphertext;
 use openmls_traits::OpenMlsCryptoProvider;
 use private_tree::PrivateTree;
-use tls_codec::{Size, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
 
 use crate::schedule::{CommitSecret, PreSharedKeys};
 pub(crate) use serde::{

--- a/openmls/src/tree/node.rs
+++ b/openmls/src/tree/node.rs
@@ -1,5 +1,5 @@
 use tls_codec::TlsByteVecU8;
-use tls_codec::{Size, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
 
 use crate::ciphersuite::*;
 use crate::extensions::*;

--- a/openmls/src/tree/secret_tree.rs
+++ b/openmls/src/tree/secret_tree.rs
@@ -1,4 +1,4 @@
-use tls_codec::{Serialize, Size, TlsSerialize, TlsSize};
+use tls_codec::{Serialize, TlsSerialize, TlsSize};
 
 use crate::ciphersuite::*;
 use crate::framing::*;

--- a/rust_crypto/Cargo.toml
+++ b/rust_crypto/Cargo.toml
@@ -15,6 +15,6 @@ p256 = { version = "0.9" }
 hkdf = { version = "0.11" }
 rand = "0.8"
 rand_chacha = { version = "0.3" }
-hpke = { version = "0.0.12", package = "hpke-rs", default-features = false, features = ["hazmat", "serialization"] }
-hpke-rs-crypto = { version = "0.1.0" }
-hpke-rs-rust-crypto = { version = "0.1.0" }
+hpke = { version = "0.1.0-pre.1", package = "hpke-rs", default-features = false, features = ["hazmat", "serialization"] }
+hpke-rs-crypto = { version = "0.1.1-pre.1" }
+hpke-rs-rust-crypto = { version = "0.1.1-pre.1" }

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -8,4 +8,4 @@ path = "src/traits.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tls_codec = { version = "0.1", features = ["derive", "serde_serialize"] }
+tls_codec = { version = "0.2.0-pre.1", features = ["derive", "serde_serialize"] }

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -8,4 +8,4 @@ path = "src/traits.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tls_codec = { version = "0.2.0-pre.1", features = ["derive", "serde_serialize"] }
+tls_codec = { version = "0.2.0-pre.2", features = ["derive", "serde_serialize"] }

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
-use tls_codec::{Size, TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u16)]


### PR DESCRIPTION
What the title says.
The changes required to OpenMLS are

- `Size` doesn't need to be imported anymore when deriving
- The traits have to be implemented for borrowed types explicitly.