### PR TITLE
New Rust version, new clippy warnings

### DIFF
--- a/openmls/src/framing/codec.rs
+++ b/openmls/src/framing/codec.rs
@@ -281,11 +281,11 @@ impl tls_codec::Deserialize for MlsMessageIn {
                 match wire_format {
                     WireFormat::MlsPlaintext => {
                         let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut chain)?;
-                        Ok(MlsMessageIn::Plaintext(plaintext))
+                        Ok(MlsMessageIn::Plaintext(Box::new(plaintext)))
                     }
                     WireFormat::MlsCiphertext => {
                         let ciphertext = MlsCiphertext::tls_deserialize(&mut chain)?;
-                        Ok(MlsMessageIn::Ciphertext(ciphertext))
+                        Ok(MlsMessageIn::Ciphertext(Box::new(ciphertext)))
                     }
                 }
             }

--- a/openmls/src/framing/message.rs
+++ b/openmls/src/framing/message.rs
@@ -4,10 +4,10 @@ use super::*;
 #[derive(Debug, Clone)]
 pub enum MlsMessageIn {
     /// An OpenMLS `VerifiableMlsPlaintext`.
-    Plaintext(VerifiableMlsPlaintext),
+    Plaintext(Box<VerifiableMlsPlaintext>),
 
     /// An OpenMLS `MlsCiphertext`.
-    Ciphertext(MlsCiphertext),
+    Ciphertext(Box<MlsCiphertext>),
 }
 
 impl MlsMessageIn {
@@ -40,21 +40,21 @@ impl MlsMessageIn {
 #[derive(PartialEq, Debug, Clone)]
 pub enum MlsMessageOut {
     /// An OpenMLS `MlsPlaintext`.
-    Plaintext(MlsPlaintext),
+    Plaintext(Box<MlsPlaintext>),
 
     /// An OpenMLS `MlsCiphertext`.
-    Ciphertext(MlsCiphertext),
+    Ciphertext(Box<MlsCiphertext>),
 }
 
 impl From<MlsPlaintext> for MlsMessageOut {
     fn from(mls_plaintext: MlsPlaintext) -> Self {
-        MlsMessageOut::Plaintext(mls_plaintext)
+        MlsMessageOut::Plaintext(Box::new(mls_plaintext))
     }
 }
 
 impl From<MlsCiphertext> for MlsMessageOut {
     fn from(mls_ciphertext: MlsCiphertext) -> Self {
-        MlsMessageOut::Ciphertext(mls_ciphertext)
+        MlsMessageOut::Ciphertext(Box::new(mls_ciphertext))
     }
 }
 
@@ -89,23 +89,21 @@ impl From<MlsMessageOut> for MlsMessageIn {
     fn from(message: MlsMessageOut) -> Self {
         match message {
             MlsMessageOut::Plaintext(pt) => {
-                MlsMessageIn::Plaintext(VerifiableMlsPlaintext::from_plaintext(pt, None))
+                MlsMessageIn::Plaintext(Box::new(VerifiableMlsPlaintext::from_plaintext(*pt, None)))
             }
-            MlsMessageOut::Ciphertext(ct) => MlsMessageIn::Ciphertext(ct),
+            MlsMessageOut::Ciphertext(ct) => MlsMessageIn::Ciphertext(Box::new(*ct)),
         }
     }
 }
 
-#[cfg(any(feature = "test-utils", test))]
 impl From<VerifiableMlsPlaintext> for MlsMessageIn {
     fn from(plaintext: VerifiableMlsPlaintext) -> Self {
-        MlsMessageIn::Plaintext(plaintext)
+        MlsMessageIn::Plaintext(Box::new(plaintext))
     }
 }
 
-#[cfg(any(feature = "test-utils", test))]
 impl From<MlsCiphertext> for MlsMessageIn {
     fn from(ciphertext: MlsCiphertext) -> Self {
-        MlsMessageIn::Ciphertext(ciphertext)
+        MlsMessageIn::Ciphertext(Box::new(ciphertext))
     }
 }

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -769,13 +769,8 @@ impl Verifiable for VerifiableMlsPlaintext {
 }
 
 mod private_mod {
+    #[derive(Default)]
     pub struct Seal;
-
-    impl Default for Seal {
-        fn default() -> Self {
-            Seal {}
-        }
-    }
 }
 
 impl VerifiedStruct<VerifiableMlsPlaintext> for MlsPlaintext {

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -57,7 +57,7 @@ impl DecryptedMessage {
         inbound_message: MlsMessageIn,
     ) -> Result<Self, ValidationError> {
         if let MlsMessageIn::Plaintext(plaintext) = inbound_message {
-            Self::from_plaintext(plaintext)
+            Self::from_plaintext(*plaintext)
         } else {
             Err(ValidationError::WrongWireFormat)
         }

--- a/openmls/src/group/managed_group/application.rs
+++ b/openmls/src/group/managed_group/application.rs
@@ -40,6 +40,6 @@ impl ManagedGroup {
         // Since the state of the group might be changed, arm the state flag
         self.flag_state_change();
 
-        Ok(MlsMessageOut::Ciphertext(ciphertext))
+        Ok(MlsMessageOut::Ciphertext(Box::new(ciphertext)))
     }
 }

--- a/openmls/src/group/managed_group/mod.rs
+++ b/openmls/src/group/managed_group/mod.rs
@@ -230,12 +230,12 @@ impl ManagedGroup {
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<MlsMessageOut, ManagedGroupError> {
         let msg = match self.configuration().wire_format() {
-            WireFormat::MlsPlaintext => MlsMessageOut::Plaintext(plaintext),
+            WireFormat::MlsPlaintext => MlsMessageOut::Plaintext(Box::new(plaintext)),
             WireFormat::MlsCiphertext => {
                 let ciphertext =
                     self.group
                         .encrypt(plaintext, self.configuration().padding_size(), backend)?;
-                MlsMessageOut::Ciphertext(ciphertext)
+                MlsMessageOut::Ciphertext(Box::new(ciphertext))
             }
         };
         Ok(msg)

--- a/openmls/src/messages/public_group_state.rs
+++ b/openmls/src/messages/public_group_state.rs
@@ -64,13 +64,8 @@ pub struct VerifiablePublicGroupState {
 }
 
 mod private_mod {
+    #[derive(Default)]
     pub struct Seal;
-
-    impl Default for Seal {
-        fn default() -> Self {
-            Seal {}
-        }
-    }
 }
 
 impl VerifiedStruct<VerifiablePublicGroupState> for PublicGroupState {

--- a/openmls/src/schedule/errors.rs
+++ b/openmls/src/schedule/errors.rs
@@ -3,9 +3,9 @@ use tls_codec::Error as TlsCodecError;
 
 implement_error! {
     pub enum ErrorState {
-        NotInit = "Expected to be in initial state.",
-        NotEpoch = "Expected to be in epoch state.",
-        NotContext = "Expected to be in a state where the context is added.",
+        Init = "Expected to be in initial state.",
+        Epoch = "Expected to be in epoch state.",
+        Context = "Expected to be in a state where the context is added.",
     }
 }
 

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -151,18 +151,10 @@ pub mod kat_key_schedule;
 pub use errors::*;
 pub use psk::{PreSharedKeyId, PreSharedKeys, PskSecret};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub(crate) struct CommitSecret {
     secret: Secret,
-}
-
-impl Default for CommitSecret {
-    fn default() -> Self {
-        CommitSecret {
-            secret: Secret::default(),
-        }
-    }
 }
 
 impl From<Secret> for CommitSecret {
@@ -363,7 +355,7 @@ impl KeySchedule {
     ) -> Result<WelcomeSecret, KeyScheduleError> {
         if self.state != State::Initial || self.intermediate_secret.is_none() {
             log::error!("Trying to derive a welcome secret while not in the initial state.");
-            return Err(KeyScheduleError::InvalidState(ErrorState::NotInit));
+            return Err(KeyScheduleError::InvalidState(ErrorState::Init));
         }
 
         // We can return a library error here, because there must be a mistake in the state machine
@@ -389,7 +381,7 @@ impl KeySchedule {
             log::error!(
                 "Trying to add context to the key schedule while not in the initial state."
             );
-            return Err(KeyScheduleError::InvalidState(ErrorState::NotInit));
+            return Err(KeyScheduleError::InvalidState(ErrorState::Init));
         }
         self.state = State::Context;
 
@@ -425,7 +417,7 @@ impl KeySchedule {
     ) -> Result<EpochSecrets, KeyScheduleError> {
         if self.state != State::Context || self.epoch_secret.is_none() {
             log::error!("Trying to derive the epoch secrets while not in the right state.");
-            return Err(KeyScheduleError::InvalidState(ErrorState::NotContext));
+            return Err(KeyScheduleError::InvalidState(ErrorState::Context));
         }
         self.state = State::Done;
 


### PR DESCRIPTION
This PR fixes new clippy warning introduced in v1.57. 
It also fixes #585, because it just meant lifting the test-only visibility of the conversion.

The main change is that `MlsMessageIn/Out` now use `Box`, which makes sense, since they are likely to be used in a `Vec` anyway.