### PR TITLE
crypto-subtle feature

### DIFF
--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -30,6 +30,7 @@ evercrypt_backend = { version = "0.1", path = "../evercrypt_backend", optional =
 
 [features]
 default = []
+crypto-subtle = [] # Enable subtle crypto APIs that have to be used with care.
 test-utils = ["itertools", "openmls_rust_crypto", "rand"]
 evercrypt = ["evercrypt_backend"] # Evercrypt needs to be enabled individually
 crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information

--- a/openmls/src/ciphersuite/signature.rs
+++ b/openmls/src/ciphersuite/signature.rs
@@ -43,7 +43,10 @@ impl<T> SignedStruct<T> for Signature {
 }
 
 impl SignatureKeypair {
-    /// Construct a new [SignatureKeypair] from bytes of a private and a public key
+    #[cfg(feature = "crypto-subtle")]
+    /// Construct a new [`SignatureKeypair`] from bytes of a private and a public key.
+    ///
+    /// **NO CHECKS ARE PERFORMED ON THE KEYS. USE AT YOUR OWN RISK.**
     pub fn from_bytes(
         signature_scheme: SignatureScheme,
         private_key: Vec<u8>,
@@ -103,11 +106,11 @@ impl SignatureKeypair {
 
         Ok(SignatureKeypair {
             private_key: SignaturePrivateKey {
-                value: sk.to_vec(),
+                value: sk,
                 signature_scheme,
             },
             public_key: SignaturePublicKey {
-                value: pk.to_vec(),
+                value: pk,
                 signature_scheme,
             },
         })


### PR DESCRIPTION
With a feature flag on top I'm fine with this for now.

Ideally all the signature key structs move out of the main library. But that's a bigger effort. Then the crypto backends could handle this whatever way they liked.