### PR TITLE
Assert that only members add a context to MlsPlaintextTBS

### DIFF
--- a/openmls/src/framing/codec.rs
+++ b/openmls/src/framing/codec.rs
@@ -148,6 +148,8 @@ pub(super) fn serialize_plaintext_tbs<'a, W: Write>(
     buffer: &mut W,
 ) -> Result<usize, tls_codec::Error> {
     let mut written = if let Some(serialized_context) = serialized_context.into() {
+        // Only a member should have a context.
+        debug_assert_eq!(sender.sender_type, SenderType::Member);
         buffer.write(serialized_context)?
     } else {
         0


### PR DESCRIPTION
At this point the sender type is always member. This will change in future though.
But the context should only be present for members.
That's why we just assert this here.

Fixes #477