### PR TITLE
Rename MlsGroup to CoreGroup

### DIFF
--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -25,7 +25,7 @@ pub struct Group {
     group_aad: Vec<u8>,
     members: Vec<Vec<u8>>,
     conversation: Conversation,
-    mls_group: RefCell<MlsGroup>,
+    core_group: RefCell<CoreGroup>,
     pending_proposals: Vec<MlsPlaintext>,
 }
 
@@ -95,7 +95,7 @@ impl User {
             None => return Err("Unknown group".to_string()),
         };
 
-        let mls_ciphertext = match group.mls_group.borrow_mut().create_application_message(
+        let mls_ciphertext = match group.core_group.borrow_mut().create_application_message(
             &group.group_aad,
             msg.as_bytes(),
             &self.identity.borrow().credential,
@@ -135,7 +135,7 @@ impl User {
                 Message::MlsMessage(message) => {
                     let mut groups = self.groups.borrow_mut();
                     let mut group = match groups.get(message.group_id()) {
-                        Some(g) => g.mls_group.borrow_mut(),
+                        Some(g) => g.core_group.borrow_mut(),
                         None => {
                             log::error!(
                                 "Error getting group {:?} for a message. Dropping message.",
@@ -218,15 +218,15 @@ impl User {
                                     .map_err(|e| format!("{}", e))?,
                                 )
                             }
-                            let mut mls_group = group.mls_group.borrow_mut();
-                            match mls_group.stage_commit(
+                            let mut core_group = group.core_group.borrow_mut();
+                            match core_group.stage_commit(
                                 &msg,
                                 &proposal_store,
                                 &[], // TODO: store key packages.
                                 &self.crypto,
                             ) {
                                 Ok(staged_commit) => {
-                                    mls_group
+                                    core_group
                                         .merge_commit(staged_commit)
                                         .map_err(|e| format!("{}", e))?;
                                 }
@@ -273,11 +273,11 @@ impl User {
         let mut group_aad = group_id.to_vec();
         group_aad.extend(b" AAD");
         let kpb = self.identity.borrow_mut().update(&self.crypto);
-        let config = MlsGroupConfig {
+        let config = CoreGroupConfig {
             add_ratchet_tree_extension: true,
             ..Default::default()
         };
-        let mls_group = MlsGroup::builder(GroupId::from_slice(group_id), kpb)
+        let core_group = CoreGroup::builder(GroupId::from_slice(group_id), kpb)
             .with_config(config)
             .build(&self.crypto)
             .unwrap();
@@ -286,7 +286,7 @@ impl User {
             group_name: name.clone(),
             members: Vec::new(),
             conversation: Conversation::default(),
-            mls_group: RefCell::new(mls_group),
+            core_group: RefCell::new(core_group),
             group_aad,
             pending_proposals: Vec::new(),
         };
@@ -327,7 +327,7 @@ impl User {
         // Framing parameters
         let framing_parameters = FramingParameters::new(&group.group_aad, WireFormat::MlsPlaintext);
         let add_proposal = group
-            .mls_group
+            .core_group
             .borrow()
             .create_add_proposal(framing_parameters, credentials, key_package, &self.crypto)
             .expect("Could not create proposal.");
@@ -346,19 +346,19 @@ impl User {
             .force_self_update(false)
             .build();
         let (commit, welcome_msg, _kpb) = group
-            .mls_group
+            .core_group
             .borrow()
             .create_commit(params, &self.crypto)
             .expect("Error creating commit");
         let welcome_msg = welcome_msg.expect("Welcome message wasn't created by create_commit.");
 
         let staged_commit = group
-            .mls_group
+            .core_group
             .borrow_mut()
             .stage_commit(&commit, &proposal_store, &[], &self.crypto)
             .expect("error applying commit");
         group
-            .mls_group
+            .core_group
             .borrow_mut()
             .merge_commit(staged_commit)
             .map_err(|e| format!("{}", e))?;
@@ -399,7 +399,7 @@ impl User {
         log::debug!("{} joining group ...", self.username);
 
         let kpb = self.identity.borrow_mut().update(&self.crypto);
-        let mls_group = match MlsGroup::new_from_welcome(
+        let core_group = match CoreGroup::new_from_welcome(
             welcome,
             None, /* no public tree here, has to be in the extension */
             kpb,
@@ -413,14 +413,14 @@ impl User {
             }
         };
 
-        let group_id = mls_group.group_id();
+        let group_id = core_group.group_id();
         // XXX: Add application layer protocol for name etc.
         let group_name = String::from_utf8(group_id.to_vec()).unwrap();
         let group_aad = group_name.clone() + " AAD";
         let group_id = group_id.to_vec();
 
         // FIXME
-        let members: Vec<Vec<u8>> = mls_group
+        let members: Vec<Vec<u8>> = core_group
             .members()
             .map_err(|e| format!("{}", e))?
             .into_iter()
@@ -432,7 +432,7 @@ impl User {
             group_name: group_name.clone(),
             members,
             conversation: Conversation::default(),
-            mls_group: RefCell::new(mls_group),
+            core_group: RefCell::new(core_group),
             group_aad: group_aad.as_bytes().to_vec(),
             pending_proposals: Vec::new(),
         };

--- a/delivery-service/ds-lib/src/lib.rs
+++ b/delivery-service/ds-lib/src/lib.rs
@@ -119,7 +119,7 @@ pub enum MessageType {
     Welcome = 2,
 }
 
-/// An MLS group message.
+/// An core group message.
 /// This is an `MLSMessage` plus the list of recipients as a vector of client
 /// names.
 #[derive(Debug)]

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -175,7 +175,7 @@ async fn test_group() {
     let group_aad = b"MyFirstGroup AAD";
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
     let group_ciphersuite = key_package_bundles[0].key_package().ciphersuite_name();
-    let mut group = MlsGroup::builder(GroupId::from_slice(group_id), key_package_bundles.remove(0))
+    let mut group = CoreGroup::builder(GroupId::from_slice(group_id), key_package_bundles.remove(0))
         .build(crypto)
         .unwrap();
 
@@ -277,7 +277,7 @@ async fn test_group() {
     assert_eq!(welcome_msg, welcome_message);
     assert!(messages.is_empty());
 
-    let mut group_on_client2 = MlsGroup::new_from_welcome(
+    let mut group_on_client2 = CoreGroup::new_from_welcome(
         welcome_message,
         Some(group.treesync().export_nodes()), // delivered out of band
         key_package_bundles.remove(0),

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -57,7 +57,7 @@ impl TryFrom<i32> for TestVectorType {
 /// doesn't consider scenarios where a credential is re-used across groups, so
 /// this simple structure is sufficient.
 pub struct InteropGroup {
-    group: MlsGroup,
+    group: CoreGroup,
     wire_format: WireFormat,
     credential_bundle: CredentialBundle,
     own_kpbs: Vec<KeyPackageBundle>,
@@ -89,7 +89,7 @@ impl MlsClientImpl {
     }
 }
 
-fn into_status(e: MlsGroupError) -> Status {
+fn into_status(e: CoreGroupError) -> Status {
     let message = "managed group error ".to_string() + &e.to_string();
     tonic::Status::new(tonic::Code::Aborted, message)
 }
@@ -414,11 +414,11 @@ impl MlsClient for MlsClientImpl {
             vec![],
         )
         .unwrap();
-        let config = MlsGroupConfig {
+        let config = CoreGroupConfig {
             add_ratchet_tree_extension: true,
             ..Default::default()
         };
-        let group = MlsGroup::builder(
+        let group = CoreGroup::builder(
             GroupId::from_slice(&create_group_request.group_id),
             key_package_bundle,
         )
@@ -505,7 +505,7 @@ impl MlsClient for MlsClientImpl {
                     "No key package could be found for the given Welcome message.",
                 )
             })?;
-        let group = MlsGroup::new_from_welcome(welcome, None, kpb, &self.crypto_provider)
+        let group = CoreGroup::new_from_welcome(welcome, None, kpb, &self.crypto_provider)
             .map_err(into_status)?;
 
         let interop_group = InteropGroup {

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -128,13 +128,13 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
     .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
-    let config = MlsGroupConfig {
+    let config = CoreGroupConfig {
         add_ratchet_tree_extension: true,
-        ..MlsGroupConfig::default()
+        ..CoreGroupConfig::default()
     };
 
     // === Alice creates a group with the ratchet tree extension ===
-    let mut alice_group = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .with_config(config)
         .build(backend)
         .expect("Error creating group.");
@@ -171,7 +171,7 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
         .merge_commit(staged_commit)
         .expect("error merging commit");
 
-    let bob_group = match MlsGroup::new_from_welcome(
+    let bob_group = match CoreGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         None,
         bob_key_package_bundle,
@@ -211,12 +211,12 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
     .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
-    let config = MlsGroupConfig {
+    let config = CoreGroupConfig {
         add_ratchet_tree_extension: false,
-        ..MlsGroupConfig::default()
+        ..CoreGroupConfig::default()
     };
 
-    let mut alice_group = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .with_config(config)
         .build(backend)
         .expect("Error creating group.");
@@ -253,7 +253,7 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
         .merge_commit(staged_commit)
         .expect("error merging commit");
 
-    let error = MlsGroup::new_from_welcome(
+    let error = CoreGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         None,
         bob_key_package_bundle,
@@ -264,7 +264,7 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
     // We expect an error because the ratchet tree is missing
     assert_eq!(
         error.expect("We expected an error"),
-        MlsGroupError::WelcomeError(WelcomeError::MissingRatchetTree)
+        CoreGroupError::WelcomeError(WelcomeError::MissingRatchetTree)
     );
 }
 

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -380,7 +380,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
     .expect("An unexpected error occurred.");
 
     // Alice creates a group
-    let mut group_alice = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut group_alice = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .build(backend)
         .expect("Error creating group.");
 
@@ -450,7 +450,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
         .merge_commit(staged_commit)
         .expect("error merging commit");
 
-    let mut group_charlie = MlsGroup::new_from_welcome(
+    let mut group_charlie = CoreGroup::new_from_welcome(
         welcome_option.expect("An unexpected error occurred."),
         Some(group_alice.treesync().export_nodes()),
         charlie_key_package_bundle,
@@ -537,7 +537,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
     let received_message = group_charlie.verify(received_message, backend);
     assert_eq!(
         received_message.unwrap_err(),
-        MlsGroupError::MlsPlaintextError(MlsPlaintextError::UnknownSender)
+        CoreGroupError::MlsPlaintextError(MlsPlaintextError::UnknownSender)
     );
 
     // Alice sends a message with a sender that is outside of the group
@@ -573,7 +573,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
     let received_message = group_charlie.decrypt(&enc_message, backend);
     assert_eq!(
         received_message.unwrap_err(),
-        MlsGroupError::MlsCiphertextError(MlsCiphertextError::GenerationOutOfBound)
+        CoreGroupError::MlsCiphertextError(MlsCiphertextError::GenerationOutOfBound)
     );
 }
 
@@ -620,7 +620,7 @@ fn confirmation_tag_presence(
     .expect("An unexpected error occurred.");
 
     // Alice creates a group
-    let mut group_alice = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut group_alice = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .build(backend)
         .expect("Error creating group.");
 
@@ -657,7 +657,7 @@ fn confirmation_tag_presence(
 
     assert_eq!(
         err,
-        MlsGroupError::StageCommitError(StageCommitError::ConfirmationTagMissing)
+        CoreGroupError::StageCommitError(StageCommitError::ConfirmationTagMissing)
     );
 }
 
@@ -704,7 +704,7 @@ fn invalid_plaintext_signature(
     .expect("An unexpected error occurred.");
 
     // Alice creates a group
-    let mut group_alice = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut group_alice = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .build(backend)
         .expect("Error creating group.");
 
@@ -751,7 +751,7 @@ fn invalid_plaintext_signature(
 
     assert_eq!(
         membership_error,
-        MlsGroupError::MlsPlaintextError(MlsPlaintextError::VerificationError(
+        CoreGroupError::MlsPlaintextError(MlsPlaintextError::VerificationError(
             VerificationError::MissingMembershipTag
         ))
     );
@@ -769,7 +769,7 @@ fn invalid_plaintext_signature(
 
     assert_eq!(
         membership_error,
-        MlsGroupError::MlsPlaintextError(MlsPlaintextError::VerificationError(
+        CoreGroupError::MlsPlaintextError(MlsPlaintextError::VerificationError(
             VerificationError::InvalidMembershipTag
         ))
     );
@@ -797,7 +797,7 @@ fn invalid_plaintext_signature(
         decoded_commit
             .err()
             .expect("group.verify() should have returned an error"),
-        MlsGroupError::MlsPlaintextError(MlsPlaintextError::CredentialError(
+        CoreGroupError::MlsPlaintextError(MlsPlaintextError::CredentialError(
             CredentialError::InvalidSignature
         ))
     );
@@ -815,7 +815,7 @@ fn invalid_plaintext_signature(
         .expect_err("Staging commit should have yielded an error.");
     assert_eq!(
         error,
-        MlsGroupError::StageCommitError(StageCommitError::ConfirmationTagMissing)
+        CoreGroupError::StageCommitError(StageCommitError::ConfirmationTagMissing)
     );
 
     // Tamper with confirmation tag.
@@ -838,7 +838,7 @@ fn invalid_plaintext_signature(
         .expect_err("Staging commit should have yielded an error.");
     assert_eq!(
         error,
-        MlsGroupError::StageCommitError(StageCommitError::ConfirmationTagMismatch)
+        CoreGroupError::StageCommitError(StageCommitError::ConfirmationTagMismatch)
     );
     let serialized_group_after =
         serde_json::to_string(&group_alice).expect("An unexpected error occurred.");

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -1,4 +1,4 @@
-//! # MLS Group errors
+//! # MLS CoreGroup errors
 //!
 //! `WelcomeError`, `StageCommitError`, `DecryptionError`, and
 //! `CreateCommitError`.
@@ -18,7 +18,7 @@ use openmls_traits::types::CryptoError;
 use tls_codec::Error as TlsCodecError;
 
 implement_error! {
-    pub enum MlsGroupError {
+    pub enum CoreGroupError {
         Simple {
             InitSecretNotFound =
                 "Missing init secret when creating commit.",

--- a/openmls/src/group/managed_group/creation.rs
+++ b/openmls/src/group/managed_group/creation.rs
@@ -23,11 +23,11 @@ impl ManagedGroup {
             .key_store()
             .delete(&kph)
             .map_err(|_| ManagedGroupError::KeyStoreError)?;
-        let group_config = MlsGroupConfig {
+        let group_config = CoreGroupConfig {
             add_ratchet_tree_extension: managed_group_config.use_ratchet_tree_extension,
             ..Default::default()
         };
-        let group = MlsGroup::builder(group_id, key_package_bundle)
+        let group = CoreGroup::builder(group_id, key_package_bundle)
             .with_config(group_config)
             .with_required_capabilities(managed_group_config.required_capabilities.clone())
             .build(backend)?;
@@ -69,7 +69,8 @@ impl ManagedGroup {
             })
             .ok_or(ManagedGroupError::NoMatchingKeyPackageBundle)?;
         // TODO #141
-        let group = MlsGroup::new_from_welcome(welcome, ratchet_tree, key_package_bundle, backend)?;
+        let group =
+            CoreGroup::new_from_welcome(welcome, ratchet_tree, key_package_bundle, backend)?;
 
         let managed_group = ManagedGroup {
             managed_group_config: managed_group_config.clone(),

--- a/openmls/src/group/managed_group/errors.rs
+++ b/openmls/src/group/managed_group/errors.rs
@@ -7,7 +7,7 @@ use crate::config::ConfigError;
 use crate::credentials::CredentialError;
 use crate::error::ErrorString;
 use crate::framing::MlsCiphertextError;
-use crate::group::{CreateCommitError, ExporterError, MlsGroupError, StageCommitError};
+use crate::group::{CoreGroupError, CreateCommitError, ExporterError, StageCommitError};
 use crate::prelude::ValidationError;
 use crate::treesync::TreeSyncError;
 use openmls_traits::types::CryptoError;
@@ -27,8 +27,8 @@ implement_error! {
                 "An internal library error occurred. Additional detail is provided.",
             Config(ConfigError) =
                 "See [`ConfigError`](`crate::config::ConfigError`) for details",
-            Group(MlsGroupError) =
-                "See [`MlsGroupError`](`crate::group::MlsGroupError`) for details",
+            Group(CoreGroupError) =
+                "See [`CoreGroupError`](`crate::group::CoreGroupError`) for details",
             CreateCommit(CreateCommitError) =
                 "See [`CreateCommitError`](`crate::group::CreateCommitError`) for details",
             UseAfterEviction(UseAfterEviction) =
@@ -94,8 +94,8 @@ implement_error! {
                 "An invalid ciphertext was provided. The error returns the associated data of the ciphertext.",
             CommitError(StageCommitError) =
                 "See [`StageCommitError`](`crate::group::StageCommitError`) for details",
-            GroupError(MlsGroupError) =
-                "See [`MlsGroupError`](`crate::group::MlsGroupError`) for details",
+            GroupError(CoreGroupError) =
+                "See [`CoreGroupError`](`crate::group::CoreGroupError`) for details",
         }
     }
 }

--- a/openmls/src/group/managed_group/mod.rs
+++ b/openmls/src/group/managed_group/mod.rs
@@ -40,7 +40,7 @@ use ser::*;
 use super::past_secrets::MessageSecretsStore;
 use super::proposals::{ProposalStore, StagedProposal};
 
-/// A `ManagedGroup` represents an [MlsGroup] with
+/// A `ManagedGroup` represents an [CoreGroup] with
 /// an easier, high-level API designed to be used in production. The API exposes
 /// high level functions to manage a group by adding/removing members, get the
 /// current member list, etc.
@@ -72,9 +72,9 @@ use super::proposals::{ProposalStore, StagedProposal};
 pub struct ManagedGroup {
     // The group configuration. See `ManagedGroupCongig` for more information.
     managed_group_config: ManagedGroupConfig,
-    // the internal `MlsGroup` used for lower level operations. See `MlsGroup` for more
+    // the internal `CoreGroup` used for lower level operations. See `CoreGroup` for more
     // information.
-    group: MlsGroup,
+    group: CoreGroup,
     // A [ProposalStore] that stores incoming proposals from the DS within one epoch.
     // The store is emptied after every epoch change.
     proposal_store: ProposalStore,
@@ -207,9 +207,9 @@ impl ManagedGroup {
         _print_tree(self.group.treesync(), message)
     }
 
-    /// Get the underlying [MlsGroup].
+    /// Get the underlying [CoreGroup].
     #[cfg(any(feature = "test-utils", test))]
-    pub fn group(&self) -> &MlsGroup {
+    pub fn group(&self) -> &CoreGroup {
         &self.group
     }
 }

--- a/openmls/src/group/managed_group/ser.rs
+++ b/openmls/src/group/managed_group/ser.rs
@@ -7,7 +7,7 @@ use serde::{
 #[derive(Serialize, Deserialize)]
 pub struct SerializedManagedGroup {
     managed_group_config: ManagedGroupConfig,
-    group: MlsGroup,
+    group: CoreGroup,
     proposal_store: ProposalStore,
     message_secrets_store: MessageSecretsStore,
     own_kpbs: Vec<KeyPackageBundle>,

--- a/openmls/src/group/managed_group/test_managed_group.rs
+++ b/openmls/src/group/managed_group/test_managed_group.rs
@@ -410,7 +410,7 @@ fn test_invalid_plaintext(ciphersuite: &'static Ciphersuite) {
         .expect_err("No error when distributing message with invalid signature.");
 
     assert_eq!(
-        ClientError::ManagedGroupError(ManagedGroupError::Group(MlsGroupError::ValidationError(
+        ClientError::ManagedGroupError(ManagedGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::MlsPlaintextError(MlsPlaintextError::VerificationError(
                 VerificationError::InvalidMembershipTag
             ))
@@ -434,7 +434,7 @@ fn test_invalid_plaintext(ciphersuite: &'static Ciphersuite) {
 
     assert_eq!(
         ClientError::ManagedGroupError(ManagedGroupError::Group(
-            MlsGroupError::FramingValidationError(FramingValidationError::UnknownMember)
+            CoreGroupError::FramingValidationError(FramingValidationError::UnknownMember)
         )),
         error
     );

--- a/openmls/src/group/mls_group/apply_proposals.rs
+++ b/openmls/src/group/mls_group/apply_proposals.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{
     proposals::{CreationProposalQueue, StagedProposalQueue},
-    MlsGroup,
+    CoreGroup,
 };
 
 /// This struct contain the return values of the `apply_proposals()` function
@@ -44,7 +44,7 @@ impl ApplyProposalsValues {
 /// current epoch `updates_key_package_bundles` is the list of own
 /// KeyPackageBundles corresponding to updates or commits sent in the
 /// current epoch
-impl MlsGroup {
+impl CoreGroup {
     pub(crate) fn apply_proposals(
         &self,
         diff: &mut TreeSyncDiff,

--- a/openmls/src/group/mls_group/create_commit.rs
+++ b/openmls/src/group/mls_group/create_commit.rs
@@ -34,7 +34,7 @@ struct PathProcessingResult {
     key_package_bundle: Option<KeyPackageBundle>,
 }
 
-impl MlsGroup {
+impl CoreGroup {
     pub fn create_commit(
         &self,
         params: CreateCommitParams,
@@ -148,7 +148,7 @@ impl MlsGroup {
             // It is ok to a library error here, because we know the MlsPlaintext contains a
             // Commit
             &MlsPlaintextCommitContent::try_from(&mls_plaintext)
-                .map_err(|_| MlsGroupError::LibraryError)?,
+                .map_err(|_| CoreGroupError::LibraryError)?,
             &self.interim_transcript_hash,
         )?;
 
@@ -169,7 +169,7 @@ impl MlsGroup {
             path_processing_result.commit_secret,
             self.group_epoch_secrets()
                 .init_secret()
-                .ok_or(MlsGroupError::InitSecretNotFound)?,
+                .ok_or(CoreGroupError::InitSecretNotFound)?,
         )?;
 
         // Create group secrets for later use, so we can afterwards consume the

--- a/openmls/src/group/mls_group/create_commit_params.rs
+++ b/openmls/src/group/mls_group/create_commit_params.rs
@@ -1,4 +1,4 @@
-//! Builder for [CreateCommitParams] that is used in [MlsGroup::create_commit()]
+//! Builder for [CreateCommitParams] that is used in [CoreGroup::create_commit()]
 
 use super::{proposals::ProposalStore, *};
 

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -53,15 +53,15 @@ use std::io::{Error, Read, Write};
 use tls_codec::Serialize as TlsSerializeTrait;
 
 use super::errors::{
-    ExporterError, FramingValidationError, MlsGroupError, ProposalValidationError,
+    CoreGroupError, ExporterError, FramingValidationError, ProposalValidationError,
 };
 
 pub type CreateCommitResult =
-    Result<(MlsPlaintext, Option<Welcome>, Option<KeyPackageBundle>), MlsGroupError>;
+    Result<(MlsPlaintext, Option<Welcome>, Option<KeyPackageBundle>), CoreGroupError>;
 
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
-pub struct MlsGroup {
+pub struct CoreGroup {
     ciphersuite: &'static Ciphersuite,
     group_context: GroupContext,
     group_epoch_secrets: GroupEpochSecrets,
@@ -77,7 +77,7 @@ pub struct MlsGroup {
 }
 
 implement_persistence!(
-    MlsGroup,
+    CoreGroup,
     group_context,
     group_epoch_secrets,
     message_secrets,
@@ -87,18 +87,18 @@ implement_persistence!(
     mls_version
 );
 
-/// Builder for [`MlsGroup`].
-pub struct MlsGroupBuilder {
+/// Builder for [`CoreGroup`].
+pub struct CoreGroupBuilder {
     key_package_bundle: KeyPackageBundle,
     group_id: GroupId,
-    config: Option<MlsGroupConfig>,
+    config: Option<CoreGroupConfig>,
     psk_ids: Vec<PreSharedKeyId>,
     version: Option<ProtocolVersion>,
     required_capabilities: Option<RequiredCapabilitiesExtension>,
 }
 
-impl MlsGroupBuilder {
-    /// Create a new [`MlsGroupBuilder`].
+impl CoreGroupBuilder {
+    /// Create a new [`CoreGroupBuilder`].
     pub fn new(group_id: GroupId, key_package_bundle: KeyPackageBundle) -> Self {
         Self {
             key_package_bundle,
@@ -109,22 +109,22 @@ impl MlsGroupBuilder {
             required_capabilities: None,
         }
     }
-    /// Set the [`MlsGroupConfig`] of the [`MlsGroup`].
-    pub fn with_config(mut self, config: MlsGroupConfig) -> Self {
+    /// Set the [`CoreGroupConfig`] of the [`CoreGroup`].
+    pub fn with_config(mut self, config: CoreGroupConfig) -> Self {
         self.config = Some(config);
         self
     }
-    /// Set the [`Vec<PreSharedKeyId>`] of the [`MlsGroup`].
+    /// Set the [`Vec<PreSharedKeyId>`] of the [`CoreGroup`].
     pub fn with_psk(mut self, psk_ids: Vec<PreSharedKeyId>) -> Self {
         self.psk_ids = psk_ids;
         self
     }
-    /// Set the [`ProtocolVersion`] of the [`MlsGroup`].
+    /// Set the [`ProtocolVersion`] of the [`CoreGroup`].
     pub fn with_version(mut self, version: ProtocolVersion) -> Self {
         self.version = Some(version);
         self
     }
-    /// Set the [`RequiredCapabilitiesExtension`] of the [`MlsGroup`].
+    /// Set the [`RequiredCapabilitiesExtension`] of the [`CoreGroup`].
     pub fn with_required_capabilities(
         mut self,
         required_capabilities: RequiredCapabilitiesExtension,
@@ -133,13 +133,13 @@ impl MlsGroupBuilder {
         self
     }
 
-    /// Build the [`MlsGroup`].
+    /// Build the [`CoreGroup`].
     /// Any values that haven't been set in the builder are set to their default
     /// values (which might be random).
     ///
     /// This function performs cryptographic operations and there requires an
     /// [`OpenMlsCryptoProvider`].
-    pub fn build(self, backend: &impl OpenMlsCryptoProvider) -> Result<MlsGroup, MlsGroupError> {
+    pub fn build(self, backend: &impl OpenMlsCryptoProvider) -> Result<CoreGroup, CoreGroupError> {
         let ciphersuite = self.key_package_bundle.key_package().ciphersuite();
         let config = self.config.unwrap_or_default();
         let required_capabilities = self.required_capabilities.unwrap_or_default();
@@ -182,7 +182,7 @@ impl MlsGroupBuilder {
 
         let interim_transcript_hash = vec![];
 
-        Ok(MlsGroup {
+        Ok(CoreGroup {
             ciphersuite,
             group_context,
             group_epoch_secrets,
@@ -195,11 +195,11 @@ impl MlsGroupBuilder {
     }
 }
 
-/// Public [`MlsGroup`] functions.
-impl MlsGroup {
-    /// Get a builder for [`MlsGroup`].
-    pub fn builder(group_id: GroupId, key_package_bundle: KeyPackageBundle) -> MlsGroupBuilder {
-        MlsGroupBuilder::new(group_id, key_package_bundle)
+/// Public [`CoreGroup`] functions.
+impl CoreGroup {
+    /// Get a builder for [`CoreGroup`].
+    pub fn builder(group_id: GroupId, key_package_bundle: KeyPackageBundle) -> CoreGroupBuilder {
+        CoreGroupBuilder::new(group_id, key_package_bundle)
     }
 
     // Join a group from a welcome message
@@ -208,7 +208,7 @@ impl MlsGroup {
         nodes_option: Option<Vec<Option<Node>>>,
         kpb: KeyPackageBundle,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<Self, MlsGroupError> {
+    ) -> Result<Self, CoreGroupError> {
         Ok(Self::new_from_welcome_internal(
             welcome,
             nodes_option,
@@ -230,7 +230,7 @@ impl MlsGroup {
         credential_bundle: &CredentialBundle,
         joiner_key_package: KeyPackage,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<MlsPlaintext, MlsGroupError> {
+    ) -> Result<MlsPlaintext, CoreGroupError> {
         joiner_key_package.validate_required_capabilities(self.required_capabilities())?;
         let add_proposal = AddProposal {
             key_package: joiner_key_package,
@@ -258,7 +258,7 @@ impl MlsGroup {
         credential_bundle: &CredentialBundle,
         key_package: KeyPackage,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<MlsPlaintext, MlsGroupError> {
+    ) -> Result<MlsPlaintext, CoreGroupError> {
         let update_proposal = UpdateProposal { key_package };
         let proposal = Proposal::Update(update_proposal);
         MlsPlaintext::member_proposal(
@@ -283,7 +283,7 @@ impl MlsGroup {
         credential_bundle: &CredentialBundle,
         removed_index: LeafIndex,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<MlsPlaintext, MlsGroupError> {
+    ) -> Result<MlsPlaintext, CoreGroupError> {
         let remove_proposal = RemoveProposal {
             removed: removed_index,
         };
@@ -310,7 +310,7 @@ impl MlsGroup {
         credential_bundle: &CredentialBundle,
         psk: PreSharedKeyId,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<MlsPlaintext, MlsGroupError> {
+    ) -> Result<MlsPlaintext, CoreGroupError> {
         let presharedkey_proposal = PreSharedKeyProposal::new(psk);
         let proposal = Proposal::PreSharedKey(presharedkey_proposal);
         MlsPlaintext::member_proposal(
@@ -332,7 +332,7 @@ impl MlsGroup {
         credential_bundle: &CredentialBundle,
         extensions: &[Extension],
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<MlsPlaintext, MlsGroupError> {
+    ) -> Result<MlsPlaintext, CoreGroupError> {
         // Ensure that the group supports all the extensions that are wanted.
         let required_extension = extensions
             .iter()
@@ -373,7 +373,7 @@ impl MlsGroup {
         credential_bundle: &CredentialBundle,
         padding_size: usize,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<MlsCiphertext, MlsGroupError> {
+    ) -> Result<MlsCiphertext, CoreGroupError> {
         let mls_plaintext = MlsPlaintext::new_application(
             self.sender_index(),
             aad,
@@ -392,7 +392,7 @@ impl MlsGroup {
         mls_plaintext: MlsPlaintext,
         padding_size: usize,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<MlsCiphertext, MlsGroupError> {
+    ) -> Result<MlsCiphertext, CoreGroupError> {
         log::trace!("{:?}", mls_plaintext.confirmation_tag());
         MlsCiphertext::try_from_plaintext(
             &mls_plaintext,
@@ -406,7 +406,7 @@ impl MlsGroup {
             self.message_secrets_mut(),
             padding_size,
         )
-        .map_err(MlsGroupError::MlsCiphertextError)
+        .map_err(CoreGroupError::MlsCiphertextError)
     }
 
     /// Decrypt an MlsCiphertext into an MlsPlaintext
@@ -414,7 +414,7 @@ impl MlsGroup {
         &mut self,
         mls_ciphertext: &MlsCiphertext,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<VerifiableMlsPlaintext, MlsGroupError> {
+    ) -> Result<VerifiableMlsPlaintext, CoreGroupError> {
         Ok(mls_ciphertext.to_plaintext(self.ciphersuite(), backend, &mut self.message_secrets)?)
     }
 
@@ -424,7 +424,7 @@ impl MlsGroup {
         &self,
         mut verifiable: VerifiableMlsPlaintext,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<MlsPlaintext, MlsGroupError> {
+    ) -> Result<MlsPlaintext, CoreGroupError> {
         // Verify the signature on the plaintext.
         let tree = self.treesync();
 
@@ -453,7 +453,7 @@ impl MlsGroup {
         &self,
         backend: &impl OpenMlsCryptoProvider,
         verifiable_mls_plaintext: &mut VerifiableMlsPlaintext,
-    ) -> Result<(), MlsGroupError> {
+    ) -> Result<(), CoreGroupError> {
         verifiable_mls_plaintext.set_context(self.context().tls_serialize_detached()?);
         Ok(verifiable_mls_plaintext
             .verify_membership(backend, self.message_secrets().membership_key())?)
@@ -466,7 +466,7 @@ impl MlsGroup {
         label: &str,
         context: &[u8],
         key_length: usize,
-    ) -> Result<Vec<u8>, MlsGroupError> {
+    ) -> Result<Vec<u8>, CoreGroupError> {
         if key_length > u16::MAX.into() {
             log::error!("Got a key that is larger than u16::MAX");
             return Err(ExporterError::KeyLengthTooLong.into());
@@ -483,14 +483,14 @@ impl MlsGroup {
     }
 
     /// Loads the state from persisted state
-    pub fn load<R: Read>(reader: R) -> Result<MlsGroup, Error> {
+    pub fn load<R: Read>(reader: R) -> Result<CoreGroup, Error> {
         serde_json::from_reader(reader).map_err(|e| e.into())
     }
 
     /// Persists the state
     pub fn save<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        let serialized_mls_group = serde_json::to_string_pretty(self)?;
-        writer.write_all(&serialized_mls_group.into_bytes())
+        let serialized_core_group = serde_json::to_string_pretty(self)?;
+        writer.write_all(&serialized_core_group.into_bytes())
     }
 
     /// Returns the ratchet tree
@@ -514,7 +514,7 @@ impl MlsGroup {
     }
 
     /// Get the members of the group, indexed by their leaves.
-    pub fn members(&self) -> Result<BTreeMap<LeafIndex, &Credential>, MlsGroupError> {
+    pub fn members(&self) -> Result<BTreeMap<LeafIndex, &Credential>, CoreGroupError> {
         Ok(self
             .tree
             .full_leaves()?
@@ -560,7 +560,7 @@ impl MlsGroup {
 }
 
 // Private and crate functions
-impl MlsGroup {
+impl CoreGroup {
     pub(crate) fn sender_index(&self) -> LeafIndex {
         self.tree.own_leaf_index()
     }
@@ -598,7 +598,7 @@ pub(crate) fn update_confirmed_transcript_hash(
     backend: &impl OpenMlsCryptoProvider,
     mls_plaintext_commit_content: &MlsPlaintextCommitContent,
     interim_transcript_hash: &[u8],
-) -> Result<Vec<u8>, MlsGroupError> {
+) -> Result<Vec<u8>, CoreGroupError> {
     let commit_content_bytes = mls_plaintext_commit_content.tls_serialize_detached()?;
     Ok(ciphersuite.hash(
         backend,

--- a/openmls/src/group/mls_group/new_from_welcome.rs
+++ b/openmls/src/group/mls_group/new_from_welcome.rs
@@ -10,14 +10,14 @@ use crate::messages::*;
 use crate::schedule::*;
 use crate::treesync::node::Node;
 
-impl MlsGroup {
+impl CoreGroup {
     pub(crate) fn new_from_welcome_internal(
         welcome: Welcome,
         nodes_option: Option<Vec<Option<Node>>>,
         key_package_bundle: KeyPackageBundle,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<Self, WelcomeError> {
-        log::debug!("MlsGroup::new_from_welcome_internal");
+        log::debug!("CoreGroup::new_from_welcome_internal");
         let mls_version = *welcome.version();
         if !Config::supported_versions().contains(&mls_version) {
             return Err(WelcomeError::UnsupportedMlsVersion);
@@ -179,7 +179,7 @@ impl MlsGroup {
             log_crypto!(trace, "  Expected: {:x?}", group_info.confirmation_tag());
             Err(WelcomeError::ConfirmationTagMismatch)
         } else {
-            Ok(MlsGroup {
+            Ok(CoreGroup {
                 ciphersuite,
                 group_context,
                 group_epoch_secrets,

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -10,7 +10,7 @@ use super::*;
 use core::fmt::Debug;
 use std::mem;
 
-impl MlsGroup {
+impl CoreGroup {
     /// Stages a commit message.
     /// This function does the following:
     ///  - Applies the proposals covered by the commit to the tree
@@ -19,7 +19,7 @@ impl MlsGroup {
     ///  - Initializes the key schedule for epoch rollover
     ///  - Verifies the confirmation tag/membership tag
     /// Returns a [StagedCommit] that can be inspected and later merged
-    /// into the group state with [MlsGroup::merge_commit()]
+    /// into the group state with [CoreGroup::merge_commit()]
     /// This function does the following checks:
     ///  - ValSem100
     ///  - ValSem101
@@ -40,7 +40,7 @@ impl MlsGroup {
         proposal_store: &ProposalStore,
         own_key_packages: &[KeyPackageBundle],
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<StagedCommit, MlsGroupError> {
+    ) -> Result<StagedCommit, CoreGroupError> {
         let ciphersuite = self.ciphersuite();
 
         // Extract the sender of the Commit message
@@ -191,7 +191,7 @@ impl MlsGroup {
             backend,
             // It is ok to use return a library error here, because we know the MlsPlaintext contains a Commit
             &MlsPlaintextCommitContent::try_from(mls_plaintext)
-                .map_err(|_| MlsGroupError::LibraryError)?,
+                .map_err(|_| CoreGroupError::LibraryError)?,
             &self.interim_transcript_hash,
         )?;
 
@@ -255,7 +255,7 @@ impl MlsGroup {
                 proposal,
                 *mls_plaintext.sender(),
             )
-            .map_err(|_| MlsGroupError::LibraryError)?;
+            .map_err(|_| CoreGroupError::LibraryError)?;
             proposal_queue.add(staged_proposal);
         }
 
@@ -282,7 +282,7 @@ impl MlsGroup {
     ///
     /// This function should not fail and only returns a [`Result`], because it
     /// might throw a `LibraryError`.
-    pub fn merge_commit(&mut self, staged_commit: StagedCommit) -> Result<(), MlsGroupError> {
+    pub fn merge_commit(&mut self, staged_commit: StagedCommit) -> Result<(), CoreGroupError> {
         if let Some(state) = staged_commit.state {
             self.group_context = state.group_context;
             self.group_epoch_secrets = state.group_epoch_secrets;
@@ -301,7 +301,7 @@ impl MlsGroup {
     pub fn merge_commit_take_message_secrets(
         &mut self,
         staged_commit: StagedCommit,
-    ) -> Result<Option<MessageSecrets>, MlsGroupError> {
+    ) -> Result<Option<MessageSecrets>, CoreGroupError> {
         Ok(if let Some(state) = staged_commit.state {
             self.group_context = state.group_context;
             self.group_epoch_secrets = state.group_epoch_secrets;

--- a/openmls/src/group/mls_group/test_duplicate_extension.rs
+++ b/openmls/src/group/mls_group/test_duplicate_extension.rs
@@ -51,14 +51,14 @@ fn duplicate_ratchet_tree_extension(
     .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
-    let config = MlsGroupConfig {
+    let config = CoreGroupConfig {
         add_ratchet_tree_extension: true,
-        ..MlsGroupConfig::default()
+        ..CoreGroupConfig::default()
     };
 
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
-    let mut alice_group = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .with_config(config)
         .build(backend)
         .expect("Error creating group.");
@@ -100,7 +100,7 @@ fn duplicate_ratchet_tree_extension(
     //  === Duplicate the ratchet tree extension ===
 
     // Find key_package in welcome secrets
-    let egs = MlsGroup::find_key_package_from_welcome_secrets(
+    let egs = CoreGroup::find_key_package_from_welcome_secrets(
         bob_key_package_bundle.key_package(),
         welcome.secrets(),
         backend,
@@ -169,11 +169,11 @@ fn duplicate_ratchet_tree_extension(
     welcome.set_encrypted_group_info(encrypted_group_info);
 
     // Try to join group
-    let error = MlsGroup::new_from_welcome(welcome, None, bob_key_package_bundle, backend).err();
+    let error = CoreGroup::new_from_welcome(welcome, None, bob_key_package_bundle, backend).err();
 
     // We expect an error because the ratchet tree is duplicated
     assert_eq!(
         error.expect("We expected an error"),
-        MlsGroupError::WelcomeError(WelcomeError::DuplicateRatchetTreeExtension)
+        CoreGroupError::WelcomeError(WelcomeError::DuplicateRatchetTreeExtension)
     );
 }

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 #[apply(ciphersuites_and_backends)]
-fn test_mls_group_persistence(
+fn test_core_group_persistence(
     ciphersuite: &'static Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) {
@@ -44,7 +44,7 @@ fn test_mls_group_persistence(
     .expect("An unexpected error occurred.");
 
     // Alice creates a group
-    let alice_group = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .build(backend)
         .expect("Error creating group.");
 
@@ -57,7 +57,7 @@ fn test_mls_group_persistence(
         .reopen()
         .expect("Error re-opening serialized group state file");
     let alice_group_deserialized =
-        MlsGroup::load(file_in).expect("Could not deserialize managed group");
+        CoreGroup::load(file_in).expect("Could not deserialize managed group");
 
     assert_eq!(alice_group, alice_group_deserialized);
 }
@@ -172,8 +172,8 @@ fn test_failed_groupinfo_decryption(
         );
 
         let error =
-            MlsGroup::new_from_welcome_internal(broken_welcome, None, key_package_bundle, backend)
-                .expect_err("Creation of MLS group from a broken Welcome was successful.");
+            CoreGroup::new_from_welcome_internal(broken_welcome, None, key_package_bundle, backend)
+                .expect_err("Creation of core group from a broken Welcome was successful.");
 
         assert_eq!(
             error,
@@ -225,7 +225,7 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
     let bob_key_package = bob_key_package_bundle.key_package();
 
     // === Alice creates a group ===
-    let mut alice_group = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .build(backend)
         .expect("Error creating group.");
 
@@ -273,7 +273,7 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .expect("error merging commit");
     let ratchet_tree = alice_group.treesync().export_nodes();
 
-    let group_bob = MlsGroup::new_from_welcome(
+    let group_bob = CoreGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,
@@ -374,7 +374,7 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         alice_group.stage_commit(&broken_plaintext, &proposal_store, &[], backend);
     assert_eq!(
         staged_commit_res.expect_err("Successful processing of a broken commit."),
-        MlsGroupError::TreeKemError(TreeKemError::PathSecretError(
+        CoreGroupError::TreeKemError(TreeKemError::PathSecretError(
             PathSecretError::DecryptionError(CryptoError::HpkeDecryptionError)
         ))
     );
@@ -435,7 +435,7 @@ fn test_psks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProv
         .key_store()
         .store(&preshared_key_id, &psk_bundle)
         .expect("An unexpected error occured.");
-    let mut alice_group = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .with_psk(vec![preshared_key_id.clone()])
         .build(backend)
         .expect("Error creating group.");
@@ -490,7 +490,7 @@ fn test_psks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProv
         .expect("error merging commit");
     let ratchet_tree = alice_group.treesync().export_nodes();
 
-    let group_bob = MlsGroup::new_from_welcome(
+    let group_bob = CoreGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,

--- a/openmls/src/group/mls_group/test_proposals.rs
+++ b/openmls/src/group/mls_group/test_proposals.rs
@@ -11,7 +11,7 @@ use crate::{
     framing::{FramingParameters, MlsPlaintext},
     group::{
         create_commit_params::CreateCommitParams,
-        errors::MlsGroupError,
+        errors::CoreGroupError,
         proposals::{CreationProposalQueue, ProposalStore, StagedProposal, StagedProposalQueue},
         GroupContext, GroupEpoch, GroupId, WireFormat,
     },
@@ -20,7 +20,7 @@ use crate::{
     schedule::MembershipKey,
 };
 
-use super::MlsGroup;
+use super::CoreGroup;
 
 fn setup_client(
     id: &str,
@@ -306,15 +306,15 @@ fn test_required_unsupported_proposals(
     let required_capabilities = RequiredCapabilitiesExtension::new(extensions, proposals);
 
     // This must fail because we don't actually support AppAck proposals
-    let e = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let e = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .with_required_capabilities(required_capabilities)
         .build(backend)
         .expect_err(
-            "MlsGroup creation must fail because AppAck proposals aren't supported in OpenMLS yet.",
+            "CoreGroup creation must fail because AppAck proposals aren't supported in OpenMLS yet.",
         );
     assert_eq!(
         e,
-        MlsGroupError::ConfigError(ConfigError::UnsupportedProposalType)
+        CoreGroupError::ConfigError(ConfigError::UnsupportedProposalType)
     )
 }
 
@@ -347,10 +347,10 @@ fn test_required_extension_key_package_mismatch(
     ];
     let required_capabilities = RequiredCapabilitiesExtension::new(extensions, proposals);
 
-    let alice_group = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .with_required_capabilities(required_capabilities)
         .build(backend)
-        .expect("Error creating MlsGroup.");
+        .expect("Error creating CoreGroup.");
 
     let e = alice_group
         .create_add_proposal(
@@ -362,7 +362,7 @@ fn test_required_extension_key_package_mismatch(
         .expect_err("Proposal was created even though the key package didn't support the required extensions.");
     assert_eq!(
         e,
-        MlsGroupError::KeyPackageError(KeyPackageError::UnsupportedExtension)
+        CoreGroupError::KeyPackageError(KeyPackageError::UnsupportedExtension)
     );
 }
 
@@ -398,10 +398,10 @@ fn test_group_context_extensions(
     ];
     let required_capabilities = RequiredCapabilitiesExtension::new(extensions, proposals);
 
-    let mut alice_group = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .with_required_capabilities(required_capabilities)
         .build(backend)
-        .expect("Error creating MlsGroup.");
+        .expect("Error creating CoreGroup.");
 
     let bob_add_proposal = alice_group
         .create_add_proposal(
@@ -439,7 +439,7 @@ fn test_group_context_extensions(
 
     // Make sure that Bob can join the group with the required extension in place
     // and Bob's key package supporting them.
-    let _bob_group = MlsGroup::new_from_welcome(
+    let _bob_group = CoreGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,
@@ -480,10 +480,10 @@ fn test_group_context_extension_proposal_fails(
     ];
     let required_capabilities = RequiredCapabilitiesExtension::new(extensions, proposals);
 
-    let mut alice_group = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .with_required_capabilities(required_capabilities)
         .build(backend)
-        .expect("Error creating MlsGroup.");
+        .expect("Error creating CoreGroup.");
 
     // Alice tries to add a required capability she doesn't support herself.
     let required_key_id = Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
@@ -498,7 +498,7 @@ fn test_group_context_extension_proposal_fails(
     ).expect_err("Alice was able to create a gce proposal with a required extensions she doesn't support.");
     assert_eq!(
         e,
-        MlsGroupError::KeyPackageError(KeyPackageError::UnsupportedExtension)
+        CoreGroupError::KeyPackageError(KeyPackageError::UnsupportedExtension)
     );
 
     // Well, this failed luckily.
@@ -538,7 +538,7 @@ fn test_group_context_extension_proposal_fails(
         .expect("error merging commit");
     let ratchet_tree = alice_group.treesync().export_nodes();
 
-    let bob_group = MlsGroup::new_from_welcome(
+    let bob_group = CoreGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,
@@ -558,7 +558,7 @@ fn test_group_context_extension_proposal_fails(
         .expect_err("Bob was able to create a gce proposal for an extension not supported by all other parties.");
     assert_eq!(
         e,
-        MlsGroupError::KeyPackageError(KeyPackageError::UnsupportedExtension)
+        CoreGroupError::KeyPackageError(KeyPackageError::UnsupportedExtension)
     );
 }
 
@@ -600,10 +600,10 @@ fn test_group_context_extension_proposal(
     ];
     let required_capabilities = RequiredCapabilitiesExtension::new(extensions, proposals);
 
-    let mut alice_group = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .with_required_capabilities(required_capabilities)
         .build(backend)
-        .expect("Error creating MlsGroup.");
+        .expect("Error creating CoreGroup.");
 
     // Adding Bob
     let bob_add_proposal = alice_group
@@ -640,7 +640,7 @@ fn test_group_context_extension_proposal(
         .expect("error merging commit");
     let ratchet_tree = alice_group.treesync().export_nodes();
 
-    let mut bob_group = MlsGroup::new_from_welcome(
+    let mut bob_group = CoreGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,

--- a/openmls/src/group/mls_group/validation.rs
+++ b/openmls/src/group/mls_group/validation.rs
@@ -5,13 +5,13 @@ use std::collections::HashSet;
 
 use super::{proposals::StagedProposalQueue, *};
 
-impl MlsGroup {
+impl CoreGroup {
     // === Messages ===
 
     /// Checks the following semantic validation:
     ///  - ValSem2
     ///  - ValSem3
-    pub fn validate_framing(&self, message: &MlsMessageIn) -> Result<(), MlsGroupError> {
+    pub fn validate_framing(&self, message: &MlsMessageIn) -> Result<(), CoreGroupError> {
         // ValSem2
         if message.group_id() != self.group_id() {
             return Err(FramingValidationError::WrongGroupId.into());
@@ -45,7 +45,7 @@ impl MlsGroup {
     pub fn validate_plaintext(
         &self,
         plaintext: &VerifiableMlsPlaintext,
-    ) -> Result<(), MlsGroupError> {
+    ) -> Result<(), CoreGroupError> {
         // ValSem4
         let sender = plaintext.sender();
         if sender.is_member() {
@@ -100,7 +100,7 @@ impl MlsGroup {
     pub fn validate_add_proposals(
         &self,
         staged_proposal_queue: &StagedProposalQueue,
-    ) -> Result<(), MlsGroupError> {
+    ) -> Result<(), CoreGroupError> {
         let add_proposals = staged_proposal_queue.add_proposals();
 
         let mut identity_set = HashSet::new();
@@ -167,7 +167,7 @@ impl MlsGroup {
     pub fn validate_remove_proposals(
         &self,
         staged_proposal_queue: &StagedProposalQueue,
-    ) -> Result<(), MlsGroupError> {
+    ) -> Result<(), CoreGroupError> {
         let remove_proposals = staged_proposal_queue.remove_proposals();
 
         let mut removes_set = HashSet::new();
@@ -198,7 +198,7 @@ impl MlsGroup {
         &self,
         staged_proposal_queue: &StagedProposalQueue,
         path_key_package: Option<(LeafIndex, &KeyPackage)>,
-    ) -> Result<(), MlsGroupError> {
+    ) -> Result<(), CoreGroupError> {
         let mut public_key_set = HashSet::new();
         for (_index, key_package) in self.treesync().full_leaves()? {
             let public_key = key_package.hpke_init_key().as_slice().to_vec();

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -23,8 +23,8 @@ use openmls_traits::OpenMlsCryptoProvider;
 pub(crate) use serde::{Deserialize, Serialize};
 
 pub use errors::{
-    CreateCommitError, ExporterError, FramingValidationError, InterimTranscriptHashError,
-    MlsGroupError, ProposalValidationError, StageCommitError, WelcomeError,
+    CoreGroupError, CreateCommitError, ExporterError, FramingValidationError,
+    InterimTranscriptHashError, ProposalValidationError, StageCommitError, WelcomeError,
 };
 pub use group_context::*;
 pub use managed_group::*;
@@ -108,9 +108,9 @@ impl GroupContext {
     }
 }
 
-/// Configuration for an MLS group.
+/// Configuration for core group.
 #[derive(Clone, Copy, Debug)]
-pub struct MlsGroupConfig {
+pub struct CoreGroupConfig {
     /// Flag whether to send the ratchet tree along with the `GroupInfo` or not.
     /// Defaults to false.
     pub add_ratchet_tree_extension: bool,
@@ -118,14 +118,14 @@ pub struct MlsGroupConfig {
     pub additional_as_epochs: u32,
 }
 
-impl MlsGroupConfig {
+impl CoreGroupConfig {
     /// Get the padding block size used in this config.
     pub fn padding_block_size(&self) -> u32 {
         self.padding_block_size
     }
 }
 
-impl Default for MlsGroupConfig {
+impl Default for CoreGroupConfig {
     fn default() -> Self {
         Self {
             add_ratchet_tree_extension: false,

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -65,7 +65,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
     let lifetime = LifetimeExtension::default();
 
     // Let's create a group
-    let mut group = MlsGroup::builder(GroupId::random(&crypto), key_package_bundle)
+    let mut group = CoreGroup::builder(GroupId::random(&crypto), key_package_bundle)
         .build(&crypto)
         .expect("Could not create group.");
 

--- a/openmls/src/group/tests/mod.rs
+++ b/openmls/src/group/tests/mod.rs
@@ -1,4 +1,4 @@
-//! Unit tests for the MLS group
+//! Unit tests for the core group
 
 pub mod kat_messages;
 pub mod kat_transcripts;

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -12,7 +12,7 @@ use crate::{
     credentials::{CredentialBundle, CredentialType},
     framing::{MlsCiphertextError, ProcessedMessage},
     group::{
-        GroupId, ManagedGroup, ManagedGroupConfig, ManagedGroupError, MlsGroupError, WireFormat,
+        CoreGroupError, GroupId, ManagedGroup, ManagedGroupConfig, ManagedGroupError, WireFormat,
     },
     key_packages::KeyPackageBundle,
     tree::secret_tree::SecretTreeError,
@@ -204,7 +204,7 @@ fn test_past_secrets_in_group(
                 .expect_err("An unexpected error occurred.");
             assert_eq!(
                 err,
-                ManagedGroupError::Group(MlsGroupError::MlsCiphertextError(
+                ManagedGroupError::Group(CoreGroupError::MlsCiphertextError(
                     MlsCiphertextError::SecretTreeError(SecretTreeError::TooDistantInThePast,),
                 ))
             );

--- a/openmls/src/group/tests/test_validation.rs
+++ b/openmls/src/group/tests/test_validation.rs
@@ -19,8 +19,8 @@ use crate::{
         ValidationError, VerifiableMlsPlaintext, VerificationError,
     },
     group::{
-        FramingValidationError, GroupEpoch, GroupId, ManagedGroup, ManagedGroupConfig,
-        ManagedGroupError, MlsGroupError, WireFormat,
+        CoreGroupError, FramingValidationError, GroupEpoch, GroupId, ManagedGroup,
+        ManagedGroupConfig, ManagedGroupError, WireFormat,
     },
     key_packages::{KeyPackage, KeyPackageBundle, KeyPackageError},
     prelude::ProcessedMessage,
@@ -235,7 +235,7 @@ fn test_valsem2(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(MlsGroupError::FramingValidationError(
+        ManagedGroupError::Group(CoreGroupError::FramingValidationError(
             FramingValidationError::WrongGroupId
         ))
     );
@@ -301,7 +301,7 @@ fn test_valsem3(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(MlsGroupError::FramingValidationError(
+        ManagedGroupError::Group(CoreGroupError::FramingValidationError(
             FramingValidationError::WrongEpoch
         ))
     );
@@ -317,7 +317,7 @@ fn test_valsem3(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(MlsGroupError::FramingValidationError(
+        ManagedGroupError::Group(CoreGroupError::FramingValidationError(
             FramingValidationError::WrongEpoch
         ))
     );
@@ -365,7 +365,7 @@ fn test_valsem4(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(MlsGroupError::FramingValidationError(
+        ManagedGroupError::Group(CoreGroupError::FramingValidationError(
             FramingValidationError::UnknownMember
         ))
     );
@@ -411,7 +411,7 @@ fn test_valsem5(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(MlsGroupError::ValidationError(
+        ManagedGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::UnencryptedApplicationMessage
         ))
     );
@@ -456,7 +456,7 @@ fn test_valsem6(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(MlsGroupError::ValidationError(
+        ManagedGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::MlsCiphertextError(MlsCiphertextError::DecryptionError)
         ))
     );
@@ -501,7 +501,7 @@ fn test_valsem7(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(MlsGroupError::ValidationError(
+        ManagedGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::MissingMembershipTag
         ))
     );
@@ -553,7 +553,7 @@ fn test_valsem8(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(MlsGroupError::ValidationError(
+        ManagedGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::MlsPlaintextError(MlsPlaintextError::VerificationError(
                 VerificationError::InvalidMembershipTag
             ))
@@ -603,7 +603,7 @@ fn test_valsem9(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(MlsGroupError::ValidationError(
+        ManagedGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::MissingConfirmationTag
         ))
     );
@@ -690,7 +690,7 @@ fn test_valsem10(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypto
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(MlsGroupError::ValidationError(
+        ManagedGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::CredentialError(CredentialError::InvalidSignature)
         ))
     );

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -3,7 +3,7 @@
 //! OpenMLS is an implementation of the [MLS RFC].
 //!
 //! The main entry point for most consumers should be the [ManagedGroup](prelude::ManagedGroup).
-//! It provides an safe, opinionated API for interacting with MLS groups.
+//! It provides an safe, opinionated API for interacting with core groups.
 //!
 //! ## Error handling
 //!

--- a/openmls/src/messages/public_group_state.rs
+++ b/openmls/src/messages/public_group_state.rs
@@ -13,7 +13,7 @@ use crate::{
         CiphersuiteName, HpkePublicKey, Signature,
     },
     extensions::Extension,
-    group::{GroupEpoch, GroupId, MlsGroup},
+    group::{CoreGroup, GroupEpoch, GroupId},
     treesync::LeafIndex,
 };
 
@@ -147,31 +147,31 @@ impl PublicGroupStateTbs {
     /// of the group.
     pub(crate) fn new(
         backend: &impl OpenMlsCryptoProvider,
-        mls_group: &MlsGroup,
+        core_group: &CoreGroup,
     ) -> Result<Self, CryptoError> {
-        let ciphersuite = mls_group.ciphersuite();
-        let external_pub = mls_group
+        let ciphersuite = core_group.ciphersuite();
+        let external_pub = core_group
             .group_epoch_secrets()
             .external_secret()
             .derive_external_keypair(backend.crypto(), ciphersuite)
             .public;
 
-        let group_id = mls_group.group_id().clone();
-        let epoch = mls_group.context().epoch();
-        let tree_hash = mls_group.treesync().tree_hash().into();
-        let interim_transcript_hash = mls_group.interim_transcript_hash().into();
-        let other_extensions = mls_group.other_extensions().into();
+        let group_id = core_group.group_id().clone();
+        let epoch = core_group.context().epoch();
+        let tree_hash = core_group.treesync().tree_hash().into();
+        let interim_transcript_hash = core_group.interim_transcript_hash().into();
+        let other_extensions = core_group.other_extensions().into();
 
         Ok(PublicGroupStateTbs {
             group_id,
             epoch,
             tree_hash,
             interim_transcript_hash,
-            group_context_extensions: mls_group.group_context_extensions().into(),
+            group_context_extensions: core_group.group_context_extensions().into(),
             other_extensions,
             external_pub: external_pub.into(),
             ciphersuite: ciphersuite.name(),
-            signer_index: mls_group.treesync().own_leaf_index(),
+            signer_index: core_group.treesync().own_leaf_index(),
         })
     }
 }

--- a/openmls/src/messages/tests/test_pgs.rs
+++ b/openmls/src/messages/tests/test_pgs.rs
@@ -13,7 +13,7 @@ use crate::{
     key_packages::KeyPackageBundle,
     messages::{
         public_group_state::{PublicGroupState, VerifiablePublicGroupState},
-        MlsGroup,
+        CoreGroup,
     },
     prelude::FramingParameters,
 };
@@ -60,7 +60,7 @@ fn test_pgs(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvi
     .expect("An unexpected error occurred.");
 
     // Alice creates a group
-    let mut group_alice = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut group_alice = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .build(backend)
         .expect("Could not create group.");
 

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -1,8 +1,8 @@
 //! Prelude for OpenMLS.
 //! Include this to get access to all the public functions of OpenMLS.
 
-pub use crate::group::MlsGroup;
-pub use crate::group::MlsGroupConfig;
+pub use crate::group::CoreGroup;
+pub use crate::group::CoreGroupConfig;
 pub use crate::group::{
     proposals::{ProposalStore, StagedProposal},
     InvalidMessageError, ManagedGroup, ManagedGroupConfig, ManagedGroupError, UpdatePolicy,
@@ -10,7 +10,7 @@ pub use crate::group::{
 };
 // Errors
 pub use crate::group::errors::{
-    CreateCommitError, FramingValidationError, MlsGroupError, StageCommitError, WelcomeError,
+    CoreGroupError, CreateCommitError, FramingValidationError, StageCommitError, WelcomeError,
 };
 
 // Indexes

--- a/openmls/src/test_utils/test_framework/errors.rs
+++ b/openmls/src/test_utils/test_framework/errors.rs
@@ -45,9 +45,9 @@ pub enum ClientError {
     NoMatchingGroup,
     NoCiphersuite,
     FailedToJoinGroup(WelcomeError),
-    InvalidMessage(MlsGroupError),
+    InvalidMessage(CoreGroupError),
     ManagedGroupError(ManagedGroupError),
-    GroupError(MlsGroupError),
+    GroupError(CoreGroupError),
     TlsCodecError(tls_codec::Error),
     KeyPackageError(KeyPackageError),
     Unknown,
@@ -65,8 +65,8 @@ impl From<ManagedGroupError> for ClientError {
     }
 }
 
-impl From<MlsGroupError> for ClientError {
-    fn from(e: MlsGroupError) -> Self {
+impl From<CoreGroupError> for ClientError {
+    fn from(e: CoreGroupError) -> Self {
         ClientError::GroupError(e)
     }
 }

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -136,7 +136,7 @@ pub struct EncryptionTestVector {
 fn group(
     ciphersuite: &Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
-) -> (MlsGroup, CredentialBundle) {
+) -> (CoreGroup, CredentialBundle) {
     let credential_bundle = CredentialBundle::new(
         "Kreator".into(),
         CredentialType::Basic,
@@ -152,9 +152,9 @@ fn group(
     )
     .expect("An unexpected error occurred.");
     (
-        MlsGroup::builder(GroupId::random(backend), key_package_bundle)
+        CoreGroup::builder(GroupId::random(backend), key_package_bundle)
             .build(backend)
-            .expect("Error creating MlsGroup"),
+            .expect("Error creating CoreGroup"),
         credential_bundle,
     )
 }
@@ -164,7 +164,7 @@ fn receiver_group(
     ciphersuite: &Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
     group_id: &GroupId,
-) -> MlsGroup {
+) -> CoreGroup {
     let credential_bundle = CredentialBundle::new(
         "Receiver".into(),
         CredentialType::Basic,
@@ -179,16 +179,16 @@ fn receiver_group(
         Vec::new(),
     )
     .expect("An unexpected error occurred.");
-    MlsGroup::builder(group_id.clone(), key_package_bundle)
+    CoreGroup::builder(group_id.clone(), key_package_bundle)
         .build(backend)
-        .expect("Error creating MlsGroup")
+        .expect("Error creating CoreGroup")
 }
 
 // XXX: we could be more creative in generating these messages.
 #[cfg(any(feature = "test-utils", test))]
 fn build_handshake_messages(
     leaf: LeafIndex,
-    group: &mut MlsGroup,
+    group: &mut CoreGroup,
     credential_bundle: &CredentialBundle,
     backend: &impl OpenMlsCryptoProvider,
 ) -> (Vec<u8>, Vec<u8>) {
@@ -240,7 +240,7 @@ fn build_handshake_messages(
 #[cfg(any(feature = "test-utils", test))]
 fn build_application_messages(
     leaf: LeafIndex,
-    group: &mut MlsGroup,
+    group: &mut CoreGroup,
     credential_bundle: &CredentialBundle,
     backend: &impl OpenMlsCryptoProvider,
 ) -> (Vec<u8>, Vec<u8>) {

--- a/openmls/tests/test_encoding.rs
+++ b/openmls/tests/test_encoding.rs
@@ -31,7 +31,7 @@ fn create_encoding_test_setup(backend: &impl OpenMlsCryptoProvider) -> TestSetup
     for ciphersuite_name in Config::supported_ciphersuite_names() {
         let test_group = TestGroupConfig {
             ciphersuite: *ciphersuite_name,
-            config: MlsGroupConfig {
+            config: CoreGroupConfig {
                 add_ratchet_tree_extension: true,
                 padding_block_size: 10,
                 additional_as_epochs: 0,
@@ -439,7 +439,7 @@ fn test_welcome_message_encoding(backend: &impl OpenMlsCryptoProvider) {
 
         // This makes Charlie decode the internals of the Welcome message, for
         // example the RatchetTreeExtension.
-        assert!(MlsGroup::new_from_welcome(
+        assert!(CoreGroup::new_from_welcome(
             welcome,
             Some(group_state.treesync().export_nodes()),
             charlie_key_package_bundle,

--- a/openmls/tests/test_framing.rs
+++ b/openmls/tests/test_framing.rs
@@ -18,7 +18,7 @@ fn padding(backend: &impl OpenMlsCryptoProvider) {
     for ciphersuite_name in Config::supported_ciphersuite_names() {
         let test_group = TestGroupConfig {
             ciphersuite: *ciphersuite_name,
-            config: MlsGroupConfig::default(),
+            config: CoreGroupConfig::default(),
             members: vec![alice_config.clone()],
         };
         test_group_configs.push(test_group);

--- a/openmls/tests/test_group.rs
+++ b/openmls/tests/test_group.rs
@@ -62,9 +62,9 @@ fn create_commit_optional_path(
     assert!(alice_update_key_package.verify(backend,).is_ok());
 
     // Alice creates a group
-    let mut group_alice = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut group_alice = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .build(backend)
-        .expect("Error creating MlsGroup.");
+        .expect("Error creating CoreGroup.");
 
     // Alice proposes to add Bob with forced self-update
     // Even though there are only Add Proposals, this should generated a path field
@@ -147,7 +147,7 @@ fn create_commit_optional_path(
     let ratchet_tree = group_alice.treesync().export_nodes();
 
     // Bob creates group from Welcome
-    let group_bob = match MlsGroup::new_from_welcome(
+    let group_bob = match CoreGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,
@@ -251,9 +251,9 @@ fn basic_group_setup(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCr
     .expect("An unexpected error occurred.");
 
     // Alice creates a group
-    let group_alice = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let group_alice = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .build(backend)
-        .expect("Error creating MlsGroup.");
+        .expect("Error creating CoreGroup.");
 
     // Alice adds Bob
     let bob_add_proposal = group_alice
@@ -344,9 +344,9 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
     let bob_key_package = bob_key_package_bundle.key_package();
 
     // === Alice creates a group ===
-    let mut group_alice = MlsGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let mut group_alice = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .build(backend)
-        .expect("Error creating MlsGroup.");
+        .expect("Error creating CoreGroup.");
 
     // === Alice adds Bob ===
     let bob_add_proposal = group_alice
@@ -388,7 +388,7 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .expect("error merging commit");
     let ratchet_tree = group_alice.treesync().export_nodes();
 
-    let mut group_bob = match MlsGroup::new_from_welcome(
+    let mut group_bob = match CoreGroup::new_from_welcome(
         welcome_bundle_alice_bob_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         bob_key_package_bundle,
@@ -686,7 +686,7 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .expect("error merging commit");
 
     let ratchet_tree = group_alice.treesync().export_nodes();
-    let mut group_charlie = match MlsGroup::new_from_welcome(
+    let mut group_charlie = match CoreGroup::new_from_welcome(
         welcome_for_charlie_option.expect("An unexpected error occurred."),
         Some(ratchet_tree),
         charlie_key_package_bundle,

--- a/openmls/tests/test_managed_group.rs
+++ b/openmls/tests/test_managed_group.rs
@@ -923,7 +923,7 @@ fn managed_group_operations(
         // Should fail because you cannot remove yourself from a group
         assert_eq!(
             bob_group.commit_to_pending_proposals(backend,),
-            Err(ManagedGroupError::Group(MlsGroupError::CreateCommitError(
+            Err(ManagedGroupError::Group(CoreGroupError::CreateCommitError(
                 CreateCommitError::CannotRemoveSelf
             )))
         );
@@ -1244,7 +1244,7 @@ fn managed_group_ratchet_tree_extension(
 
         assert_eq!(
             error,
-            ManagedGroupError::Group(MlsGroupError::WelcomeError(
+            ManagedGroupError::Group(CoreGroupError::WelcomeError(
                 WelcomeError::MissingRatchetTree
             ))
         );

--- a/openmls/tests/utils/mls_utils/mod.rs
+++ b/openmls/tests/utils/mls_utils/mod.rs
@@ -26,7 +26,7 @@ pub(crate) struct TestClientConfig {
 /// Configuration of a group meant to be used in a test setup.
 pub(crate) struct TestGroupConfig {
     pub(crate) ciphersuite: CiphersuiteName,
-    pub(crate) config: MlsGroupConfig,
+    pub(crate) config: CoreGroupConfig,
     pub(crate) members: Vec<TestClientConfig>,
 }
 
@@ -41,7 +41,7 @@ pub(crate) struct TestSetupConfig {
 pub(crate) struct TestClient {
     pub(crate) credential_bundles: HashMap<CiphersuiteName, CredentialBundle>,
     pub(crate) key_package_bundles: RefCell<Vec<KeyPackageBundle>>,
-    pub(crate) group_states: RefCell<HashMap<GroupId, MlsGroup>>,
+    pub(crate) group_states: RefCell<HashMap<GroupId, CoreGroup>>,
 }
 
 impl TestClient {
@@ -153,13 +153,13 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
             .get(&group_config.ciphersuite)
             .expect("An unexpected error occurred.");
         // Initialize the group state for the initial member.
-        let mls_group = MlsGroup::builder(
+        let core_group = CoreGroup::builder(
             GroupId::from_slice(&group_id.to_be_bytes()),
             initial_key_package_bundle,
         )
         .with_config(group_config.config)
         .build(backend)
-        .expect("Error creating new MlsGroup");
+        .expect("Error creating new CoreGroup");
         let mut proposal_list = Vec::new();
         let group_aad = b"";
         // Framing parameters
@@ -167,13 +167,13 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
         initial_group_member
             .group_states
             .borrow_mut()
-            .insert(mls_group.context().group_id().clone(), mls_group);
+            .insert(core_group.context().group_id().clone(), core_group);
         // If there is more than one member in the group, prepare proposals and
         // commit. Then distribute the Welcome message to the new
         // members.
         if group_config.members.len() > 1 {
             let mut group_states = initial_group_member.group_states.borrow_mut();
-            let mls_group = group_states
+            let core_group = group_states
                 .get_mut(&GroupId::from_slice(&group_id.to_be_bytes()))
                 .expect("An unexpected error occurred.");
             for client_id in 1..group_config.members.len() {
@@ -188,7 +188,7 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
                     .expect("An unexpected error occurred.");
                 // Have the initial member create an Add proposal using the new
                 // KeyPackage.
-                let add_proposal = mls_group
+                let add_proposal = core_group
                     .create_add_proposal(
                         framing_parameters,
                         initial_credential_bundle,
@@ -217,7 +217,7 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
                 .credential_bundle(initial_credential_bundle)
                 .proposal_store(&proposal_store)
                 .build();
-            let (commit_mls_plaintext, welcome_option, key_package_bundle_option) = mls_group
+            let (commit_mls_plaintext, welcome_option, key_package_bundle_option) = core_group
                 .create_commit(params, backend)
                 .expect("An unexpected error occurred.");
             let welcome = welcome_option.expect("An unexpected error occurred.");
@@ -226,7 +226,7 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
 
             // Apply the commit to the initial group member's group state using
             // the key package bundle returned by the create_commit earlier.
-            let staged_commit = mls_group
+            let staged_commit = core_group
                 .stage_commit(
                     &commit_mls_plaintext,
                     &proposal_store,
@@ -234,7 +234,7 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
                     backend,
                 )
                 .expect("Error applying Commit");
-            mls_group
+            core_group
                 .merge_commit(staged_commit)
                 .expect("error merging commit");
 
@@ -279,9 +279,9 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
                     .remove(kpb_position);
                 // Create the local group state of the new member based on the
                 // Welcome.
-                let new_group = match MlsGroup::new_from_welcome(
+                let new_group = match CoreGroup::new_from_welcome(
                     welcome.clone(),
-                    Some(mls_group.treesync().export_nodes()),
+                    Some(core_group.treesync().export_nodes()),
                     key_package_bundle,
                     backend,
                 ) {
@@ -329,7 +329,7 @@ fn test_setup(backend: &impl OpenMlsCryptoProvider) {
         name: "TestClientConfigB",
         ciphersuites: vec![CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519],
     };
-    let group_config = MlsGroupConfig::default();
+    let group_config = CoreGroupConfig::default();
     let test_group_config = TestGroupConfig {
         ciphersuite: CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
         config: group_config,

--- a/openmls/tests/utils/mod.rs
+++ b/openmls/tests/utils/mod.rs
@@ -1,3 +1,3 @@
-//! A framework to create integration tests of the "raw" mls_group API.
+//! A framework to create integration tests of the "raw" core_group API.
 
 pub mod mls_utils;


### PR DESCRIPTION
This PR renames the `MlsGroup` struct to `CoreGroup`, as well as the variable names.

There are no other changes. In the next PR the directories will be moved as well.