### PR TITLE
Correct decryption methods for AEAD

### DIFF
--- a/rust_crypto/src/lib.rs
+++ b/rust_crypto/src/lib.rs
@@ -184,14 +184,14 @@ impl OpenMlsCrypto for RustCrypto {
             AeadType::Aes256Gcm => {
                 let aes =
                     Aes256Gcm::new_from_slice(key).map_err(|_| CryptoError::CryptoLibraryError)?;
-                aes.encrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                aes.decrypt(nonce.into(), Payload { msg: ct_tag, aad })
                     .map(|r| r.as_slice().into())
                     .map_err(|_| CryptoError::AeadDecryptionError)
             }
             AeadType::ChaCha20Poly1305 => {
                 let aes = ChaCha20Poly1305::new_from_slice(key)
                     .map_err(|_| CryptoError::CryptoLibraryError)?;
-                aes.encrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                aes.decrypt(nonce.into(), Payload { msg: ct_tag, aad })
                     .map(|r| r.as_slice().into())
                     .map_err(|_| CryptoError::AeadDecryptionError)
             }

--- a/rust_crypto/src/lib.rs
+++ b/rust_crypto/src/lib.rs
@@ -156,9 +156,10 @@ impl OpenMlsCrypto for RustCrypto {
                     .map_err(|_| CryptoError::CryptoLibraryError)
             }
             AeadType::ChaCha20Poly1305 => {
-                let aes = ChaCha20Poly1305::new_from_slice(key)
+                let chacha_poly = ChaCha20Poly1305::new_from_slice(key)
                     .map_err(|_| CryptoError::CryptoLibraryError)?;
-                aes.encrypt(nonce.into(), Payload { msg: data, aad })
+                chacha_poly
+                    .encrypt(nonce.into(), Payload { msg: data, aad })
                     .map(|r| r.as_slice().into())
                     .map_err(|_| CryptoError::CryptoLibraryError)
             }
@@ -189,9 +190,10 @@ impl OpenMlsCrypto for RustCrypto {
                     .map_err(|_| CryptoError::AeadDecryptionError)
             }
             AeadType::ChaCha20Poly1305 => {
-                let aes = ChaCha20Poly1305::new_from_slice(key)
+                let chacha_poly = ChaCha20Poly1305::new_from_slice(key)
                     .map_err(|_| CryptoError::CryptoLibraryError)?;
-                aes.decrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                chacha_poly
+                    .decrypt(nonce.into(), Payload { msg: ct_tag, aad })
                     .map(|r| r.as_slice().into())
                     .map_err(|_| CryptoError::AeadDecryptionError)
             }


### PR DESCRIPTION
The given decryption implementations for AEAD in `rust_crypto` for the cases `ChaCha20Poly1305` and `Aes256Gcm` did not use the regarding decryption but encryption methods of `aes-gcm`. I assume this bug was introduced by copy / paste, this PR should fix it :+1: