### PR TITLE
Replace 'unwrap' by 'expect' in tests

### DIFF
--- a/openmls/benches/benchmark.rs
+++ b/openmls/benches/benchmark.rs
@@ -24,7 +24,7 @@ fn criterion_kp_bundle(c: &mut Criterion) {
                             ciphersuite.signature_scheme(),
                             crypto,
                         )
-                        .unwrap()
+                        .expect("An unexpected error occurred.")
                     },
                     |credential_bundle: CredentialBundle| {
                         let crypto = &OpenMlsRustCrypto::default();
@@ -34,7 +34,7 @@ fn criterion_kp_bundle(c: &mut Criterion) {
                             crypto,
                             Vec::new(),
                         )
-                        .unwrap();
+                        .expect("An unexpected error occurred.");
                     },
                 );
             },

--- a/openmls/src/credentials/tests.rs
+++ b/openmls/src/credentials/tests.rs
@@ -7,9 +7,13 @@ fn test_protocol_version() {
     use crate::config::ProtocolVersion;
     let mls10_version = ProtocolVersion::Mls10;
     let default_version = ProtocolVersion::default();
-    let mls10_e = mls10_version.tls_serialize_detached().unwrap();
+    let mls10_e = mls10_version
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
     assert_eq!(mls10_e[0], mls10_version as u8);
-    let default_e = default_version.tls_serialize_detached().unwrap();
+    let default_e = default_version
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
     assert_eq!(default_e[0], default_version as u8);
     assert_eq!(mls10_e[0], 1);
     assert_eq!(default_e[0], 1);

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -23,13 +23,16 @@ fn capabilities() {
     let ext = Extension::Capabilities(CapabilitiesExtension::default());
 
     // Check that decoding works
-    let capabilities_extension = Extension::tls_deserialize(&mut extension_bytes_mut).unwrap();
+    let capabilities_extension = Extension::tls_deserialize(&mut extension_bytes_mut)
+        .expect("An unexpected error occurred.");
     assert_eq!(ext, capabilities_extension);
 
     // Encoding creates the expected bytes.
     assert_eq!(
         extension_bytes,
-        &capabilities_extension.tls_serialize_detached().unwrap()[..]
+        &capabilities_extension
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.")[..]
     );
 
     // Test encoding and decoding
@@ -48,10 +51,13 @@ fn key_package_id() {
     let data = &[0u8, 8, 1, 2, 3, 4, 5, 6, 6, 6];
     let kpi = KeyIdExtension::new(&data[2..]);
 
-    let kpi_from_bytes = KeyIdExtension::tls_deserialize(&mut (data as &[u8])).unwrap();
+    let kpi_from_bytes = KeyIdExtension::tls_deserialize(&mut (data as &[u8]))
+        .expect("An unexpected error occurred.");
     assert_eq!(kpi, kpi_from_bytes);
 
-    let serialized_extension_struct = kpi.tls_serialize_detached().unwrap();
+    let serialized_extension_struct = kpi
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
     assert_eq!(&data[..], &serialized_extension_struct);
 }
 
@@ -85,7 +91,7 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
     let crypto = &OpenMlsRustCrypto::default();
 
     log::info!("Testing ciphersuite {:?}", ciphersuite_name);
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
 
     // Basic group setup.
     let group_aad = b"Alice's test group";
@@ -98,14 +104,14 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
         ciphersuite.signature_scheme(),
         crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let bob_credential_bundle = CredentialBundle::new(
         "Bob".into(),
         CredentialType::Basic,
         ciphersuite.signature_scheme(),
         crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     // Generate KeyPackages
     let alice_key_package_bundle =
@@ -114,7 +120,7 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
             crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     let bob_key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()],
@@ -122,7 +128,7 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
             crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
     let config = MlsGroupConfig {
@@ -165,7 +171,7 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
     alice_group.merge_commit(staged_commit);
 
     let bob_group = match MlsGroup::new_from_welcome(
-        welcome_bundle_alice_bob_option.unwrap(),
+        welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         None,
         bob_key_package_bundle,
         None,
@@ -190,11 +196,11 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
     // Generate KeyPackages
     let alice_key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()], &alice_credential_bundle, crypto, Vec::new())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
     let bob_key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle, crypto, Vec::new())
-            .unwrap();
+            .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
     let config = MlsGroupConfig {
@@ -233,7 +239,7 @@ ctest_ciphersuites!(ratchet_tree_extension, test(ciphersuite_name: CiphersuiteNa
     alice_group.merge_commit(staged_commit);
 
     let error = MlsGroup::new_from_welcome(
-        welcome_bundle_alice_bob_option.unwrap(),
+        welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         None,
         bob_key_package_bundle,
         None,
@@ -257,13 +263,16 @@ fn required_capabilities() {
     let ext = Extension::RequiredCapabilities(RequiredCapabilitiesExtension::default());
 
     // Check that decoding works
-    let required_capabilities = Extension::tls_deserialize(&mut extension_bytes_mut).unwrap();
+    let required_capabilities = Extension::tls_deserialize(&mut extension_bytes_mut)
+        .expect("An unexpected error occurred.");
     assert_eq!(ext, required_capabilities);
 
     // Encoding creates the expected bytes.
     assert_eq!(
         extension_bytes,
-        &required_capabilities.tls_serialize_detached().unwrap()[..]
+        &required_capabilities
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.")[..]
     );
 
     // Build one with some content.

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -24,16 +24,18 @@ fn codec_plaintext() {
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let sender = Sender {
             sender_type: SenderType::Member,
             sender: LeafIndex::from(2u32),
         };
         let group_context =
             GroupContext::new(GroupId::random(&crypto), GroupEpoch(1), vec![], vec![], &[])
-                .unwrap();
+                .expect("An unexpected error occurred.");
 
-        let serialized_context = group_context.tls_serialize_detached().unwrap();
+        let serialized_context = group_context
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
         let signature_input = MlsPlaintextTbs::new(
             WireFormat::MlsPlaintext,
             GroupId::random(&crypto),
@@ -50,12 +52,15 @@ fn codec_plaintext() {
             .sign(&crypto, &credential_bundle)
             .expect("Signing failed.");
 
-        let enc = orig.tls_serialize_detached().unwrap();
-        let mut copy = VerifiableMlsPlaintext::tls_deserialize(&mut enc.as_slice()).unwrap();
+        let enc = orig
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
+        let mut copy = VerifiableMlsPlaintext::tls_deserialize(&mut enc.as_slice())
+            .expect("An unexpected error occurred.");
         copy.set_context(serialized_context);
         let copy = copy
             .verify(&crypto, credential_bundle.credential())
-            .unwrap();
+            .expect("An unexpected error occurred.");
         assert_eq!(orig, copy);
         assert!(!orig.is_handshake_message());
     }
@@ -73,7 +78,7 @@ fn codec_ciphertext() {
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let sender = Sender {
             sender_type: SenderType::Member,
             sender: LeafIndex::from(0u32),
@@ -85,9 +90,11 @@ fn codec_ciphertext() {
             vec![],
             &[],
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
-        let serialized_context = group_context.tls_serialize_detached().unwrap();
+        let serialized_context = group_context
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
         let signature_input = MlsPlaintextTbs::new(
             WireFormat::MlsCiphertext,
             GroupId::random(&crypto),
@@ -140,8 +147,11 @@ fn codec_ciphertext() {
         )
         .expect("Could not encrypt MlsPlaintext.");
 
-        let enc = orig.tls_serialize_detached().unwrap();
-        let copy = MlsCiphertext::tls_deserialize(&mut enc.as_slice()).unwrap();
+        let enc = orig
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
+        let copy = MlsCiphertext::tls_deserialize(&mut enc.as_slice())
+            .expect("An unexpected error occurred.");
 
         assert_eq!(orig, copy);
         assert!(!orig.is_handshake_message());
@@ -160,7 +170,7 @@ fn wire_format_checks() {
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let sender = Sender {
             sender_type: SenderType::Member,
             sender: LeafIndex::from(0u32),
@@ -172,9 +182,11 @@ fn wire_format_checks() {
             vec![],
             &[],
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
-        let serialized_context = group_context.tls_serialize_detached().unwrap();
+        let serialized_context = group_context
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
         let signature_input = MlsPlaintextTbs::new(
             WireFormat::MlsCiphertext,
             GroupId::random(&crypto),
@@ -283,9 +295,10 @@ fn membership_tag() {
             ciphersuite.signature_scheme(),
             crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let group_context =
-            GroupContext::new(GroupId::random(crypto), GroupEpoch(1), vec![], vec![], &[]).unwrap();
+            GroupContext::new(GroupId::random(crypto), GroupEpoch(1), vec![], vec![], &[])
+                .expect("An unexpected error occurred.");
         let membership_key = MembershipKey::from_secret(
             Secret::random(ciphersuite, crypto, None /* MLS version */)
                 .expect("Not enough randomness."),
@@ -299,8 +312,10 @@ fn membership_tag() {
             &membership_key,
             crypto,
         )
-        .unwrap();
-        let serialized_context: Vec<u8> = group_context.tls_serialize_detached().unwrap();
+        .expect("An unexpected error occurred.");
+        let serialized_context: Vec<u8> = group_context
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
 
         let verifiable_mls_plaintext = VerifiableMlsPlaintext::from_plaintext(
             mls_plaintext.clone(),
@@ -344,21 +359,21 @@ fn unknown_sender() {
             ciphersuite.signature_scheme(),
             crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_credential_bundle = CredentialBundle::new(
             "Bob".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
             crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let charlie_credential_bundle = CredentialBundle::new(
             "Charlie".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
             crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Generate KeyPackages
         let bob_key_package_bundle = KeyPackageBundle::new(
@@ -367,7 +382,7 @@ fn unknown_sender() {
             crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_key_package = bob_key_package_bundle.key_package();
 
         let charlie_key_package_bundle = KeyPackageBundle::new(
@@ -376,7 +391,7 @@ fn unknown_sender() {
             crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let charlie_key_package = charlie_key_package_bundle.key_package();
 
         let alice_key_package_bundle = KeyPackageBundle::new(
@@ -385,7 +400,7 @@ fn unknown_sender() {
             crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Alice creates a group
         let mut group_alice = MlsGroup::builder(GroupId::random(crypto), alice_key_package_bundle)
@@ -455,7 +470,7 @@ fn unknown_sender() {
         group_alice.merge_commit(staged_commit);
 
         let mut group_charlie = MlsGroup::new_from_welcome(
-            welcome_option.unwrap(),
+            welcome_option.expect("An unexpected error occurred."),
             Some(group_alice.tree().public_key_tree_copy()),
             charlie_key_package_bundle,
             None,
@@ -497,7 +512,7 @@ fn unknown_sender() {
             .stage_commit(
                 &commit,
                 &proposal_store,
-                &[kpb_option.unwrap()],
+                &[kpb_option.expect("An unexpected error occurred.")],
                 None,
                 crypto,
             )
@@ -605,14 +620,14 @@ fn confirmation_tag_presence() {
             ciphersuite.signature_scheme(),
             crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_credential_bundle = CredentialBundle::new(
             "Bob".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
             crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Generate KeyPackages
         let bob_key_package_bundle = KeyPackageBundle::new(
@@ -621,7 +636,7 @@ fn confirmation_tag_presence() {
             crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_key_package = bob_key_package_bundle.key_package();
 
         let alice_key_package_bundle = KeyPackageBundle::new(
@@ -630,7 +645,7 @@ fn confirmation_tag_presence() {
             crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Alice creates a group
         let mut group_alice = MlsGroup::builder(GroupId::random(crypto), alice_key_package_bundle)
@@ -680,7 +695,7 @@ ctest_ciphersuites!(invalid_plaintext_signature,test (ciphersuite_name: Ciphersu
         let crypto = &OpenMlsRustCrypto::default();
 
         log::info!("Testing ciphersuite {:?}", ciphersuite_name);
-        let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+        let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
         let group_aad = b"Alice's test group";
         let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
@@ -691,14 +706,14 @@ ctest_ciphersuites!(invalid_plaintext_signature,test (ciphersuite_name: Ciphersu
             ciphersuite.signature_scheme(),
             crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_credential_bundle = CredentialBundle::new(
             "Bob".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
             crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Generate KeyPackages
         let bob_key_package_bundle = KeyPackageBundle::new(
@@ -707,7 +722,7 @@ ctest_ciphersuites!(invalid_plaintext_signature,test (ciphersuite_name: Ciphersu
             crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_key_package = bob_key_package_bundle.key_package();
 
         let alice_key_package_bundle = KeyPackageBundle::new(
@@ -716,7 +731,7 @@ ctest_ciphersuites!(invalid_plaintext_signature,test (ciphersuite_name: Ciphersu
             crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Alice creates a group
         let mut group_alice = MlsGroup::builder(GroupId::random(crypto), alice_key_package_bundle)
@@ -748,10 +763,10 @@ ctest_ciphersuites!(invalid_plaintext_signature,test (ciphersuite_name: Ciphersu
             .create_commit(params, crypto)
             .expect("Error creating Commit");
 
-        let original_encoded_commit = commit.tls_serialize_detached().unwrap();
+        let original_encoded_commit = commit.tls_serialize_detached().expect("An unexpected error occurred.");
         let mut input_commit =
             VerifiableMlsPlaintext::tls_deserialize(&mut original_encoded_commit.as_slice())
-                .unwrap();
+                .expect("An unexpected error occurred.");
         let original_input_commit = input_commit.clone();
 
         // Remove membership tag.
@@ -791,16 +806,16 @@ ctest_ciphersuites!(invalid_plaintext_signature,test (ciphersuite_name: Ciphersu
             .verify(original_input_commit, crypto)
             .expect("Error verifying valid commit message");
         assert_eq!(
-            decoded_commit.tls_serialize_detached().unwrap(),
+            decoded_commit.tls_serialize_detached().expect("An unexpected error occurred."),
             original_encoded_commit
         );
 
         // Tamper with signature.
         let good_signature = commit.signature().clone();
         commit.invalidate_signature();
-        let encoded_commit = commit.tls_serialize_detached().unwrap();
+        let encoded_commit = commit.tls_serialize_detached().expect("An unexpected error occurred.");
         let input_commit =
-            VerifiableMlsPlaintext::tls_deserialize(&mut encoded_commit.as_slice()).unwrap();
+            VerifiableMlsPlaintext::tls_deserialize(&mut encoded_commit.as_slice()).expect("An unexpected error occurred.");
         let decoded_commit = group_alice.verify(input_commit, crypto);
         assert_eq!(
             decoded_commit
@@ -813,7 +828,7 @@ ctest_ciphersuites!(invalid_plaintext_signature,test (ciphersuite_name: Ciphersu
 
         // Fix commit
         commit.set_signature(good_signature);
-        commit.set_membership_tag_test(good_membership_tag.unwrap());
+        commit.set_membership_tag_test(good_membership_tag.expect("An unexpected error occurred."));
 
         // Remove confirmation tag.
         let good_confirmation_tag = commit.confirmation_tag().cloned();
@@ -834,7 +849,7 @@ ctest_ciphersuites!(invalid_plaintext_signature,test (ciphersuite_name: Ciphersu
             .expect("There should have been a membership tag.");
         modified_confirmation_tag.0.mac_value[0] ^= 0xFF;
         commit.set_confirmation_tag(modified_confirmation_tag);
-        let serialized_group_before = serde_json::to_string(&group_alice).unwrap();
+        let serialized_group_before = serde_json::to_string(&group_alice).expect("An unexpected error occurred.");
 
         proposal_store.empty();
         proposal_store.add(
@@ -849,20 +864,20 @@ ctest_ciphersuites!(invalid_plaintext_signature,test (ciphersuite_name: Ciphersu
             error,
             MlsGroupError::StageCommitError(StageCommitError::ConfirmationTagMismatch)
         );
-        let serialized_group_after = serde_json::to_string(&group_alice).unwrap();
+        let serialized_group_after = serde_json::to_string(&group_alice).expect("An unexpected error occurred.");
         assert_eq!(serialized_group_before, serialized_group_after);
 
         // Fix commit again and stage it.
-        commit.set_confirmation_tag(good_confirmation_tag.unwrap());
-        let encoded_commit = commit.tls_serialize_detached().unwrap();
+        commit.set_confirmation_tag(good_confirmation_tag.expect("An unexpected error occurred."));
+        let encoded_commit = commit.tls_serialize_detached().expect("An unexpected error occurred.");
         let input_commit =
-            VerifiableMlsPlaintext::tls_deserialize(&mut encoded_commit.as_slice()).unwrap();
+            VerifiableMlsPlaintext::tls_deserialize(&mut encoded_commit.as_slice()).expect("An unexpected error occurred.");
         let decoded_commit = group_alice
             .verify(input_commit, crypto)
             .expect("Error verifying commit");
         assert_eq!(
             original_encoded_commit,
-            decoded_commit.tls_serialize_detached().unwrap()
+            decoded_commit.tls_serialize_detached().expect("An unexpected error occurred.")
         );
 
         proposal_store.empty();

--- a/openmls/src/group/mls_group/test_duplicate_extension.rs
+++ b/openmls/src/group/mls_group/test_duplicate_extension.rs
@@ -11,7 +11,7 @@ use tls_codec::Deserialize;
 ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(ciphersuite_name: CiphersuiteName) {
     let crypto = OpenMlsRustCrypto::default();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
 
     // Basic group setup.
     let group_aad = b"Alice's test group";
@@ -23,23 +23,23 @@ ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(ciphersuite_name: Cip
         ciphersuite.signature_scheme(),
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let bob_credential_bundle = CredentialBundle::new(
         "Bob".into(),
         CredentialType::Basic,
         ciphersuite.signature_scheme(),
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     // Generate KeyPackages
     let alice_key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()], &alice_credential_bundle, &crypto, Vec::new())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
     let bob_key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle, &crypto, Vec::new())
-            .unwrap();
+            .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
     let config = MlsGroupConfig {
@@ -136,7 +136,7 @@ ctest_ciphersuites!(duplicate_ratchet_tree_extension, test(ciphersuite_name: Cip
 
     let encrypted_group_info = welcome_key
         .aead_seal(&crypto, &group_info.tls_serialize_detached().expect("Could not encode GroupInfo"), &[], &welcome_nonce)
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     welcome.set_encrypted_group_info(encrypted_group_info);
 

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -27,7 +27,7 @@ fn test_mls_group_persistence() {
         ciphersuite.signature_scheme(),
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     // Generate KeyPackages
     let alice_key_package_bundle = KeyPackageBundle::new(
@@ -36,7 +36,7 @@ fn test_mls_group_persistence() {
         &crypto,
         Vec::new(),
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     // Alice creates a group
     let alice_group = MlsGroup::builder(GroupId::random(&crypto), alice_key_package_bundle)
@@ -59,7 +59,10 @@ fn test_mls_group_persistence() {
 
 /// This function flips the last byte of the ciphertext.
 pub fn flip_last_byte(ctxt: &mut HpkeCiphertext) {
-    let mut last_bits = ctxt.ciphertext.pop().unwrap();
+    let mut last_bits = ctxt
+        .ciphertext
+        .pop()
+        .expect("An unexpected error occurred.");
     last_bits ^= 0xff;
     ctxt.ciphertext.push(last_bits);
 }
@@ -117,7 +120,7 @@ fn test_failed_groupinfo_decryption() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
             let group_info = group_info
                 .sign(&crypto, &alice_credential_bundle)
                 .expect("Error signing group info");
@@ -128,7 +131,7 @@ fn test_failed_groupinfo_decryption() {
                 &crypto,
                 vec![],
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             // Mess with the ciphertext by flipping the last byte.
             flip_last_byte(&mut encrypted_group_secrets);
@@ -146,11 +149,13 @@ fn test_failed_groupinfo_decryption() {
             let encrypted_group_info = welcome_key
                 .aead_seal(
                     &crypto,
-                    &group_info.tls_serialize_detached().unwrap(),
+                    &group_info
+                        .tls_serialize_detached()
+                        .expect("An unexpected error occurred."),
                     &[],
                     &welcome_nonce,
                 )
-                .unwrap();
+                .expect("An unexpected error occurred.");
 
             // Now build the welcome message.
             let broken_welcome = Welcome::new(
@@ -194,14 +199,14 @@ fn test_update_path() {
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_credential_bundle = CredentialBundle::new(
             "Bob".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Generate KeyPackages
         let alice_key_package_bundle = KeyPackageBundle::new(
@@ -210,7 +215,7 @@ fn test_update_path() {
             &crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         let bob_key_package_bundle = KeyPackageBundle::new(
             &[ciphersuite.name()],
@@ -218,7 +223,7 @@ fn test_update_path() {
             &crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_key_package = bob_key_package_bundle.key_package();
 
         // === Alice creates a group ===
@@ -269,13 +274,13 @@ fn test_update_path() {
         let ratchet_tree = alice_group.tree().public_key_tree_copy();
 
         let group_bob = MlsGroup::new_from_welcome(
-            welcome_bundle_alice_bob_option.unwrap(),
+            welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
             Some(ratchet_tree),
             bob_key_package_bundle,
             None,
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // === Bob updates and commits ===
         let bob_update_key_package_bundle = KeyPackageBundle::new(
@@ -284,7 +289,7 @@ fn test_update_path() {
             &crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         let update_proposal_bob = group_bob
             .create_update_proposal(
@@ -304,8 +309,9 @@ fn test_update_path() {
             .proposal_store(&proposal_store)
             .force_self_update(false)
             .build();
-        let (mls_plaintext_commit, _welcome_option, _kpb_option) =
-            group_bob.create_commit(params, &crypto).unwrap();
+        let (mls_plaintext_commit, _welcome_option, _kpb_option) = group_bob
+            .create_commit(params, &crypto)
+            .expect("An unexpected error occurred.");
 
         // Now we break Alice's HPKE ciphertext in Bob's commit by breaking
         // apart the commit, manipulating the ciphertexts and the piecing it
@@ -317,7 +323,7 @@ fn test_update_path() {
 
         let commit = commit.clone();
 
-        let path = commit.path.unwrap();
+        let path = commit.path.expect("An unexpected error occurred.");
 
         // For simplicity, let's just break all the ciphertexts.
         let mut new_nodes = Vec::new();
@@ -356,16 +362,22 @@ fn test_update_path() {
         )
         .expect("Could not create plaintext.");
 
-        broken_plaintext
-            .set_confirmation_tag(mls_plaintext_commit.confirmation_tag().cloned().unwrap());
+        broken_plaintext.set_confirmation_tag(
+            mls_plaintext_commit
+                .confirmation_tag()
+                .cloned()
+                .expect("An unexpected error occurred."),
+        );
 
         println!(
             "Confirmation tag: {:?}",
             broken_plaintext.confirmation_tag()
         );
 
-        let serialized_context =
-            &group_bob.group_context.tls_serialize_detached().unwrap() as &[u8];
+        let serialized_context = &group_bob
+            .group_context
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.") as &[u8];
 
         broken_plaintext
             .set_membership_tag(
@@ -409,7 +421,7 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
         }
     }
 
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
 
     // Basic group setup.
     let group_aad = b"Alice's test group";
@@ -423,7 +435,7 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
 
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let bob_credential_bundle = CredentialBundle::new(
         "Bob".into(),
         CredentialType::Basic,
@@ -431,16 +443,16 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
 
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     // Generate KeyPackages
     let alice_key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()], &alice_credential_bundle,  &crypto, Vec::new())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
     let bob_key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle,  &crypto, Vec::new())
-            .unwrap();
+            .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
     // === Alice creates a group with a PSK ===
@@ -521,7 +533,7 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
     let ratchet_tree = alice_group.tree().public_key_tree_copy();
 
     let group_bob = MlsGroup::new_from_welcome(
-        welcome_bundle_alice_bob_option.unwrap(),
+        welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,
         Some(psk_fetcher),
@@ -532,7 +544,7 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
     // === Bob updates and commits ===
     let bob_update_key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite.name()], &bob_credential_bundle,  &crypto, Vec::new())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
     let update_proposal_bob = group_bob
         .create_update_proposal(
@@ -554,6 +566,6 @@ ctest_ciphersuites!(test_psks, test(ciphersuite_name: CiphersuiteName) {
         .build();
     let (_mls_plaintext_commit, _welcome_option, _kpb_option) = group_bob
         .create_commit(params, &crypto)
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
 });

--- a/openmls/src/group/mls_group/test_proposals.rs
+++ b/openmls/src/group/mls_group/test_proposals.rs
@@ -33,14 +33,14 @@ fn setup_client(
         ciphersuite.signature_scheme(),
         backend,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let key_package_bundle = KeyPackageBundle::new(
         &[ciphersuite.name()],
         &credential_bundle,
         backend,
         Vec::new(),
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     (credential_bundle, key_package_bundle)
 }
 
@@ -66,7 +66,7 @@ fn proposal_queue_functions() {
             &crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let alice_update_key_package = alice_update_key_package_bundle.key_package();
         assert!(alice_update_key_package.verify(&crypto).is_ok());
 
@@ -87,13 +87,16 @@ fn proposal_queue_functions() {
 
         let proposal_add_alice1 = Proposal::Add(add_proposal_alice1);
         let proposal_reference_add_alice1 =
-            ProposalReference::from_proposal(ciphersuite, &crypto, &proposal_add_alice1).unwrap();
+            ProposalReference::from_proposal(ciphersuite, &crypto, &proposal_add_alice1)
+                .expect("An unexpected error occurred.");
         let proposal_add_alice2 = Proposal::Add(add_proposal_alice2);
         let proposal_reference_add_alice2 =
-            ProposalReference::from_proposal(ciphersuite, &crypto, &proposal_add_alice2).unwrap();
+            ProposalReference::from_proposal(ciphersuite, &crypto, &proposal_add_alice2)
+                .expect("An unexpected error occurred.");
         let proposal_add_bob1 = Proposal::Add(add_proposal_bob1);
         let proposal_reference_add_bob1 =
-            ProposalReference::from_proposal(ciphersuite, &crypto, &proposal_add_bob1).unwrap();
+            ProposalReference::from_proposal(ciphersuite, &crypto, &proposal_add_bob1)
+                .expect("An unexpected error occurred.");
 
         // Test proposal types
         assert!(proposal_add_alice1.is_type(ProposalType::Add));
@@ -201,13 +204,13 @@ fn proposal_queue_order() {
             &crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let alice_update_key_package = alice_update_key_package_bundle.key_package();
         assert!(alice_update_key_package.verify(&crypto).is_ok());
 
         let group_context =
             GroupContext::new(GroupId::random(&crypto), GroupEpoch(0), vec![], vec![], &[])
-                .unwrap();
+                .expect("An unexpected error occurred.");
 
         // Let's create some proposals
         let add_proposal_alice1 = AddProposal {
@@ -219,7 +222,8 @@ fn proposal_queue_order() {
 
         let proposal_add_alice1 = Proposal::Add(add_proposal_alice1);
         let proposal_reference_add_alice1 =
-            ProposalReference::from_proposal(ciphersuite, &crypto, &proposal_add_alice1).unwrap();
+            ProposalReference::from_proposal(ciphersuite, &crypto, &proposal_add_alice1)
+                .expect("An unexpected error occurred.");
         let proposal_add_bob1 = Proposal::Add(add_proposal_bob1);
 
         // Frame proposals in MlsPlaintext
@@ -280,7 +284,7 @@ fn proposal_queue_order() {
             &proposal_store,
             sender,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         let proposal_collection: Vec<&StagedProposal> =
             proposal_queue.filtered_by_type(ProposalType::Add).collect();
@@ -383,7 +387,7 @@ fn test_group_context_extensions() {
         &crypto,
         vec![Extension::KeyPackageId(KeyIdExtension::default())],
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
     // Set required capabilities
@@ -436,7 +440,7 @@ fn test_group_context_extensions() {
     // Make sure that Bob can join the group with the required extension in place
     // and Bob's key package supporting them.
     let _bob_group = MlsGroup::new_from_welcome(
-        welcome_bundle_alice_bob_option.unwrap(),
+        welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,
         None,
@@ -464,7 +468,7 @@ fn test_group_context_extension_proposal_fails() {
         &crypto,
         vec![Extension::KeyPackageId(KeyIdExtension::default())],
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
     // Set required capabilities
@@ -534,7 +538,7 @@ fn test_group_context_extension_proposal_fails() {
     let ratchet_tree = alice_group.tree().public_key_tree_copy();
 
     let bob_group = MlsGroup::new_from_welcome(
-        welcome_bundle_alice_bob_option.unwrap(),
+        welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,
         None,
@@ -576,14 +580,14 @@ fn test_group_context_extension_proposal() {
         &crypto,
         vec![Extension::KeyPackageId(KeyIdExtension::default())],
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let alice_key_package_bundle = KeyPackageBundle::new(
         &[ciphersuite.name()],
         &alice_credential_bundle,
         &crypto,
         vec![Extension::KeyPackageId(KeyIdExtension::default())],
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
     // Set required capabilities
@@ -635,7 +639,7 @@ fn test_group_context_extension_proposal() {
     let ratchet_tree = alice_group.tree().public_key_tree_copy();
 
     let mut bob_group = MlsGroup::new_from_welcome(
-        welcome_bundle_alice_bob_option.unwrap(),
+        welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,
         None,

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -58,10 +58,10 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
         SignatureScheme::from(ciphersuite_name),
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, &crypto, Vec::new())
-            .unwrap();
+            .expect("An unexpected error occurred.");
     let capabilities = CapabilitiesExtension::default();
     let lifetime = LifetimeExtension::default();
 
@@ -76,8 +76,14 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
     let group_info = GroupInfoPayload::new(
         group.group_id().clone(),
         GroupEpoch(0),
-        crypto.rand().random_vec(ciphersuite.hash_length()).unwrap(),
-        crypto.rand().random_vec(ciphersuite.hash_length()).unwrap(),
+        crypto
+            .rand()
+            .random_vec(ciphersuite.hash_length())
+            .expect("An unexpected error occurred."),
+        crypto
+            .rand()
+            .random_vec(ciphersuite.hash_length())
+            .expect("An unexpected error occurred."),
         &[Extension::RequiredCapabilities(
             RequiredCapabilitiesExtension::default(),
         )],
@@ -88,22 +94,24 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
             mac_value: crypto
                 .rand()
                 .random_vec(ciphersuite.hash_length())
-                .unwrap()
+                .expect("An unexpected error occurred.")
                 .into(),
         }),
         LeafIndex::from(random_u32()),
     );
-    let group_info = group_info.sign(&crypto, &credential_bundle).unwrap();
+    let group_info = group_info
+        .sign(&crypto, &credential_bundle)
+        .expect("An unexpected error occurred.");
     let group_secrets =
         GroupSecrets::random_encoded(ciphersuite, &crypto, ProtocolVersion::default());
     let public_group_state = group
         .export_public_group_state(&crypto, &credential_bundle)
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     // Create some proposals
     let key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, &crypto, Vec::new())
-            .unwrap();
+            .expect("An unexpected error occurred.");
     let key_package = key_package_bundle.key_package();
 
     let add_proposal = AddProposal {
@@ -119,9 +127,15 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
     let psk_id = PreSharedKeyId::new(
         PskType::External,
         Psk::External(ExternalPsk::new(
-            crypto.rand().random_vec(ciphersuite.hash_length()).unwrap(),
+            crypto
+                .rand()
+                .random_vec(ciphersuite.hash_length())
+                .expect("An unexpected error occurred."),
         )),
-        crypto.rand().random_vec(ciphersuite.hash_length()).unwrap(),
+        crypto
+            .rand()
+            .random_vec(ciphersuite.hash_length())
+            .expect("An unexpected error occurred."),
     );
 
     let psk_proposal = PreSharedKeyProposal::new(psk_id);
@@ -140,7 +154,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
     let app_ack_proposal = tls_codec::TlsByteVecU32::new(Vec::new());
     let joiner_key_package_bundle =
         KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, &crypto, Vec::new())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
     let framing_parameters = FramingParameters::new(b"aad", WireFormat::MlsCiphertext);
 
@@ -151,23 +165,26 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
             joiner_key_package_bundle.key_package().clone(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, &crypto, add_proposal_pt.clone()).unwrap(),
+        StagedProposal::from_mls_plaintext(ciphersuite, &crypto, add_proposal_pt.clone())
+            .expect("An unexpected error occurred."),
     );
     let params = CreateCommitParams::builder()
         .framing_parameters(framing_parameters)
         .credential_bundle(&credential_bundle)
         .proposal_store(&proposal_store)
         .build();
-    let (commit_pt, welcome_option, _option_kpb) = group.create_commit(params, &crypto).unwrap();
+    let (commit_pt, welcome_option, _option_kpb) = group
+        .create_commit(params, &crypto)
+        .expect("An unexpected error occurred.");
     let commit = if let MlsPlaintextContentType::Commit(commit) = commit_pt.content() {
         commit.clone()
     } else {
         panic!("Wrong content of MLS plaintext");
     };
-    let welcome = welcome_option.unwrap();
+    let welcome = welcome_option.expect("An unexpected error occurred.");
     let mls_ciphertext_application = group
         .create_application_message(
             b"aad",
@@ -176,13 +193,14 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
             random_u8() as usize,
             &crypto,
         )
-        .unwrap();
-    let verifiable_mls_plaintext_application =
-        group.decrypt(&mls_ciphertext_application, &crypto).unwrap();
+        .expect("An unexpected error occurred.");
+    let verifiable_mls_plaintext_application = group
+        .decrypt(&mls_ciphertext_application, &crypto)
+        .expect("An unexpected error occurred.");
     // Sets the context implicitly.
     let mls_plaintext_application = group
         .verify(verifiable_mls_plaintext_application, &crypto)
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     let encryption_target = match random_u32() % 3 {
         0 => commit_pt.clone(),
@@ -193,38 +211,110 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
 
     let mls_ciphertext = group
         .encrypt(encryption_target, random_u8() as usize, &crypto)
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     MessagesTestVector {
-        key_package: bytes_to_hex(&key_package.tls_serialize_detached().unwrap()), // serialized KeyPackage,
-        capabilities: bytes_to_hex(&capabilities.tls_serialize_detached().unwrap()), // serialized Capabilities,
-        lifetime: bytes_to_hex(&lifetime.tls_serialize_detached().unwrap()), // serialized {uint64 not_before; uint64 not_after;},
-        ratchet_tree: bytes_to_hex(&TlsSliceU32(&ratchet_tree).tls_serialize_detached().unwrap()), /* serialized optional<Node> ratchet_tree<1..2^32-1>; */
+        key_package: bytes_to_hex(
+            &key_package
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), // serialized KeyPackage,
+        capabilities: bytes_to_hex(
+            &capabilities
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), // serialized Capabilities,
+        lifetime: bytes_to_hex(
+            &lifetime
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), // serialized {uint64 not_before; uint64 not_after;},
+        ratchet_tree: bytes_to_hex(
+            &TlsSliceU32(&ratchet_tree)
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized optional<Node> ratchet_tree<1..2^32-1>; */
 
-        group_info: bytes_to_hex(&group_info.tls_serialize_detached().unwrap()), /* serialized GroupInfo */
-        group_secrets: bytes_to_hex(&group_secrets.unwrap()), /* serialized GroupSecrets */
-        welcome: bytes_to_hex(&welcome.tls_serialize_detached().unwrap()), /* serialized Welcome */
+        group_info: bytes_to_hex(
+            &group_info
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized GroupInfo */
+        group_secrets: bytes_to_hex(&group_secrets.expect("An unexpected error occurred.")), /* serialized GroupSecrets */
+        welcome: bytes_to_hex(
+            &welcome
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized Welcome */
 
-        public_group_state: bytes_to_hex(&public_group_state.tls_serialize_detached().unwrap()), /* serialized PublicGroupState */
+        public_group_state: bytes_to_hex(
+            &public_group_state
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized PublicGroupState */
 
-        add_proposal: bytes_to_hex(&add_proposal.tls_serialize_detached().unwrap()), /* serialized Add */
-        update_proposal: bytes_to_hex(&update_proposal.tls_serialize_detached().unwrap()), /* serialized Update */
-        remove_proposal: bytes_to_hex(&remove_proposal.tls_serialize_detached().unwrap()), /* serialized Remove */
-        pre_shared_key_proposal: bytes_to_hex(&psk_proposal.tls_serialize_detached().unwrap()), /* serialized PreSharedKey */
-        re_init_proposal: bytes_to_hex(&reinit_proposal.tls_serialize_detached().unwrap()), /* serialized ReInit */
+        add_proposal: bytes_to_hex(
+            &add_proposal
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized Add */
+        update_proposal: bytes_to_hex(
+            &update_proposal
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized Update */
+        remove_proposal: bytes_to_hex(
+            &remove_proposal
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized Remove */
+        pre_shared_key_proposal: bytes_to_hex(
+            &psk_proposal
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized PreSharedKey */
+        re_init_proposal: bytes_to_hex(
+            &reinit_proposal
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized ReInit */
         external_init_proposal: bytes_to_hex(
-            &external_init_proposal.tls_serialize_detached().unwrap(),
+            &external_init_proposal
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
         ), /* serialized ExternalInit */
-        app_ack_proposal: bytes_to_hex(&app_ack_proposal.tls_serialize_detached().unwrap()), /* serialized AppAck */
+        app_ack_proposal: bytes_to_hex(
+            &app_ack_proposal
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized AppAck */
 
-        commit: bytes_to_hex(&commit.tls_serialize_detached().unwrap()), /* serialized Commit */
+        commit: bytes_to_hex(
+            &commit
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized Commit */
 
         mls_plaintext_application: bytes_to_hex(
-            &mls_plaintext_application.tls_serialize_detached().unwrap(),
+            &mls_plaintext_application
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
         ), /* serialized MLSPlaintext(ApplicationData) */
-        mls_plaintext_proposal: bytes_to_hex(&add_proposal_pt.tls_serialize_detached().unwrap()), /* serialized MLSPlaintext(Proposal(*)) */
-        mls_plaintext_commit: bytes_to_hex(&commit_pt.tls_serialize_detached().unwrap()), /* serialized MLSPlaintext(Commit) */
-        mls_ciphertext: bytes_to_hex(&mls_ciphertext.tls_serialize_detached().unwrap()), /* serialized MLSCiphertext */
+        mls_plaintext_proposal: bytes_to_hex(
+            &add_proposal_pt
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized MLSPlaintext(Proposal(*)) */
+        mls_plaintext_commit: bytes_to_hex(
+            &commit_pt
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized MLSPlaintext(Commit) */
+        mls_ciphertext: bytes_to_hex(
+            &mls_ciphertext
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ), /* serialized MLSCiphertext */
     }
 }
 
@@ -248,9 +338,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     let tv_key_package = hex_to_bytes(&tv.key_package);
     let mut tv_key_package_slice = tv_key_package.as_slice();
     let my_key_package = KeyPackage::tls_deserialize(&mut tv_key_package_slice)
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
     if tv_key_package != my_key_package {
         log::error!("  KeyPackage encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_key_package);
@@ -265,9 +355,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     log::debug!("Capabilities tv: {}", tv.capabilities);
     let tv_capabilities = hex_to_bytes(&tv.capabilities);
     let my_capabilities = CapabilitiesExtension::tls_deserialize(&mut tv_capabilities.as_slice())
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
     if tv_capabilities != my_capabilities {
         log::error!("  Capabilities encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_capabilities);
@@ -281,9 +371,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // Lifetime
     let tv_lifetime = hex_to_bytes(&tv.lifetime);
     let my_lifetime = LifetimeExtension::tls_deserialize(&mut tv_lifetime.as_slice())
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
     if tv_lifetime != my_lifetime {
         log::error!("  Lifetime encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_lifetime);
@@ -298,8 +388,11 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     log::trace!("  Serialized ratchet tree: {}", tv.ratchet_tree);
     let tv_ratchet_tree = hex_to_bytes(&tv.ratchet_tree);
     let dec_ratchet_tree =
-        TlsVecU32::<Option<Node>>::tls_deserialize(&mut tv_ratchet_tree.as_slice()).unwrap();
-    let my_ratchet_tree = dec_ratchet_tree.tls_serialize_detached().unwrap();
+        TlsVecU32::<Option<Node>>::tls_deserialize(&mut tv_ratchet_tree.as_slice())
+            .expect("An unexpected error occurred.");
+    let my_ratchet_tree = dec_ratchet_tree
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
     if tv_ratchet_tree != my_ratchet_tree {
         log::error!("  RatchetTree encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_ratchet_tree);
@@ -313,9 +406,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // GroupInfo
     let tv_group_info = hex_to_bytes(&tv.group_info);
     let my_group_info = GroupInfo::tls_deserialize(&mut tv_group_info.as_slice())
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
     if tv_group_info != my_group_info {
         log::error!("  GroupInfo encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_group_info);
@@ -328,9 +421,11 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
 
     // GroupSecrets
     let tv_group_secrets = hex_to_bytes(&tv.group_secrets);
-    let gs = GroupSecrets::tls_deserialize(&mut tv_group_secrets.as_slice()).unwrap();
+    let gs = GroupSecrets::tls_deserialize(&mut tv_group_secrets.as_slice())
+        .expect("An unexpected error occurred.");
     let my_group_secrets =
-        GroupSecrets::new_encoded(&gs.joiner_secret, gs.path_secret.as_ref(), &gs.psks).unwrap();
+        GroupSecrets::new_encoded(&gs.joiner_secret, gs.path_secret.as_ref(), &gs.psks)
+            .expect("An unexpected error occurred.");
     if tv_group_secrets != my_group_secrets {
         log::error!("  GroupSecrets encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_group_secrets);
@@ -344,9 +439,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // Welcome
     let tv_welcome = hex_to_bytes(&tv.welcome);
     let my_welcome = Welcome::tls_deserialize(&mut tv_welcome.as_slice())
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
     if tv_welcome != my_welcome {
         log::error!("  Welcome encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_welcome);
@@ -361,9 +456,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     let tv_public_group_state = hex_to_bytes(&tv.public_group_state);
     let my_public_group_state =
         VerifiablePublicGroupState::tls_deserialize(&mut tv_public_group_state.as_slice())
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .tls_serialize_detached()
-            .unwrap();
+            .expect("An unexpected error occurred.");
     if tv_public_group_state != my_public_group_state {
         log::error!("  PublicGroupState encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_public_group_state);
@@ -377,9 +472,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // AddProposal
     let tv_add_proposal = hex_to_bytes(&tv.add_proposal);
     let my_add_proposal = AddProposal::tls_deserialize(&mut tv_add_proposal.as_slice())
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
     if tv_add_proposal != my_add_proposal {
         log::error!("  AddProposal encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_add_proposal);
@@ -394,9 +489,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // UpdateProposal
     let tv_update_proposal = hex_to_bytes(&tv.update_proposal);
     let my_update_proposal = UpdateProposal::tls_deserialize(&mut tv_update_proposal.as_slice())
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
     if tv_update_proposal != my_update_proposal {
         log::error!("  UpdateProposal encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_update_proposal);
@@ -410,9 +505,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // RemoveProposal
     let tv_remove_proposal = hex_to_bytes(&tv.remove_proposal);
     let my_remove_proposal = RemoveProposal::tls_deserialize(&mut tv_remove_proposal.as_slice())
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
     if tv_remove_proposal != my_remove_proposal {
         log::error!("  RemoveProposal encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_remove_proposal);
@@ -427,9 +522,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     let tv_pre_shared_key_proposal = hex_to_bytes(&tv.pre_shared_key_proposal);
     let my_pre_shared_key_proposal =
         PreSharedKeyProposal::tls_deserialize(&mut tv_pre_shared_key_proposal.as_slice())
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .tls_serialize_detached()
-            .unwrap();
+            .expect("An unexpected error occurred.");
     if tv_pre_shared_key_proposal != my_pre_shared_key_proposal {
         log::error!("  PreSharedKeyProposal encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_pre_shared_key_proposal);
@@ -445,9 +540,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // Commit
     let tv_commit = hex_to_bytes(&tv.commit);
     let my_commit = Commit::tls_deserialize(&mut tv_commit.as_slice())
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
     if tv_commit != my_commit {
         log::error!("  Commit encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_commit);
@@ -464,9 +559,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     tv_mls_plaintext_application[0] = WireFormat::MlsPlaintext as u8;
     let my_mls_plaintext_application =
         VerifiableMlsPlaintext::tls_deserialize(&mut tv_mls_plaintext_application.as_slice())
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .tls_serialize_detached()
-            .unwrap();
+            .expect("An unexpected error occurred.");
     if tv_mls_plaintext_application != my_mls_plaintext_application {
         log::error!("  MlsPlaintextApplication encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_mls_plaintext_application);
@@ -483,9 +578,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     tv_mls_plaintext_proposal[0] = WireFormat::MlsPlaintext as u8;
     let my_mls_plaintext_proposal =
         VerifiableMlsPlaintext::tls_deserialize(&mut tv_mls_plaintext_proposal.as_slice())
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .tls_serialize_detached()
-            .unwrap();
+            .expect("An unexpected error occurred.");
     if tv_mls_plaintext_proposal != my_mls_plaintext_proposal {
         log::error!("  MlsPlaintext(Proposal) encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_mls_plaintext_proposal);
@@ -502,9 +597,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     tv_mls_plaintext_commit[0] = WireFormat::MlsPlaintext as u8;
     let my_mls_plaintext_commit =
         VerifiableMlsPlaintext::tls_deserialize(&mut tv_mls_plaintext_commit.as_slice())
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .tls_serialize_detached()
-            .unwrap();
+            .expect("An unexpected error occurred.");
     if tv_mls_plaintext_commit != my_mls_plaintext_commit {
         log::error!("  MlsPlaintext(Commit) encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_mls_plaintext_commit);
@@ -518,9 +613,9 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // MlsCiphertext
     let tv_mls_ciphertext = hex_to_bytes(&tv.mls_ciphertext);
     let my_mls_ciphertext = MlsCiphertext::tls_deserialize(&mut tv_mls_ciphertext.as_slice())
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
     if tv_mls_ciphertext != my_mls_ciphertext {
         log::error!("  MlsCiphertext encoding mismatch");
         log::debug!("    Encoded: {:x?}", my_mls_ciphertext);

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -53,11 +53,18 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
     // Generate random values.
     let group_id = GroupId::random(&crypto);
     let epoch = random_u64();
-    let tree_hash_before = crypto.rand().random_vec(ciphersuite.hash_length()).unwrap();
-    let confirmed_transcript_hash_before =
-        crypto.rand().random_vec(ciphersuite.hash_length()).unwrap();
-    let interim_transcript_hash_before =
-        crypto.rand().random_vec(ciphersuite.hash_length()).unwrap();
+    let tree_hash_before = crypto
+        .rand()
+        .random_vec(ciphersuite.hash_length())
+        .expect("An unexpected error occurred.");
+    let confirmed_transcript_hash_before = crypto
+        .rand()
+        .random_vec(ciphersuite.hash_length())
+        .expect("An unexpected error occurred.");
+    let interim_transcript_hash_before = crypto
+        .rand()
+        .random_vec(ciphersuite.hash_length())
+        .expect("An unexpected error occurred.");
     let membership_key = MembershipKey::from_secret(
         Secret::random(ciphersuite, &crypto, None /* MLS version */)
             .expect("Not enough randomness."),
@@ -74,7 +81,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
         SignatureScheme::from(ciphersuite.name()),
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let context = GroupContext::new(
         group_id.clone(),
         GroupEpoch(epoch),
@@ -83,7 +90,10 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
         &[], // extensions
     )
     .expect("Error creating group context");
-    let aad = crypto.rand().random_vec(48).unwrap();
+    let aad = crypto
+        .rand()
+        .random_vec(48)
+        .expect("An unexpected error occurred.");
     let framing_parameters = FramingParameters::new(&aad, WireFormat::MlsPlaintext);
     let mut commit = MlsPlaintext::new_commit(
         framing_parameters,
@@ -96,12 +106,12 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
         &context,
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     let confirmed_transcript_hash_after = update_confirmed_transcript_hash(
         ciphersuite,
         &crypto,
-        &MlsPlaintextCommitContent::try_from(&commit).unwrap(),
+        &MlsPlaintextCommitContent::try_from(&commit).expect("An unexpected error occurred."),
         &interim_transcript_hash_before,
     )
     .expect("Error updating confirmed transcript hash");
@@ -113,21 +123,23 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
     let interim_transcript_hash_after = update_interim_transcript_hash(
         ciphersuite,
         &crypto,
-        &MlsPlaintextCommitAuthData::try_from(&commit).unwrap(),
+        &MlsPlaintextCommitAuthData::try_from(&commit).expect("An unexpected error occurred."),
         &confirmed_transcript_hash_after,
     )
     .expect("Error updating interim transcript hash");
     commit
         .set_membership_tag(
             &crypto,
-            &context.tls_serialize_detached().unwrap(),
+            &context
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
             &membership_key,
         )
         .expect("Error adding membership tag");
     let credential = credential_bundle
         .credential()
         .tls_serialize_detached()
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     TranscriptTestVector {
         cipher_suite: ciphersuite.name() as u16,
@@ -145,7 +157,11 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
                 .expect("Error encoding commit"),
         ),
 
-        group_context: bytes_to_hex(&context.tls_serialize_detached().unwrap()),
+        group_context: bytes_to_hex(
+            &context
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        ),
         confirmed_transcript_hash_after: bytes_to_hex(&confirmed_transcript_hash_after),
         interim_transcript_hash_after: bytes_to_hex(&interim_transcript_hash_after),
     }
@@ -203,7 +219,8 @@ pub fn run_test_vector(test_vector: TranscriptTestVector) -> Result<(), Transcri
         ciphersuite,
     ));
     let credential =
-        Credential::tls_deserialize(&mut hex_to_bytes(&test_vector.credential).as_slice()).unwrap();
+        Credential::tls_deserialize(&mut hex_to_bytes(&test_vector.credential).as_slice())
+            .expect("An unexpected error occurred.");
 
     // Check membership and confirmation tags.
     let commit_bytes = hex_to_bytes(&test_vector.commit);
@@ -218,11 +235,17 @@ pub fn run_test_vector(test_vector: TranscriptTestVector) -> Result<(), Transcri
     )
     .expect("Error creating group context");
     let expected_group_context = hex_to_bytes(&test_vector.group_context);
-    if context.tls_serialize_detached().unwrap() != expected_group_context {
+    if context
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.")
+        != expected_group_context
+    {
         log::error!("  Group context mismatch");
         log::debug!(
             "    Computed: {:x?}",
-            context.tls_serialize_detached().unwrap()
+            context
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred.")
         );
         log::debug!("    Expected: {:x?}", expected_group_context);
         if cfg!(test) {
@@ -230,7 +253,11 @@ pub fn run_test_vector(test_vector: TranscriptTestVector) -> Result<(), Transcri
         }
         return Err(TranscriptTestVectorError::GroupContextMismatch);
     }
-    commit.set_context(context.tls_serialize_detached().unwrap());
+    commit.set_context(
+        context
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred."),
+    );
     if commit.verify_membership(&crypto, &membership_key).is_err() {
         if cfg!(test) {
             panic!("Invalid membership tag");
@@ -255,7 +282,12 @@ pub fn run_test_vector(test_vector: TranscriptTestVector) -> Result<(), Transcri
     {
         log::error!("  Confirmation tag mismatch");
         log::debug!("    Computed: {:x?}", my_confirmation_tag);
-        log::debug!("    Expected: {:x?}", commit.confirmation_tag().unwrap());
+        log::debug!(
+            "    Expected: {:x?}",
+            commit
+                .confirmation_tag()
+                .expect("An unexpected error occurred.")
+        );
         if cfg!(test) {
             panic!("Invalid confirmation tag");
         }
@@ -266,7 +298,7 @@ pub fn run_test_vector(test_vector: TranscriptTestVector) -> Result<(), Transcri
     let my_confirmed_transcript_hash_after = update_confirmed_transcript_hash(
         ciphersuite,
         &crypto,
-        &MlsPlaintextCommitContent::try_from(&commit).unwrap(),
+        &MlsPlaintextCommitContent::try_from(&commit).expect("An unexpected error occurred."),
         &interim_transcript_hash_before,
     )
     .expect("Error updating confirmed transcript hash");
@@ -285,7 +317,7 @@ pub fn run_test_vector(test_vector: TranscriptTestVector) -> Result<(), Transcri
     let my_interim_transcript_hash_after = update_interim_transcript_hash(
         ciphersuite,
         &crypto,
-        &MlsPlaintextCommitAuthData::try_from(&commit).unwrap(),
+        &MlsPlaintextCommitAuthData::try_from(&commit).expect("An unexpected error occurred."),
         &my_confirmed_transcript_hash_after,
     )
     .expect("Error updating interim transcript hash");

--- a/openmls/src/group/tests/test_validation.rs
+++ b/openmls/src/group/tests/test_validation.rs
@@ -35,7 +35,7 @@ fn generate_credential_bundle(
     backend
         .key_store()
         .store(credential.signature_key(), &cb)
-        .unwrap();
+        .expect("An unexpected error occurred.");
     Ok(credential)
 }
 
@@ -49,13 +49,13 @@ fn generate_key_package_bundle(
     let credential_bundle = backend
         .key_store()
         .read(credential.signature_key())
-        .unwrap();
+        .expect("An unexpected error occurred.");
     let kpb = KeyPackageBundle::new(ciphersuites, &credential_bundle, backend, extensions)?;
     let kp = kpb.key_package().clone();
     backend
         .key_store()
         .store(&kp.hash(backend).expect("Could not hash KeyPackage."), &kpb)
-        .unwrap();
+        .expect("An unexpected error occurred.");
     Ok(kp)
 }
 
@@ -76,7 +76,8 @@ fn validation_test_setup(wire_format: WireFormat) -> ValidationTestSetup {
     let backend = OpenMlsRustCrypto::default();
 
     let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519).unwrap();
+        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+            .expect("An unexpected error occurred.");
     let group_id = GroupId::from_slice(b"Test Group");
 
     // Generate credential bundles
@@ -86,7 +87,7 @@ fn validation_test_setup(wire_format: WireFormat) -> ValidationTestSetup {
         ciphersuite.signature_scheme(),
         &backend,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     let bob_credential = generate_credential_bundle(
         "Bob".into(),
@@ -94,16 +95,16 @@ fn validation_test_setup(wire_format: WireFormat) -> ValidationTestSetup {
         ciphersuite.signature_scheme(),
         &backend,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     // Generate KeyPackages
     let alice_key_package =
         generate_key_package_bundle(&[ciphersuite.name()], &alice_credential, vec![], &backend)
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
     let bob_key_package =
         generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![], &backend)
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
     // Define the managed group configuration
 
@@ -120,7 +121,7 @@ fn validation_test_setup(wire_format: WireFormat) -> ValidationTestSetup {
             .hash(&backend)
             .expect("Could not hash KeyPackage."),
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     ValidationTestSetup {
         backend,

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -15,7 +15,7 @@ fn generate_key_package() {
             ciphersuite.name().into(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Generate a valid KeyPackage.
         let lifetime_extension = Extension::LifeTime(LifetimeExtension::new(60));
@@ -25,7 +25,7 @@ fn generate_key_package() {
             &crypto,
             vec![lifetime_extension],
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         std::thread::sleep(std::time::Duration::from_millis(1));
         assert!(kpb.key_package().verify(&crypto).is_ok());
 
@@ -37,7 +37,7 @@ fn generate_key_package() {
             &crypto,
             vec![lifetime_extension],
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         std::thread::sleep(std::time::Duration::from_millis(1));
         assert!(kpb.key_package().verify(&crypto).is_err());
 
@@ -65,22 +65,28 @@ fn test_codec() {
             ciphersuite.name().into(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let mut kpb = KeyPackageBundle::new(
             &[ciphersuite.name()],
             &credential_bundle,
             &crypto,
             Vec::new(),
         )
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .unsigned();
 
         kpb.add_extension(Extension::LifeTime(LifetimeExtension::new(60)));
-        let kpb = kpb.sign(&crypto, &credential_bundle).unwrap();
-        let enc = kpb.key_package().tls_serialize_detached().unwrap();
+        let kpb = kpb
+            .sign(&crypto, &credential_bundle)
+            .expect("An unexpected error occurred.");
+        let enc = kpb
+            .key_package()
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
 
         // Now it's valid.
-        let kp = KeyPackage::tls_deserialize(&mut enc.as_slice()).unwrap();
+        let kp = KeyPackage::tls_deserialize(&mut enc.as_slice())
+            .expect("An unexpected error occurred.");
         assert_eq!(kpb.key_package, kp);
     }
 }
@@ -97,14 +103,14 @@ fn key_package_id_extension() {
             ciphersuite.name().into(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let kpb = KeyPackageBundle::new(
             &[ciphersuite.name()],
             &credential_bundle,
             &crypto,
             vec![Extension::LifeTime(LifetimeExtension::new(60))],
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         assert!(kpb.key_package().verify(&crypto).is_ok());
         let mut kpb = kpb.unsigned();
 
@@ -113,7 +119,9 @@ fn key_package_id_extension() {
         kpb.add_extension(Extension::KeyPackageId(KeyIdExtension::new(&id)));
 
         // Sign it to make it valid.
-        let kpb = kpb.sign(&crypto, &credential_bundle).unwrap();
+        let kpb = kpb
+            .sign(&crypto, &credential_bundle)
+            .expect("An unexpected error occurred.");
         assert!(kpb.key_package().verify(&crypto).is_ok());
 
         // Check ID

--- a/openmls/src/messages/tests/test_codec.rs
+++ b/openmls/src/messages/tests/test_codec.rs
@@ -23,8 +23,11 @@ fn test_pre_shared_key_proposal_codec() {
         psk_nonce: vec![1, 2, 3].into(),
     };
     let orig = PreSharedKeyProposal::new(psk);
-    let encoded = orig.tls_serialize_detached().unwrap();
-    let decoded = PreSharedKeyProposal::tls_deserialize(&mut encoded.as_slice()).unwrap();
+    let encoded = orig
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
+    let decoded = PreSharedKeyProposal::tls_deserialize(&mut encoded.as_slice())
+        .expect("An unexpected error occurred.");
     assert_eq!(decoded, orig);
 
     // External
@@ -34,8 +37,11 @@ fn test_pre_shared_key_proposal_codec() {
         psk_nonce: vec![1, 2, 3].into(),
     };
     let orig = PreSharedKeyProposal::new(psk);
-    let encoded = orig.tls_serialize_detached().unwrap();
-    let decoded = PreSharedKeyProposal::tls_deserialize(&mut encoded.as_slice()).unwrap();
+    let encoded = orig
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
+    let decoded = PreSharedKeyProposal::tls_deserialize(&mut encoded.as_slice())
+        .expect("An unexpected error occurred.");
     assert_eq!(decoded, orig);
 
     // Branch
@@ -48,8 +54,11 @@ fn test_pre_shared_key_proposal_codec() {
         psk_nonce: vec![1, 2, 3].into(),
     };
     let orig = PreSharedKeyProposal::new(psk);
-    let encoded = orig.tls_serialize_detached().unwrap();
-    let decoded = PreSharedKeyProposal::tls_deserialize(&mut encoded.as_slice()).unwrap();
+    let encoded = orig
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
+    let decoded = PreSharedKeyProposal::tls_deserialize(&mut encoded.as_slice())
+        .expect("An unexpected error occurred.");
     assert_eq!(decoded, orig);
 }
 /// Test the encoding for ReInitProposal, that also covers some of the
@@ -64,8 +73,11 @@ fn test_reinit_proposal_codec() {
             ciphersuite: *ciphersuite_name,
             extensions: vec![].into(),
         };
-        let encoded = orig.tls_serialize_detached().unwrap();
-        let decoded = ReInitProposal::tls_deserialize(&mut encoded.as_slice()).unwrap();
+        let encoded = orig
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
+        let decoded = ReInitProposal::tls_deserialize(&mut encoded.as_slice())
+            .expect("An unexpected error occurred.");
         assert_eq!(decoded, orig);
     }
 }

--- a/openmls/src/messages/tests/test_pgs.rs
+++ b/openmls/src/messages/tests/test_pgs.rs
@@ -34,14 +34,14 @@ fn test_pgs() {
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_credential_bundle = CredentialBundle::new(
             "Bob".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Generate KeyPackages
         let bob_key_package_bundle = KeyPackageBundle::new(
@@ -50,7 +50,7 @@ fn test_pgs() {
             &crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_key_package = bob_key_package_bundle.key_package();
 
         let alice_key_package_bundle = KeyPackageBundle::new(
@@ -59,7 +59,7 @@ fn test_pgs() {
             &crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Alice creates a group
         let mut group_alice = MlsGroup::builder(GroupId::random(&crypto), alice_key_package_bundle)

--- a/openmls/src/messages/tests/test_proposals.rs
+++ b/openmls/src/messages/tests/test_proposals.rs
@@ -12,24 +12,32 @@ use crate::{
 fn proposals_codec() {
     let crypto = OpenMlsRustCrypto::default();
     let ciphersuite =
-        &Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519).unwrap();
+        &Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+            .expect("An unexpected error occurred.");
 
     // Proposal
 
     let remove_proposal = RemoveProposal { removed: 123 };
     let proposal = Proposal::Remove(remove_proposal);
     let proposal_or_ref = ProposalOrRef::Proposal(proposal.clone());
-    let encoded = proposal_or_ref.tls_serialize_detached().unwrap();
-    let decoded = ProposalOrRef::tls_deserialize(&mut encoded.as_slice()).unwrap();
+    let encoded = proposal_or_ref
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
+    let decoded = ProposalOrRef::tls_deserialize(&mut encoded.as_slice())
+        .expect("An unexpected error occurred.");
 
     assert_eq!(proposal_or_ref, decoded);
 
     // Reference
 
-    let reference = ProposalReference::from_proposal(ciphersuite, &crypto, &proposal).unwrap();
+    let reference = ProposalReference::from_proposal(ciphersuite, &crypto, &proposal)
+        .expect("An unexpected error occurred.");
     let proposal_or_ref = ProposalOrRef::Reference(reference);
-    let encoded = proposal_or_ref.tls_serialize_detached().unwrap();
-    let decoded = ProposalOrRef::tls_deserialize(&mut encoded.as_slice()).unwrap();
+    let encoded = proposal_or_ref
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
+    let decoded = ProposalOrRef::tls_deserialize(&mut encoded.as_slice())
+        .expect("An unexpected error occurred.");
 
     assert_eq!(proposal_or_ref, decoded);
 }

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -39,7 +39,7 @@ macro_rules! test_welcome_msg {
                 $ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
             let group_info = group_info
                 .sign(&crypto, &credential_bundle)
                 .expect("Error signing GroupInfo");
@@ -74,11 +74,13 @@ macro_rules! test_welcome_msg {
             let encrypted_group_info = welcome_key
                 .aead_seal(
                     &crypto,
-                    &group_info.tls_serialize_detached().unwrap(),
+                    &group_info
+                        .tls_serialize_detached()
+                        .expect("An unexpected error occurred."),
                     &[],
                     &welcome_nonce,
                 )
-                .unwrap();
+                .expect("An unexpected error occurred.");
 
             // Now build the welcome message.
             let msg = Welcome::new(
@@ -89,9 +91,12 @@ macro_rules! test_welcome_msg {
             );
 
             // Encode, decode and re-assemble
-            let msg_encoded = msg.tls_serialize_detached().unwrap();
+            let msg_encoded = msg
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred.");
             println!("encoded msg: {:?}", msg_encoded);
-            let msg_decoded = Welcome::tls_deserialize(&mut msg_encoded.as_slice()).unwrap();
+            let msg_decoded = Welcome::tls_deserialize(&mut msg_encoded.as_slice())
+                .expect("An unexpected error occurred.");
 
             // Check that the welcome message is the same
             assert_eq!(msg_decoded.version, $version);
@@ -123,20 +128,22 @@ macro_rules! test_welcome_msg {
 
 test_welcome_msg!(
     test_welcome_MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
-    Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519).unwrap(),
+    Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+        .expect("An unexpected error occurred."),
     Config::supported_versions()[0]
 );
 
 test_welcome_msg!(
     test_welcome_MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
     Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519)
-        .unwrap(),
+        .expect("An unexpected error occurred."),
     Config::supported_versions()[0]
 );
 
 test_welcome_msg!(
     test_welcome_MLS10_128_DHKEMP256_AES128GCM_SHA256_P256,
-    Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256).unwrap(),
+    Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256)
+        .expect("An unexpected error occurred."),
     Config::supported_versions()[0]
 );
 

--- a/openmls/src/schedule/kat_key_schedule.rs
+++ b/openmls/src/schedule/kat_key_schedule.rs
@@ -87,7 +87,10 @@ fn generate(
     HpkeKeyPair,
 ) {
     let crypto = OpenMlsRustCrypto::default();
-    let tree_hash = crypto.rand().random_vec(ciphersuite.hash_length()).unwrap();
+    let tree_hash = crypto
+        .rand()
+        .random_vec(ciphersuite.hash_length())
+        .expect("An unexpected error occurred.");
     let commit_secret = CommitSecret::random(ciphersuite, &crypto);
 
     // Build the PSK secret.
@@ -103,14 +106,15 @@ fn generate(
                 psk_group_id: GroupId::random(&crypto),
                 psk_epoch: GroupEpoch(epoch),
             }),
-            crypto.rand().random_vec(13).unwrap(),
+            crypto.rand().random_vec(13).expect("An unexpected error occurred."),
         );
         let psk = PskSecret::random(ciphersuite, &crypto);
         psk_ids.push(psk_id.clone());
         psks.push(psk.secret().clone());
         psks_out.push((psk_id, psk.secret().clone()));
     }
-    let psk_secret = PskSecret::new(ciphersuite, &crypto, &psk_ids, &psks).unwrap();
+    let psk_secret = PskSecret::new(ciphersuite, &crypto, &psk_ids, &psks)
+        .expect("An unexpected error occurred.");
 
     let joiner_secret = JoinerSecret::new(&crypto, &commit_secret, init_secret)
         .expect("Could not create JoinerSecret.");
@@ -121,9 +125,14 @@ fn generate(
         Some(psk_secret.clone()),
     )
     .expect("Could not create KeySchedule.");
-    let welcome_secret = key_schedule.welcome(&crypto).unwrap();
+    let welcome_secret = key_schedule
+        .welcome(&crypto)
+        .expect("An unexpected error occurred.");
 
-    let confirmed_transcript_hash = crypto.rand().random_vec(ciphersuite.hash_length()).unwrap();
+    let confirmed_transcript_hash = crypto
+        .rand()
+        .random_vec(ciphersuite.hash_length())
+        .expect("An unexpected error occurred.");
 
     let group_context = GroupContext::new(
         GroupId::from_slice(group_id),
@@ -132,7 +141,7 @@ fn generate(
         confirmed_transcript_hash.clone(),
         &[], // Extensions
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     let serialized_group_context = group_context
         .tls_serialize_detached()
@@ -140,8 +149,10 @@ fn generate(
 
     key_schedule
         .add_context(&crypto, &serialized_group_context)
-        .unwrap();
-    let epoch_secrets = key_schedule.epoch_secrets(&crypto, true).unwrap();
+        .expect("An unexpected error occurred.");
+    let epoch_secrets = key_schedule
+        .epoch_secrets(&crypto, true)
+        .expect("An unexpected error occurred.");
 
     // Calculate external HPKE key pair
     let external_key_pair = epoch_secrets
@@ -175,7 +186,10 @@ pub fn generate_test_vector(
     let mut init_secret = InitSecret::random(ciphersuite, &crypto, ProtocolVersion::default())
         .expect("Not enough randomness.");
     let initial_init_secret = init_secret.clone();
-    let group_id = crypto.rand().random_vec(16).unwrap();
+    let group_id = crypto
+        .rand()
+        .random_vec(16)
+        .expect("An unexpected error occurred.");
 
     let mut epochs = Vec::new();
 
@@ -197,7 +211,11 @@ pub fn generate_test_vector(
         let psks = psks
             .iter()
             .map(|(psk_id, psk)| PskValue {
-                psk_id: bytes_to_hex(&psk_id.tls_serialize_detached().unwrap()),
+                psk_id: bytes_to_hex(
+                    &psk_id
+                        .tls_serialize_detached()
+                        .expect("An unexpected error occurred."),
+                ),
                 psk: bytes_to_hex(psk.as_slice()),
             })
             .collect::<Vec<_>>();
@@ -207,10 +225,19 @@ pub fn generate_test_vector(
             commit_secret: bytes_to_hex(commit_secret.as_slice()),
             psks,
             confirmed_transcript_hash: bytes_to_hex(&confirmed_transcript_hash),
-            group_context: bytes_to_hex(&group_context.tls_serialize_detached().unwrap()),
+            group_context: bytes_to_hex(
+                &group_context
+                    .tls_serialize_detached()
+                    .expect("An unexpected error occurred."),
+            ),
             joiner_secret: bytes_to_hex(joiner_secret.as_slice()),
             welcome_secret: bytes_to_hex(welcome_secret.as_slice()),
-            init_secret: bytes_to_hex(epoch_secrets.init_secret().unwrap().as_slice()),
+            init_secret: bytes_to_hex(
+                epoch_secrets
+                    .init_secret()
+                    .expect("An unexpected error occurred.")
+                    .as_slice(),
+            ),
             sender_data_secret: bytes_to_hex(epoch_secrets.sender_data_secret().as_slice()),
             encryption_secret: bytes_to_hex(epoch_secrets.encryption_secret().as_slice()),
             exporter_secret: bytes_to_hex(epoch_secrets.exporter_secret().as_slice()),
@@ -222,11 +249,14 @@ pub fn generate_test_vector(
             external_pub: bytes_to_hex(
                 &HpkePublicKey::from(external_key_pair.public)
                     .tls_serialize_detached()
-                    .unwrap(),
+                    .expect("An unexpected error occurred."),
             ),
         };
         epochs.push(epoch_info);
-        init_secret = epoch_secrets.init_secret().unwrap().clone();
+        init_secret = epoch_secrets
+            .init_secret()
+            .expect("An unexpected error occurred.")
+            .clone();
     }
 
     KeyScheduleTestVector {
@@ -319,7 +349,7 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
         for psk_value in epoch.psks.iter() {
             psk_ids.push(
                 PreSharedKeyId::tls_deserialize(&mut hex_to_bytes(&psk_value.psk_id).as_slice())
-                    .unwrap(),
+                    .expect("An unexpected error occurred."),
             );
             psks.push(Secret::from_slice(
                 &hex_to_bytes(&psk_value.psk),
@@ -328,7 +358,8 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
             ));
         }
         // let psk = Vec::new();
-        let psk_secret = PskSecret::new(ciphersuite, &crypto, &psk_ids, &psks).unwrap();
+        let psk_secret = PskSecret::new(ciphersuite, &crypto, &psk_ids, &psks)
+            .expect("An unexpected error occurred.");
 
         let joiner_secret = JoinerSecret::new(&crypto, &commit_secret, &init_secret)
             .expect("Could not create JoinerSecret.");
@@ -346,7 +377,9 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
             Some(psk_secret),
         )
         .expect("Could not create KeySchedule.");
-        let welcome_secret = key_schedule.welcome(&crypto).unwrap();
+        let welcome_secret = key_schedule
+            .welcome(&crypto)
+            .expect("An unexpected error occurred.");
 
         if hex_to_bytes(&epoch.welcome_secret) != welcome_secret.as_slice() {
             if cfg!(test) {
@@ -367,7 +400,9 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
         .expect("Error creating group context");
 
         let expected_group_context = hex_to_bytes(&epoch.group_context);
-        let group_context_serialized = group_context.tls_serialize_detached().unwrap();
+        let group_context_serialized = group_context
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
         if group_context_serialized != expected_group_context {
             log::error!("  Group context mismatch");
             log::debug!("    Computed: {:x?}", group_context_serialized);
@@ -380,11 +415,16 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
 
         key_schedule
             .add_context(&crypto, &group_context_serialized)
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
-        let epoch_secrets = key_schedule.epoch_secrets(&crypto, true).unwrap();
+        let epoch_secrets = key_schedule
+            .epoch_secrets(&crypto, true)
+            .expect("An unexpected error occurred.");
 
-        init_secret = epoch_secrets.init_secret().unwrap().clone();
+        init_secret = epoch_secrets
+            .init_secret()
+            .expect("An unexpected error occurred.")
+            .clone();
         if hex_to_bytes(&epoch.init_secret) != init_secret.as_slice() {
             log_crypto!(
                 debug,
@@ -456,14 +496,14 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
         if hex_to_bytes(&epoch.external_pub)
             != HpkePublicKey::from(external_key_pair.public.clone())
                 .tls_serialize_detached()
-                .unwrap()
+                .expect("An unexpected error occurred.")
         {
             log::error!("  External public key mismatch");
             log::debug!(
                 "    Computed: {:x?}",
                 HpkePublicKey::from(external_key_pair.public)
                     .tls_serialize_detached()
-                    .unwrap()
+                    .expect("An unexpected error occurred.")
             );
             log::debug!("    Expected: {:x?}", hex_to_bytes(&epoch.external_pub));
             if cfg!(test) {

--- a/openmls/src/schedule/unit_tests.rs
+++ b/openmls/src/schedule/unit_tests.rs
@@ -21,7 +21,7 @@ fn test_psks() {
             .iter()
             .map(|_| {
                 Secret::from_slice(
-                    &prng.random_vec(55).unwrap(),
+                    &prng.random_vec(55).expect("An unexpected error occurred."),
                     Config::supported_versions()[0],
                     ciphersuite,
                 )
@@ -30,8 +30,8 @@ fn test_psks() {
         let psk_ids = &vec![0u8; 33]
             .iter()
             .map(|_| {
-                let id = prng.random_vec(12).unwrap();
-                let nonce = prng.random_vec(17).unwrap();
+                let id = prng.random_vec(12).expect("An unexpected error occurred.");
+                let nonce = prng.random_vec(17).expect("An unexpected error occurred.");
                 PreSharedKeyId::new(
                     PskType::External,
                     Psk::External(ExternalPsk::new(id)),

--- a/openmls/src/test_utils/mod.rs
+++ b/openmls/src/test_utils/mod.rs
@@ -48,7 +48,9 @@ pub(crate) fn hex_to_bytes(hex: &str) -> Vec<u8> {
     assert!(hex.len() % 2 == 0);
     let mut bytes = Vec::new();
     for i in 0..(hex.len() / 2) {
-        bytes.push(u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).unwrap());
+        bytes.push(
+            u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).expect("An unexpected error occurred."),
+        );
     }
     bytes
 }

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -53,12 +53,12 @@ impl Client {
             &self.crypto,
             mandatory_extensions,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let kp = kpb.key_package().clone();
         self.crypto
             .key_store()
             .store(&kp.hash(&self.crypto)?, &kpb)
-            .unwrap();
+            .expect("An unexpected error occurred.");
         Ok(kp)
     }
 
@@ -88,12 +88,12 @@ impl Client {
             &self.crypto,
             mandatory_extensions,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let key_package = kpb.key_package().clone();
         self.crypto
             .key_store()
             .store(&key_package.hash(&self.crypto)?, &kpb)
-            .unwrap();
+            .expect("An unexpected error occurred.");
         let group_state = ManagedGroup::new(
             &self.crypto,
             &managed_group_config,
@@ -166,7 +166,9 @@ impl Client {
         for (index, leaf) in tree.iter().enumerate() {
             if index % 2 == 0 {
                 if let Some(leaf_node) = leaf {
-                    let key_package = leaf_node.key_package().unwrap();
+                    let key_package = leaf_node
+                        .key_package()
+                        .expect("An unexpected error occurred.");
                     members.push((index / 2, key_package.credential().clone()));
                 }
             }

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -141,12 +141,12 @@ impl ManagedTestSetup {
                     SignatureScheme::from(*ciphersuite),
                     &crypto,
                 )
-                .unwrap();
+                .expect("An unexpected error occurred.");
                 let credential = cb.credential().clone();
                 crypto
                     .key_store()
                     .store(cb.credential().signature_key(), &cb)
-                    .unwrap();
+                    .expect("An unexpected error occurred.");
                 credentials.insert(*ciphersuite, credential);
             }
             let client = Client {
@@ -210,7 +210,10 @@ impl ManagedTestSetup {
                 .borrow_mut()
                 .remove(egs.key_package_hash.as_slice())
                 .ok_or(SetupError::NoFreshKeyPackage)?;
-            let client = clients.get(&client_id).unwrap().borrow();
+            let client = clients
+                .get(&client_id)
+                .expect("An unexpected error occurred.")
+                .borrow();
             client.join_group(
                 group.group_config.clone(),
                 welcome.clone(),
@@ -243,13 +246,21 @@ impl ManagedTestSetup {
         let clients = self.clients.borrow();
         // Distribute message to all members.
         for (_index, member_id) in &group.members {
-            let member = clients.get(member_id).unwrap().borrow();
+            let member = clients
+                .get(member_id)
+                .expect("An unexpected error occurred.")
+                .borrow();
             member.receive_messages_for_group(&message)?;
         }
         // Get the current tree and figure out who's still in the group.
-        let sender = clients.get(sender_id).unwrap().borrow();
+        let sender = clients
+            .get(sender_id)
+            .expect("An unexpected error occurred.")
+            .borrow();
         let sender_groups = sender.groups.borrow();
-        let sender_group = sender_groups.get(&group.group_id).unwrap();
+        let sender_group = sender_groups
+            .get(&group.group_id)
+            .expect("An unexpected error occurred.");
         group.members = sender
             .get_members_of_group(&group.group_id)?
             .iter()
@@ -269,7 +280,10 @@ impl ManagedTestSetup {
         let clients = self.clients.borrow();
         let mut messages = Vec::new();
         for (_, m_id) in &group.members {
-            let m = clients.get(m_id).unwrap().borrow();
+            let m = clients
+                .get(m_id)
+                .expect("An unexpected error occurred.")
+                .borrow();
             let mut group_states = m.groups.borrow_mut();
             // Some group members may not have received their welcome messages yet.
             if let Some(group_state) = group_states.get_mut(&group.group_id) {
@@ -277,7 +291,7 @@ impl ManagedTestSetup {
                 assert_eq!(
                     group_state
                         .export_secret(&m.crypto, "test", &[], 32)
-                        .unwrap(),
+                        .expect("An unexpected error occurred."),
                     group.exporter_secret
                 );
                 let message = group_state
@@ -326,7 +340,7 @@ impl ManagedTestSetup {
             let new_member_id = clients
                 .keys()
                 .find(|&client_id| !is_in_group(client_id) && !is_in_new_members(client_id))
-                .unwrap();
+                .expect("An unexpected error occurred.");
             new_member_ids.push(new_member_id.clone());
         }
         Ok(new_member_ids)
@@ -344,13 +358,18 @@ impl ManagedTestSetup {
         let group_creator_id = ((OsRng.next_u32() as usize) % clients.len())
             .to_be_bytes()
             .to_vec();
-        let group_creator = clients.get(&group_creator_id).unwrap().borrow();
+        let group_creator = clients
+            .get(&group_creator_id)
+            .expect("An unexpected error occurred.")
+            .borrow();
         let mut groups = self.groups.borrow_mut();
         let group_id = GroupId::from_slice(&groups.len().to_string().into_bytes());
 
         group_creator.create_group(group_id.clone(), self.default_mgc.clone(), ciphersuite)?;
         let creator_groups = group_creator.groups.borrow();
-        let group = creator_groups.get(&group_id).unwrap();
+        let group = creator_groups
+            .get(&group_id)
+            .expect("An unexpected error occurred.");
         let public_tree = group.export_ratchet_tree();
         let exporter_secret = group.export_secret(&group_creator.crypto, "test", &[], 32)?;
         let member_ids = vec![(0, group_creator_id)];
@@ -376,7 +395,9 @@ impl ManagedTestSetup {
         let group_id = self.create_group(ciphersuite)?;
 
         let mut groups = self.groups.borrow_mut();
-        let group = groups.get_mut(&group_id).unwrap();
+        let group = groups
+            .get_mut(&group_id)
+            .expect("An unexpected error occurred.");
 
         // Get new members to add to the group.
         let mut new_members = self.random_new_members_for_group(group, target_group_size - 1)?;
@@ -557,7 +578,7 @@ impl ManagedTestSetup {
                         .members
                         .iter()
                         .find(|(_, identity)| identity == &member_id)
-                        .unwrap()
+                        .expect("An unexpected error occurred.")
                         .clone();
                     println!(
                         "Index of the member performing the {:?}: {:?}",
@@ -594,7 +615,7 @@ impl ManagedTestSetup {
                     let number_of_adds = (((OsRng.next_u32() as usize) % clients_left) % 5) + 1;
                     let new_member_ids = self
                         .random_new_members_for_group(group, number_of_adds)
-                        .unwrap();
+                        .expect("An unexpected error occurred.");
                     println!(
                         "{:?}: Adding new clients: {:?}",
                         action_type, new_member_ids

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -143,14 +143,14 @@ fn group(
         SignatureScheme::from(ciphersuite.name()),
         backend,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let key_package_bundle = KeyPackageBundle::new(
         &[ciphersuite.name()],
         &credential_bundle,
         backend,
         Vec::new(),
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     (
         MlsGroup::builder(GroupId::random(backend), key_package_bundle)
             .build(backend)
@@ -173,14 +173,14 @@ fn receiver_group(
         SignatureScheme::from(ciphersuite.name()),
         backend,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let key_package_bundle = KeyPackageBundle::new(
         &[ciphersuite.name()],
         &credential_bundle,
         backend,
         Vec::new(),
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     MlsGroup::builder(group_id.clone(), key_package_bundle)
         .build(backend)
         .expect("Error creating MlsGroup")
@@ -212,7 +212,7 @@ fn build_handshake_messages(
         &membership_key,
         backend,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     plaintext.remove_membership_tag();
     let ciphertext = MlsCiphertext::try_from_plaintext(
         &plaintext,
@@ -228,8 +228,12 @@ fn build_handshake_messages(
     )
     .expect("Could not create MlsCiphertext");
     (
-        plaintext.tls_serialize_detached().unwrap(),
-        ciphertext.tls_serialize_detached().unwrap(),
+        plaintext
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred."),
+        ciphertext
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred."),
     )
 }
 
@@ -257,7 +261,7 @@ fn build_application_messages(
         &membership_key,
         backend,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     plaintext.remove_membership_tag();
     let ciphertext = match MlsCiphertext::try_from_plaintext(
         &plaintext,
@@ -275,8 +279,12 @@ fn build_application_messages(
         Err(e) => panic!("Could not create MlsCiphertext {}", e),
     };
     (
-        plaintext.tls_serialize_detached().unwrap(),
-        ciphertext.tls_serialize_detached().unwrap(),
+        plaintext
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred."),
+        ciphertext
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred."),
     )
 }
 
@@ -290,7 +298,10 @@ pub fn generate_test_vector(
 
     let ciphersuite_name = ciphersuite.name();
     let crypto = OpenMlsRustCrypto::default();
-    let epoch_secret = crypto.rand().random_vec(ciphersuite.hash_length()).unwrap();
+    let epoch_secret = crypto
+        .rand()
+        .random_vec(ciphersuite.hash_length())
+        .expect("An unexpected error occurred.");
     let encryption_secret =
         EncryptionSecret::from_slice(&epoch_secret[..], ProtocolVersion::default(), ciphersuite);
     let encryption_secret_group =
@@ -302,7 +313,10 @@ pub fn generate_test_vector(
     let group_secret_tree = SecretTree::new(encryption_secret_group, LeafIndex::from(n_leaves));
 
     // Create sender_data_key/secret
-    let ciphertext = crypto.rand().random_vec(77).unwrap();
+    let ciphertext = crypto
+        .rand()
+        .random_vec(77)
+        .expect("An unexpected error occurred.");
     let sender_data_key = sender_data_secret
         .derive_aead_key(&crypto, &ciphertext)
         .expect("Could not derive AEAD key.");

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_hashes.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_hashes.rs
@@ -19,10 +19,10 @@ fn test_parent_hash() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
             let key_package_bundle =
                 KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, &crypto, vec![])
-                    .unwrap();
+                    .expect("An unexpected error occurred.");
 
             // We build a leaf node from the key packages
             let leaf_node = Node {
@@ -42,7 +42,8 @@ fn test_parent_hash() {
         // The first key package bundle is used for the tree holder
         let key_package_bundle = key_package_bundles.remove(0);
 
-        let mut tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes).unwrap();
+        let mut tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes)
+            .expect("An unexpected error occurred.");
 
         assert!(tree.verify_parent_hashes(&crypto).is_ok());
 

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_path_keys.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_path_keys.rs
@@ -23,5 +23,11 @@ fn test_insert_retrieve() {
     path_keys.add(private_keys, &path[1001..2001]);
 
     // Get out the key [6, 6, 6]
-    assert_eq!(&[6, 6, 6], path_keys.get(path[1000]).unwrap().as_slice());
+    assert_eq!(
+        &[6, 6, 6],
+        path_keys
+            .get(path[1000])
+            .expect("An unexpected error occurred.")
+            .as_slice()
+    );
 }

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_private_tree.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_private_tree.rs
@@ -23,9 +23,10 @@ fn setup(ciphersuite: &Ciphersuite, len: usize) -> (KeyPackageBundle, LeafIndex,
         ciphersuite.signature_scheme(),
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let key_package_bundle =
-        KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, &crypto, vec![]).unwrap();
+        KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, &crypto, vec![])
+            .expect("An unexpected error occurred.");
     let own_index = LeafIndex::from(0u32);
     let direct_path = generate_path_u8(len);
 
@@ -44,8 +45,14 @@ fn test_private_tree(
     let path_index = 15;
     let index = direct_path[path_index];
     let public_key = &public_keys[path_index];
-    let private_key = private_tree.path_keys().get(index).unwrap();
-    let data = crypto.rand().random_vec(55).unwrap();
+    let private_key = private_tree
+        .path_keys()
+        .get(index)
+        .expect("An unexpected error occurred.");
+    let data = crypto
+        .rand()
+        .random_vec(55)
+        .expect("An unexpected error occurred.");
     let info = b"PrivateTree Test Info";
     let aad = b"PrivateTree Test AAD";
 

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_resolution.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_resolution.rs
@@ -33,10 +33,10 @@ fn test_exclusion_list() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
             let key_package_bundle =
                 KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, &crypto, vec![])
-                    .unwrap();
+                    .expect("An unexpected error occurred.");
 
             // We build a leaf node from the key packages
             let leaf_node = Node {
@@ -56,7 +56,8 @@ fn test_exclusion_list() {
         // The first key package bundle is used for the tree holder
         let key_package_bundle = key_package_bundles.remove(0);
 
-        let tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes).unwrap();
+        let tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes)
+            .expect("An unexpected error occurred.");
 
         let root = treemath::root(LeafIndex::from(NODES / 2));
 
@@ -113,10 +114,10 @@ fn test_original_child_resolution() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
             let key_package_bundle =
                 KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, &crypto, vec![])
-                    .unwrap();
+                    .expect("An unexpected error occurred.");
 
             // We build a leaf node from the key packages
             let leaf_node = Node {
@@ -139,16 +140,23 @@ fn test_original_child_resolution() {
         // The first key package bundle is used for the tree holder
         let key_package_bundle = key_package_bundles.remove(0);
 
-        let mut tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes).unwrap();
+        let mut tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes)
+            .expect("An unexpected error occurred.");
 
         // Left child index
-        let left_child_index = treemath::left(root_index).unwrap();
+        let left_child_index = treemath::left(root_index).expect("An unexpected error occurred.");
 
         // Populate the expected public key list
         let expected_public_keys_full = LEFT_CHILD_RESOLUTION
             .iter()
             .filter(|index| nodes[**index].is_some())
-            .map(|index| nodes[*index].as_ref().unwrap().public_hpke_key().unwrap())
+            .map(|index| {
+                nodes[*index]
+                    .as_ref()
+                    .expect("An unexpected error occurred.")
+                    .public_hpke_key()
+                    .expect("An unexpected error occurred.")
+            })
             .collect::<Vec<&HpkePublicKey>>();
 
         // Since the root node has no unmerged leaves, we expect all keys to be returned
@@ -186,7 +194,13 @@ fn test_original_child_resolution() {
         let expected_public_keys_filtered = EXPECTED_CHILD_RESOLUTION
             .iter()
             .filter(|index| nodes[**index].is_some())
-            .map(|index| nodes[*index].as_ref().unwrap().public_hpke_key().unwrap())
+            .map(|index| {
+                nodes[*index]
+                    .as_ref()
+                    .expect("An unexpected error occurred.")
+                    .public_hpke_key()
+                    .expect("An unexpected error occurred.")
+            })
             .collect::<Vec<&HpkePublicKey>>();
 
         // Since the root node now has unmerged leaves, we expect only certain public
@@ -214,24 +228,32 @@ fn test_exclusion_for_parent_nodes() {
         CodecUse::SerializedMessages,
     );
 
-    let group_id = setup.create_group(Ciphersuite::default()).unwrap();
+    let group_id = setup
+        .create_group(Ciphersuite::default())
+        .expect("An unexpected error occurred.");
 
     let mut groups = setup.groups.borrow_mut();
-    let group = groups.get_mut(&group_id).unwrap();
+    let group = groups
+        .get_mut(&group_id)
+        .expect("An unexpected error occurred.");
 
-    let (_, group_creator_id) = group.members.first().unwrap().clone();
+    let (_, group_creator_id) = group
+        .members
+        .first()
+        .expect("An unexpected error occurred.")
+        .clone();
 
     // We add 16 - 2 = 14 members such that we have a group of 15. We add the
     // last member manually later.
     let addees = setup
         .random_new_members_for_group(group, number_of_clients - 2)
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     // Have one client add all the other clients, such that only the direct path
     // of the group creator is non-blank.
     setup
         .add_clients(ActionType::Commit, group, &group_creator_id, addees)
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     // Now we have two clients in the right tree half do an update. This is such
     // that the right child of the root has two children that are full nodes. It
@@ -242,21 +264,27 @@ fn test_exclusion_for_parent_nodes() {
 
     setup
         .self_update(ActionType::Commit, group, &updater_id, None)
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     let (_, updater_id) = group.members[8].clone();
 
     setup
         .self_update(ActionType::Commit, group, &updater_id, None)
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     // Now we add the final group member, which should lead to an unmerged leaf
     // being added to the right child of the right child of the root, thus
     // invalidating the parent hash of the left child of the right child of the
     // root if the exclusion list is not applied to parent nodes.
-    let (_, group_creator_id) = group.members.first().unwrap().clone();
+    let (_, group_creator_id) = group
+        .members
+        .first()
+        .expect("An unexpected error occurred.")
+        .clone();
 
-    let addees = setup.random_new_members_for_group(group, 1).unwrap();
+    let addees = setup
+        .random_new_members_for_group(group, 1)
+        .expect("An unexpected error occurred.");
 
     // We now add a new client to the group. Upon receiving the new message, the
     // client will check the parent hash of all nodes in the tree as mandated by

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_secret_tree.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_secret_tree.rs
@@ -176,7 +176,10 @@ fn secret_tree() {
     let n_leaves = 10u32;
     let mut secret_tree = SecretTree::new(
         EncryptionSecret::from_slice(
-            &crypto.rand().random_vec(ciphersuite.hash_length()).unwrap()[..],
+            &crypto
+                .rand()
+                .random_vec(ciphersuite.hash_length())
+                .expect("An unexpected error occurred.")[..],
             ProtocolVersion::default(),
             ciphersuite,
         ),

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_tree_truncation.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_tree_truncation.rs
@@ -27,10 +27,10 @@ fn test_trim() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
             let key_package_bundle =
                 KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, &crypto, vec![])
-                    .unwrap();
+                    .expect("An unexpected error occurred.");
 
             // We build a leaf node from the key packages
             let leaf_node = Node {
@@ -51,7 +51,8 @@ fn test_trim() {
         println!("final number of nodes: {:?}", nodes.len());
 
         let key_package_bundle = key_package_bundles.remove(0);
-        let mut tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes).unwrap();
+        let mut tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes)
+            .expect("An unexpected error occurred.");
 
         let size_untrimmed = tree.tree_size();
         println!("size untrimmed: {:?}", size_untrimmed);
@@ -88,17 +89,19 @@ fn test_truncation_after_removal() {
 
         let group_id = setup
             .create_random_group(number_of_clients, Ciphersuite::default())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
         let mut groups = setup.groups.borrow_mut();
-        let group = groups.get_mut(&group_id).unwrap();
+        let group = groups
+            .get_mut(&group_id)
+            .expect("An unexpected error occurred.");
 
         // Get the id of the member at index 0
         let (_, remover_id) = group
             .members
             .iter()
             .find(|(index, _)| *index == 0)
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .clone();
 
         // Remove the rightmost 2 members in the tree
@@ -131,17 +134,19 @@ fn test_truncation_after_update() {
 
         let group_id = setup
             .create_random_group(number_of_clients, Ciphersuite::default())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
         let mut groups = setup.groups.borrow_mut();
-        let group = groups.get_mut(&group_id).unwrap();
+        let group = groups
+            .get_mut(&group_id)
+            .expect("An unexpected error occurred.");
 
         // Get the id of the member at index 0
         let (_, updater_id) = group
             .members
             .iter()
             .find(|(index, _)| *index == 0)
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .clone();
 
         // Remove the rightmost 2 members in the tree

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_treemath.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_treemath.rs
@@ -19,7 +19,8 @@ fn test_dir_path() {
         for i in (0..size / 2).step_by(2) {
             let leaf_index = LeafIndex::try_from(i).expect("Could not create LeafIndex");
             let tree_size = LeafIndex::from(size);
-            let leaf_dir_path = treemath::leaf_direct_path(leaf_index, tree_size).unwrap();
+            let leaf_dir_path = treemath::leaf_direct_path(leaf_index, tree_size)
+                .expect("An unexpected error occurred.");
             let parent_node = treemath::parent(NodeIndex::from(leaf_index), tree_size)
                 .expect("Could not calculate parent node");
             let parent_direct_path = treemath::parent_direct_path(parent_node, tree_size)
@@ -42,8 +43,9 @@ fn test_tree_hash() {
             signature_scheme,
             &crypto,
         )
-        .unwrap();
-        KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, &crypto, Vec::new()).unwrap()
+        .expect("An unexpected error occurred.");
+        KeyPackageBundle::new(&[ciphersuite_name], &credential_bundle, &crypto, Vec::new())
+            .expect("An unexpected error occurred.")
     }
 
     for ciphersuite in Config::supported_ciphersuites() {

--- a/openmls/src/tree/treemath.rs
+++ b/openmls/src/tree/treemath.rs
@@ -284,7 +284,7 @@ fn invalid_inputs() {
 fn test_node_in_tree() {
     let tests = [(0u32, 2u32), (1, 2), (2, 2), (5, 5), (8, 5)];
     for test in tests.iter() {
-        node_in_tree(test.0.into(), test.1.into()).unwrap();
+        node_in_tree(test.0.into(), test.1.into()).expect("An unexpected error occurred.");
     }
 }
 
@@ -303,7 +303,7 @@ fn test_node_not_in_tree() {
 fn test_leaf_in_tree() {
     let tests = [(0u32, 2u32), (1, 2), (4, 5), (9, 10)];
     for test in tests.iter() {
-        leaf_in_tree(test.0.into(), test.1.into()).unwrap();
+        leaf_in_tree(test.0.into(), test.1.into()).expect("An unexpected error occurred.");
     }
 }
 

--- a/openmls/tests/test_config.rs
+++ b/openmls/tests/test_config.rs
@@ -14,11 +14,15 @@ fn protocol_version() {
     let default_version = ProtocolVersion::default();
 
     // The encoding of the protocol version is the version as u8.
-    let mls10_encoded = mls10_version.tls_serialize_detached().unwrap();
+    let mls10_encoded = mls10_version
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
     assert_eq!(1, mls10_encoded.len());
     assert_eq!(mls10_encoded[0], mls10_version as u8);
 
-    let default_encoded = default_version.tls_serialize_detached().unwrap();
+    let default_encoded = default_version
+        .tls_serialize_detached()
+        .expect("An unexpected error occurred.");
     assert_eq!(1, default_encoded.len());
     assert_eq!(default_encoded[0], default_version as u8);
 

--- a/openmls/tests/test_decryption_key_index.rs
+++ b/openmls/tests/test_decryption_key_index.rs
@@ -9,7 +9,7 @@ mod utils;
 
 ctest_ciphersuites!(decryption_key_index_computation, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
 
     // Some basic setup functions for the managed group.
     let managed_group_config =
@@ -19,9 +19,9 @@ ctest_ciphersuites!(decryption_key_index_computation, test(ciphersuite_name: Cip
     let number_of_clients = 20;
     let setup = ManagedTestSetup::new(managed_group_config, number_of_clients, CodecUse::StructMessages);
     // Create a basic group with more than 4 members to create a tree with intermediate nodes.
-    let group_id = setup.create_random_group(10, ciphersuite).unwrap();
+    let group_id = setup.create_random_group(10, ciphersuite).expect("An unexpected error occurred.");
     let mut groups = setup.groups.borrow_mut();
-    let group = groups.get_mut(&group_id).unwrap();
+    let group = groups.get_mut(&group_id).expect("An unexpected error occurred.");
 
     // Now we have to create a situation, where the resolution is neither
     // the leaf, nor the common ancestor closest to the root. To do that, we
@@ -33,11 +33,11 @@ ctest_ciphersuites!(decryption_key_index_computation, test(ciphersuite_name: Cip
         .members
         .iter()
         .find(|(index, _)| index == &0)
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .clone();
     setup
         .remove_clients_by_index(ActionType::Commit, group, remover_id, &[2])
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     // Then we have the member at index 7 remove the one at index 3. This
     // causes a secret to be encrypted to the parent node of index 0, which
@@ -49,11 +49,11 @@ ctest_ciphersuites!(decryption_key_index_computation, test(ciphersuite_name: Cip
         .members
         .iter()
         .find(|(index, _)| index == &7)
-        .unwrap()
+        .expect("An unexpected error occurred.")
         .clone();
     setup
         .remove_clients_by_index(ActionType::Commit, group, remover_id, &[3])
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
     // Since the decryption failure doesn't cause a panic, but only an error
     // message in the callback, we also have to check that the group states

--- a/openmls/tests/test_encoding.rs
+++ b/openmls/tests/test_encoding.rs
@@ -56,22 +56,27 @@ fn test_application_message_encoding() {
     let crypto = OpenMlsRustCrypto::default();
     let test_setup = create_encoding_test_setup();
     let test_clients = test_setup.clients.borrow();
-    let alice = test_clients.get("alice").unwrap().borrow();
+    let alice = test_clients
+        .get("alice")
+        .expect("An unexpected error occurred.")
+        .borrow();
 
     // Create a message in each group and test the padding.
     for group_state in alice.group_states.borrow_mut().values_mut() {
         let credential_bundle = alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
-            .unwrap();
+            .expect("An unexpected error occurred.");
         for _ in 0..100 {
             // Test encoding/decoding of Application messages.
             let message = randombytes(random_usize() % 1000);
             let aad = randombytes(random_usize() % 1000);
             let encrypted_message = group_state
                 .create_application_message(&aad, &message, credential_bundle, 0, &crypto)
-                .unwrap();
-            let encrypted_message_bytes = encrypted_message.tls_serialize_detached().unwrap();
+                .expect("An unexpected error occurred.");
+            let encrypted_message_bytes = encrypted_message
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred.");
             let encrypted_message_decoded =
                 match MlsCiphertext::tls_deserialize(&mut encrypted_message_bytes.as_slice()) {
                     Ok(a) => a,
@@ -88,7 +93,10 @@ fn test_update_proposal_encoding() {
     let crypto = OpenMlsRustCrypto::default();
     let test_setup = create_encoding_test_setup();
     let test_clients = test_setup.clients.borrow();
-    let alice = test_clients.get("alice").unwrap().borrow();
+    let alice = test_clients
+        .get("alice")
+        .expect("An unexpected error occurred.")
+        .borrow();
     // Framing parameters
     let framing_parameters = FramingParameters::new(&[], WireFormat::MlsPlaintext);
 
@@ -96,7 +104,7 @@ fn test_update_proposal_encoding() {
         let credential_bundle = alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
         let capabilities_extension = Extension::Capabilities(CapabilitiesExtension::new(
             None,
@@ -113,7 +121,7 @@ fn test_update_proposal_encoding() {
             &crypto,
             mandatory_extensions,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         let update = group_state
             .create_update_proposal(
@@ -131,7 +139,12 @@ fn test_update_proposal_encoding() {
                 Ok(a) => a,
                 Err(err) => panic!("Error decoding MPLSPlaintext Update: {:?}", err),
             };
-        update_decoded.set_context(group_state.context().tls_serialize_detached().unwrap());
+        update_decoded.set_context(
+            group_state
+                .context()
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        );
         let update_decoded = update_decoded
             .verify(&crypto, credential_bundle.credential())
             .expect("Error verifying MlsPlaintext");
@@ -146,7 +159,10 @@ fn test_add_proposal_encoding() {
     let crypto = OpenMlsRustCrypto::default();
     let test_setup = create_encoding_test_setup();
     let test_clients = test_setup.clients.borrow();
-    let alice = test_clients.get("alice").unwrap().borrow();
+    let alice = test_clients
+        .get("alice")
+        .expect("An unexpected error occurred.")
+        .borrow();
     // Framing parameters
     let framing_parameters = FramingParameters::new(&[], WireFormat::MlsPlaintext);
 
@@ -154,7 +170,7 @@ fn test_add_proposal_encoding() {
         let credential_bundle = alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
         let capabilities_extension = Extension::Capabilities(CapabilitiesExtension::new(
             None,
@@ -171,7 +187,7 @@ fn test_add_proposal_encoding() {
             &crypto,
             mandatory_extensions,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Adds
         let add = group_state
@@ -203,7 +219,10 @@ fn test_remove_proposal_encoding() {
     let crypto = OpenMlsRustCrypto::default();
     let test_setup = create_encoding_test_setup();
     let test_clients = test_setup.clients.borrow();
-    let alice = test_clients.get("alice").unwrap().borrow();
+    let alice = test_clients
+        .get("alice")
+        .expect("An unexpected error occurred.")
+        .borrow();
     // Framing parameters
     let framing_parameters = FramingParameters::new(&[], WireFormat::MlsPlaintext);
 
@@ -211,7 +230,7 @@ fn test_remove_proposal_encoding() {
         let credential_bundle = alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
         let remove = group_state
             .create_remove_proposal(
@@ -242,7 +261,10 @@ fn test_commit_encoding() {
     let crypto = OpenMlsRustCrypto::default();
     let test_setup = create_encoding_test_setup();
     let test_clients = test_setup.clients.borrow();
-    let alice = test_clients.get("alice").unwrap().borrow();
+    let alice = test_clients
+        .get("alice")
+        .expect("An unexpected error occurred.")
+        .borrow();
     // Framing parameters
     let framing_parameters = FramingParameters::new(&[], WireFormat::MlsPlaintext);
 
@@ -250,7 +272,7 @@ fn test_commit_encoding() {
         let alice_credential_bundle = alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
         let capabilities_extension = Extension::Capabilities(CapabilitiesExtension::new(
             None,
@@ -267,7 +289,7 @@ fn test_commit_encoding() {
             &crypto,
             mandatory_extensions.clone(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Create a few proposals to put into the commit
 
@@ -286,9 +308,9 @@ fn test_commit_encoding() {
             ._key_store
             .borrow_mut()
             .get_mut(&("charlie", group_state.ciphersuite().name()))
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .pop()
-            .unwrap();
+            .expect("An unexpected error occurred.");
         let add = group_state
             .create_add_proposal(
                 framing_parameters,
@@ -326,9 +348,12 @@ fn test_commit_encoding() {
             .credential_bundle(alice_credential_bundle)
             .proposal_store(&proposal_store)
             .build();
-        let (commit, _welcome_option, _key_package_bundle_option) =
-            group_state.create_commit(params, &crypto).unwrap();
-        let commit_encoded = commit.tls_serialize_detached().unwrap();
+        let (commit, _welcome_option, _key_package_bundle_option) = group_state
+            .create_commit(params, &crypto)
+            .expect("An unexpected error occurred.");
+        let commit_encoded = commit
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
         let commit_decoded =
             match VerifiableMlsPlaintext::tls_deserialize(&mut commit_encoded.as_slice()) {
                 Ok(a) => group_state
@@ -346,7 +371,10 @@ fn test_welcome_message_encoding() {
     let crypto = OpenMlsRustCrypto::default();
     let test_setup = create_encoding_test_setup();
     let test_clients = test_setup.clients.borrow();
-    let alice = test_clients.get("alice").unwrap().borrow();
+    let alice = test_clients
+        .get("alice")
+        .expect("An unexpected error occurred.")
+        .borrow();
     // Framing parameters
     let framing_parameters = FramingParameters::new(&[], WireFormat::MlsPlaintext);
 
@@ -354,7 +382,7 @@ fn test_welcome_message_encoding() {
         let credential_bundle = alice
             .credential_bundles
             .get(&group_state.ciphersuite().name())
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
         // Create a few proposals to put into the commit
 
@@ -363,9 +391,9 @@ fn test_welcome_message_encoding() {
             ._key_store
             .borrow_mut()
             .get_mut(&("charlie", group_state.ciphersuite().name()))
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .pop()
-            .unwrap();
+            .expect("An unexpected error occurred.");
         let add = group_state
             .create_add_proposal(
                 framing_parameters,
@@ -385,14 +413,15 @@ fn test_welcome_message_encoding() {
             .credential_bundle(credential_bundle)
             .proposal_store(&proposal_store)
             .build();
-        let (commit, welcome_option, key_package_bundle_option) =
-            group_state.create_commit(params, &crypto).unwrap();
+        let (commit, welcome_option, key_package_bundle_option) = group_state
+            .create_commit(params, &crypto)
+            .expect("An unexpected error occurred.");
         // Alice applies the commit
         let staged_commit = group_state
             .stage_commit(
                 &commit,
                 &proposal_store,
-                &[key_package_bundle_option.unwrap()],
+                &[key_package_bundle_option.expect("An unexpected error occurred.")],
                 None,
                 &crypto,
             )
@@ -401,9 +430,11 @@ fn test_welcome_message_encoding() {
 
         // Welcome messages
 
-        let welcome = welcome_option.unwrap();
+        let welcome = welcome_option.expect("An unexpected error occurred.");
 
-        let welcome_encoded = welcome.tls_serialize_detached().unwrap();
+        let welcome_encoded = welcome
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
         let welcome_decoded = match Welcome::tls_deserialize(&mut welcome_encoded.as_slice()) {
             Ok(a) => a,
             Err(err) => panic!("Error decoding Welcome message: {:?}", err),
@@ -411,11 +442,14 @@ fn test_welcome_message_encoding() {
 
         assert_eq!(welcome, welcome_decoded);
 
-        let charlie = test_clients.get("charlie").unwrap().borrow();
+        let charlie = test_clients
+            .get("charlie")
+            .expect("An unexpected error occurred.")
+            .borrow();
 
         let charlie_key_package_bundle = charlie
             .find_key_package_bundle(&charlie_key_package, &crypto)
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
         // This makes Charlie decode the internals of the Welcome message, for
         // example the RatchetTreeExtension.

--- a/openmls/tests/test_framing.rs
+++ b/openmls/tests/test_framing.rs
@@ -35,7 +35,10 @@ fn padding() {
     let test_setup = setup(test_setup_config);
 
     let test_clients = test_setup.clients.borrow();
-    let alice = test_clients.get("alice").unwrap().borrow();
+    let alice = test_clients
+        .get("alice")
+        .expect("An unexpected error occurred.")
+        .borrow();
 
     for padding_size in 0..50 {
         // Create a message in each group and test the padding.
@@ -43,7 +46,7 @@ fn padding() {
             let credential_bundle = alice
                 .credential_bundles
                 .get(&group_state.ciphersuite().name())
-                .unwrap();
+                .expect("An unexpected error occurred.");
             for _ in 0..10 {
                 let message = randombytes(random_usize() % 1000);
                 let aad = randombytes(random_usize() % 1000);
@@ -55,7 +58,7 @@ fn padding() {
                         padding_size,
                         &crypto,
                     )
-                    .unwrap();
+                    .expect("An unexpected error occurred.");
                 let ciphertext = mls_ciphertext.ciphertext();
                 let length = ciphertext.len();
                 let overflow = if padding_size > 0 {

--- a/openmls/tests/test_group.rs
+++ b/openmls/tests/test_group.rs
@@ -17,14 +17,14 @@ fn create_commit_optional_path() {
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_credential_bundle = CredentialBundle::new(
             "Bob".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Mandatory extensions, will be fixed in #164
         let lifetime_extension = Extension::LifeTime(LifetimeExtension::new(60));
@@ -37,7 +37,7 @@ fn create_commit_optional_path() {
             &crypto,
             mandatory_extensions.clone(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         let bob_key_package_bundle = KeyPackageBundle::new(
             &[ciphersuite.name()],
@@ -45,7 +45,7 @@ fn create_commit_optional_path() {
             &crypto,
             mandatory_extensions.clone(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_key_package = bob_key_package_bundle.key_package();
 
         let alice_update_key_package_bundle = KeyPackageBundle::new(
@@ -54,7 +54,7 @@ fn create_commit_optional_path() {
             &crypto,
             mandatory_extensions,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let alice_update_key_package = alice_update_key_package_bundle.key_package();
         assert!(alice_update_key_package.verify(&crypto,).is_ok());
 
@@ -143,7 +143,7 @@ fn create_commit_optional_path() {
 
         // Bob creates group from Welcome
         let group_bob = match MlsGroup::new_from_welcome(
-            welcome_bundle_alice_bob_option.unwrap(),
+            welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
             Some(ratchet_tree),
             bob_key_package_bundle,
             None, /* PSK fetcher */
@@ -197,7 +197,7 @@ fn create_commit_optional_path() {
             .stage_commit(
                 &commit_mls_plaintext,
                 &proposal_store,
-                &[kpb_option.unwrap()],
+                &[kpb_option.expect("An unexpected error occurred.")],
                 None, /* PSK fetcher */
                 &crypto,
             )
@@ -221,14 +221,14 @@ fn basic_group_setup() {
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_credential_bundle = CredentialBundle::new(
             "Bob".into(),
             CredentialType::Basic,
             ciphersuite.signature_scheme(),
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Generate KeyPackages
         let bob_key_package_bundle = KeyPackageBundle::new(
@@ -237,7 +237,7 @@ fn basic_group_setup() {
             &crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
         let bob_key_package = bob_key_package_bundle.key_package();
 
         let alice_key_package_bundle = KeyPackageBundle::new(
@@ -246,7 +246,7 @@ fn basic_group_setup() {
             &crypto,
             Vec::new(),
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
 
         // Alice creates a group
         let group_alice = MlsGroup::builder(GroupId::random(&crypto), alice_key_package_bundle)
@@ -292,14 +292,14 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
         ciphersuite.signature_scheme(),
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let bob_credential_bundle = CredentialBundle::new(
         "Bob".into(),
         CredentialType::Basic,
         ciphersuite.signature_scheme(),
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     // Mandatory extensions
     let capabilities_extension = Extension::Capabilities(CapabilitiesExtension::new(
@@ -318,7 +318,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
         &crypto,
         mandatory_extensions.clone(),
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     let bob_key_package_bundle = KeyPackageBundle::new(
         &[ciphersuite.name()],
@@ -326,7 +326,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
         &crypto,
         mandatory_extensions.clone(),
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
     // === Alice creates a group ===
@@ -379,7 +379,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
     let ratchet_tree = group_alice.tree().public_key_tree_copy();
 
     let mut group_bob = match MlsGroup::new_from_welcome(
-        welcome_bundle_alice_bob_option.unwrap(),
+        welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,
         None, /* PSK fetcher */
@@ -403,7 +403,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
     let message_alice = [1, 2, 3];
     let mls_ciphertext_alice = group_alice
         .create_application_message(&[], &message_alice, &alice_credential_bundle, 0, &crypto)
-        .unwrap();
+        .expect("An unexpected error occurred.");
     let mls_plaintext_bob = match group_bob.decrypt(&mls_ciphertext_alice, &crypto) {
         Ok(mls_plaintext) => group_bob
             .verify(mls_plaintext, &crypto)
@@ -412,7 +412,9 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
     };
     assert_eq!(
         message_alice,
-        mls_plaintext_bob.as_application_message().unwrap()
+        mls_plaintext_bob
+            .as_application_message()
+            .expect("An unexpected error occurred.")
     );
 
     // === Bob updates and commits ===
@@ -470,7 +472,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
         .stage_commit(
             &mls_plaintext_commit,
             &proposal_store,
-            &[kpb_option.unwrap()],
+            &[kpb_option.expect("An unexpected error occurred.")],
             None, /* PSK fetcher */
             &crypto,
         )
@@ -526,7 +528,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
         .stage_commit(
             &mls_plaintext_commit,
             &proposal_store,
-            &[kpb_option.unwrap()],
+            &[kpb_option.expect("An unexpected error occurred.")],
             None, /* PSK fetcher */
             &crypto,
         )
@@ -591,7 +593,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
         .stage_commit(
             &mls_plaintext_commit,
             &proposal_store,
-            &[kpb_option.unwrap()],
+            &[kpb_option.expect("An unexpected error occurred.")],
             None,
             /* PSK fetcher */ &crypto,
         )
@@ -621,7 +623,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
         ciphersuite.signature_scheme(),
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     let charlie_key_package_bundle = KeyPackageBundle::new(
         &[ciphersuite.name()],
@@ -688,7 +690,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
 
     let ratchet_tree = group_alice.tree().public_key_tree_copy();
     let mut group_charlie = match MlsGroup::new_from_welcome(
-        welcome_for_charlie_option.unwrap(),
+        welcome_for_charlie_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         charlie_key_package_bundle,
         None,
@@ -718,7 +720,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
             0,
             &crypto,
         )
-        .unwrap();
+        .expect("An unexpected error occurred.");
     let mls_plaintext_alice = match group_alice.decrypt(&mls_ciphertext_charlie.clone(), &crypto) {
         Ok(mls_plaintext) => group_alice
             .verify(mls_plaintext, &crypto)
@@ -733,11 +735,15 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
     };
     assert_eq!(
         message_charlie,
-        mls_plaintext_alice.as_application_message().unwrap()
+        mls_plaintext_alice
+            .as_application_message()
+            .expect("An unexpected error occurred.")
     );
     assert_eq!(
         message_charlie,
-        mls_plaintext_bob.as_application_message().unwrap()
+        mls_plaintext_bob
+            .as_application_message()
+            .expect("An unexpected error occurred.")
     );
 
     // === Charlie updates and commits ===
@@ -802,7 +808,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
         .stage_commit(
             &mls_plaintext_commit,
             &proposal_store,
-            &[kpb_option.unwrap()],
+            &[kpb_option.expect("An unexpected error occurred.")],
             None,
             /* PSK fetcher */ &crypto,
         )
@@ -874,7 +880,7 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
         .stage_commit(
             &mls_plaintext_commit,
             &proposal_store,
-            &[kpb_option.unwrap()],
+            &[kpb_option.expect("An unexpected error occurred.")],
             None,
             /* PSK fetcher */ &crypto,
         )
@@ -894,10 +900,10 @@ fn do_group_operations<Crypto: OpenMlsCryptoProvider>(crypto: Crypto, ciphersuit
     // Make sure all groups export the same key
     let alice_exporter = group_alice
         .export_secret(&crypto, "export test", &[], 32)
-        .unwrap();
+        .expect("An unexpected error occurred.");
     let charlie_exporter = group_charlie
         .export_secret(&crypto, "export test", &[], 32)
-        .unwrap();
+        .expect("An unexpected error occurred.");
     assert_eq!(alice_exporter, charlie_exporter);
 
     // Now alice tries to derive an exporter with too large of a key length.

--- a/openmls/tests/test_interop_scenarios.rs
+++ b/openmls/tests/test_interop_scenarios.rs
@@ -25,7 +25,7 @@ fn default_managed_group_config() -> ManagedGroupConfig {
 // ***:  Verify group state
 ctest_ciphersuites!(one_to_one_join, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
     let number_of_clients = 2;
     let setup = ManagedTestSetup::new(
         default_managed_group_config(),
@@ -38,12 +38,12 @@ ctest_ciphersuites!(one_to_one_join, test(ciphersuite_name: CiphersuiteName) {
         .create_group(ciphersuite)
         .expect("Error while trying to create group.");
     let mut groups = setup.groups.borrow_mut();
-    let group = groups.get_mut(&group_id).unwrap();
+    let group = groups.get_mut(&group_id).expect("An unexpected error occurred.");
 
-    let (_, alice_id) = group.members.first().unwrap().clone();
+    let (_, alice_id) = group.members.first().expect("An unexpected error occurred.").clone();
 
     // A vector including bob's id.
-    let bob_id = setup.random_new_members_for_group(group, 1).unwrap();
+    let bob_id = setup.random_new_members_for_group(group, 1).expect("An unexpected error occurred.");
 
     setup
         .add_clients(ActionType::Commit, group, &alice_id, bob_id)
@@ -63,7 +63,7 @@ ctest_ciphersuites!(one_to_one_join, test(ciphersuite_name: CiphersuiteName) {
 // ***:  Verify group state
 ctest_ciphersuites!(three_party_join, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
 
     let number_of_clients = 3;
     let setup = ManagedTestSetup::new(
@@ -77,12 +77,12 @@ ctest_ciphersuites!(three_party_join, test(ciphersuite_name: CiphersuiteName) {
         .create_group(ciphersuite)
         .expect("Error while trying to create group.");
     let mut groups = setup.groups.borrow_mut();
-    let group = groups.get_mut(&group_id).unwrap();
+    let group = groups.get_mut(&group_id).expect("An unexpected error occurred.");
 
-    let (_, alice_id) = group.members.first().unwrap().clone();
+    let (_, alice_id) = group.members.first().expect("An unexpected error occurred.").clone();
 
     // A vector including Bob's id.
-    let bob_id = setup.random_new_members_for_group(group, 1).unwrap();
+    let bob_id = setup.random_new_members_for_group(group, 1).expect("An unexpected error occurred.");
 
     // Create the add commit and deliver the welcome.
     setup
@@ -90,7 +90,7 @@ ctest_ciphersuites!(three_party_join, test(ciphersuite_name: CiphersuiteName) {
         .expect("Error adding Bob");
 
     // A vector including Charly's id.
-    let charly_id = setup.random_new_members_for_group(group, 1).unwrap();
+    let charly_id = setup.random_new_members_for_group(group, 1).expect("An unexpected error occurred.");
 
     setup
         .add_clients(ActionType::Commit, group, &alice_id, charly_id)
@@ -109,7 +109,7 @@ ctest_ciphersuites!(three_party_join, test(ciphersuite_name: CiphersuiteName) {
 // ***:  Verify group state
 ctest_ciphersuites!(multiple_joins, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
 
     let number_of_clients = 3;
     let setup = ManagedTestSetup::new(
@@ -123,12 +123,12 @@ ctest_ciphersuites!(multiple_joins, test(ciphersuite_name: CiphersuiteName) {
         .create_group(ciphersuite)
         .expect("Error while trying to create group.");
     let mut groups = setup.groups.borrow_mut();
-    let group = groups.get_mut(&group_id).unwrap();
+    let group = groups.get_mut(&group_id).expect("An unexpected error occurred.");
 
-    let (_, alice_id) = group.members.first().unwrap().clone();
+    let (_, alice_id) = group.members.first().expect("An unexpected error occurred.").clone();
 
     // A vector including Bob's and Charly's id.
-    let bob_charly_id = setup.random_new_members_for_group(group, 2).unwrap();
+    let bob_charly_id = setup.random_new_members_for_group(group, 2).expect("An unexpected error occurred.");
 
     // Create the add commit and deliver the welcome.
     setup
@@ -149,7 +149,7 @@ ctest_ciphersuites!(multiple_joins, test(ciphersuite_name: CiphersuiteName) {
 // ***:  Verify group state
 ctest_ciphersuites!(update, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
 
     let number_of_clients = 2;
     let setup = ManagedTestSetup::new(
@@ -163,9 +163,9 @@ ctest_ciphersuites!(update, test(ciphersuite_name: CiphersuiteName) {
         .create_random_group(2, ciphersuite)
         .expect("Error while trying to create group.");
     let mut groups = setup.groups.borrow_mut();
-    let group = groups.get_mut(&group_id).unwrap();
+    let group = groups.get_mut(&group_id).expect("An unexpected error occurred.");
 
-    let (_, alice_id) = group.members.first().unwrap().clone();
+    let (_, alice_id) = group.members.first().expect("An unexpected error occurred.").clone();
 
     // Let Alice create an update with a self-generated KeyPackageBundle.
     setup
@@ -186,7 +186,7 @@ ctest_ciphersuites!(update, test(ciphersuite_name: CiphersuiteName) {
 // ***:  Verify group state
 ctest_ciphersuites!(remove, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
 
     let number_of_clients = 2;
     let setup = ManagedTestSetup::new(
@@ -200,10 +200,10 @@ ctest_ciphersuites!(remove, test(ciphersuite_name: CiphersuiteName) {
         .create_random_group(2, ciphersuite)
         .expect("Error while trying to create group.");
     let mut groups = setup.groups.borrow_mut();
-    let group = groups.get_mut(&group_id).unwrap();
+    let group = groups.get_mut(&group_id).expect("An unexpected error occurred.");
 
-    let (_, alice_id) = group.members.first().unwrap().clone();
-    let (_, bob_id) = group.members.last().unwrap().clone();
+    let (_, alice_id) = group.members.first().expect("An unexpected error occurred.").clone();
+    let (_, bob_id) = group.members.last().expect("An unexpected error occurred.").clone();
 
     // Have alice remove Bob.
     setup
@@ -227,7 +227,7 @@ ctest_ciphersuites!(remove, test(ciphersuite_name: CiphersuiteName) {
 //   randomly-chosen other group member
 ctest_ciphersuites!(large_group_lifecycle, test(ciphersuite_name: CiphersuiteName) {
     println!("Testing ciphersuite {:?}", ciphersuite_name);
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
 
     // "Large" is 20 for now.
     let number_of_clients = 20;
@@ -244,7 +244,7 @@ ctest_ciphersuites!(large_group_lifecycle, test(ciphersuite_name: CiphersuiteNam
         .create_random_group(number_of_clients, ciphersuite)
         .expect("Error while trying to create group.");
     let mut groups = setup.groups.borrow_mut();
-    let group = groups.get_mut(&group_id).unwrap();
+    let group = groups.get_mut(&group_id).expect("An unexpected error occurred.");
 
     let mut group_members = group.members.clone();
 

--- a/openmls/tests/test_key_packages.rs
+++ b/openmls/tests/test_key_packages.rs
@@ -10,13 +10,13 @@ mod utils;
 ctest_ciphersuites!(key_package_generation, test(ciphersuite_name: CiphersuiteName) {
     let crypto = OpenMlsRustCrypto::default();
     println!("Testing ciphersuite {:?}", ciphersuite_name);
-    let ciphersuite = Config::ciphersuite(ciphersuite_name).unwrap();
+    let ciphersuite = Config::ciphersuite(ciphersuite_name).expect("An unexpected error occurred.");
 
     let id = vec![1, 2, 3];
     let credential_bundle =
-        CredentialBundle::new(id, CredentialType::Basic, ciphersuite.signature_scheme(),&crypto).unwrap();
+        CredentialBundle::new(id, CredentialType::Basic, ciphersuite.signature_scheme(),&crypto).expect("An unexpected error occurred.");
     let kpb =
-        KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle,&crypto, Vec::new()).unwrap();
+        KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle,&crypto, Vec::new()).expect("An unexpected error occurred.");
 
     // After creation, the signature should be ok.
     assert!(kpb.key_package().verify(&crypto).is_ok());
@@ -30,7 +30,7 @@ ctest_ciphersuites!(key_package_generation, test(ciphersuite_name: CiphersuiteNa
             .iter()
             .find(|e| e.extension_type() == ExtensionType::Capabilities)
             .expect("Capabilities extension is missing in key package");
-        let capabilities_extension = capabilities_extension.as_capabilities_extension().unwrap();
+        let capabilities_extension = capabilities_extension.as_capabilities_extension().expect("An unexpected error occurred.");
 
         // Only the single ciphersuite is set.
         assert_eq!(1, capabilities_extension.ciphersuites().len());
@@ -53,7 +53,7 @@ ctest_ciphersuites!(key_package_generation, test(ciphersuite_name: CiphersuiteNa
             .iter()
             .find(|e| e.extension_type() == ExtensionType::Lifetime)
             .expect("Lifetime extension is missing in key package");
-        let _lifetime_extension = lifetime_extension.as_lifetime_extension().unwrap();
+        let _lifetime_extension = lifetime_extension.as_lifetime_extension().expect("An unexpected error occurred.");
     }
 
     // Add and retrieve a key package ID.
@@ -62,7 +62,7 @@ ctest_ciphersuites!(key_package_generation, test(ciphersuite_name: CiphersuiteNa
     kpb_unsigned.add_extension(Extension::KeyPackageId(KeyIdExtension::new(&key_id)));
 
     // After re-signing the package it is valid.
-    let kpb = kpb_unsigned.sign(&crypto, &credential_bundle).unwrap();
+    let kpb = kpb_unsigned.sign(&crypto, &credential_bundle).expect("An unexpected error occurred.");
     assert!(kpb.key_package().verify(&crypto).is_ok());
 
     // Get the key ID extension.
@@ -71,6 +71,6 @@ ctest_ciphersuites!(key_package_generation, test(ciphersuite_name: CiphersuiteNa
         .iter()
         .find(|e| e.extension_type() == ExtensionType::KeyId)
         .expect("Key ID extension is missing in key package");
-    let key_id_extension = key_id_extension.as_key_id_extension().unwrap();
+    let key_id_extension = key_id_extension.as_key_id_extension().expect("An unexpected error occurred.");
     assert_eq!(&key_id, key_id_extension.as_slice());
 });

--- a/openmls/tests/test_managed_api.rs
+++ b/openmls/tests/test_managed_api.rs
@@ -19,23 +19,29 @@ fn test_managed_api() {
     );
 
     for ciphersuite in Config::supported_ciphersuites() {
-        let group_id = setup.create_random_group(3, ciphersuite).unwrap();
+        let group_id = setup
+            .create_random_group(3, ciphersuite)
+            .expect("An unexpected error occurred.");
         let mut groups = setup.groups.borrow_mut();
-        let group = groups.get_mut(&group_id).unwrap();
+        let group = groups
+            .get_mut(&group_id)
+            .expect("An unexpected error occurred.");
 
         // Add two new members.
         let (_, adder_id) = group.members[0].clone();
-        let new_members = setup.random_new_members_for_group(group, 2).unwrap();
+        let new_members = setup
+            .random_new_members_for_group(group, 2)
+            .expect("An unexpected error occurred.");
         setup
             .add_clients(ActionType::Commit, group, &adder_id, new_members)
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
         // Remove a member
         let (_, remover_id) = group.members[2].clone();
         let (_, target_id) = group.members[3].clone();
         setup
             .remove_clients(ActionType::Commit, group, &remover_id, vec![target_id])
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
         // Check that all group members agree on the same group state.
         setup.check_group_states(group);

--- a/openmls/tests/test_managed_group.rs
+++ b/openmls/tests/test_managed_group.rs
@@ -31,7 +31,7 @@ fn generate_credential_bundle(
     backend
         .key_store()
         .store(credential.signature_key(), &cb)
-        .unwrap();
+        .expect("An unexpected error occurred.");
     Ok(credential)
 }
 
@@ -44,13 +44,13 @@ fn generate_key_package_bundle(
     let credential_bundle = backend
         .key_store()
         .read(credential.signature_key())
-        .unwrap();
+        .expect("An unexpected error occurred.");
     let kpb = KeyPackageBundle::new(ciphersuites, &credential_bundle, backend, extensions)?;
     let kp = kpb.key_package().clone();
     backend
         .key_store()
         .store(&kp.hash(backend).expect("Could not hash KeyPackage."), &kpb)
-        .unwrap();
+        .expect("An unexpected error occurred.");
     Ok(kp)
 }
 
@@ -124,7 +124,7 @@ fn managed_group_operations() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             let bob_credential = generate_credential_bundle(
                 "Bob".into(),
@@ -132,7 +132,7 @@ fn managed_group_operations() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             let charlie_credential = generate_credential_bundle(
                 "Charlie".into(),
@@ -140,7 +140,7 @@ fn managed_group_operations() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             // Generate KeyPackages
             let alice_key_package = generate_key_package_bundle(
@@ -149,7 +149,7 @@ fn managed_group_operations() {
                 vec![],
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             let bob_key_package = generate_key_package_bundle(
                 &[ciphersuite.name()],
@@ -157,7 +157,7 @@ fn managed_group_operations() {
                 vec![],
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             // Define the managed group configuration
 
@@ -174,7 +174,7 @@ fn managed_group_operations() {
                     .hash(&crypto)
                     .expect("Could not hash KeyPackage."),
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             // === Alice adds Bob ===
             let (queued_message, welcome) =
@@ -455,7 +455,7 @@ fn managed_group_operations() {
                 vec![],
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             let (queued_message, welcome) =
                 match bob_group.add_members(&crypto, &[charlie_key_package]) {
@@ -724,7 +724,7 @@ fn managed_group_operations() {
                 vec![],
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             // Create RemoveProposal and process it
             let queued_message = alice_group
@@ -1067,7 +1067,7 @@ fn managed_group_operations() {
                 vec![],
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             // Add Bob to the group
             let (queued_message, welcome) = alice_group
@@ -1135,12 +1135,12 @@ fn test_empty_input_errors() {
         ciphersuite.signature_scheme(),
         &crypto,
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     // Generate KeyPackages
     let alice_key_package =
         generate_key_package_bundle(&[ciphersuite.name()], &alice_credential, vec![], &crypto)
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
     // Define the managed group configuration
     let managed_group_config = ManagedGroupConfig::test_default();
@@ -1154,7 +1154,7 @@ fn test_empty_input_errors() {
             .hash(&crypto)
             .expect("Could not hash KeyPackage."),
     )
-    .unwrap();
+    .expect("An unexpected error occurred.");
 
     assert_eq!(
         alice_group
@@ -1187,7 +1187,7 @@ fn managed_group_ratchet_tree_extension() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             let bob_credential = generate_credential_bundle(
                 "Bob".into(),
@@ -1195,7 +1195,7 @@ fn managed_group_ratchet_tree_extension() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             // Generate KeyPackages
             let alice_key_package = generate_key_package_bundle(
@@ -1204,7 +1204,7 @@ fn managed_group_ratchet_tree_extension() {
                 vec![],
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             let bob_key_package = generate_key_package_bundle(
                 &[ciphersuite.name()],
@@ -1212,7 +1212,7 @@ fn managed_group_ratchet_tree_extension() {
                 vec![],
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             let managed_group_config = ManagedGroupConfig::builder()
                 .wire_format(wire_format)
@@ -1228,7 +1228,7 @@ fn managed_group_ratchet_tree_extension() {
                     .hash(&crypto)
                     .expect("Could not hash KeyPackage."),
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             // === Alice adds Bob ===
             let (_queued_message, welcome) =
@@ -1251,7 +1251,7 @@ fn managed_group_ratchet_tree_extension() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             let bob_credential = generate_credential_bundle(
                 "Bob".into(),
@@ -1259,7 +1259,7 @@ fn managed_group_ratchet_tree_extension() {
                 ciphersuite.signature_scheme(),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             // Generate KeyPackages
             let alice_key_package = generate_key_package_bundle(
@@ -1268,7 +1268,7 @@ fn managed_group_ratchet_tree_extension() {
                 vec![],
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             let bob_key_package = generate_key_package_bundle(
                 &[ciphersuite.name()],
@@ -1276,7 +1276,7 @@ fn managed_group_ratchet_tree_extension() {
                 vec![],
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             let managed_group_config = ManagedGroupConfig::test_default();
 
@@ -1289,7 +1289,7 @@ fn managed_group_ratchet_tree_extension() {
                     .hash(&crypto)
                     .expect("Could not hash KeyPackage."),
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
 
             // === Alice adds Bob ===
             let (_queued_message, welcome) =

--- a/openmls/tests/utils/mls_utils/mod.rs
+++ b/openmls/tests/utils/mls_utils/mod.rs
@@ -91,7 +91,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                 SignatureScheme::from(ciphersuite),
                 &crypto,
             )
-            .unwrap();
+            .expect("An unexpected error occurred.");
             // Create a number of key packages.
             let mut key_packages = Vec::new();
             for _ in 0..KEY_PACKAGE_COUNT {
@@ -110,7 +110,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                     &crypto,
                     mandatory_extensions,
                 )
-                .unwrap();
+                .expect("An unexpected error occurred.");
                 key_packages.push(key_package_bundle.key_package().clone());
                 key_package_bundles.push(key_package_bundle);
             }
@@ -136,23 +136,23 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
         // initiator.
         let initial_group_member = test_clients
             .get(group_config.members[0].name)
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .borrow_mut();
         // Pull the inital member's KeyPackage from the key_store.
         let initial_key_package = key_store
             .remove(&(group_config.members[0].name, group_config.ciphersuite))
-            .unwrap()
+            .expect("An unexpected error occurred.")
             .pop()
-            .unwrap();
+            .expect("An unexpected error occurred.");
         // Figure out which KeyPackageBundle that key package corresponds to.
         let initial_key_package_bundle = initial_group_member
             .find_key_package_bundle(&initial_key_package, &crypto)
-            .unwrap();
+            .expect("An unexpected error occurred.");
         // Get the credential bundle corresponding to the ciphersuite.
         let initial_credential_bundle = initial_group_member
             .credential_bundles
             .get(&group_config.ciphersuite)
-            .unwrap();
+            .expect("An unexpected error occurred.");
         // Initialize the group state for the initial member.
         let mls_group = MlsGroup::builder(
             GroupId::from_slice(&group_id.to_be_bytes()),
@@ -176,7 +176,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
             let mut group_states = initial_group_member.group_states.borrow_mut();
             let mls_group = group_states
                 .get_mut(&GroupId::from_slice(&group_id.to_be_bytes()))
-                .unwrap();
+                .expect("An unexpected error occurred.");
             for client_id in 1..group_config.members.len() {
                 // Pull a KeyPackage from the key_store for the new member.
                 let next_member_key_package = key_store
@@ -184,9 +184,9 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                         group_config.members[client_id].name,
                         group_config.ciphersuite,
                     ))
-                    .unwrap()
+                    .expect("An unexpected error occurred.")
                     .pop()
-                    .unwrap();
+                    .expect("An unexpected error occurred.");
                 // Have the initial member create an Add proposal using the new
                 // KeyPackage.
                 let add_proposal = mls_group
@@ -196,7 +196,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                         next_member_key_package,
                         &crypto,
                     )
-                    .unwrap();
+                    .expect("An unexpected error occurred.");
                 proposal_list.push(add_proposal);
             }
             // Create the commit based on the previously compiled list of
@@ -218,10 +218,12 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                 .credential_bundle(initial_credential_bundle)
                 .proposal_store(&proposal_store)
                 .build();
-            let (commit_mls_plaintext, welcome_option, key_package_bundle_option) =
-                mls_group.create_commit(params, &crypto).unwrap();
-            let welcome = welcome_option.unwrap();
-            let key_package_bundle = key_package_bundle_option.unwrap();
+            let (commit_mls_plaintext, welcome_option, key_package_bundle_option) = mls_group
+                .create_commit(params, &crypto)
+                .expect("An unexpected error occurred.");
+            let welcome = welcome_option.expect("An unexpected error occurred.");
+            let key_package_bundle =
+                key_package_bundle_option.expect("An unexpected error occurred.");
 
             // Apply the commit to the initial group member's group state using
             // the key package bundle returned by the create_commit earlier.
@@ -240,7 +242,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
             for client_id in 1..group_config.members.len() {
                 let new_group_member = test_clients
                     .get(group_config.members[client_id].name)
-                    .unwrap()
+                    .expect("An unexpected error occurred.")
                     .borrow_mut();
                 // Figure out which key package bundle we should use. This is
                 // a bit ugly and inefficient.
@@ -259,7 +261,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                                     == x.key_package_hash.as_slice()
                             })
                     })
-                    .unwrap();
+                    .expect("An unexpected error occurred.");
                 let kpb_position = new_group_member
                     .key_package_bundles
                     .borrow()
@@ -270,7 +272,7 @@ pub(crate) fn setup(config: TestSetupConfig) -> TestSetup {
                             .expect("Could not hash KeyPackage.")
                             == member_secret.key_package_hash.as_slice()
                     })
-                    .unwrap();
+                    .expect("An unexpected error occurred.");
                 let key_package_bundle = new_group_member
                     .key_package_bundles
                     .borrow_mut()


### PR DESCRIPTION
This PR replaces every `unwrap()` by `expect("An unexpected error occurred.")` in all unit & integration tests. It does nothing more than that.
The goal is to spot remaining `unwrap`s more easily and to increase the codecov test coverage.

Sorry for the size of the PR, but it should be easy to review.