### PR TITLE
Fix interop client

### DIFF
--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -11,7 +11,8 @@ openmls = { path = "../openmls", features = ["test-utils"]}
 tonic = "0.3"
 prost = "0.6"
 tokio = { version = "0.2", features = ["macros",  "net"] }
-clap = "3.0.0-beta.4"
+clap = "3.0.0-rc.0"
+clap_derive = "3.0.0-rc.0"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tls_codec = { version = "0.2.0-pre.2", features = ["derive", "serde_serialize"] }

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -4,6 +4,7 @@
 //! It is based on the Mock client written by Richard Barnes.
 
 use clap::Parser;
+use clap_derive::*;
 use openmls::{
     ciphersuite::signable::Verifiable,
     group::{


### PR DESCRIPTION
This PR fixes the interop client. `clap` v3 is not stable yet and a breaking change was recently introduced that broke the CI. It looks like the current version of `clap` is the RC, so hopefully this won't happen anymore.