### PR TITLE
Sender and Commit Types

### DIFF
--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -221,7 +221,7 @@ impl MlsPlaintext {
     }
 
     /// This constructor builds an `MlsPlaintext` containing a Commit. The given
-    /// `CommitType` determines the `SenderType`: If it's an `Internal` commit,
+    /// `CommitType` determines the `SenderType`: If it's an `Member` commit,
     /// it's `SenderType::Member` and `SenderType::NewMember` otherwise.
     pub fn commit(
         framing_parameters: FramingParameters,

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -221,7 +221,7 @@ impl MlsPlaintext {
     }
 
     /// This constructor builds an `MlsPlaintext` containing a Commit. The given
-    /// `CommitType` determines the `SenderType`: If it's an `Member` commit,
+    /// `CommitType` determines the `SenderType`: If it's a `Member` commit,
     /// it's `SenderType::Member` and `SenderType::NewMember` otherwise.
     pub fn commit(
         framing_parameters: FramingParameters,

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -118,18 +118,13 @@ impl MlsPlaintext {
     #[inline]
     fn new(
         framing_parameters: FramingParameters,
-        sender_index: LeafIndex,
-        sender_type: SenderType,
+        sender: Sender,
         payload: Payload,
         credential_bundle: &CredentialBundle,
         context: &GroupContext,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<Self, MlsPlaintextError> {
         let serialized_context = context.tls_serialize_detached()?;
-        let sender = Sender {
-            sender_type,
-            sender: sender_index,
-        };
         let mls_plaintext = MlsPlaintextTbs::new(
             framing_parameters.wire_format(),
             context.group_id().clone(),
@@ -153,10 +148,13 @@ impl MlsPlaintext {
         membership_key: &MembershipKey,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<Self, MlsPlaintextError> {
+        let sender = Sender {
+            sender_type: SenderType::Member,
+            sender: sender_index,
+        };
         let mut mls_plaintext = Self::new(
             framing_parameters,
-            sender_index,
-            SenderType::Member,
+            sender,
             payload,
             credential_bundle,
             context,
@@ -205,10 +203,13 @@ impl MlsPlaintext {
         context: &GroupContext,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<Self, MlsPlaintextError> {
+        let sender = Sender {
+            sender_type: SenderType::NewMember,
+            sender: sender_index,
+        };
         Self::new(
             framing_parameters,
-            sender_index,
-            SenderType::NewMember,
+            sender,
             Payload {
                 payload: MlsPlaintextContentType::Proposal(proposal),
                 content_type: ContentType::Proposal,
@@ -219,8 +220,9 @@ impl MlsPlaintext {
         )
     }
 
-    /// This constructor builds an `MlsPlaintext` containing a Commit.
-    /// The sender type is always `SenderType::NewMember`.
+    /// This constructor builds an `MlsPlaintext` containing a Commit. The given
+    /// `CommitType` determines the `SenderType`: If it's an `Internal` commit,
+    /// it's `SenderType::Member` and `SenderType::NewMember` otherwise.
     pub fn commit(
         framing_parameters: FramingParameters,
         sender_index: LeafIndex,
@@ -230,10 +232,13 @@ impl MlsPlaintext {
         context: &GroupContext,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<Self, MlsPlaintextError> {
+        let sender = Sender {
+            sender_type: commit_type.into(),
+            sender: sender_index,
+        };
         Self::new(
             framing_parameters,
-            sender_index,
-            SenderType::Member,
+            sender,
             Payload {
                 payload: MlsPlaintextContentType::Commit(commit),
                 content_type: ContentType::Commit,

--- a/openmls/src/framing/sender.rs
+++ b/openmls/src/framing/sender.rs
@@ -43,7 +43,7 @@ pub enum SenderType {
 impl From<CommitType> for SenderType {
     fn from(commit_type: CommitType) -> Self {
         match commit_type {
-            CommitType::External => SenderType::NewMember,
+            CommitType::Member => SenderType::NewMember,
             CommitType::Internal => SenderType::Member,
         }
     }

--- a/openmls/src/framing/sender.rs
+++ b/openmls/src/framing/sender.rs
@@ -26,6 +26,7 @@
 //! ```
 
 use super::*;
+use mls_group::create_commit_params::CommitType;
 use std::convert::TryFrom;
 use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 
@@ -37,6 +38,15 @@ pub enum SenderType {
     Member = 1,
     Preconfigured = 2,
     NewMember = 3,
+}
+
+impl From<CommitType> for SenderType {
+    fn from(commit_type: CommitType) -> Self {
+        match commit_type {
+            CommitType::External => SenderType::NewMember,
+            CommitType::Internal => SenderType::Member,
+        }
+    }
 }
 
 impl TryFrom<u8> for SenderType {
@@ -66,15 +76,5 @@ impl Sender {
     }
     pub fn to_leaf_index(self) -> LeafIndex {
         self.sender
-    }
-}
-
-//Private and crate functions
-impl Sender {
-    pub(crate) fn member(sender: LeafIndex) -> Self {
-        Sender {
-            sender_type: SenderType::Member,
-            sender,
-        }
     }
 }

--- a/openmls/src/framing/sender.rs
+++ b/openmls/src/framing/sender.rs
@@ -43,8 +43,8 @@ pub enum SenderType {
 impl From<CommitType> for SenderType {
     fn from(commit_type: CommitType) -> Self {
         match commit_type {
-            CommitType::Member => SenderType::NewMember,
-            CommitType::Internal => SenderType::Member,
+            CommitType::External => SenderType::NewMember,
+            CommitType::Member => SenderType::Member,
         }
     }
 }

--- a/openmls/src/group/mls_group/create_commit.rs
+++ b/openmls/src/group/mls_group/create_commit.rs
@@ -43,7 +43,7 @@ impl MlsGroup {
         let ciphersuite = self.ciphersuite();
 
         let sender_type = match params.commit_type() {
-            CommitType::External => SenderType::NewMember,
+            CommitType::Member => SenderType::NewMember,
             CommitType::Internal => SenderType::Member,
         };
         // Filter proposals

--- a/openmls/src/group/mls_group/create_commit.rs
+++ b/openmls/src/group/mls_group/create_commit.rs
@@ -43,8 +43,8 @@ impl MlsGroup {
         let ciphersuite = self.ciphersuite();
 
         let sender_type = match params.commit_type() {
-            CommitType::Member => SenderType::NewMember,
-            CommitType::Internal => SenderType::Member,
+            CommitType::External => SenderType::NewMember,
+            CommitType::Member => SenderType::Member,
         };
         // Filter proposals
         let (proposal_queue, contains_own_updates) = CreationProposalQueue::filter_proposals(

--- a/openmls/src/group/mls_group/create_commit.rs
+++ b/openmls/src/group/mls_group/create_commit.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 use super::{
-    create_commit_params::CreateCommitParams,
+    create_commit_params::{CommitType, CreateCommitParams},
     proposals::{CreationProposalQueue, ProposalStore},
 };
 
@@ -42,10 +42,15 @@ impl MlsGroup {
     ) -> CreateCommitResult {
         let ciphersuite = self.ciphersuite();
 
+        let sender_type = match params.commit_type() {
+            CommitType::External => SenderType::NewMember,
+            CommitType::Internal => SenderType::Member,
+        };
         // Filter proposals
         let (proposal_queue, contains_own_updates) = CreationProposalQueue::filter_proposals(
             ciphersuite,
             backend,
+            sender_type,
             params.proposal_store(),
             params.inline_proposals(),
             self.treesync().own_leaf_index(),
@@ -126,10 +131,11 @@ impl MlsGroup {
         provisional_epoch.increment();
 
         // Build MlsPlaintext
-        let mut mls_plaintext = MlsPlaintext::new_commit(
+        let mut mls_plaintext = MlsPlaintext::commit(
             *params.framing_parameters(),
             sender_index,
             commit,
+            params.commit_type(),
             params.credential_bundle(),
             &self.group_context,
             backend,

--- a/openmls/src/group/mls_group/create_commit_params.rs
+++ b/openmls/src/group/mls_group/create_commit_params.rs
@@ -5,8 +5,8 @@ use super::{proposals::ProposalStore, *};
 /// Can be used to denote the type of a commit.
 #[derive(Debug, Copy, Clone)]
 pub enum CommitType {
+    External,
     Member,
-    Internal,
 }
 
 pub struct CreateCommitParams<'a> {
@@ -64,7 +64,7 @@ impl<'a> TempBuilderCCPM2<'a> {
                 proposal_store,
                 inline_proposals: vec![],
                 force_self_update: true,
-                commit_type: CommitType::Internal,
+                commit_type: CommitType::Member,
                 psk_fetcher_option: None,
             },
         }

--- a/openmls/src/group/mls_group/create_commit_params.rs
+++ b/openmls/src/group/mls_group/create_commit_params.rs
@@ -15,7 +15,7 @@ pub struct CreateCommitParams<'a> {
     proposal_store: &'a ProposalStore,         // Mandatory
     inline_proposals: Vec<Proposal>,           // Optional
     force_self_update: bool,                   // Optional
-    commit_type: CommitType,                   // Optional (default is `Internal`)
+    commit_type: CommitType,                   // Optional (default is `Member`)
     psk_fetcher_option: Option<PskFetcher>,    // Optional
 }
 

--- a/openmls/src/group/mls_group/create_commit_params.rs
+++ b/openmls/src/group/mls_group/create_commit_params.rs
@@ -2,12 +2,20 @@
 
 use super::{proposals::ProposalStore, *};
 
+/// Can be used to denote the type of a commit.
+#[derive(Debug, Copy, Clone)]
+pub enum CommitType {
+    External,
+    Internal,
+}
+
 pub struct CreateCommitParams<'a> {
     framing_parameters: FramingParameters<'a>, // Mandatory
     credential_bundle: &'a CredentialBundle,   // Mandatory
     proposal_store: &'a ProposalStore,         // Mandatory
     inline_proposals: Vec<Proposal>,           // Optional
     force_self_update: bool,                   // Optional
+    commit_type: CommitType,                   // Optional (default is `Internal`)
     psk_fetcher_option: Option<PskFetcher>,    // Optional
 }
 
@@ -56,6 +64,7 @@ impl<'a> TempBuilderCCPM2<'a> {
                 proposal_store,
                 inline_proposals: vec![],
                 force_self_update: true,
+                commit_type: CommitType::Internal,
                 psk_fetcher_option: None,
             },
         }
@@ -73,6 +82,10 @@ impl<'a> CreateCommitParamsBuilder<'a> {
     }
     pub fn psk_fetcher_option(mut self, psk_fetcher_option: Option<PskFetcher>) -> Self {
         self.ccp.psk_fetcher_option = psk_fetcher_option;
+        self
+    }
+    pub fn commit_type(mut self, commit_type: CommitType) -> Self {
+        self.ccp.commit_type = commit_type;
         self
     }
     pub fn build(self) -> CreateCommitParams<'a> {
@@ -98,6 +111,9 @@ impl<'a> CreateCommitParams<'a> {
     }
     pub fn force_self_update(&self) -> bool {
         self.force_self_update
+    }
+    pub fn commit_type(&self) -> CommitType {
+        self.commit_type
     }
     pub fn psk_fetcher_option(&self) -> &Option<PskFetcher> {
         &self.psk_fetcher_option

--- a/openmls/src/group/mls_group/create_commit_params.rs
+++ b/openmls/src/group/mls_group/create_commit_params.rs
@@ -5,7 +5,7 @@ use super::{proposals::ProposalStore, *};
 /// Can be used to denote the type of a commit.
 #[derive(Debug, Copy, Clone)]
 pub enum CommitType {
-    External,
+    Member,
     Internal,
 }
 

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -232,7 +232,7 @@ impl MlsGroup {
             key_package: joiner_key_package,
         };
         let proposal = Proposal::Add(add_proposal);
-        MlsPlaintext::new_proposal(
+        MlsPlaintext::member_proposal(
             framing_parameters,
             self.sender_index(),
             proposal,
@@ -257,7 +257,7 @@ impl MlsGroup {
     ) -> Result<MlsPlaintext, MlsGroupError> {
         let update_proposal = UpdateProposal { key_package };
         let proposal = Proposal::Update(update_proposal);
-        MlsPlaintext::new_proposal(
+        MlsPlaintext::member_proposal(
             framing_parameters,
             self.sender_index(),
             proposal,
@@ -284,7 +284,7 @@ impl MlsGroup {
             removed: removed_index,
         };
         let proposal = Proposal::Remove(remove_proposal);
-        MlsPlaintext::new_proposal(
+        MlsPlaintext::member_proposal(
             framing_parameters,
             self.sender_index(),
             proposal,
@@ -309,7 +309,7 @@ impl MlsGroup {
     ) -> Result<MlsPlaintext, MlsGroupError> {
         let presharedkey_proposal = PreSharedKeyProposal::new(psk);
         let proposal = Proposal::PreSharedKey(presharedkey_proposal);
-        MlsPlaintext::new_proposal(
+        MlsPlaintext::member_proposal(
             framing_parameters,
             self.sender_index(),
             proposal,
@@ -349,7 +349,7 @@ impl MlsGroup {
         }
         let proposal = GroupContextExtensionProposal::new(extensions);
         let proposal = Proposal::GroupContextExtensions(proposal);
-        MlsPlaintext::new_proposal(
+        MlsPlaintext::member_proposal(
             framing_parameters,
             self.sender_index(),
             proposal,

--- a/openmls/src/group/mls_group/proposals.rs
+++ b/openmls/src/group/mls_group/proposals.rs
@@ -460,6 +460,7 @@ impl<'a> CreationProposalQueue<'a> {
     pub(crate) fn filter_proposals(
         ciphersuite: &Ciphersuite,
         backend: &impl OpenMlsCryptoProvider,
+        sender_type: SenderType,
         proposal_store: &'a ProposalStore,
         inline_proposals: &'a [Proposal],
         own_index: LeafIndex,
@@ -487,7 +488,7 @@ impl<'a> CreationProposalQueue<'a> {
         let mut contains_own_updates = false;
 
         let sender = Sender {
-            sender_type: SenderType::Member,
+            sender_type,
             sender: own_index,
         };
 

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -8,7 +8,10 @@ use tls_codec::Serialize;
 
 use crate::{
     ciphersuite::{signable::Signable, AeadNonce},
-    group::{create_commit_params::CreateCommitParams, GroupEpoch},
+    group::{
+        create_commit_params::{CommitType, CreateCommitParams},
+        GroupEpoch,
+    },
     messages::{Commit, ConfirmationTag, EncryptedGroupSecrets, GroupInfoPayload, PathSecretError},
     prelude::*,
     schedule::psk::*,
@@ -340,6 +343,7 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         framing_parameters,
         mls_plaintext_commit.sender_index(),
         broken_commit,
+        CommitType::Internal,
         &bob_credential_bundle,
         group_bob.context(),
         backend,

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -343,7 +343,7 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         framing_parameters,
         mls_plaintext_commit.sender_index(),
         broken_commit,
-        CommitType::Internal,
+        CommitType::Member,
         &bob_credential_bundle,
         group_bob.context(),
         backend,

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -336,7 +336,7 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         path: Some(broken_path),
     };
 
-    let mut broken_plaintext = MlsPlaintext::new_commit(
+    let mut broken_plaintext = MlsPlaintext::commit(
         framing_parameters,
         mls_plaintext_commit.sender_index(),
         broken_commit,

--- a/openmls/src/group/mls_group/test_proposals.rs
+++ b/openmls/src/group/mls_group/test_proposals.rs
@@ -105,7 +105,7 @@ fn proposal_queue_functions(
     assert!(!proposal_add_alice1.is_type(ProposalType::Remove));
 
     // Frame proposals in MlsPlaintext
-    let mls_plaintext_add_alice1 = MlsPlaintext::new_proposal(
+    let mls_plaintext_add_alice1 = MlsPlaintext::member_proposal(
         framing_parameters,
         0u32,
         proposal_add_alice1,
@@ -117,7 +117,7 @@ fn proposal_queue_functions(
         backend,
     )
     .expect("Could not create proposal.");
-    let mls_plaintext_add_alice2 = MlsPlaintext::new_proposal(
+    let mls_plaintext_add_alice2 = MlsPlaintext::member_proposal(
         framing_parameters,
         1u32,
         proposal_add_alice2,
@@ -129,7 +129,7 @@ fn proposal_queue_functions(
         backend,
     )
     .expect("Could not create proposal.");
-    let _mls_plaintext_add_bob1 = MlsPlaintext::new_proposal(
+    let _mls_plaintext_add_bob1 = MlsPlaintext::member_proposal(
         framing_parameters,
         1u32,
         proposal_add_bob1,
@@ -154,6 +154,7 @@ fn proposal_queue_functions(
     let (proposal_queue, own_update) = CreationProposalQueue::filter_proposals(
         ciphersuite,
         backend,
+        SenderType::Member,
         &proposal_store,
         &[],
         0u32,
@@ -225,7 +226,7 @@ fn proposal_queue_order(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
     let proposal_add_bob1 = Proposal::Add(add_proposal_bob1);
 
     // Frame proposals in MlsPlaintext
-    let mls_plaintext_add_alice1 = MlsPlaintext::new_proposal(
+    let mls_plaintext_add_alice1 = MlsPlaintext::member_proposal(
         framing_parameters,
         0u32,
         proposal_add_alice1.clone(),
@@ -238,7 +239,7 @@ fn proposal_queue_order(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
         backend,
     )
     .expect("Could not create proposal.");
-    let mls_plaintext_add_bob1 = MlsPlaintext::new_proposal(
+    let mls_plaintext_add_bob1 = MlsPlaintext::member_proposal(
         framing_parameters,
         1u32,
         proposal_add_bob1.clone(),

--- a/openmls/src/group/mls_group/validation.rs
+++ b/openmls/src/group/mls_group/validation.rs
@@ -85,6 +85,34 @@ impl MlsGroup {
     ///  - ValSem104
     ///  - ValSem105
     ///  - TODO: ValSem106
+    ///  - TODO: Assign ValSem ID to checks relating to external init. In
+    ///  particular (quote from the spec):
+    ///
+    /// External Commits work like regular Commits, with a few differences:
+    /// The proposals included by value in an External Commit MUST meet the
+    /// following conditions:
+    ///
+    /// * There MUST be a single ExternalInit proposal
+    ///
+    /// * There MUST NOT be any Add or Update proposalsIf a Remove proposal is
+    /// present, then the credential and endpoint_id of the removed leaf MUST be
+    /// the same as the corresponding values in the Add KeyPackage.
+    ///
+    /// * The proposals included by reference in an External Commit MUST meet
+    /// the following conditions:
+    ///
+    /// * There MUST NOT be any ExternalInit proposals
+    ///
+    /// * External Commits MUST contain a path field (and is therefore a "full"
+    /// Commit). The joiner is added at the leftmost free leaf node (just as if
+    /// they were added with an Add proposal), and the path is calculated
+    /// relative to that leaf node.External Commits MUST be signed by the new
+    /// member. In particular, the signature on the enclosing MLSPlaintext MUST
+    /// verify using the public key for the credential in the leaf_key_package
+    /// of the path field.When processing a Commit, both existing and new
+    /// members MUST use the external init secret as described in Section
+    /// 8.1.The sender type for the MLSPlaintext encapsulating the External
+    /// Commit MUST be new_member
     pub fn validate_add_proposals(
         &self,
         staged_proposal_queue: &StagedProposalQueue,

--- a/openmls/src/group/mls_group/validation.rs
+++ b/openmls/src/group/mls_group/validation.rs
@@ -85,34 +85,6 @@ impl MlsGroup {
     ///  - ValSem104
     ///  - ValSem105
     ///  - TODO: ValSem106
-    ///  - TODO: Assign ValSem ID to checks relating to external init. In
-    ///  particular (quote from the spec):
-    ///
-    /// External Commits work like regular Commits, with a few differences:
-    /// The proposals included by value in an External Commit MUST meet the
-    /// following conditions:
-    ///
-    /// * There MUST be a single ExternalInit proposal
-    ///
-    /// * There MUST NOT be any Add or Update proposalsIf a Remove proposal is
-    /// present, then the credential and endpoint_id of the removed leaf MUST be
-    /// the same as the corresponding values in the Add KeyPackage.
-    ///
-    /// * The proposals included by reference in an External Commit MUST meet
-    /// the following conditions:
-    ///
-    /// * There MUST NOT be any ExternalInit proposals
-    ///
-    /// * External Commits MUST contain a path field (and is therefore a "full"
-    /// Commit). The joiner is added at the leftmost free leaf node (just as if
-    /// they were added with an Add proposal), and the path is calculated
-    /// relative to that leaf node.External Commits MUST be signed by the new
-    /// member. In particular, the signature on the enclosing MLSPlaintext MUST
-    /// verify using the public key for the credential in the leaf_key_package
-    /// of the path field.When processing a Commit, both existing and new
-    /// members MUST use the external init secret as described in Section
-    /// 8.1.The sender type for the MLSPlaintext encapsulating the External
-    /// Commit MUST be new_member
     pub fn validate_add_proposals(
         &self,
         staged_proposal_queue: &StagedProposalQueue,

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -13,8 +13,8 @@ use crate::{
     config::{Config, ProtocolVersion},
     credentials::{Credential, CredentialBundle, CredentialType},
     group::{
-        update_confirmed_transcript_hash, update_interim_transcript_hash, GroupContext, GroupEpoch,
-        GroupId, WireFormat,
+        create_commit_params::CommitType, update_confirmed_transcript_hash,
+        update_interim_transcript_hash, GroupContext, GroupEpoch, GroupId, WireFormat,
     },
     messages::Commit,
     prelude::{
@@ -101,6 +101,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
             proposals: vec![].into(),
             path: None,
         },
+        CommitType::Internal,
         &credential_bundle,
         &context,
         &crypto,

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -101,7 +101,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
             proposals: vec![].into(),
             path: None,
         },
-        CommitType::Internal,
+        CommitType::Member,
         &credential_bundle,
         &context,
         &crypto,

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -94,7 +94,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
         .random_vec(48)
         .expect("An unexpected error occurred.");
     let framing_parameters = FramingParameters::new(&aad, WireFormat::MlsPlaintext);
-    let mut commit = MlsPlaintext::new_commit(
+    let mut commit = MlsPlaintext::commit(
         framing_parameters,
         random_u32(),
         Commit {

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -203,7 +203,7 @@ fn build_handshake_messages(
             .expect("Not enough randomness."),
     );
     let framing_parameters = FramingParameters::new(&[1, 2, 3, 4], WireFormat::MlsCiphertext);
-    let mut plaintext = MlsPlaintext::new_proposal(
+    let mut plaintext = MlsPlaintext::member_proposal(
         framing_parameters,
         leaf,
         Proposal::Remove(RemoveProposal { removed: 0 }),


### PR DESCRIPTION
This PR allows the creation of Commits, MlsPlaintexts and Proposals with a `SenderType` other than `Member`. This is in preparation of the external init feature.