### PR TITLE
Rename ManagedGroup to MlsGroup

### DIFF
--- a/delivery-service/ds-lib/src/lib.rs
+++ b/delivery-service/ds-lib/src/lib.rs
@@ -56,7 +56,7 @@ impl ClientInfo {
     }
 }
 
-/// Unified message type similar to the one in the managed group.
+/// Unified message type similar to the one in the MlsGroup.
 /// But this version only operates on [`VerifiableMlsPlaintext`].
 #[derive(Debug, Clone)]
 pub enum DsMlsMessage {

--- a/delivery-service/ds/src/main.rs
+++ b/delivery-service/ds/src/main.rs
@@ -210,7 +210,7 @@ async fn msg_send(mut body: Payload, data: web::Data<Mutex<DsData>>) -> impl Res
     // about.
     // XXX: There's no test for this block in here right now because it's pretty
     //      painful to test in the current setting. This should get tested through
-    //      the client and maybe later with the managed API.
+    //      the client and maybe later with the MlsGroup API.
     if group_msg.msg.is_handshake_message() {
         let epoch = group_msg.epoch();
         let group_id = group_msg.group_id();

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -90,7 +90,7 @@ impl MlsClientImpl {
 }
 
 fn into_status(e: CoreGroupError) -> Status {
-    let message = "managed group error ".to_string() + &e.to_string();
+    let message = "mls group error ".to_string() + &e.to_string();
     tonic::Status::new(tonic::Code::Aborted, message)
 }
 

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -57,7 +57,7 @@ fn test_core_group_persistence(
         .reopen()
         .expect("Error re-opening serialized group state file");
     let alice_group_deserialized =
-        CoreGroup::load(file_in).expect("Could not deserialize managed group");
+        CoreGroup::load(file_in).expect("Could not deserialize mls group");
 
     assert_eq!(alice_group, alice_group_deserialized);
 }

--- a/openmls/src/group/managed_group/application.rs
+++ b/openmls/src/group/managed_group/application.rs
@@ -1,24 +1,24 @@
 use super::*;
 
-impl ManagedGroup {
+impl MlsGroup {
     // === Application messages ===
 
     /// Creates an application message.
-    /// Returns `ManagedGroupError::UseAfterEviction(UseAfterEviction::Error)`
+    /// Returns `MlsGroupError::UseAfterEviction(UseAfterEviction::Error)`
     /// if the member is no longer part of the group.
-    /// Returns `ManagedGroupError::PendingProposalsExist` if pending proposals
+    /// Returns `MlsGroupError::PendingProposalsExist` if pending proposals
     /// exist. In that case `.process_pending_proposals()` must be called first
     /// and incoming messages from the DS must be processed afterwards.
     pub fn create_message(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
         message: &[u8],
-    ) -> Result<MlsMessageOut, ManagedGroupError> {
+    ) -> Result<MlsMessageOut, MlsGroupError> {
         if !self.active {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
         if !self.proposal_store.is_empty() {
-            return Err(ManagedGroupError::PendingProposalsExist(
+            return Err(MlsGroupError::PendingProposalsExist(
                 PendingProposalsError::Exists,
             ));
         }
@@ -27,7 +27,7 @@ impl ManagedGroup {
         let credential_bundle: CredentialBundle = backend
             .key_store()
             .read(credential.signature_key())
-            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+            .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         let ciphertext = self.group.create_application_message(
             &self.aad,

--- a/openmls/src/group/managed_group/config.rs
+++ b/openmls/src/group/managed_group/config.rs
@@ -2,9 +2,9 @@ use super::*;
 
 use serde::{Deserialize, Serialize};
 
-/// Specifies the configuration parameters for a [`ManagedGroup`]
+/// Specifies the configuration parameters for a [`MlsGroup`]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct ManagedGroupConfig {
+pub struct MlsGroupConfig {
     /// Defines whether handshake messages (Proposals & Commits) are encrypted.
     /// Application are always encrypted regardless. `Plaintext`: Handshake messages
     /// are returned as MlsPlaintext messages `Ciphertext`: Handshake messages are
@@ -25,38 +25,38 @@ pub struct ManagedGroupConfig {
     pub(crate) required_capabilities: RequiredCapabilitiesExtension,
 }
 
-impl ManagedGroupConfig {
-    /// Returns a builder for [`ManagedGroupConfig`]
-    pub fn builder() -> ManagedGroupConfigBuilder {
-        ManagedGroupConfigBuilder::new()
+impl MlsGroupConfig {
+    /// Returns a builder for [`MlsGroupConfig`]
+    pub fn builder() -> MlsGroupConfigBuilder {
+        MlsGroupConfigBuilder::new()
     }
 
-    /// Get the [`ManagedGroupConfig`] wire format.
+    /// Get the [`MlsGroupConfig`] wire format.
     pub fn wire_format(&self) -> WireFormat {
         self.wire_format
     }
 
-    /// Get the [`ManagedGroupConfig`] padding size.
+    /// Get the [`MlsGroupConfig`] padding size.
     pub fn padding_size(&self) -> usize {
         self.padding_size
     }
 
-    /// Get the [`ManagedGroupConfig`] max past epochs.
+    /// Get the [`MlsGroupConfig`] max past epochs.
     pub fn max_past_epochs(&self) -> usize {
         self.max_past_epochs
     }
 
-    /// Get a reference to the [`ManagedGroupConfig`] update policy.
+    /// Get a reference to the [`MlsGroupConfig`] update policy.
     pub fn update_policy(&self) -> &UpdatePolicy {
         &self.update_policy
     }
 
-    /// Get the [`ManagedGroupConfig`] number of resumption secrets.
+    /// Get the [`MlsGroupConfig`] number of resumption secrets.
     pub fn number_of_resumption_secrets(&self) -> usize {
         self.number_of_resumption_secrets
     }
 
-    /// Get the [`ManagedGroupConfig`] boolean flag that indicates whether ratchet_tree_extension should be used.
+    /// Get the [`MlsGroupConfig`] boolean flag that indicates whether ratchet_tree_extension should be used.
     pub fn use_ratchet_tree_extension(&self) -> bool {
         self.use_ratchet_tree_extension
     }
@@ -69,9 +69,9 @@ impl ManagedGroupConfig {
     }
 }
 
-impl Default for ManagedGroupConfig {
+impl Default for MlsGroupConfig {
     fn default() -> Self {
-        ManagedGroupConfig {
+        MlsGroupConfig {
             wire_format: WireFormat::MlsCiphertext,
             update_policy: UpdatePolicy::default(),
             padding_size: 0,
@@ -84,35 +84,35 @@ impl Default for ManagedGroupConfig {
 }
 
 #[derive(Default)]
-pub struct ManagedGroupConfigBuilder {
-    config: ManagedGroupConfig,
+pub struct MlsGroupConfigBuilder {
+    config: MlsGroupConfig,
 }
-impl ManagedGroupConfigBuilder {
+impl MlsGroupConfigBuilder {
     pub fn new() -> Self {
-        ManagedGroupConfigBuilder {
-            config: ManagedGroupConfig::default(),
+        MlsGroupConfigBuilder {
+            config: MlsGroupConfig::default(),
         }
     }
 
-    /// Sets the `wire_format` property of the ManagedGroupConfig.
+    /// Sets the `wire_format` property of the MlsGroupConfig.
     pub fn wire_format(mut self, wire_format: WireFormat) -> Self {
         self.config.wire_format = wire_format;
         self
     }
 
-    /// Sets the `update_policy` property of the ManagedGroupConfig.
+    /// Sets the `update_policy` property of the MlsGroupConfig.
     pub fn update_policy(mut self, update_policy: UpdatePolicy) -> Self {
         self.config.update_policy = update_policy;
         self
     }
 
-    /// Sets the `padding_size` property of the ManagedGroupConfig.
+    /// Sets the `padding_size` property of the MlsGroupConfig.
     pub fn padding_size(mut self, padding_size: usize) -> Self {
         self.config.padding_size = padding_size;
         self
     }
 
-    /// Sets the `max_past_epochs` property of the ManagedGroupConfig.
+    /// Sets the `max_past_epochs` property of the MlsGroupConfig.
     /// This allows application messages from previous epochs to be decrypted.
     ///
     /// **WARNING**
@@ -127,19 +127,19 @@ impl ManagedGroupConfigBuilder {
         self
     }
 
-    /// Sets the `number_of_resumption_secrets` property of the ManagedGroupConfig.
+    /// Sets the `number_of_resumption_secrets` property of the MlsGroupConfig.
     pub fn number_of_resumtion_secrets(mut self, number_of_resumption_secrets: usize) -> Self {
         self.config.number_of_resumption_secrets = number_of_resumption_secrets;
         self
     }
 
-    /// Sets the `use_ratchet_tree_extension` property of the ManagedGroupConfig.
+    /// Sets the `use_ratchet_tree_extension` property of the MlsGroupConfig.
     pub fn use_ratchet_tree_extension(mut self, use_ratchet_tree_extension: bool) -> Self {
         self.config.use_ratchet_tree_extension = use_ratchet_tree_extension;
         self
     }
 
-    pub fn build(self) -> ManagedGroupConfig {
+    pub fn build(self) -> MlsGroupConfig {
         self.config
     }
 }

--- a/openmls/src/group/managed_group/creation.rs
+++ b/openmls/src/group/managed_group/creation.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl ManagedGroup {
+impl MlsGroup {
     // === Group creation ===
 
     /// Creates a new group from scratch with only the creator as a member. This
@@ -9,37 +9,37 @@ impl ManagedGroup {
     /// `KeyPackageBundle` can be found.
     pub fn new(
         backend: &impl OpenMlsCryptoProvider,
-        managed_group_config: &ManagedGroupConfig,
+        mls_group_config: &MlsGroupConfig,
         group_id: GroupId,
         key_package_hash: &[u8],
-    ) -> Result<Self, ManagedGroupError> {
+    ) -> Result<Self, MlsGroupError> {
         // TODO #141
         let kph = key_package_hash.to_vec();
         let key_package_bundle: KeyPackageBundle = backend
             .key_store()
             .read(&kph)
-            .ok_or(ManagedGroupError::NoMatchingKeyPackageBundle)?;
+            .ok_or(MlsGroupError::NoMatchingKeyPackageBundle)?;
         backend
             .key_store()
             .delete(&kph)
-            .map_err(|_| ManagedGroupError::KeyStoreError)?;
+            .map_err(|_| MlsGroupError::KeyStoreError)?;
         let group_config = CoreGroupConfig {
-            add_ratchet_tree_extension: managed_group_config.use_ratchet_tree_extension,
+            add_ratchet_tree_extension: mls_group_config.use_ratchet_tree_extension,
             ..Default::default()
         };
         let group = CoreGroup::builder(group_id, key_package_bundle)
             .with_config(group_config)
-            .with_required_capabilities(managed_group_config.required_capabilities.clone())
+            .with_required_capabilities(mls_group_config.required_capabilities.clone())
             .build(backend)?;
 
         let resumption_secret_store =
-            ResumptionSecretStore::new(managed_group_config.number_of_resumption_secrets);
+            ResumptionSecretStore::new(mls_group_config.number_of_resumption_secrets);
 
-        let managed_group = ManagedGroup {
-            managed_group_config: managed_group_config.clone(),
+        let mls_group = MlsGroup {
+            mls_group_config: mls_group_config.clone(),
             group,
             proposal_store: ProposalStore::new(),
-            message_secrets_store: MessageSecretsStore::new(managed_group_config.max_past_epochs()),
+            message_secrets_store: MessageSecretsStore::new(mls_group_config.max_past_epochs()),
             own_kpbs: vec![],
             aad: vec![],
             resumption_secret_store,
@@ -47,18 +47,18 @@ impl ManagedGroup {
             state_changed: InnerState::Changed,
         };
 
-        Ok(managed_group)
+        Ok(mls_group)
     }
 
     /// Creates a new group from a `Welcome` message
     pub fn new_from_welcome(
         backend: &impl OpenMlsCryptoProvider,
-        managed_group_config: &ManagedGroupConfig,
+        mls_group_config: &MlsGroupConfig,
         welcome: Welcome,
         ratchet_tree: Option<Vec<Option<Node>>>,
-    ) -> Result<Self, ManagedGroupError> {
+    ) -> Result<Self, MlsGroupError> {
         let resumption_secret_store =
-            ResumptionSecretStore::new(managed_group_config.number_of_resumption_secrets);
+            ResumptionSecretStore::new(mls_group_config.number_of_resumption_secrets);
         let key_package_bundle = welcome
             .secrets()
             .iter()
@@ -67,16 +67,16 @@ impl ManagedGroup {
                     .key_store()
                     .read(&egs.key_package_hash.as_slice().to_vec())
             })
-            .ok_or(ManagedGroupError::NoMatchingKeyPackageBundle)?;
+            .ok_or(MlsGroupError::NoMatchingKeyPackageBundle)?;
         // TODO #141
         let group =
             CoreGroup::new_from_welcome(welcome, ratchet_tree, key_package_bundle, backend)?;
 
-        let managed_group = ManagedGroup {
-            managed_group_config: managed_group_config.clone(),
+        let mls_group = MlsGroup {
+            mls_group_config: mls_group_config.clone(),
             group,
             proposal_store: ProposalStore::new(),
-            message_secrets_store: MessageSecretsStore::new(managed_group_config.max_past_epochs()),
+            message_secrets_store: MessageSecretsStore::new(mls_group_config.max_past_epochs()),
             own_kpbs: vec![],
             aad: vec![],
             resumption_secret_store,
@@ -84,6 +84,6 @@ impl ManagedGroup {
             state_changed: InnerState::Changed,
         };
 
-        Ok(managed_group)
+        Ok(mls_group)
     }
 }

--- a/openmls/src/group/managed_group/errors.rs
+++ b/openmls/src/group/managed_group/errors.rs
@@ -1,4 +1,4 @@
-//! # MLS Managed Group errors
+//! # MLS MlsGroup errors
 //!
 //! `WelcomeError`, `StageCommitError`, `DecryptionError`, and
 //! `CreateCommitError`.
@@ -14,7 +14,7 @@ use openmls_traits::types::CryptoError;
 use tls_codec::Error as TlsCodecError;
 
 implement_error! {
-    pub enum ManagedGroupError {
+    pub enum MlsGroupError {
         Simple {
             NoMatchingCredentialBundle = "Couldn't find a `CredentialBundle` in the `KeyStore` that matches the one in my leaf.",
             NoMatchingKeyPackageBundle = "Couldn't find a `KeyPackageBundle` in the `KeyStore` that matches the given `KeyPackage` hash.",

--- a/openmls/src/group/managed_group/exporting.rs
+++ b/openmls/src/group/managed_group/exporting.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl ManagedGroup {
+impl MlsGroup {
     // === Export secrets ===
 
     /// Exports a secret from the current epoch
@@ -10,13 +10,13 @@ impl ManagedGroup {
         label: &str,
         context: &[u8],
         key_length: usize,
-    ) -> Result<Vec<u8>, ManagedGroupError> {
+    ) -> Result<Vec<u8>, MlsGroupError> {
         if self.active {
             Ok(self
                 .group
                 .export_secret(backend, label, context, key_length)?)
         } else {
-            Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error))
+            Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error))
         }
     }
 

--- a/openmls/src/group/managed_group/membership.rs
+++ b/openmls/src/group/managed_group/membership.rs
@@ -5,7 +5,7 @@ use core_group::create_commit_params::CreateCommitParams;
 
 use super::*;
 
-impl ManagedGroup {
+impl MlsGroup {
     // === Membership management ===
 
     /// Adds members to the group
@@ -20,13 +20,13 @@ impl ManagedGroup {
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
         key_packages: &[KeyPackage],
-    ) -> Result<(MlsMessageOut, Welcome), ManagedGroupError> {
+    ) -> Result<(MlsMessageOut, Welcome), MlsGroupError> {
         if !self.active {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
         if key_packages.is_empty() {
-            return Err(ManagedGroupError::EmptyInput(EmptyInputError::AddMembers));
+            return Err(MlsGroupError::EmptyInput(EmptyInputError::AddMembers));
         }
 
         // Create inline add proposals from key packages
@@ -43,7 +43,7 @@ impl ManagedGroup {
         let credential_bundle: CredentialBundle = backend
             .key_store()
             .read(credential.signature_key())
-            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+            .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all proposals
         // TODO #141
@@ -59,7 +59,7 @@ impl ManagedGroup {
         let welcome = match welcome_option {
             Some(welcome) => welcome,
             None => {
-                return Err(ManagedGroupError::LibraryError(
+                return Err(MlsGroupError::LibraryError(
                     "No secrets to generate commit message.".into(),
                 ))
             }
@@ -90,15 +90,13 @@ impl ManagedGroup {
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
         members: &[usize],
-    ) -> Result<(MlsMessageOut, Option<Welcome>), ManagedGroupError> {
+    ) -> Result<(MlsMessageOut, Option<Welcome>), MlsGroupError> {
         if !self.active {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
         if members.is_empty() {
-            return Err(ManagedGroupError::EmptyInput(
-                EmptyInputError::RemoveMembers,
-            ));
+            return Err(MlsGroupError::EmptyInput(EmptyInputError::RemoveMembers));
         }
 
         // Create inline remove proposals
@@ -115,7 +113,7 @@ impl ManagedGroup {
         let credential_bundle: CredentialBundle = backend
             .key_store()
             .read(credential.signature_key())
-            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+            .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all proposals
         // TODO #141
@@ -131,7 +129,7 @@ impl ManagedGroup {
         if let Some(kpb) = kpb_option {
             self.own_kpbs.push(kpb);
         } else {
-            return Err(ManagedGroupError::LibraryError(
+            return Err(MlsGroupError::LibraryError(
                 "We didn't get a key package for a full commit.".into(),
             ));
         }
@@ -152,16 +150,16 @@ impl ManagedGroup {
         backend: &impl OpenMlsCryptoProvider,
 
         key_package: &KeyPackage,
-    ) -> Result<MlsMessageOut, ManagedGroupError> {
+    ) -> Result<MlsMessageOut, MlsGroupError> {
         if !self.active {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
             .read(credential.signature_key())
-            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+            .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         let add_proposal = self.group.create_add_proposal(
             self.framing_parameters(),
@@ -183,16 +181,16 @@ impl ManagedGroup {
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
         member: LeafIndex,
-    ) -> Result<MlsMessageOut, ManagedGroupError> {
+    ) -> Result<MlsMessageOut, MlsGroupError> {
         if !self.active {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
             .read(credential.signature_key())
-            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+            .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         let remove_proposal = self.group.create_remove_proposal(
             self.framing_parameters(),
@@ -213,16 +211,16 @@ impl ManagedGroup {
     pub fn leave_group(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<MlsMessageOut, ManagedGroupError> {
+    ) -> Result<MlsMessageOut, MlsGroupError> {
         if !self.active {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
             .read(credential.signature_key())
-            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+            .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         let remove_proposal = self.group.create_remove_proposal(
             self.framing_parameters(),
@@ -235,7 +233,7 @@ impl ManagedGroup {
     }
 
     /// Gets the current list of members
-    pub fn members(&self) -> Result<Vec<&Credential>, ManagedGroupError> {
+    pub fn members(&self) -> Result<Vec<&Credential>, MlsGroupError> {
         Ok(self
             .group
             .treesync()
@@ -247,7 +245,7 @@ impl ManagedGroup {
 
     /// Gets the current list of members
     #[cfg(any(feature = "test-utils", test))]
-    pub fn indexed_members(&self) -> Result<BTreeMap<LeafIndex, &KeyPackage>, ManagedGroupError> {
+    pub fn indexed_members(&self) -> Result<BTreeMap<LeafIndex, &KeyPackage>, MlsGroupError> {
         Ok(self.group.treesync().full_leaves()?)
     }
 }

--- a/openmls/src/group/managed_group/mod.rs
+++ b/openmls/src/group/managed_group/mod.rs
@@ -31,8 +31,7 @@ use std::io::{Error, Read, Write};
 
 pub use config::*;
 pub use errors::{
-    EmptyInputError, InvalidMessageError, ManagedGroupError, PendingProposalsError,
-    UseAfterEviction,
+    EmptyInputError, InvalidMessageError, MlsGroupError, PendingProposalsError, UseAfterEviction,
 };
 pub(crate) use resumption::ResumptionSecretStore;
 use ser::*;
@@ -40,7 +39,7 @@ use ser::*;
 use super::past_secrets::MessageSecretsStore;
 use super::proposals::{ProposalStore, StagedProposal};
 
-/// A `ManagedGroup` represents an [CoreGroup] with
+/// A `MlsGroup` represents an [CoreGroup] with
 /// an easier, high-level API designed to be used in production. The API exposes
 /// high level functions to manage a group by adding/removing members, get the
 /// current member list, etc.
@@ -49,12 +48,12 @@ use super::proposals::{ProposalStore, StagedProposal};
 /// Delivery Service. Functions that modify the public state of the group will
 /// return a `Vec<MLSMessage>` that can be sent to the Delivery
 /// Service directly. Conversely, incoming messages from the Delivery Service
-/// can be fed into [process_message()](`ManagedGroup::process_message()`).
+/// can be fed into [process_message()](`MlsGroup::process_message()`).
 ///
-/// A `ManagedGroup` has an internal queue of pending proposals that builds up
+/// A `MlsGroup` has an internal queue of pending proposals that builds up
 /// as new messages are processed. When creating proposals, those messages are
 /// not automatically appended to this queue, instead they have to be processed
-/// again through [process_message()](`ManagedGroup::process_message()`). This
+/// again through [process_message()](`MlsGroup::process_message()`). This
 /// allows the Delivery Service to reject them (e.g. if they reference the wrong
 /// epoch).
 ///
@@ -64,14 +63,14 @@ use super::proposals::{ProposalStore, StagedProposal};
 ///
 /// The application policy for the group can be enforced by implementing the
 /// validator callback functions and selectively allowing/ disallowing each
-/// operation (see [`ManagedGroupCallbacks`])
+/// operation (see [`MlsGroupCallbacks`])
 ///
 /// Changes to the group state are dispatched as events through callback
-/// functions (see [`ManagedGroupCallbacks`]).
+/// functions (see [`MlsGroupCallbacks`]).
 #[derive(Debug)]
-pub struct ManagedGroup {
-    // The group configuration. See `ManagedGroupCongig` for more information.
-    managed_group_config: ManagedGroupConfig,
+pub struct MlsGroup {
+    // The group configuration. See `MlsGroupCongig` for more information.
+    mls_group_config: MlsGroupConfig,
     // the internal `CoreGroup` used for lower level operations. See `CoreGroup` for more
     // information.
     group: CoreGroup,
@@ -99,17 +98,17 @@ pub struct ManagedGroup {
     state_changed: InnerState,
 }
 
-impl ManagedGroup {
+impl MlsGroup {
     // === Configuration ===
 
     /// Gets the configuration
-    pub fn configuration(&self) -> &ManagedGroupConfig {
-        &self.managed_group_config
+    pub fn configuration(&self) -> &MlsGroupConfig {
+        &self.mls_group_config
     }
 
     /// Sets the configuration
-    pub fn set_configuration(&mut self, managed_group_config: &ManagedGroupConfig) {
-        self.managed_group_config = managed_group_config.clone();
+    pub fn set_configuration(&mut self, mls_group_config: &MlsGroupConfig) {
+        self.mls_group_config = mls_group_config.clone();
 
         // Since the state of the group might be changed, arm the state flag
         self.flag_state_change();
@@ -145,9 +144,9 @@ impl ManagedGroup {
     /// `UseAfterEviction` error. This function currently returns a full
     /// `Credential` rather than just a reference. This issue is tracked in
     /// issue #387.
-    pub fn credential(&self) -> Result<Credential, ManagedGroupError> {
+    pub fn credential(&self) -> Result<Credential, MlsGroupError> {
         if !self.is_active() {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
         let tree = self.group.treesync();
         Ok(tree.own_leaf_node()?.key_package().credential().clone())
@@ -166,15 +165,15 @@ impl ManagedGroup {
     // === Load & save ===
 
     /// Loads the state from persisted state
-    pub fn load<R: Read>(reader: R) -> Result<ManagedGroup, Error> {
-        let serialized_managed_group: SerializedManagedGroup = serde_json::from_reader(reader)?;
-        Ok(serialized_managed_group.into_managed_group())
+    pub fn load<R: Read>(reader: R) -> Result<MlsGroup, Error> {
+        let serialized_mls_group: SerializedMlsGroup = serde_json::from_reader(reader)?;
+        Ok(serialized_mls_group.into_mls_group())
     }
 
     /// Persists the state
     pub fn save<W: Write>(&mut self, writer: &mut W) -> Result<(), Error> {
-        let serialized_managed_group = serde_json::to_string_pretty(self)?;
-        writer.write_all(&serialized_managed_group.into_bytes())?;
+        let serialized_mls_group = serde_json::to_string_pretty(self)?;
+        writer.write_all(&serialized_mls_group.into_bytes())?;
         self.state_changed = InnerState::Persisted;
         Ok(())
     }
@@ -214,8 +213,8 @@ impl ManagedGroup {
     }
 }
 
-// Private methods of ManagedGroup
-impl ManagedGroup {
+// Private methods of MlsGroup
+impl MlsGroup {
     /// Converts MlsPlaintext to MLSMessage. Depending on whether handshake
     /// message should be encrypted, MlsPlaintext messages are encrypted to
     /// MlsCiphertext first.
@@ -223,7 +222,7 @@ impl ManagedGroup {
         &mut self,
         plaintext: MlsPlaintext,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<MlsMessageOut, ManagedGroupError> {
+    ) -> Result<MlsMessageOut, MlsGroupError> {
         let msg = match self.configuration().wire_format() {
             WireFormat::MlsPlaintext => MlsMessageOut::Plaintext(Box::new(plaintext)),
             WireFormat::MlsCiphertext => {
@@ -243,7 +242,7 @@ impl ManagedGroup {
 
     /// Group framing parameters
     fn framing_parameters(&self) -> FramingParameters {
-        FramingParameters::new(&self.aad, self.managed_group_config.wire_format)
+        FramingParameters::new(&self.aad, self.mls_group_config.wire_format)
     }
 }
 

--- a/openmls/src/group/managed_group/processing.rs
+++ b/openmls/src/group/managed_group/processing.rs
@@ -5,7 +5,7 @@ use core_group::{
 
 use super::*;
 
-impl ManagedGroup {
+impl MlsGroup {
     /// This function is used to parse messages from the DS.
     /// It checks for syntactic errors and makes some semantic checks as well.
     /// If the input is a [MlsCiphertext] message, it will be decrypted.
@@ -15,10 +15,10 @@ impl ManagedGroup {
         &mut self,
         message: MlsMessageIn,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<UnverifiedMessage, ManagedGroupError> {
+    ) -> Result<UnverifiedMessage, MlsGroupError> {
         // Make sure we are still a member of the group
         if !self.active {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
         // Since the state of the group might be changed, arm the state flag
@@ -27,7 +27,7 @@ impl ManagedGroup {
         // Parse the message
         self.group
             .parse_message(message, &mut self.message_secrets_store, backend)
-            .map_err(ManagedGroupError::Group)
+            .map_err(MlsGroupError::Group)
     }
 
     /// This processing function does most of the semantic verifications.
@@ -37,7 +37,7 @@ impl ManagedGroup {
         unverified_message: UnverifiedMessage,
         signature_key: Option<&SignaturePublicKey>,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<ProcessedMessage, ManagedGroupError> {
+    ) -> Result<ProcessedMessage, MlsGroupError> {
         self.group
             .process_unverified_message(
                 unverified_message,
@@ -64,16 +64,16 @@ impl ManagedGroup {
     pub fn commit_to_pending_proposals(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<(MlsMessageOut, Option<Welcome>), ManagedGroupError> {
+    ) -> Result<(MlsMessageOut, Option<Welcome>), MlsGroupError> {
         if !self.active {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
             .read(credential.signature_key())
-            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+            .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all pending proposals
         // TODO #141
@@ -103,7 +103,7 @@ impl ManagedGroup {
     pub fn merge_staged_commit(
         &mut self,
         staged_commit: StagedCommit,
-    ) -> Result<(), ManagedGroupError> {
+    ) -> Result<(), MlsGroupError> {
         // Check if we were removed from the group
         if staged_commit.self_removed() {
             self.active = false;
@@ -119,7 +119,7 @@ impl ManagedGroup {
                 &mut self.proposal_store,
                 &mut self.message_secrets_store,
             )
-            .map_err(ManagedGroupError::Group)?;
+            .map_err(MlsGroupError::Group)?;
 
         // Extract and store the resumption secret for the current epoch
         let resumption_secret = self.group.group_epoch_secrets().resumption_secret();

--- a/openmls/src/group/managed_group/ser.rs
+++ b/openmls/src/group/managed_group/ser.rs
@@ -5,8 +5,8 @@ use serde::{
     Deserialize, Serialize,
 };
 #[derive(Serialize, Deserialize)]
-pub struct SerializedManagedGroup {
-    managed_group_config: ManagedGroupConfig,
+pub struct SerializedMlsGroup {
+    mls_group_config: MlsGroupConfig,
     group: CoreGroup,
     proposal_store: ProposalStore,
     message_secrets_store: MessageSecretsStore,
@@ -16,10 +16,10 @@ pub struct SerializedManagedGroup {
     active: bool,
 }
 
-impl SerializedManagedGroup {
-    pub(crate) fn into_managed_group(self) -> ManagedGroup {
-        ManagedGroup {
-            managed_group_config: self.managed_group_config,
+impl SerializedMlsGroup {
+    pub(crate) fn into_mls_group(self) -> MlsGroup {
+        MlsGroup {
+            mls_group_config: self.mls_group_config,
             group: self.group,
             proposal_store: self.proposal_store,
             message_secrets_store: self.message_secrets_store,
@@ -32,13 +32,13 @@ impl SerializedManagedGroup {
     }
 }
 
-impl Serialize for ManagedGroup {
+impl Serialize for MlsGroup {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("SerializedManagedGroup", 6)?;
-        state.serialize_field("managed_group_config", &self.managed_group_config)?;
+        let mut state = serializer.serialize_struct("SerializedMlsGroup", 6)?;
+        state.serialize_field("mls_group_config", &self.mls_group_config)?;
         state.serialize_field("group", &self.group)?;
         state.serialize_field("proposal_store", &self.proposal_store)?;
         state.serialize_field("message_secrets_store", &self.message_secrets_store)?;

--- a/openmls/src/group/managed_group/test_managed_group.rs
+++ b/openmls/src/group/managed_group/test_managed_group.rs
@@ -5,7 +5,7 @@ use crate::{
     group::InnerState,
     prelude::*,
     test_utils::test_framework::{
-        errors::ClientError, ActionType::Commit, CodecUse, ManagedTestSetup,
+        errors::ClientError, ActionType::Commit, CodecUse, MlsGroupTestSetup,
     },
     test_utils::*,
 };
@@ -48,7 +48,7 @@ fn generate_key_package_bundle(
 }
 
 #[apply(ciphersuites_and_backends)]
-fn test_managed_group_persistence(
+fn test_mls_group_persistence(
     ciphersuite: &'static Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) {
@@ -68,14 +68,14 @@ fn test_managed_group_persistence(
         generate_key_package_bundle(backend, &[ciphersuite.name()], &alice_credential, vec![])
             .expect("An unexpected error occurred.");
 
-    // Define the managed group configuration
-    let managed_group_config = ManagedGroupConfig::test_default();
+    // Define the MlsGroup configuration
+    let mls_group_config = MlsGroupConfig::test_default();
 
     // === Alice creates a group ===
 
-    let mut alice_group = ManagedGroup::new(
+    let mut alice_group = MlsGroup::new(
         backend,
-        &managed_group_config,
+        &mls_group_config,
         group_id,
         &alice_key_package
             .hash(backend)
@@ -94,8 +94,7 @@ fn test_managed_group_persistence(
     let file_in = file_out
         .reopen()
         .expect("Error re-opening serialized group state file");
-    let alice_group_deserialized =
-        ManagedGroup::load(file_in).expect("Could not deserialize managed group");
+    let alice_group_deserialized = MlsGroup::load(file_in).expect("Could not deserialize MlsGroup");
 
     assert_eq!(
         (
@@ -153,13 +152,13 @@ fn remover(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvid
         generate_key_package_bundle(backend, &[ciphersuite.name()], &charlie_credential, vec![])
             .expect("An unexpected error occurred.");
 
-    // Define the managed group configuration
-    let managed_group_config = ManagedGroupConfig::default();
+    // Define the MlsGroup configuration
+    let mls_group_config = MlsGroupConfig::default();
 
     // === Alice creates a group ===
-    let mut alice_group = ManagedGroup::new(
+    let mut alice_group = MlsGroup::new(
         backend,
-        &managed_group_config,
+        &mls_group_config,
         group_id,
         &alice_key_package
             .hash(backend)
@@ -188,9 +187,9 @@ fn remover(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvid
         unreachable!("Expected a StagedCommit.");
     }
 
-    let mut bob_group = ManagedGroup::new_from_welcome(
+    let mut bob_group = MlsGroup::new_from_welcome(
         backend,
-        &managed_group_config,
+        &mls_group_config,
         welcome,
         Some(alice_group.export_ratchet_tree()),
     )
@@ -230,9 +229,9 @@ fn remover(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvid
         unreachable!("Expected a StagedCommit.");
     }
 
-    let mut charlie_group = ManagedGroup::new_from_welcome(
+    let mut charlie_group = MlsGroup::new_from_welcome(
         backend,
-        &managed_group_config,
+        &mls_group_config,
         welcome,
         Some(bob_group.export_ratchet_tree()),
     )
@@ -319,15 +318,15 @@ fn export_secret(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypto
         generate_key_package_bundle(backend, &[ciphersuite.name()], &alice_credential, vec![])
             .expect("An unexpected error occurred.");
 
-    // Define the managed group configuration
-    let managed_group_config = ManagedGroupConfig::builder()
+    // Define the MlsGroup configuration
+    let mls_group_config = MlsGroupConfig::builder()
         .wire_format(WireFormat::MlsPlaintext)
         .build();
 
     // === Alice creates a group ===
-    let alice_group = ManagedGroup::new(
+    let alice_group = MlsGroup::new(
         backend,
-        &managed_group_config,
+        &mls_group_config,
         group_id,
         &alice_key_package
             .hash(backend)
@@ -355,15 +354,15 @@ fn export_secret(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypto
 
 #[apply(ciphersuites)]
 fn test_invalid_plaintext(ciphersuite: &'static Ciphersuite) {
-    // Some basic setup functions for the managed group.
-    let managed_group_config = ManagedGroupConfig::builder()
+    // Some basic setup functions for the MlsGroup.
+    let mls_group_config = MlsGroupConfig::builder()
         .wire_format(WireFormat::MlsPlaintext)
         .padding_size(10)
         .build();
 
     let number_of_clients = 20;
-    let setup = ManagedTestSetup::new(
-        managed_group_config,
+    let setup = MlsGroupTestSetup::new(
+        mls_group_config,
         number_of_clients,
         CodecUse::StructMessages,
     );
@@ -410,7 +409,7 @@ fn test_invalid_plaintext(ciphersuite: &'static Ciphersuite) {
         .expect_err("No error when distributing message with invalid signature.");
 
     assert_eq!(
-        ClientError::ManagedGroupError(ManagedGroupError::Group(CoreGroupError::ValidationError(
+        ClientError::MlsGroupError(MlsGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::MlsPlaintextError(MlsPlaintextError::VerificationError(
                 VerificationError::InvalidMembershipTag
             ))
@@ -433,7 +432,7 @@ fn test_invalid_plaintext(ciphersuite: &'static Ciphersuite) {
         .expect_err("No error when distributing message with invalid signature.");
 
     assert_eq!(
-        ClientError::ManagedGroupError(ManagedGroupError::Group(
+        ClientError::MlsGroupError(MlsGroupError::Group(
             CoreGroupError::FramingValidationError(FramingValidationError::UnknownMember)
         )),
         error

--- a/openmls/src/group/managed_group/updates.rs
+++ b/openmls/src/group/managed_group/updates.rs
@@ -2,7 +2,7 @@ use core_group::create_commit_params::CreateCommitParams;
 
 use super::*;
 
-impl ManagedGroup {
+impl MlsGroup {
     /// Updates the own leaf node
     ///
     /// A [`KeyPackageBundle`](crate::prelude::KeyPackageBundle) can optionally
@@ -14,16 +14,16 @@ impl ManagedGroup {
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
         key_package_bundle_option: Option<KeyPackageBundle>,
-    ) -> Result<(MlsMessageOut, Option<Welcome>), ManagedGroupError> {
+    ) -> Result<(MlsMessageOut, Option<Welcome>), MlsGroupError> {
         if !self.active {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
             .read(credential.signature_key())
-            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+            .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all proposals. If a `KeyPackageBundle` was passed
         // in, use it to create an update proposal by value. TODO #141
@@ -52,7 +52,7 @@ impl ManagedGroup {
 
         // Take the new KeyPackageBundle and save it for later
         let kpb = kpb_option.ok_or_else(|| {
-            ManagedGroupError::LibraryError(
+            MlsGroupError::LibraryError(
                 "We didn't get a key package for a full commit on self update.".into(),
             )
         })?;
@@ -74,16 +74,16 @@ impl ManagedGroup {
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
         key_package_bundle_option: Option<KeyPackageBundle>,
-    ) -> Result<MlsMessageOut, ManagedGroupError> {
+    ) -> Result<MlsMessageOut, MlsGroupError> {
         if !self.active {
-            return Err(ManagedGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
             .read(credential.signature_key())
-            .ok_or(ManagedGroupError::NoMatchingCredentialBundle)?;
+            .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         let tree = self.group.treesync();
         let existing_key_package = tree.own_leaf_node()?.key_package();

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -3,7 +3,7 @@
 //! This file contains the API to interact with groups.
 //!
 //! The low-level standard API is described in the `Api` trait.\
-//! The high-level API is exposed in `ManagedGroup`.
+//! The high-level API is exposed in `MlsGroup`.
 
 pub mod core_group;
 pub mod errors;

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -1,4 +1,4 @@
-//! This module contains tests regarding the use of [`MessageSecretsStore`] in [`ManagedGroup`]
+//! This module contains tests regarding the use of [`MessageSecretsStore`] in [`MlsGroup`]
 
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::{key_store::OpenMlsKeyStore, OpenMlsCryptoProvider};
@@ -11,9 +11,7 @@ use crate::{
     config::Config,
     credentials::{CredentialBundle, CredentialType},
     framing::{MlsCiphertextError, ProcessedMessage},
-    group::{
-        CoreGroupError, GroupId, ManagedGroup, ManagedGroupConfig, ManagedGroupError, WireFormat,
-    },
+    group::{CoreGroupError, GroupId, MlsGroup, MlsGroupConfig, MlsGroupError, WireFormat},
     key_packages::KeyPackageBundle,
     tree::secret_tree::SecretTreeError,
 };
@@ -93,17 +91,17 @@ fn test_past_secrets_in_group(
             )
             .expect("An unexpected error occurred.");
 
-        // Define the managed group configuration
+        // Define the MlsGroup configuration
 
-        let managed_group_config = ManagedGroupConfig::builder()
+        let mls_group_config = MlsGroupConfig::builder()
             .wire_format(WireFormat::MlsCiphertext)
             .max_past_epochs(max_epochs / 2)
             .build();
 
         // === Alice creates a group ===
-        let mut alice_group = ManagedGroup::new(
+        let mut alice_group = MlsGroup::new(
             backend,
-            &managed_group_config,
+            &mls_group_config,
             group_id,
             &alice_key_package
                 .hash(backend)
@@ -132,9 +130,9 @@ fn test_past_secrets_in_group(
             unreachable!("Expected a StagedCommit.");
         }
 
-        let mut bob_group = ManagedGroup::new_from_welcome(
+        let mut bob_group = MlsGroup::new_from_welcome(
             backend,
-            &managed_group_config,
+            &mls_group_config,
             welcome,
             Some(alice_group.export_ratchet_tree()),
         )
@@ -204,7 +202,7 @@ fn test_past_secrets_in_group(
                 .expect_err("An unexpected error occurred.");
             assert_eq!(
                 err,
-                ManagedGroupError::Group(CoreGroupError::MlsCiphertextError(
+                MlsGroupError::Group(CoreGroupError::MlsCiphertextError(
                     MlsCiphertextError::SecretTreeError(SecretTreeError::TooDistantInThePast,),
                 ))
             );

--- a/openmls/src/group/tests/test_validation.rs
+++ b/openmls/src/group/tests/test_validation.rs
@@ -19,8 +19,8 @@ use crate::{
         ValidationError, VerifiableMlsPlaintext, VerificationError,
     },
     group::{
-        CoreGroupError, FramingValidationError, GroupEpoch, GroupId, ManagedGroup,
-        ManagedGroupConfig, ManagedGroupError, WireFormat,
+        CoreGroupError, FramingValidationError, GroupEpoch, GroupId, MlsGroup, MlsGroupConfig,
+        MlsGroupError, WireFormat,
     },
     key_packages::{KeyPackage, KeyPackageBundle, KeyPackageError},
     prelude::ProcessedMessage,
@@ -65,7 +65,7 @@ fn generate_key_package_bundle(
 // Test setup values
 #[cfg(test)]
 struct ValidationTestSetup {
-    alice_group: ManagedGroup,
+    alice_group: MlsGroup,
     _alice_credential: Credential,
     _bob_credential: Credential,
     _alice_key_package: KeyPackage,
@@ -106,16 +106,14 @@ fn validation_test_setup(
         generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![], backend)
             .expect("An unexpected error occurred.");
 
-    // Define the managed group configuration
+    // Define the MlsGroup configuration
 
-    let managed_group_config = ManagedGroupConfig::builder()
-        .wire_format(wire_format)
-        .build();
+    let mls_group_config = MlsGroupConfig::builder().wire_format(wire_format).build();
 
     // === Alice creates a group ===
-    let alice_group = ManagedGroup::new(
+    let alice_group = MlsGroup::new(
         backend,
-        &managed_group_config,
+        &mls_group_config,
         group_id,
         &alice_key_package
             .hash(backend)
@@ -235,7 +233,7 @@ fn test_valsem2(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(CoreGroupError::FramingValidationError(
+        MlsGroupError::Group(CoreGroupError::FramingValidationError(
             FramingValidationError::WrongGroupId
         ))
     );
@@ -301,7 +299,7 @@ fn test_valsem3(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(CoreGroupError::FramingValidationError(
+        MlsGroupError::Group(CoreGroupError::FramingValidationError(
             FramingValidationError::WrongEpoch
         ))
     );
@@ -317,7 +315,7 @@ fn test_valsem3(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(CoreGroupError::FramingValidationError(
+        MlsGroupError::Group(CoreGroupError::FramingValidationError(
             FramingValidationError::WrongEpoch
         ))
     );
@@ -365,7 +363,7 @@ fn test_valsem4(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(CoreGroupError::FramingValidationError(
+        MlsGroupError::Group(CoreGroupError::FramingValidationError(
             FramingValidationError::UnknownMember
         ))
     );
@@ -411,7 +409,7 @@ fn test_valsem5(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(CoreGroupError::ValidationError(
+        MlsGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::UnencryptedApplicationMessage
         ))
     );
@@ -456,7 +454,7 @@ fn test_valsem6(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(CoreGroupError::ValidationError(
+        MlsGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::MlsCiphertextError(MlsCiphertextError::DecryptionError)
         ))
     );
@@ -501,7 +499,7 @@ fn test_valsem7(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(CoreGroupError::ValidationError(
+        MlsGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::MissingMembershipTag
         ))
     );
@@ -553,7 +551,7 @@ fn test_valsem8(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(CoreGroupError::ValidationError(
+        MlsGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::MlsPlaintextError(MlsPlaintextError::VerificationError(
                 VerificationError::InvalidMembershipTag
             ))
@@ -603,7 +601,7 @@ fn test_valsem9(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(CoreGroupError::ValidationError(
+        MlsGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::MissingConfirmationTag
         ))
     );
@@ -690,7 +688,7 @@ fn test_valsem10(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypto
 
     assert_eq!(
         err,
-        ManagedGroupError::Group(CoreGroupError::ValidationError(
+        MlsGroupError::Group(CoreGroupError::ValidationError(
             ValidationError::CredentialError(CredentialError::InvalidSignature)
         ))
     );

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! OpenMLS is an implementation of the [MLS RFC].
 //!
-//! The main entry point for most consumers should be the [ManagedGroup](prelude::ManagedGroup).
+//! The main entry point for most consumers should be the [MlsGroup](prelude::MlsGroup).
 //! It provides an safe, opinionated API for interacting with core groups.
 //!
 //! ## Error handling

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -5,8 +5,7 @@ pub use crate::group::CoreGroup;
 pub use crate::group::CoreGroupConfig;
 pub use crate::group::{
     proposals::{ProposalStore, StagedProposal},
-    InvalidMessageError, ManagedGroup, ManagedGroupConfig, ManagedGroupError, UpdatePolicy,
-    WireFormat,
+    InvalidMessageError, MlsGroup, MlsGroupConfig, MlsGroupError, UpdatePolicy, WireFormat,
 };
 // Errors
 pub use crate::group::errors::{

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -21,7 +21,7 @@ pub struct Client {
     /// Ciphersuites supported by the client.
     pub credentials: HashMap<CiphersuiteName, Credential>,
     pub crypto: OpenMlsRustCrypto,
-    pub groups: RefCell<HashMap<GroupId, ManagedGroup>>,
+    pub groups: RefCell<HashMap<GroupId, MlsGroup>>,
 }
 
 impl Client {
@@ -63,12 +63,12 @@ impl Client {
     }
 
     /// Create a group with the given `group_id`, `ciphersuite` and
-    /// `managed_group_config`. Throws an error if the client doesn't support
+    /// `mls_group_config`. Throws an error if the client doesn't support
     /// the `ciphersuite`, i.e. if no corresponding `CredentialBundle` exists.
     pub fn create_group(
         &self,
         group_id: GroupId,
-        managed_group_config: ManagedGroupConfig,
+        mls_group_config: MlsGroupConfig,
         ciphersuite: &Ciphersuite,
     ) -> Result<(), ClientError> {
         let credential = self
@@ -94,9 +94,9 @@ impl Client {
             .key_store()
             .store(&key_package.hash(&self.crypto)?, &kpb)
             .expect("An unexpected error occurred.");
-        let group_state = ManagedGroup::new(
+        let group_state = MlsGroup::new(
             &self.crypto,
-            &managed_group_config,
+            &mls_group_config,
             group_id.clone(),
             &key_package.hash(&self.crypto)?,
         )?;
@@ -105,21 +105,17 @@ impl Client {
     }
 
     /// Join a group based on the given `welcome` and `ratchet_tree`. The group
-    /// is created with the given `ManagedGroupConfig`. Throws an error if no
+    /// is created with the given `MlsGroupConfig`. Throws an error if no
     /// `KeyPackage` exists matching the `Welcome`, if the client doesn't
     /// support the ciphersuite, or if an error occurs processing the `Welcome`.
     pub fn join_group(
         &self,
-        managed_group_config: ManagedGroupConfig,
+        mls_group_config: MlsGroupConfig,
         welcome: Welcome,
         ratchet_tree: Option<Vec<Option<Node>>>,
     ) -> Result<(), ClientError> {
-        let new_group: ManagedGroup = ManagedGroup::new_from_welcome(
-            &self.crypto,
-            &managed_group_config,
-            welcome,
-            ratchet_tree,
-        )?;
+        let new_group: MlsGroup =
+            MlsGroup::new_from_welcome(&self.crypto, &mls_group_config, welcome, ratchet_tree)?;
         self.groups
             .borrow_mut()
             .insert(new_group.group_id().to_owned(), new_group);

--- a/openmls/src/test_utils/test_framework/errors.rs
+++ b/openmls/src/test_utils/test_framework/errors.rs
@@ -19,9 +19,9 @@ impl From<ClientError> for SetupError {
     }
 }
 
-impl From<ManagedGroupError> for SetupError {
-    fn from(e: ManagedGroupError) -> Self {
-        SetupError::ClientError(ClientError::ManagedGroupError(e))
+impl From<MlsGroupError> for SetupError {
+    fn from(e: MlsGroupError) -> Self {
+        SetupError::ClientError(ClientError::MlsGroupError(e))
     }
 }
 
@@ -46,7 +46,7 @@ pub enum ClientError {
     NoCiphersuite,
     FailedToJoinGroup(WelcomeError),
     InvalidMessage(CoreGroupError),
-    ManagedGroupError(ManagedGroupError),
+    MlsGroupError(MlsGroupError),
     GroupError(CoreGroupError),
     TlsCodecError(tls_codec::Error),
     KeyPackageError(KeyPackageError),
@@ -59,9 +59,9 @@ impl From<WelcomeError> for ClientError {
     }
 }
 
-impl From<ManagedGroupError> for ClientError {
-    fn from(e: ManagedGroupError) -> Self {
-        ClientError::ManagedGroupError(e)
+impl From<MlsGroupError> for ClientError {
+    fn from(e: MlsGroupError) -> Self {
+        ClientError::MlsGroupError(e)
     }
 }
 

--- a/openmls/src/test_utils/test_framework/messages.rs
+++ b/openmls/src/test_utils/test_framework/messages.rs
@@ -1,5 +1,5 @@
 //! This module contains code to serialize `MlsMessage`/`MlsMessageIn` as used
-//! by the Managed API, which the Clients are built on. These
+//! by the MlsGroup API, which the Clients are built on. These
 //! serialization/deserialization functions attach an additional byte that
 //! indicates if a message is a plaintext or a ciphertext
 

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -1,5 +1,5 @@
 //! This crate provides a framework to set up clients and groups using the
-//! OpenMLS managed_group API. To use the framework, start by creating a new
+//! OpenMLS mls_group API. To use the framework, start by creating a new
 //! `TestSetup` with a number of clients. After that, `create_clients` has to be
 //! called before the the `TestSetup` can be used.
 //!
@@ -52,7 +52,7 @@ pub struct Group {
     pub group_id: GroupId,
     pub members: Vec<(usize, Vec<u8>)>,
     pub ciphersuite: Ciphersuite,
-    pub group_config: ManagedGroupConfig,
+    pub group_config: MlsGroupConfig,
     pub public_tree: Vec<Option<Node>>,
     pub exporter_secret: Vec<u8>,
 }
@@ -80,27 +80,27 @@ pub enum CodecUse {
     StructMessages,
 }
 
-/// `ManagedTestSetup` is the main struct of the framework. It contains the
+/// `MlsGroupTestSetup` is the main struct of the framework. It contains the
 /// state of all clients, as well as the global `KeyStore` containing the
 /// clients' `CredentialBundles`. The `waiting_for_welcome` field acts as a
 /// temporary store for `KeyPackage`s that are used to add new members to
-/// groups. Note, that the `ManagedTestSetup` can only be initialized with a
+/// groups. Note, that the `MlsGroupTestSetup` can only be initialized with a
 /// fixed number of clients and that `create_clients` has to be called before it
 /// can be otherwise used.
-pub struct ManagedTestSetup {
+pub struct MlsGroupTestSetup {
     // The clients identity is its position in the vector in be_bytes.
     pub clients: RefCell<HashMap<Vec<u8>, RefCell<Client>>>,
     pub groups: RefCell<HashMap<GroupId, Group>>,
     // This maps key package hashes to client ids.
     pub waiting_for_welcome: RefCell<HashMap<Vec<u8>, Vec<u8>>>,
-    pub default_mgc: ManagedGroupConfig,
+    pub default_mgc: MlsGroupConfig,
     /// Flag to indicate if messages should be serialized and de-serialized as
     /// part of message distribution
     pub use_codec: CodecUse,
 }
 
-// Some notes regarding the layout of the `ManagedTestSetup` implementation
-// below: The references to the credentials in the ManagedGroups (in the
+// Some notes regarding the layout of the `MlsGroupTestSetup` implementation
+// below: The references to the credentials in the MlsGroups (in the
 // clients) are essentially references to the keystore, which in turns means
 // they are references to the top-level object, i.e. the setup.
 //
@@ -114,21 +114,17 @@ pub struct ManagedTestSetup {
 //   object and won't live long enough.
 //
 // Finally, this means we have to initialize the KeyStore before we create the
-// ManagedTestSetup object and we can create the clients (which contain the
+// MlsGroupTestSetup object and we can create the clients (which contain the
 // references to the KeyStore) only after we do that. This has to happen in the
-// context that the `ManagedTestSetup` lives in, because otherwise the
+// context that the `MlsGroupTestSetup` lives in, because otherwise the
 // references don't live long enough.
 
-impl ManagedTestSetup {
-    /// Create a new `ManagedTestSetup` with the given default
-    /// `ManagedGroupConfig` and the given number of clients. For lifetime
+impl MlsGroupTestSetup {
+    /// Create a new `MlsGroupTestSetup` with the given default
+    /// `MlsGroupConfig` and the given number of clients. For lifetime
     /// reasons, `create_clients` has to be called in addition with the same
     /// number of clients.
-    pub fn new(
-        default_mgc: ManagedGroupConfig,
-        number_of_clients: usize,
-        use_codec: CodecUse,
-    ) -> Self {
+    pub fn new(default_mgc: MlsGroupConfig, number_of_clients: usize, use_codec: CodecUse) -> Self {
         let mut clients = HashMap::new();
         for i in 0..number_of_clients {
             let identity = i.to_be_bytes().to_vec();
@@ -160,7 +156,7 @@ impl ManagedTestSetup {
         }
         let groups = RefCell::new(HashMap::new());
         let waiting_for_welcome = RefCell::new(HashMap::new());
-        ManagedTestSetup {
+        MlsGroupTestSetup {
             clients: RefCell::new(clients),
             groups,
             waiting_for_welcome,

--- a/openmls/src/tree/tests_and_kats/kats/kat_tree_kem.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_tree_kem.rs
@@ -33,7 +33,7 @@ use crate::{
     test_utils::*,
     test_utils::{
         bytes_to_hex,
-        test_framework::{ActionType, ManagedTestSetup},
+        test_framework::{ActionType, MlsGroupTestSetup},
     },
     tree::{treemath::*, CiphersuiteName, HashSet, LeafIndex, NodeIndex, RatchetTree, UpdatePath},
 };
@@ -324,7 +324,7 @@ pub fn generate_test_vector(n_leaves: u32, ciphersuite: &'static Ciphersuite) ->
 
     use crate::{
         extensions::RatchetTreeExtension,
-        prelude::{KeyPackageBundle, ManagedGroupConfig},
+        prelude::{KeyPackageBundle, MlsGroupConfig},
         test_utils::test_framework::CodecUse,
     };
 
@@ -335,10 +335,10 @@ pub fn generate_test_vector(n_leaves: u32, ciphersuite: &'static Ciphersuite) ->
         panic!("test vector can only be generated with two or more members")
     }
     // Set up a group with `n_leaves` members.
-    let managed_group_config = ManagedGroupConfig::test_default();
+    let mls_group_config = MlsGroupConfig::test_default();
 
-    let setup = ManagedTestSetup::new(
-        managed_group_config,
+    let setup = MlsGroupTestSetup::new(
+        mls_group_config,
         n_leaves as usize,
         CodecUse::SerializedMessages,
     );

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_resolution.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_resolution.rs
@@ -1,9 +1,9 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
 
 use crate::{
-    group::ManagedGroupConfig,
+    group::MlsGroupConfig,
     test_utils::{
-        test_framework::{ActionType, CodecUse, ManagedTestSetup},
+        test_framework::{ActionType, CodecUse, MlsGroupTestSetup},
         *,
     },
     tree::*,
@@ -216,13 +216,13 @@ fn test_original_child_resolution(
 #[test]
 fn test_exclusion_for_parent_nodes() {
     // Create a large tree members.
-    let managed_group_config = ManagedGroupConfig::test_default();
+    let mls_group_config = MlsGroupConfig::test_default();
 
     // We need 16 clients, such that we can create a group with 16 members. 16
     // members means that we have two layers between the root and the leaves.
     let number_of_clients = 16;
-    let setup = ManagedTestSetup::new(
-        managed_group_config,
+    let setup = MlsGroupTestSetup::new(
+        mls_group_config,
         number_of_clients,
         CodecUse::SerializedMessages,
     );

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_tree_truncation.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_tree_truncation.rs
@@ -3,10 +3,10 @@ use openmls_rust_crypto::OpenMlsRustCrypto;
 use crate::{
     ciphersuite::Ciphersuite,
     credentials::{CredentialBundle, CredentialType},
-    group::ManagedGroupConfig,
+    group::MlsGroupConfig,
     prelude::{KeyPackageBundle, LeafIndex},
     test_utils::{
-        test_framework::{ActionType, CodecUse, ManagedTestSetup},
+        test_framework::{ActionType, CodecUse, MlsGroupTestSetup},
         *,
     },
     tree::node::{Node, NodeType},
@@ -80,11 +80,11 @@ fn test_trim(backend: &impl OpenMlsCryptoProvider) {
 #[test]
 fn test_truncation_after_removal() {
     // Set up a group with 8 members.
-    let managed_group_config = ManagedGroupConfig::test_default();
+    let mls_group_config = MlsGroupConfig::test_default();
     let test_group_sizes = vec![5, 15, 21, 65];
     for number_of_clients in test_group_sizes {
-        let setup = ManagedTestSetup::new(
-            managed_group_config.clone(),
+        let setup = MlsGroupTestSetup::new(
+            mls_group_config.clone(),
             number_of_clients,
             CodecUse::SerializedMessages,
         );
@@ -125,11 +125,11 @@ fn test_truncation_after_removal() {
 #[test]
 fn test_truncation_after_update() {
     // Set up a group with 8 members.
-    let managed_group_config = ManagedGroupConfig::test_default();
+    let mls_group_config = MlsGroupConfig::test_default();
     let test_group_sizes = vec![5, 15, 21, 65];
     for number_of_clients in test_group_sizes {
-        let setup = ManagedTestSetup::new(
-            managed_group_config.clone(),
+        let setup = MlsGroupTestSetup::new(
+            mls_group_config.clone(),
             number_of_clients,
             CodecUse::SerializedMessages,
         );

--- a/openmls/tests/test_decryption_key_index.rs
+++ b/openmls/tests/test_decryption_key_index.rs
@@ -2,7 +2,7 @@
 use openmls::{
     prelude::*,
     test_utils::{
-        test_framework::{ActionType, CodecUse, ManagedTestSetup},
+        test_framework::{ActionType, CodecUse, MlsGroupTestSetup},
         *,
     },
     *,
@@ -15,14 +15,14 @@ mod utils;
 fn decryption_key_index_computation(ciphersuite: &'static Ciphersuite) {
     println!("Testing ciphersuite {:?}", ciphersuite.name());
 
-    // Some basic setup functions for the managed group.
-    let managed_group_config = ManagedGroupConfig::builder()
+    // Some basic setup functions for the MlsGroup.
+    let mls_group_config = MlsGroupConfig::builder()
         .wire_format(WireFormat::MlsPlaintext)
         .padding_size(10)
         .build();
     let number_of_clients = 20;
-    let setup = ManagedTestSetup::new(
-        managed_group_config,
+    let setup = MlsGroupTestSetup::new(
+        mls_group_config,
         number_of_clients,
         CodecUse::StructMessages,
     );

--- a/openmls/tests/test_interop_scenarios.rs
+++ b/openmls/tests/test_interop_scenarios.rs
@@ -1,6 +1,6 @@
 use openmls::{
     prelude::*,
-    test_utils::test_framework::{ActionType, CodecUse, ManagedTestSetup},
+    test_utils::test_framework::{ActionType, CodecUse, MlsGroupTestSetup},
     test_utils::*,
     *,
 };
@@ -13,8 +13,8 @@ mod utils;
 // The tests are conducted for every available ciphersuite, but currently only
 // using BasicCredentials. We can change the test setup once #134 is fixed.
 
-fn default_managed_group_config() -> ManagedGroupConfig {
-    ManagedGroupConfig::builder()
+fn default_mls_group_config() -> MlsGroupConfig {
+    MlsGroupConfig::builder()
         .wire_format(WireFormat::MlsPlaintext)
         .padding_size(10)
         .build()
@@ -29,8 +29,8 @@ fn default_managed_group_config() -> ManagedGroupConfig {
 fn one_to_one_join(ciphersuite: &'static Ciphersuite) {
     println!("Testing ciphersuite {:?}", ciphersuite.name());
     let number_of_clients = 2;
-    let setup = ManagedTestSetup::new(
-        default_managed_group_config(),
+    let setup = MlsGroupTestSetup::new(
+        default_mls_group_config(),
         number_of_clients,
         CodecUse::StructMessages,
     );
@@ -76,8 +76,8 @@ fn three_party_join(ciphersuite: &'static Ciphersuite) {
     println!("Testing ciphersuite {:?}", ciphersuite.name());
 
     let number_of_clients = 3;
-    let setup = ManagedTestSetup::new(
-        default_managed_group_config(),
+    let setup = MlsGroupTestSetup::new(
+        default_mls_group_config(),
         number_of_clients,
         CodecUse::StructMessages,
     );
@@ -132,8 +132,8 @@ fn multiple_joins(ciphersuite: &'static Ciphersuite) {
     println!("Testing ciphersuite {:?}", ciphersuite.name());
 
     let number_of_clients = 3;
-    let setup = ManagedTestSetup::new(
-        default_managed_group_config(),
+    let setup = MlsGroupTestSetup::new(
+        default_mls_group_config(),
         number_of_clients,
         CodecUse::StructMessages,
     );
@@ -180,8 +180,8 @@ fn update(ciphersuite: &'static Ciphersuite) {
     println!("Testing ciphersuite {:?}", ciphersuite.name());
 
     let number_of_clients = 2;
-    let setup = ManagedTestSetup::new(
-        default_managed_group_config(),
+    let setup = MlsGroupTestSetup::new(
+        default_mls_group_config(),
         number_of_clients,
         CodecUse::StructMessages,
     );
@@ -223,8 +223,8 @@ fn remove(ciphersuite: &'static Ciphersuite) {
     println!("Testing ciphersuite {:?}", ciphersuite.name());
 
     let number_of_clients = 2;
-    let setup = ManagedTestSetup::new(
-        default_managed_group_config(),
+    let setup = MlsGroupTestSetup::new(
+        default_mls_group_config(),
         number_of_clients,
         CodecUse::StructMessages,
     );
@@ -275,8 +275,8 @@ fn large_group_lifecycle(ciphersuite: &'static Ciphersuite) {
 
     // "Large" is 20 for now.
     let number_of_clients = 20;
-    let setup = ManagedTestSetup::new(
-        default_managed_group_config(),
+    let setup = MlsGroupTestSetup::new(
+        default_mls_group_config(),
         number_of_clients,
         CodecUse::StructMessages,
     );

--- a/openmls/tests/test_managed_api.rs
+++ b/openmls/tests/test_managed_api.rs
@@ -1,6 +1,6 @@
 use openmls::{
     prelude::*,
-    test_utils::test_framework::{ActionType, CodecUse, ManagedTestSetup},
+    test_utils::test_framework::{ActionType, CodecUse, MlsGroupTestSetup},
     test_utils::*,
     *,
 };
@@ -8,14 +8,14 @@ use openmls::{
 mod utils;
 
 #[apply(ciphersuites)]
-fn test_managed_api(ciphersuite: &'static Ciphersuite) {
-    // Some basic setup functions for the managed group.
-    let managed_group_config = ManagedGroupConfig::builder()
+fn test_mls_group_api(ciphersuite: &'static Ciphersuite) {
+    // Some basic setup functions for the MlsGroup.
+    let mls_group_config = MlsGroupConfig::builder()
         .wire_format(WireFormat::MlsPlaintext)
         .build();
     let number_of_clients = 20;
-    let setup = ManagedTestSetup::new(
-        managed_group_config,
+    let setup = MlsGroupTestSetup::new(
+        mls_group_config,
         number_of_clients,
         CodecUse::SerializedMessages,
     );

--- a/openmls/tests/test_managed_group.rs
+++ b/openmls/tests/test_managed_group.rs
@@ -64,10 +64,7 @@ fn generate_key_package_bundle(
 ///  - Bob leaves
 ///  - Test saving the group state
 #[apply(ciphersuites_and_backends)]
-fn managed_group_operations(
-    ciphersuite: &'static Ciphersuite,
-    backend: &impl OpenMlsCryptoProvider,
-) {
+fn mls_group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     for wire_format in vec![WireFormat::MlsPlaintext, WireFormat::MlsCiphertext].into_iter() {
         let group_id = GroupId::from_slice(b"Test Group");
 
@@ -105,16 +102,14 @@ fn managed_group_operations(
             generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![], backend)
                 .expect("An unexpected error occurred.");
 
-        // Define the managed group configuration
+        // Define the MlsGroup configuration
 
-        let managed_group_config = ManagedGroupConfig::builder()
-            .wire_format(wire_format)
-            .build();
+        let mls_group_config = MlsGroupConfig::builder().wire_format(wire_format).build();
 
         // === Alice creates a group ===
-        let mut alice_group = ManagedGroup::new(
+        let mut alice_group = MlsGroup::new(
             backend,
-            &managed_group_config,
+            &mls_group_config,
             group_id,
             &alice_key_package
                 .hash(backend)
@@ -182,9 +177,9 @@ fn managed_group_operations(
         assert_eq!(members[0].identity(), b"Alice");
         assert_eq!(members[1].identity(), b"Bob");
 
-        let mut bob_group = ManagedGroup::new_from_welcome(
+        let mut bob_group = MlsGroup::new_from_welcome(
             backend,
-            &managed_group_config,
+            &mls_group_config,
             welcome,
             Some(alice_group.export_ratchet_tree()),
         )
@@ -448,9 +443,9 @@ fn managed_group_operations(
             unreachable!("Expected a StagedCommit.");
         }
 
-        let mut charlie_group = ManagedGroup::new_from_welcome(
+        let mut charlie_group = MlsGroup::new_from_welcome(
             backend,
-            &managed_group_config,
+            &mls_group_config,
             welcome,
             Some(bob_group.export_ratchet_tree()),
         )
@@ -835,9 +830,9 @@ fn managed_group_operations(
         assert_eq!(members[1].identity(), b"Bob");
 
         // Bob creates a new group
-        let mut bob_group = ManagedGroup::new_from_welcome(
+        let mut bob_group = MlsGroup::new_from_welcome(
             backend,
-            &managed_group_config,
+            &mls_group_config,
             welcome_option.expect("Welcome was not returned"),
             Some(alice_group.export_ratchet_tree()),
         )
@@ -923,7 +918,7 @@ fn managed_group_operations(
         // Should fail because you cannot remove yourself from a group
         assert_eq!(
             bob_group.commit_to_pending_proposals(backend,),
-            Err(ManagedGroupError::Group(CoreGroupError::CreateCommitError(
+            Err(MlsGroupError::Group(CoreGroupError::CreateCommitError(
                 CreateCommitError::CannotRemoveSelf
             )))
         );
@@ -1029,9 +1024,9 @@ fn managed_group_operations(
             unreachable!("Expected a StagedCommit.");
         }
 
-        let mut bob_group = ManagedGroup::new_from_welcome(
+        let mut bob_group = MlsGroup::new_from_welcome(
             backend,
-            &managed_group_config,
+            &mls_group_config,
             welcome,
             Some(alice_group.export_ratchet_tree()),
         )
@@ -1056,7 +1051,7 @@ fn managed_group_operations(
         .to_lowercase();
         let path = TEMP_DIR
             .path()
-            .join(format!("test_managed_group_{}.json", &name));
+            .join(format!("test_mls_group_{}.json", &name));
         let out_file = &mut File::create(path.clone()).expect("Could not create file");
         bob_group
             .save(out_file)
@@ -1066,7 +1061,7 @@ fn managed_group_operations(
         assert_eq!(bob_group.state_changed(), InnerState::Persisted);
 
         let file = File::open(path).expect("Could not open file");
-        let bob_group = ManagedGroup::load(file).expect("Could not load group from file");
+        let bob_group = MlsGroup::load(file).expect("Could not load group from file");
 
         // Make sure the state is still the same
         assert_eq!(
@@ -1097,13 +1092,13 @@ fn test_empty_input_errors(
         generate_key_package_bundle(&[ciphersuite.name()], &alice_credential, vec![], backend)
             .expect("An unexpected error occurred.");
 
-    // Define the managed group configuration
-    let managed_group_config = ManagedGroupConfig::test_default();
+    // Define the MlsGroup configuration
+    let mls_group_config = MlsGroupConfig::test_default();
 
     // === Alice creates a group ===
-    let mut alice_group = ManagedGroup::new(
+    let mut alice_group = MlsGroup::new(
         backend,
-        &managed_group_config,
+        &mls_group_config,
         group_id,
         &alice_key_package
             .hash(backend)
@@ -1115,19 +1110,19 @@ fn test_empty_input_errors(
         alice_group
             .add_members(backend, &[])
             .expect_err("No EmptyInputError when trying to pass an empty slice to `add_members`."),
-        ManagedGroupError::EmptyInput(EmptyInputError::AddMembers)
+        MlsGroupError::EmptyInput(EmptyInputError::AddMembers)
     );
     assert_eq!(
         alice_group.remove_members(backend, &[]).expect_err(
             "No EmptyInputError when trying to pass an empty slice to `remove_members`."
         ),
-        ManagedGroupError::EmptyInput(EmptyInputError::RemoveMembers)
+        MlsGroupError::EmptyInput(EmptyInputError::RemoveMembers)
     );
 }
 
 // This tests the ratchet tree extension usage flag in the configuration
 #[apply(ciphersuites_and_backends)]
-fn managed_group_ratchet_tree_extension(
+fn mls_group_ratchet_tree_extension(
     ciphersuite: &'static Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) {
@@ -1162,15 +1157,15 @@ fn managed_group_ratchet_tree_extension(
             generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![], backend)
                 .expect("An unexpected error occurred.");
 
-        let managed_group_config = ManagedGroupConfig::builder()
+        let mls_group_config = MlsGroupConfig::builder()
             .wire_format(wire_format)
             .use_ratchet_tree_extension(true)
             .build();
 
         // === Alice creates a group ===
-        let mut alice_group = ManagedGroup::new(
+        let mut alice_group = MlsGroup::new(
             backend,
-            &managed_group_config,
+            &mls_group_config,
             group_id.clone(),
             &alice_key_package
                 .hash(backend)
@@ -1186,9 +1181,8 @@ fn managed_group_ratchet_tree_extension(
             };
 
         // === Bob joins using the ratchet tree extension ===
-        let _bob_group =
-            ManagedGroup::new_from_welcome(backend, &managed_group_config, welcome, None)
-                .expect("Error creating group from Welcome");
+        let _bob_group = MlsGroup::new_from_welcome(backend, &mls_group_config, welcome, None)
+            .expect("Error creating group from Welcome");
 
         // === Negative case: not using the ratchet tree extension ===
 
@@ -1218,12 +1212,12 @@ fn managed_group_ratchet_tree_extension(
             generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![], backend)
                 .expect("An unexpected error occurred.");
 
-        let managed_group_config = ManagedGroupConfig::test_default();
+        let mls_group_config = MlsGroupConfig::test_default();
 
         // === Alice creates a group ===
-        let mut alice_group = ManagedGroup::new(
+        let mut alice_group = MlsGroup::new(
             backend,
-            &managed_group_config,
+            &mls_group_config,
             group_id,
             &alice_key_package
                 .hash(backend)
@@ -1239,12 +1233,12 @@ fn managed_group_ratchet_tree_extension(
         };
 
         // === Bob tries to join without the ratchet tree extension ===
-        let error = ManagedGroup::new_from_welcome(backend, &managed_group_config, welcome, None)
+        let error = MlsGroup::new_from_welcome(backend, &mls_group_config, welcome, None)
             .expect_err("Could join a group without a ratchet tree");
 
         assert_eq!(
             error,
-            ManagedGroupError::Group(CoreGroupError::WelcomeError(
+            MlsGroupError::Group(CoreGroupError::WelcomeError(
                 WelcomeError::MissingRatchetTree
             ))
         );


### PR DESCRIPTION
This PR renames `ManagedGroup` to `MlsGroup` and adjusts the variables and adjacent structs.