### PR TITLE
Follow-up for #600

### DIFF
--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -304,7 +304,7 @@ impl MlsClient for MlsClientImpl {
                     &format!("mlspp_key_schedule_{}.json", kat_key_schedule.cipher_suite),
                     &obj.test_vector,
                 );
-                match kat_key_schedule::run_test_vector(kat_key_schedule) {
+                match kat_key_schedule::run_test_vector(kat_key_schedule, backend) {
                     Ok(result) => ("Key Schedule", result),
                     Err(e) => {
                         let message = "Error while running key schedule test vector: ".to_string()

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -54,3 +54,4 @@ features = ["test-utils", "evercrypt"]
 [[bench]]
 name = "benchmark"
 harness = false
+features = ["test-utils"]

--- a/openmls/benches/benchmark.rs
+++ b/openmls/benches/benchmark.rs
@@ -43,20 +43,22 @@ fn criterion_kp_bundle(c: &mut Criterion, backend: &impl OpenMlsCryptoProvider) 
 
 fn kp_bundle_rust_crypto(c: &mut Criterion) {
     let backend = &OpenMlsRustCrypto::default();
+    println!("Backend: RustCrypto");
     criterion_kp_bundle(c, backend);
 }
 
 #[cfg(feature = "evercrypt")]
 fn kp_bundle_evercrypt(c: &mut Criterion) {
     use evercrypt_backend::OpenMlsEvercrypt;
-    let backend = OpenMlsEvercrypt::default();
+    let backend = &OpenMlsEvercrypt::default();
+    println!("Backend: Evercrypt");
     criterion_kp_bundle(c, backend);
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
     kp_bundle_rust_crypto(c);
     #[cfg(feature = "evercrypt")]
-    kp_bundle_evercypt(c);
+    kp_bundle_evercrypt(c);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/openmls/src/ciphersuite/aead.rs
+++ b/openmls/src/ciphersuite/aead.rs
@@ -137,18 +137,16 @@ pub(crate) fn aead_key_gen(
 
 #[cfg(test)]
 mod unit_tests {
-    use openmls_rust_crypto::OpenMlsRustCrypto;
-
     use super::*;
+    use crate::test_utils::*;
 
     /// Make sure that xoring works by xoring a nonce with a reuse guard, testing if
     /// it has changed, xoring it again and testing that it's back in its original
     /// state.
-    #[test]
-    fn test_xor() {
-        let crypto = &OpenMlsRustCrypto::default();
-        let reuse_guard: ReuseGuard = ReuseGuard::from_random(crypto);
-        let original_nonce = AeadNonce::random(crypto);
+    #[apply(backends)]
+    fn test_xor(backend: &impl OpenMlsCryptoProvider) {
+        let reuse_guard: ReuseGuard = ReuseGuard::from_random(backend);
+        let original_nonce = AeadNonce::random(backend);
         let mut nonce = original_nonce.clone();
         nonce.xor_with_reuse_guard(&reuse_guard);
         assert_ne!(

--- a/openmls/src/ciphersuite/tests/test_ciphersuite.rs
+++ b/openmls/src/ciphersuite/tests/test_ciphersuite.rs
@@ -80,10 +80,8 @@ fn test_sign_verify(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
     assert!(keypair.verify(backend, &signature, payload).is_ok());
 }
 
-#[test]
-fn supported_ciphersuites() {
-    let backend = &OpenMlsRustCrypto::default();
-
+#[apply(backends)]
+fn supported_ciphersuites(backend: &impl OpenMlsCryptoProvider) {
     const SUPPORTED_CIPHERSUITE_NAMES: &[CiphersuiteName] = &[
         CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
         CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,

--- a/openmls/src/schedule/kat_key_schedule.rs
+++ b/openmls/src/schedule/kat_key_schedule.rs
@@ -13,7 +13,7 @@ use crate::{
     group::{GroupContext, GroupEpoch, GroupId},
     prelude::{BranchPsk, Psk, PskType::Branch},
     schedule::{EpochSecrets, InitSecret, JoinerSecret, KeySchedule, WelcomeSecret},
-    test_utils::{bytes_to_hex, hex_to_bytes},
+    test_utils::*,
 };
 
 #[cfg(test)]
@@ -277,11 +277,11 @@ fn write_test_vectors() {
     write("test_vectors/kat_key_schedule_openmls-new.json", &tests);
 }
 
-#[test]
-fn read_test_vectors_key_schedule() {
+#[apply(backends)]
+fn read_test_vectors_key_schedule(backend: &impl OpenMlsCryptoProvider) {
     let tests: Vec<KeyScheduleTestVector> = read("test_vectors/kat_key_schedule_openmls.json");
     for test_vector in tests {
-        match run_test_vector(test_vector) {
+        match run_test_vector(test_vector, backend) {
             Ok(_) => {}
             Err(e) => panic!("Error while checking key schedule test vector.\n{:?}", e),
         }
@@ -301,7 +301,10 @@ fn read_test_vectors_key_schedule() {
 }
 
 #[cfg(any(feature = "test-utils", test))]
-pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestVectorError> {
+pub fn run_test_vector(
+    test_vector: KeyScheduleTestVector,
+    backend: &impl OpenMlsCryptoProvider,
+) -> Result<(), KsTestVectorError> {
     use tls_codec::{Deserialize, Serialize};
 
     use crate::ciphersuite::HpkePublicKey;
@@ -318,7 +321,6 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
             return Ok(());
         }
     };
-    let crypto = OpenMlsRustCrypto::default();
     log::debug!("Testing test vector for ciphersuite {:?}", ciphersuite);
     log::trace!("  {:?}", test_vector);
 
@@ -358,10 +360,10 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
             ));
         }
         // let psk = Vec::new();
-        let psk_secret = PskSecret::new(ciphersuite, &crypto, &psk_ids, &psks)
+        let psk_secret = PskSecret::new(ciphersuite, backend, &psk_ids, &psks)
             .expect("An unexpected error occurred.");
 
-        let joiner_secret = JoinerSecret::new(&crypto, &commit_secret, &init_secret)
+        let joiner_secret = JoinerSecret::new(backend, &commit_secret, &init_secret)
             .expect("Could not create JoinerSecret.");
         if hex_to_bytes(&epoch.joiner_secret) != joiner_secret.as_slice() {
             if cfg!(test) {
@@ -372,13 +374,13 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
 
         let mut key_schedule = KeySchedule::init(
             ciphersuite,
-            &crypto,
+            backend,
             joiner_secret.clone(),
             Some(psk_secret),
         )
         .expect("Could not create KeySchedule.");
         let welcome_secret = key_schedule
-            .welcome(&crypto)
+            .welcome(backend)
             .expect("An unexpected error occurred.");
 
         if hex_to_bytes(&epoch.welcome_secret) != welcome_secret.as_slice() {
@@ -414,11 +416,11 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
         }
 
         key_schedule
-            .add_context(&crypto, &group_context_serialized)
+            .add_context(backend, &group_context_serialized)
             .expect("An unexpected error occurred.");
 
         let epoch_secrets = key_schedule
-            .epoch_secrets(&crypto, true)
+            .epoch_secrets(backend, true)
             .expect("An unexpected error occurred.");
 
         init_secret = epoch_secrets
@@ -492,7 +494,7 @@ pub fn run_test_vector(test_vector: KeyScheduleTestVector) -> Result<(), KsTestV
         // Calculate external HPKE key pair
         let external_key_pair = epoch_secrets
             .external_secret()
-            .derive_external_keypair(crypto.crypto(), ciphersuite);
+            .derive_external_keypair(backend.crypto(), ciphersuite);
         if hex_to_bytes(&epoch.external_pub)
             != HpkePublicKey::from(external_key_pair.public.clone())
                 .tls_serialize_detached()

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_hashes.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_hashes.rs
@@ -1,85 +1,82 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
 
-use crate::tree::*;
+use crate::{test_utils::*, tree::*};
 
-#[test]
-fn test_parent_hash() {
-    let crypto = OpenMlsRustCrypto::default();
-    for ciphersuite in Config::supported_ciphersuites() {
-        // Number of leaf nodes in the tree
-        const NODES: usize = 31;
+#[apply(ciphersuites_and_backends)]
+fn test_parent_hash(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+    // Number of leaf nodes in the tree
+    const NODES: usize = 31;
 
-        // Build a list of nodes, for which we need credentials and key package bundles
-        let mut nodes = vec![];
-        let mut key_package_bundles = vec![];
-        for i in 0..NODES {
-            let credential_bundle = CredentialBundle::new(
-                vec![i as u8],
-                CredentialType::Basic,
-                ciphersuite.signature_scheme(),
-                &crypto,
-            )
-            .expect("An unexpected error occurred.");
-            let key_package_bundle =
-                KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, &crypto, vec![])
-                    .expect("An unexpected error occurred.");
+    // Build a list of nodes, for which we need credentials and key package bundles
+    let mut nodes = vec![];
+    let mut key_package_bundles = vec![];
+    for i in 0..NODES {
+        let credential_bundle = CredentialBundle::new(
+            vec![i as u8],
+            CredentialType::Basic,
+            ciphersuite.signature_scheme(),
+            backend,
+        )
+        .expect("An unexpected error occurred.");
+        let key_package_bundle =
+            KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, backend, vec![])
+                .expect("An unexpected error occurred.");
 
-            // We build a leaf node from the key packages
-            let leaf_node = Node {
-                node_type: NodeType::Leaf,
-                key_package: Some(key_package_bundle.key_package().clone()),
-                node: None,
-            };
-            key_package_bundles.push(key_package_bundle);
-            nodes.push(Some(leaf_node));
-            // We skip the last parent node (trees should always end with a leaf node)
-            if i != NODES - 1 {
-                // We insert blank parent nodes to get a longer resolution list
-                nodes.push(None);
-            }
+        // We build a leaf node from the key packages
+        let leaf_node = Node {
+            node_type: NodeType::Leaf,
+            key_package: Some(key_package_bundle.key_package().clone()),
+            node: None,
+        };
+        key_package_bundles.push(key_package_bundle);
+        nodes.push(Some(leaf_node));
+        // We skip the last parent node (trees should always end with a leaf node)
+        if i != NODES - 1 {
+            // We insert blank parent nodes to get a longer resolution list
+            nodes.push(None);
         }
-
-        // The first key package bundle is used for the tree holder
-        let key_package_bundle = key_package_bundles.remove(0);
-
-        let mut tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes)
-            .expect("An unexpected error occurred.");
-
-        assert!(tree.verify_parent_hashes(&crypto).is_ok());
-
-        // Populate the parent nodes with fake values
-        for index in 0..tree.tree_size().as_usize() {
-            // Filter out leaf nodes
-            if NodeIndex::from(index).is_parent() {
-                let public_key = crypto
-                    .crypto()
-                    .derive_hpke_keypair(
-                        ciphersuite.hpke_config(),
-                        Secret::random(ciphersuite, &crypto, None)
-                            .expect("Not enough randomness.")
-                            .as_slice(),
-                    )
-                    .public
-                    .into();
-                let parent_node = ParentNode::new(public_key, &[], &[]);
-                let node = Node {
-                    key_package: None,
-                    node: Some(parent_node),
-                    node_type: NodeType::Parent,
-                };
-                tree.nodes[index] = node;
-            }
-        }
-
-        // Compute the recursive parent_hash for the first member
-        let original_parent_hash = tree.set_parent_hashes(&crypto, LeafIndex::from(0usize));
-
-        // Swap two leaf nodes in the left & right part of the tree
-        tree.nodes.swap(15, 47);
-
-        // Compute the parent hash again to verify it has changed
-        let leaf_swap_parent_hash = tree.set_parent_hashes(&crypto, LeafIndex::from(0usize));
-
-        assert!(leaf_swap_parent_hash != original_parent_hash);
     }
+
+    // The first key package bundle is used for the tree holder
+    let key_package_bundle = key_package_bundles.remove(0);
+
+    let mut tree = RatchetTree::new_from_nodes(backend, key_package_bundle, &nodes)
+        .expect("An unexpected error occurred.");
+
+    assert!(tree.verify_parent_hashes(backend).is_ok());
+
+    // Populate the parent nodes with fake values
+    for index in 0..tree.tree_size().as_usize() {
+        // Filter out leaf nodes
+        if NodeIndex::from(index).is_parent() {
+            let public_key = backend
+                .crypto()
+                .derive_hpke_keypair(
+                    ciphersuite.hpke_config(),
+                    Secret::random(ciphersuite, backend, None)
+                        .expect("Not enough randomness.")
+                        .as_slice(),
+                )
+                .public
+                .into();
+            let parent_node = ParentNode::new(public_key, &[], &[]);
+            let node = Node {
+                key_package: None,
+                node: Some(parent_node),
+                node_type: NodeType::Parent,
+            };
+            tree.nodes[index] = node;
+        }
+    }
+
+    // Compute the recursive parent_hash for the first member
+    let original_parent_hash = tree.set_parent_hashes(backend, LeafIndex::from(0usize));
+
+    // Swap two leaf nodes in the left & right part of the tree
+    tree.nodes.swap(15, 47);
+
+    // Compute the parent hash again to verify it has changed
+    let leaf_swap_parent_hash = tree.set_parent_hashes(backend, LeafIndex::from(0usize));
+
+    assert!(leaf_swap_parent_hash != original_parent_hash);
 }

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_resolution.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_resolution.rs
@@ -2,214 +2,213 @@ use openmls_rust_crypto::OpenMlsRustCrypto;
 
 use crate::{
     group::ManagedGroupConfig,
-    test_utils::test_framework::{ActionType, CodecUse, ManagedTestSetup},
+    test_utils::{
+        test_framework::{ActionType, CodecUse, ManagedTestSetup},
+        *,
+    },
     tree::*,
 };
 
 /// This test makes sure the filtering of the exclusion list during resolution
 /// works as intended.
-#[test]
-fn test_exclusion_list() {
-    let crypto = OpenMlsRustCrypto::default();
-    for ciphersuite in Config::supported_ciphersuites() {
-        // Number of nodes in the tree
-        const NODES: usize = 31;
-        // Resolution for the root node of that tree
-        const FULL_RESOLUTION: &[usize] =
-            &[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30];
-        // Arbitrary exclusion list (leaf indices)
-        const EXCLUSION_LIST: &[usize] = &[5, 6, 7, 8, 9, 10, 11];
-        // Expected filtered resolution (the nodes from the exclusion list should be
-        // stripped from the full resolution)
-        const FILTERED_RESOLUTION: &[usize] = &[0, 2, 4, 6, 8, 24, 26, 28, 30];
+#[apply(ciphersuites_and_backends)]
+fn test_exclusion_list(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+    // Number of nodes in the tree
+    const NODES: usize = 31;
+    // Resolution for the root node of that tree
+    const FULL_RESOLUTION: &[usize] = &[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30];
+    // Arbitrary exclusion list (leaf indices)
+    const EXCLUSION_LIST: &[usize] = &[5, 6, 7, 8, 9, 10, 11];
+    // Expected filtered resolution (the nodes from the exclusion list should be
+    // stripped from the full resolution)
+    const FILTERED_RESOLUTION: &[usize] = &[0, 2, 4, 6, 8, 24, 26, 28, 30];
 
-        // Build a list of nodes, for which we need credentials and key package bundles
-        let mut nodes = vec![];
-        let mut key_package_bundles = vec![];
-        for i in 0..NODES {
-            let credential_bundle = CredentialBundle::new(
-                vec![i as u8],
-                CredentialType::Basic,
-                ciphersuite.signature_scheme(),
-                &crypto,
-            )
-            .expect("An unexpected error occurred.");
-            let key_package_bundle =
-                KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, &crypto, vec![])
-                    .expect("An unexpected error occurred.");
+    // Build a list of nodes, for which we need credentials and key package bundles
+    let mut nodes = vec![];
+    let mut key_package_bundles = vec![];
+    for i in 0..NODES {
+        let credential_bundle = CredentialBundle::new(
+            vec![i as u8],
+            CredentialType::Basic,
+            ciphersuite.signature_scheme(),
+            backend,
+        )
+        .expect("An unexpected error occurred.");
+        let key_package_bundle =
+            KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, backend, vec![])
+                .expect("An unexpected error occurred.");
 
-            // We build a leaf node from the key packages
-            let leaf_node = Node {
-                node_type: NodeType::Leaf,
-                key_package: Some(key_package_bundle.key_package().clone()),
-                node: None,
-            };
-            key_package_bundles.push(key_package_bundle);
-            nodes.push(Some(leaf_node));
-            // We skip the last parent node (trees should always end with a leaf node)
-            if i != NODES - 1 {
-                // We insert blank parent nodes to get a longer resolution list
-                nodes.push(None);
-            }
+        // We build a leaf node from the key packages
+        let leaf_node = Node {
+            node_type: NodeType::Leaf,
+            key_package: Some(key_package_bundle.key_package().clone()),
+            node: None,
+        };
+        key_package_bundles.push(key_package_bundle);
+        nodes.push(Some(leaf_node));
+        // We skip the last parent node (trees should always end with a leaf node)
+        if i != NODES - 1 {
+            // We insert blank parent nodes to get a longer resolution list
+            nodes.push(None);
         }
-
-        // The first key package bundle is used for the tree holder
-        let key_package_bundle = key_package_bundles.remove(0);
-
-        let tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes)
-            .expect("An unexpected error occurred.");
-
-        let root = treemath::root(LeafIndex::from(NODES / 2));
-
-        // Test full resolution
-        let exclusion_list = HashSet::new();
-        let full_resolution = tree
-            .resolve(root, &exclusion_list)
-            .iter()
-            .map(|node_index| node_index.as_usize())
-            .collect::<Vec<usize>>();
-
-        // We expect to have all resolved nodes
-        assert_eq!(FULL_RESOLUTION, full_resolution);
-
-        // Test resolution with exclusion list
-        let exclusion_list_node_indexes = EXCLUSION_LIST
-            .iter()
-            .map(|&index| LeafIndex::from(index))
-            .collect::<Vec<LeafIndex>>();
-        let exclusion_list = exclusion_list_node_indexes.iter().collect();
-        let filtered_resultion = tree
-            .resolve(root, &exclusion_list)
-            .iter()
-            .map(|node_index| node_index.as_usize())
-            .collect::<Vec<usize>>();
-
-        // We expect to only see the nodes that were not removed by the filtering
-        assert_eq!(FILTERED_RESOLUTION, filtered_resultion);
     }
+
+    // The first key package bundle is used for the tree holder
+    let key_package_bundle = key_package_bundles.remove(0);
+
+    let tree = RatchetTree::new_from_nodes(backend, key_package_bundle, &nodes)
+        .expect("An unexpected error occurred.");
+
+    let root = treemath::root(LeafIndex::from(NODES / 2));
+
+    // Test full resolution
+    let exclusion_list = HashSet::new();
+    let full_resolution = tree
+        .resolve(root, &exclusion_list)
+        .iter()
+        .map(|node_index| node_index.as_usize())
+        .collect::<Vec<usize>>();
+
+    // We expect to have all resolved nodes
+    assert_eq!(FULL_RESOLUTION, full_resolution);
+
+    // Test resolution with exclusion list
+    let exclusion_list_node_indexes = EXCLUSION_LIST
+        .iter()
+        .map(|&index| LeafIndex::from(index))
+        .collect::<Vec<LeafIndex>>();
+    let exclusion_list = exclusion_list_node_indexes.iter().collect();
+    let filtered_resultion = tree
+        .resolve(root, &exclusion_list)
+        .iter()
+        .map(|node_index| node_index.as_usize())
+        .collect::<Vec<usize>>();
+
+    // We expect to only see the nodes that were not removed by the filtering
+    assert_eq!(FILTERED_RESOLUTION, filtered_resultion);
 }
 
 /// Test the `original_child_resolution` function that is used to calculate
 /// parent hashes
-#[test]
-fn test_original_child_resolution() {
-    let crypto = OpenMlsRustCrypto::default();
-    for ciphersuite in Config::supported_ciphersuites() {
-        // Number of leaf nodes in the tree
-        const NODES: usize = 10;
-        // Resolution for root left child
-        const LEFT_CHILD_RESOLUTION: &[usize] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
-        // Arbitrary unmerged leaves for root
-        const ROOT_UNMERGED_LEAVES: &[u32] = &[2, 3, 4];
-        // Expected child resolution
-        const EXPECTED_CHILD_RESOLUTION: &[usize] = &[0, 1, 2, 3, 5, 7, 9, 10, 11, 12, 13, 14];
+#[apply(ciphersuites_and_backends)]
+fn test_original_child_resolution(
+    ciphersuite: &'static Ciphersuite,
+    backend: &impl OpenMlsCryptoProvider,
+) {
+    // Number of leaf nodes in the tree
+    const NODES: usize = 10;
+    // Resolution for root left child
+    const LEFT_CHILD_RESOLUTION: &[usize] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
+    // Arbitrary unmerged leaves for root
+    const ROOT_UNMERGED_LEAVES: &[u32] = &[2, 3, 4];
+    // Expected child resolution
+    const EXPECTED_CHILD_RESOLUTION: &[usize] = &[0, 1, 2, 3, 5, 7, 9, 10, 11, 12, 13, 14];
 
-        // Build a list of nodes, for which we need credentials and key package bundles
-        let mut nodes = vec![];
-        let mut key_package_bundles = vec![];
-        for i in 0..NODES {
-            let credential_bundle = CredentialBundle::new(
-                vec![i as u8],
-                CredentialType::Basic,
-                ciphersuite.signature_scheme(),
-                &crypto,
-            )
-            .expect("An unexpected error occurred.");
-            let key_package_bundle =
-                KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, &crypto, vec![])
-                    .expect("An unexpected error occurred.");
+    // Build a list of nodes, for which we need credentials and key package bundles
+    let mut nodes = vec![];
+    let mut key_package_bundles = vec![];
+    for i in 0..NODES {
+        let credential_bundle = CredentialBundle::new(
+            vec![i as u8],
+            CredentialType::Basic,
+            ciphersuite.signature_scheme(),
+            backend,
+        )
+        .expect("An unexpected error occurred.");
+        let key_package_bundle =
+            KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, backend, vec![])
+                .expect("An unexpected error occurred.");
 
-            // We build a leaf node from the key packages
-            let leaf_node = Node {
-                node_type: NodeType::Leaf,
-                key_package: Some(key_package_bundle.key_package().clone()),
-                node: None,
-            };
-            key_package_bundles.push(key_package_bundle);
-            nodes.push(Some(leaf_node));
-            // We skip the last parent node (trees should always end with a leaf node)
-            if i != NODES - 1 {
-                // We insert blank parent nodes to get a longer resolution list
-                nodes.push(None);
-            }
-        }
-
-        // Root index
-        let root_index = treemath::root(LeafIndex::from(NODES));
-
-        // The first key package bundle is used for the tree holder
-        let key_package_bundle = key_package_bundles.remove(0);
-
-        let mut tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes)
-            .expect("An unexpected error occurred.");
-
-        // Left child index
-        let left_child_index = treemath::left(root_index).expect("An unexpected error occurred.");
-
-        // Populate the expected public key list
-        let expected_public_keys_full = LEFT_CHILD_RESOLUTION
-            .iter()
-            .filter(|index| nodes[**index].is_some())
-            .map(|index| {
-                nodes[*index]
-                    .as_ref()
-                    .expect("An unexpected error occurred.")
-                    .public_hpke_key()
-                    .expect("An unexpected error occurred.")
-            })
-            .collect::<Vec<&HpkePublicKey>>();
-
-        // Since the root node has no unmerged leaves, we expect all keys to be returned
-        assert_eq!(
-            tree.original_child_resolution(left_child_index),
-            expected_public_keys_full
-        );
-
-        // Add unmerged leaves to root node
-        let public_key = crypto
-            .crypto()
-            .derive_hpke_keypair(
-                ciphersuite.hpke_config(),
-                Secret::random(ciphersuite, &crypto, None)
-                    .expect("Not enough randomness.")
-                    .as_slice(),
-            )
-            .public
-            .into();
-        let new_root_node = Node {
-            node_type: NodeType::Parent,
-            node: Some(ParentNode {
-                parent_hash: vec![].into(),
-                public_key,
-                unmerged_leaves: ROOT_UNMERGED_LEAVES
-                    .iter()
-                    .map(|index| LeafIndex::from(*index))
-                    .collect(),
-            }),
-            key_package: None,
+        // We build a leaf node from the key packages
+        let leaf_node = Node {
+            node_type: NodeType::Leaf,
+            key_package: Some(key_package_bundle.key_package().clone()),
+            node: None,
         };
-        tree.nodes[root_index] = new_root_node;
-
-        // Populate the expected public key list
-        let expected_public_keys_filtered = EXPECTED_CHILD_RESOLUTION
-            .iter()
-            .filter(|index| nodes[**index].is_some())
-            .map(|index| {
-                nodes[*index]
-                    .as_ref()
-                    .expect("An unexpected error occurred.")
-                    .public_hpke_key()
-                    .expect("An unexpected error occurred.")
-            })
-            .collect::<Vec<&HpkePublicKey>>();
-
-        // Since the root node now has unmerged leaves, we expect only certain public
-        // keys to be returned
-        assert_eq!(
-            tree.original_child_resolution(left_child_index),
-            expected_public_keys_filtered
-        );
+        key_package_bundles.push(key_package_bundle);
+        nodes.push(Some(leaf_node));
+        // We skip the last parent node (trees should always end with a leaf node)
+        if i != NODES - 1 {
+            // We insert blank parent nodes to get a longer resolution list
+            nodes.push(None);
+        }
     }
+
+    // Root index
+    let root_index = treemath::root(LeafIndex::from(NODES));
+
+    // The first key package bundle is used for the tree holder
+    let key_package_bundle = key_package_bundles.remove(0);
+
+    let mut tree = RatchetTree::new_from_nodes(backend, key_package_bundle, &nodes)
+        .expect("An unexpected error occurred.");
+
+    // Left child index
+    let left_child_index = treemath::left(root_index).expect("An unexpected error occurred.");
+
+    // Populate the expected public key list
+    let expected_public_keys_full = LEFT_CHILD_RESOLUTION
+        .iter()
+        .filter(|index| nodes[**index].is_some())
+        .map(|index| {
+            nodes[*index]
+                .as_ref()
+                .expect("An unexpected error occurred.")
+                .public_hpke_key()
+                .expect("An unexpected error occurred.")
+        })
+        .collect::<Vec<&HpkePublicKey>>();
+
+    // Since the root node has no unmerged leaves, we expect all keys to be returned
+    assert_eq!(
+        tree.original_child_resolution(left_child_index),
+        expected_public_keys_full
+    );
+
+    // Add unmerged leaves to root node
+    let public_key = backend
+        .crypto()
+        .derive_hpke_keypair(
+            ciphersuite.hpke_config(),
+            Secret::random(ciphersuite, backend, None)
+                .expect("Not enough randomness.")
+                .as_slice(),
+        )
+        .public
+        .into();
+    let new_root_node = Node {
+        node_type: NodeType::Parent,
+        node: Some(ParentNode {
+            parent_hash: vec![].into(),
+            public_key,
+            unmerged_leaves: ROOT_UNMERGED_LEAVES
+                .iter()
+                .map(|index| LeafIndex::from(*index))
+                .collect(),
+        }),
+        key_package: None,
+    };
+    tree.nodes[root_index] = new_root_node;
+
+    // Populate the expected public key list
+    let expected_public_keys_filtered = EXPECTED_CHILD_RESOLUTION
+        .iter()
+        .filter(|index| nodes[**index].is_some())
+        .map(|index| {
+            nodes[*index]
+                .as_ref()
+                .expect("An unexpected error occurred.")
+                .public_hpke_key()
+                .expect("An unexpected error occurred.")
+        })
+        .collect::<Vec<&HpkePublicKey>>();
+
+    // Since the root node now has unmerged leaves, we expect only certain public
+    // keys to be returned
+    assert_eq!(
+        tree.original_child_resolution(left_child_index),
+        expected_public_keys_filtered
+    );
 }
 
 /// Test if unmerged leaves are properly excluded when computing the parent hash

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_secret_tree.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_secret_tree.rs
@@ -1,182 +1,176 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::random::OpenMlsRand;
 
-use crate::schedule::EncryptionSecret;
-
-use crate::config::Config;
-use crate::tree::{secret_tree::*, *};
+use crate::{
+    config::Config,
+    schedule::EncryptionSecret,
+    test_utils::*,
+    tree::{secret_tree::*, *},
+};
 use std::collections::HashMap;
 
 // This tests the boundaries of the generations from a SecretTree
-#[test]
-fn test_boundaries() {
-    let crypto = OpenMlsRustCrypto::default();
-    for ciphersuite in Config::supported_ciphersuites() {
-        let encryption_secret = EncryptionSecret::random(ciphersuite, &crypto);
-        let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(2u32));
-        let secret_type = SecretType::ApplicationSecret;
-        assert!(secret_tree
-            .secret_for_decryption(ciphersuite, &crypto, LeafIndex::from(0u32), secret_type, 0)
-            .is_ok());
-        assert!(secret_tree
-            .secret_for_decryption(ciphersuite, &crypto, LeafIndex::from(1u32), secret_type, 0)
-            .is_ok());
-        assert!(secret_tree
-            .secret_for_decryption(ciphersuite, &crypto, LeafIndex::from(0u32), secret_type, 1)
-            .is_ok());
-        assert!(secret_tree
-            .secret_for_decryption(
-                ciphersuite,
-                &crypto,
-                LeafIndex::from(0u32),
-                secret_type,
-                1_000
-            )
-            .is_ok());
-        assert_eq!(
-            secret_tree.secret_for_decryption(
-                ciphersuite,
-                &crypto,
-                LeafIndex::from(1u32),
-                secret_type,
-                1001
-            ),
-            Err(SecretTreeError::TooDistantInTheFuture)
-        );
-        assert!(secret_tree
-            .secret_for_decryption(
-                ciphersuite,
-                &crypto,
-                LeafIndex::from(0u32),
-                secret_type,
-                996
-            )
-            .is_ok());
-        assert_eq!(
-            secret_tree.secret_for_decryption(
-                ciphersuite,
-                &crypto,
-                LeafIndex::from(0u32),
-                secret_type,
-                995
-            ),
-            Err(SecretTreeError::TooDistantInThePast)
-        );
-        assert_eq!(
-            secret_tree.secret_for_decryption(
-                ciphersuite,
-                &crypto,
-                LeafIndex::from(2u32),
-                secret_type,
-                0
-            ),
-            Err(SecretTreeError::IndexOutOfBounds)
-        );
-        let encryption_secret = EncryptionSecret::random(ciphersuite, &crypto);
-        let mut largetree = SecretTree::new(encryption_secret, LeafIndex::from(100_000u32));
-        assert!(largetree
-            .secret_for_decryption(ciphersuite, &crypto, LeafIndex::from(0u32), secret_type, 0)
-            .is_ok());
-        assert!(largetree
-            .secret_for_decryption(
-                ciphersuite,
-                &crypto,
-                LeafIndex::from(99_999u32),
-                secret_type,
-                0
-            )
-            .is_ok());
-        assert!(largetree
-            .secret_for_decryption(
-                ciphersuite,
-                &crypto,
-                LeafIndex::from(99_999u32),
-                secret_type,
-                1_000
-            )
-            .is_ok());
-        assert_eq!(
-            largetree.secret_for_decryption(
-                ciphersuite,
-                &crypto,
-                LeafIndex::from(100_000u32),
-                secret_type,
-                0
-            ),
-            Err(SecretTreeError::IndexOutOfBounds)
-        );
-    }
+#[apply(ciphersuites_and_backends)]
+fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+    let encryption_secret = EncryptionSecret::random(ciphersuite, backend);
+    let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(2u32));
+    let secret_type = SecretType::ApplicationSecret;
+    assert!(secret_tree
+        .secret_for_decryption(ciphersuite, backend, LeafIndex::from(0u32), secret_type, 0)
+        .is_ok());
+    assert!(secret_tree
+        .secret_for_decryption(ciphersuite, backend, LeafIndex::from(1u32), secret_type, 0)
+        .is_ok());
+    assert!(secret_tree
+        .secret_for_decryption(ciphersuite, backend, LeafIndex::from(0u32), secret_type, 1)
+        .is_ok());
+    assert!(secret_tree
+        .secret_for_decryption(
+            ciphersuite,
+            backend,
+            LeafIndex::from(0u32),
+            secret_type,
+            1_000
+        )
+        .is_ok());
+    assert_eq!(
+        secret_tree.secret_for_decryption(
+            ciphersuite,
+            backend,
+            LeafIndex::from(1u32),
+            secret_type,
+            1001
+        ),
+        Err(SecretTreeError::TooDistantInTheFuture)
+    );
+    assert!(secret_tree
+        .secret_for_decryption(
+            ciphersuite,
+            backend,
+            LeafIndex::from(0u32),
+            secret_type,
+            996
+        )
+        .is_ok());
+    assert_eq!(
+        secret_tree.secret_for_decryption(
+            ciphersuite,
+            backend,
+            LeafIndex::from(0u32),
+            secret_type,
+            995
+        ),
+        Err(SecretTreeError::TooDistantInThePast)
+    );
+    assert_eq!(
+        secret_tree.secret_for_decryption(
+            ciphersuite,
+            backend,
+            LeafIndex::from(2u32),
+            secret_type,
+            0
+        ),
+        Err(SecretTreeError::IndexOutOfBounds)
+    );
+    let encryption_secret = EncryptionSecret::random(ciphersuite, backend);
+    let mut largetree = SecretTree::new(encryption_secret, LeafIndex::from(100_000u32));
+    assert!(largetree
+        .secret_for_decryption(ciphersuite, backend, LeafIndex::from(0u32), secret_type, 0)
+        .is_ok());
+    assert!(largetree
+        .secret_for_decryption(
+            ciphersuite,
+            backend,
+            LeafIndex::from(99_999u32),
+            secret_type,
+            0
+        )
+        .is_ok());
+    assert!(largetree
+        .secret_for_decryption(
+            ciphersuite,
+            backend,
+            LeafIndex::from(99_999u32),
+            secret_type,
+            1_000
+        )
+        .is_ok());
+    assert_eq!(
+        largetree.secret_for_decryption(
+            ciphersuite,
+            backend,
+            LeafIndex::from(100_000u32),
+            secret_type,
+            0
+        ),
+        Err(SecretTreeError::IndexOutOfBounds)
+    );
 }
 
 // This tests if the generation gets incremented correctly and that the returned
 // values are unique.
-#[test]
-fn increment_generation() {
-    let crypto = OpenMlsRustCrypto::default();
+#[apply(ciphersuites_and_backends)]
+fn increment_generation(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     const SIZE: usize = 100;
     const MAX_GENERATIONS: usize = 10;
 
-    for ciphersuite in Config::supported_ciphersuites() {
-        let mut unique_values: HashMap<Vec<u8>, bool> = HashMap::new();
-        let encryption_secret = EncryptionSecret::random(ciphersuite, &crypto);
-        let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(SIZE as u32));
-        for i in 0..SIZE {
-            assert_eq!(
-                secret_tree.generation(LeafIndex::from(i as u32), SecretType::HandshakeSecret),
-                0
-            );
-            assert_eq!(
-                secret_tree.generation(LeafIndex::from(i as u32), SecretType::ApplicationSecret),
-                0
-            );
-        }
-        for i in 0..MAX_GENERATIONS {
-            for j in 0..SIZE {
-                let (next_gen, (handshake_key, handshake_nonce)) = secret_tree
-                    .secret_for_encryption(
-                        ciphersuite,
-                        &crypto,
-                        LeafIndex::from(j as u32),
-                        SecretType::HandshakeSecret,
-                    )
-                    .expect("Index out of bounds.");
-                assert_eq!(next_gen, i as u32);
-                assert!(unique_values
-                    .insert(handshake_key.as_slice().to_vec(), true)
-                    .is_none());
-                assert!(unique_values
-                    .insert(handshake_nonce.as_slice().to_vec(), true)
-                    .is_none());
-                let (next_gen, (application_key, application_nonce)) = secret_tree
-                    .secret_for_encryption(
-                        ciphersuite,
-                        &crypto,
-                        LeafIndex::from(j as u32),
-                        SecretType::ApplicationSecret,
-                    )
-                    .expect("Index out of bounds.");
-                assert_eq!(next_gen, i as u32);
-                assert!(unique_values
-                    .insert(application_key.as_slice().to_vec(), true)
-                    .is_none());
-                assert!(unique_values
-                    .insert(application_nonce.as_slice().to_vec(), true)
-                    .is_none());
-            }
+    let mut unique_values: HashMap<Vec<u8>, bool> = HashMap::new();
+    let encryption_secret = EncryptionSecret::random(ciphersuite, backend);
+    let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(SIZE as u32));
+    for i in 0..SIZE {
+        assert_eq!(
+            secret_tree.generation(LeafIndex::from(i as u32), SecretType::HandshakeSecret),
+            0
+        );
+        assert_eq!(
+            secret_tree.generation(LeafIndex::from(i as u32), SecretType::ApplicationSecret),
+            0
+        );
+    }
+    for i in 0..MAX_GENERATIONS {
+        for j in 0..SIZE {
+            let (next_gen, (handshake_key, handshake_nonce)) = secret_tree
+                .secret_for_encryption(
+                    ciphersuite,
+                    backend,
+                    LeafIndex::from(j as u32),
+                    SecretType::HandshakeSecret,
+                )
+                .expect("Index out of bounds.");
+            assert_eq!(next_gen, i as u32);
+            assert!(unique_values
+                .insert(handshake_key.as_slice().to_vec(), true)
+                .is_none());
+            assert!(unique_values
+                .insert(handshake_nonce.as_slice().to_vec(), true)
+                .is_none());
+            let (next_gen, (application_key, application_nonce)) = secret_tree
+                .secret_for_encryption(
+                    ciphersuite,
+                    backend,
+                    LeafIndex::from(j as u32),
+                    SecretType::ApplicationSecret,
+                )
+                .expect("Index out of bounds.");
+            assert_eq!(next_gen, i as u32);
+            assert!(unique_values
+                .insert(application_key.as_slice().to_vec(), true)
+                .is_none());
+            assert!(unique_values
+                .insert(application_nonce.as_slice().to_vec(), true)
+                .is_none());
         }
     }
 }
 
-#[test]
-fn secret_tree() {
-    let crypto = OpenMlsRustCrypto::default();
-    let ciphersuite = &Config::supported_ciphersuites()[0];
+#[apply(ciphersuites_and_backends)]
+fn secret_tree(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     let leaf_index = 0u32;
     let generation = 0;
     let n_leaves = 10u32;
     let mut secret_tree = SecretTree::new(
         EncryptionSecret::from_slice(
-            &crypto
+            &backend
                 .rand()
                 .random_vec(ciphersuite.hash_length())
                 .expect("An unexpected error occurred.")[..],
@@ -189,7 +183,7 @@ fn secret_tree() {
     let (application_secret_key, application_secret_nonce) = secret_tree
         .secret_for_decryption(
             ciphersuite,
-            &crypto,
+            backend,
             LeafIndex::from(leaf_index),
             SecretType::ApplicationSecret,
             generation,

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_sender_ratchet.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_sender_ratchet.rs
@@ -1,31 +1,32 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
 
-use crate::tree::sender_ratchet::SenderRatchet;
+use crate::{
+    config::Config,
+    prelude::{LeafIndex, Secret},
+    test_utils::*,
+    tree::sender_ratchet::SenderRatchet,
+};
 
-use crate::config::Config;
-use crate::prelude::{LeafIndex, Secret};
+#[apply(ciphersuites_and_backends)]
+fn test_ratchet_generations(
+    ciphersuite: &'static Ciphersuite,
+    backend: &impl OpenMlsCryptoProvider,
+) {
+    let leaf0 = LeafIndex::from(0usize);
+    let secret = Secret::random(ciphersuite, backend, Config::supported_versions()[0])
+        .expect("Not enough randomness.");
+    let mut linear_ratchet = SenderRatchet::new(leaf0, &secret);
+    let mut testratchet = SenderRatchet::new(leaf0, &secret);
 
-#[test]
-fn test_ratchet_generations() {
-    let crypto = &OpenMlsRustCrypto::default();
-
-    for ciphersuite in Config::supported_ciphersuites() {
-        let leaf0 = LeafIndex::from(0usize);
-        let secret = Secret::random(ciphersuite, crypto, Config::supported_versions()[0])
-            .expect("Not enough randomness.");
-        let mut linear_ratchet = SenderRatchet::new(leaf0, &secret);
-        let mut testratchet = SenderRatchet::new(leaf0, &secret);
-
-        let _ = linear_ratchet.secret_for_decryption(ciphersuite, crypto, 0);
-        let _ = linear_ratchet.secret_for_decryption(ciphersuite, crypto, 1);
-        let secret = linear_ratchet
-            .secret_for_decryption(ciphersuite, crypto, 2)
-            .expect("Could not derive the secret.");
-        // jump 2 generations instead of going one by one
-        let secret2 = testratchet
-            .secret_for_decryption(ciphersuite, crypto, 2)
-            .expect("Could not derive the secret.");
-        /* We should have the same secret */
-        assert_eq!(secret, secret2);
-    }
+    let _ = linear_ratchet.secret_for_decryption(ciphersuite, backend, 0);
+    let _ = linear_ratchet.secret_for_decryption(ciphersuite, backend, 1);
+    let secret = linear_ratchet
+        .secret_for_decryption(ciphersuite, backend, 2)
+        .expect("Could not derive the secret.");
+    // jump 2 generations instead of going one by one
+    let secret2 = testratchet
+        .secret_for_decryption(ciphersuite, backend, 2)
+        .expect("Could not derive the secret.");
+    /* We should have the same secret */
+    assert_eq!(secret, secret2);
 }

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_tree_truncation.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_tree_truncation.rs
@@ -5,14 +5,16 @@ use crate::{
     credentials::{CredentialBundle, CredentialType},
     group::ManagedGroupConfig,
     prelude::{KeyPackageBundle, LeafIndex},
-    test_utils::test_framework::{ActionType, CodecUse, ManagedTestSetup},
+    test_utils::{
+        test_framework::{ActionType, CodecUse, ManagedTestSetup},
+        *,
+    },
     tree::node::{Node, NodeType},
     tree::RatchetTree,
 };
 
-#[test]
-fn test_trim() {
-    let crypto = OpenMlsRustCrypto::default();
+#[apply(backends)]
+fn test_trim(backend: &impl OpenMlsCryptoProvider) {
     // Build a list of nodes, for which we need credentials and key package bundles
     let mut nodes = vec![];
     let mut key_package_bundles = vec![];
@@ -25,11 +27,11 @@ fn test_trim() {
                 vec![i as u8],
                 CredentialType::Basic,
                 ciphersuite.signature_scheme(),
-                &crypto,
+                backend,
             )
             .expect("An unexpected error occurred.");
             let key_package_bundle =
-                KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, &crypto, vec![])
+                KeyPackageBundle::new(&[ciphersuite.name()], &credential_bundle, backend, vec![])
                     .expect("An unexpected error occurred.");
 
             // We build a leaf node from the key packages
@@ -51,7 +53,7 @@ fn test_trim() {
         println!("final number of nodes: {:?}", nodes.len());
 
         let key_package_bundle = key_package_bundles.remove(0);
-        let mut tree = RatchetTree::new_from_nodes(&crypto, key_package_bundle, &nodes)
+        let mut tree = RatchetTree::new_from_nodes(backend, key_package_bundle, &nodes)
             .expect("An unexpected error occurred.");
 
         let size_untrimmed = tree.tree_size();


### PR DESCRIPTION
This PR follows up on #600 and adds `rstests` to the tests that were missed initially.

For testing purposes, it also adds `evercrypt` to the benchmarks.

Note: Changes in indentation blow up the size of this PR again. No code was changed except for adjusting to `rstests`.