### PR TITLE
Make SenderRatchet parameters configurable

### DIFF
--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -146,7 +146,11 @@ impl User {
                     };
                     let msg = match message {
                         DsMlsMessage::Ciphertext(ctxt) => {
-                            let verifiable_plaintext = match group.decrypt(&ctxt, &self.crypto) {
+                            let verifiable_plaintext = match group.decrypt(
+                                &ctxt,
+                                &self.crypto,
+                                &SenderRatchetConfiguration::default(),
+                            ) {
                                 Ok(msg) => msg,
                                 Err(e) => {
                                     log::error!(

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -120,6 +120,7 @@ async fn test_list_clients() {
 #[actix_rt::test]
 async fn test_group() {
     let crypto = &OpenMlsRustCrypto::default();
+    let configuration = &SenderRatchetConfiguration::default();
     let data = web::Data::new(Mutex::new(DsData::default()));
     let mut app = test::init_service(
         App::new()
@@ -337,7 +338,7 @@ async fn test_group() {
 
     // Decrypt the message on Client1
     let mls_plaintext = group
-        .decrypt(&mls_ciphertext, crypto)
+        .decrypt(&mls_ciphertext, crypto, configuration)
         .expect("Error decrypting MlsCiphertext");
     let mls_plaintext = group
         .verify(mls_plaintext, crypto)

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -598,6 +598,7 @@ impl MlsClient for MlsClientImpl {
         request: tonic::Request<UnprotectRequest>,
     ) -> Result<tonic::Response<UnprotectResponse>, tonic::Status> {
         let unprotect_request = request.get_ref();
+        let configuration = &SenderRatchetConfiguration::default();
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
@@ -608,7 +609,7 @@ impl MlsClient for MlsClientImpl {
             .map_err(|_| Status::aborted("failed to deserialize ciphertext"))?;
         let upt = interop_group
             .group
-            .decrypt(&message, &self.crypto_provider)
+            .decrypt(&message, &self.crypto_provider, configuration)
             .map_err(into_status)?;
         let application_data = interop_group
             .group
@@ -778,6 +779,8 @@ impl MlsClient for MlsClientImpl {
     ) -> Result<tonic::Response<CommitResponse>, tonic::Status> {
         let commit_request = request.get_ref();
 
+        let configuration = &SenderRatchetConfiguration::default();
+
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
             .get_mut(commit_request.state_id as usize)
@@ -791,7 +794,7 @@ impl MlsClient for MlsClientImpl {
                         .map_err(|_| Status::aborted("failed to deserialize ciphertext"))?;
                     let upt = interop_group
                         .group
-                        .decrypt(&ct, &self.crypto_provider)
+                        .decrypt(&ct, &self.crypto_provider, configuration)
                         .map_err(|_| Status::aborted("failed to decrypt ciphertext"))?;
                     interop_group
                         .group
@@ -821,7 +824,7 @@ impl MlsClient for MlsClientImpl {
                         .map_err(|_| Status::aborted("failed to deserialize ciphertext"))?;
                     let upt = interop_group
                         .group
-                        .decrypt(&ct, &self.crypto_provider)
+                        .decrypt(&ct, &self.crypto_provider, configuration)
                         .map_err(|_| Status::aborted("failed to decrypt ciphertext"))?;
                     interop_group
                         .group
@@ -906,6 +909,8 @@ impl MlsClient for MlsClientImpl {
     ) -> Result<tonic::Response<HandleCommitResponse>, tonic::Status> {
         let handle_commit_request = request.get_ref();
 
+        let configuration = &SenderRatchetConfiguration::default();
+
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
             .get_mut(handle_commit_request.state_id as usize)
@@ -918,7 +923,7 @@ impl MlsClient for MlsClientImpl {
                         .map_err(|_| Status::aborted("failed to deserialize ciphertext"))?;
                 let upt = interop_group
                     .group
-                    .decrypt(&ct, &self.crypto_provider)
+                    .decrypt(&ct, &self.crypto_provider, configuration)
                     .map_err(|_| Status::aborted("failed to decrypt ciphertext"))?;
                 interop_group
                     .group
@@ -944,7 +949,7 @@ impl MlsClient for MlsClientImpl {
                         .map_err(|_| Status::aborted("failed to deserialize ciphertext"))?;
                     let upt = interop_group
                         .group
-                        .decrypt(&ct, &self.crypto_provider)
+                        .decrypt(&ct, &self.crypto_provider, configuration)
                         .map_err(|_| Status::aborted("failed to decrypt ciphertext"))?;
                     interop_group
                         .group

--- a/openmls/src/framing/ciphertext.rs
+++ b/openmls/src/framing/ciphertext.rs
@@ -4,7 +4,7 @@ use tls_codec::{
     TlsDeserialize, TlsSerialize, TlsSize,
 };
 
-use crate::tree::secret_tree::SecretType;
+use crate::tree::{secret_tree::SecretType, sender_ratchet::SenderRatchetConfiguration};
 
 use super::*;
 
@@ -148,6 +148,7 @@ impl MlsCiphertext {
         ciphersuite: &Ciphersuite,
         backend: &impl OpenMlsCryptoProvider,
         message_secrets: &mut MessageSecrets,
+        sender_ratchet_configuration: &SenderRatchetConfiguration,
     ) -> Result<VerifiableMlsPlaintext, MlsCiphertextError> {
         log::debug!("Decrypting MlsCiphertext");
         // Check the ciphertext has the correct wire format
@@ -193,6 +194,7 @@ impl MlsCiphertext {
                 sender_data.sender.into(),
                 secret_type,
                 sender_data.generation,
+                sender_ratchet_configuration,
             )
             .map_err(|_| {
                 log::error!("  Ciphertext generation out of bounds");

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -1,22 +1,22 @@
-//use crate::test_utils::*;
-use openmls_traits::OpenMlsCryptoProvider;
-
-use rstest::*;
-use rstest_reuse::{self, *};
-
-use core_group::create_commit_params::CreateCommitParams;
-use core_group::proposals::ProposalStore;
-use core_group::proposals::StagedProposal;
-use openmls_rust_crypto::OpenMlsRustCrypto;
-use tls_codec::{Deserialize, Serialize};
-
 use crate::{
     ciphersuite::signable::{Signable, Verifiable},
     config::*,
     framing::*,
+    group::core_group::{
+        create_commit_params::CreateCommitParams,
+        proposals::{ProposalStore, StagedProposal},
+    },
     key_packages::KeyPackageBundle,
+    tree::sender_ratchet::SenderRatchetConfiguration,
     utils::print_tree,
 };
+
+use rstest::*;
+use rstest_reuse::{self, *};
+
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use openmls_traits::OpenMlsCryptoProvider;
+use tls_codec::{Deserialize, Serialize};
 
 /// This tests serializing/deserializing MlsPlaintext
 #[apply(ciphersuites_and_backends)]
@@ -155,6 +155,7 @@ fn codec_ciphertext(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
 /// This tests the correctness of wire format checks
 #[apply(ciphersuites_and_backends)]
 fn wire_format_checks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+    let configuration = &SenderRatchetConfiguration::default();
     let credential_bundle = CredentialBundle::new(
         vec![7, 8, 9],
         CredentialType::Basic,
@@ -229,7 +230,7 @@ fn wire_format_checks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
     // Decrypt the ciphertext and expect the correct wire format
 
     let verifiable_plaintext = ciphertext
-        .to_plaintext(ciphersuite, backend, &mut message_secrets)
+        .to_plaintext(ciphersuite, backend, &mut message_secrets, configuration)
         .expect("Could not decrypt MlsCiphertext.");
 
     assert_eq!(
@@ -243,7 +244,7 @@ fn wire_format_checks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
 
     assert_eq!(
         ciphertext
-            .to_plaintext(ciphersuite, backend, &mut message_secrets)
+            .to_plaintext(ciphersuite, backend, &mut message_secrets, configuration)
             .expect_err("Could decrypt despite wrong wire format."),
         MlsCiphertextError::WrongWireFormat
     );
@@ -328,6 +329,7 @@ fn membership_tag(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
 fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     let group_aad = b"Alice's test group";
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
+    let configuration = &SenderRatchetConfiguration::default();
 
     // Define credential bundles
     let alice_credential_bundle = CredentialBundle::new(
@@ -532,7 +534,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
     .expect("Encryption error");
 
     let received_message = group_charlie
-        .decrypt(&enc_message, backend)
+        .decrypt(&enc_message, backend, configuration)
         .expect("error decrypting message");
     let received_message = group_charlie.verify(received_message, backend);
     assert_eq!(
@@ -570,7 +572,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
     )
     .expect("Encryption error");
 
-    let received_message = group_charlie.decrypt(&enc_message, backend);
+    let received_message = group_charlie.decrypt(&enc_message, backend, configuration);
     assert_eq!(
         received_message.unwrap_err(),
         CoreGroupError::MlsCiphertextError(MlsCiphertextError::GenerationOutOfBound)

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -34,7 +34,7 @@
 //! ProcessedMessage (Application, Proposal, ExternalProposal, Commit, External Commit)
 //! ```
 
-use crate::schedule::MessageSecrets;
+use crate::{schedule::MessageSecrets, tree::sender_ratchet::SenderRatchetConfiguration};
 use core_group::{proposals::StagedProposal, staged_commit::StagedCommit};
 use openmls_traits::OpenMlsCryptoProvider;
 
@@ -71,10 +71,16 @@ impl DecryptedMessage {
         ciphersuite: &Ciphersuite,
         backend: &impl OpenMlsCryptoProvider,
         message_secrets: &mut MessageSecrets,
+        sender_ratchet_configuration: &SenderRatchetConfiguration,
     ) -> Result<Self, ValidationError> {
         // This will be refactored with #265.
         if let MlsMessageIn::Ciphertext(ciphertext) = inbound_message {
-            let plaintext = ciphertext.to_plaintext(ciphersuite, backend, message_secrets)?;
+            let plaintext = ciphertext.to_plaintext(
+                ciphersuite,
+                backend,
+                message_secrets,
+                sender_ratchet_configuration,
+            )?;
             Self::from_plaintext(plaintext)
         } else {
             Err(ValidationError::WrongWireFormat)

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -39,6 +39,7 @@ use crate::{
     messages::{proposals::*, *},
     schedule::psk::*,
     schedule::*,
+    tree::sender_ratchet::*,
     treesync::{node::Node, *},
 };
 
@@ -427,8 +428,14 @@ impl CoreGroup {
         &mut self,
         mls_ciphertext: &MlsCiphertext,
         backend: &impl OpenMlsCryptoProvider,
+        sender_ratchet_configuration: &SenderRatchetConfiguration,
     ) -> Result<VerifiableMlsPlaintext, CoreGroupError> {
-        Ok(mls_ciphertext.to_plaintext(self.ciphersuite(), backend, &mut self.message_secrets)?)
+        Ok(mls_ciphertext.to_plaintext(
+            self.ciphersuite(),
+            backend,
+            &mut self.message_secrets,
+            sender_ratchet_configuration,
+        )?)
     }
 
     /// Set the context of the [`VerifiableMlsPlaintext`] (if it has not been

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -22,6 +22,7 @@ impl CoreGroup {
         &mut self,
         message: MlsMessageIn,
         message_secrets_store: impl Into<Option<&'a mut MessageSecretsStore>>,
+        sender_ratchet_configuration: &SenderRatchetConfiguration,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<UnverifiedMessage, CoreGroupError> {
         // Checks the following semantic validation:
@@ -62,6 +63,7 @@ impl CoreGroup {
                     &ciphersuite,
                     backend,
                     message_secrets,
+                    sender_ratchet_configuration,
                 )?
             }
         };

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -1,3 +1,5 @@
+use crate::tree::sender_ratchet::SenderRatchetConfiguration;
+
 use super::*;
 
 use serde::{Deserialize, Serialize};
@@ -23,6 +25,8 @@ pub struct MlsGroupConfig {
     pub(crate) use_ratchet_tree_extension: bool,
     /// Required capabilities (extensions and proposal types)
     pub(crate) required_capabilities: RequiredCapabilitiesExtension,
+    /// Sender ratchet configuration
+    pub(crate) sender_ratchet_configuration: SenderRatchetConfiguration,
 }
 
 impl MlsGroupConfig {
@@ -61,6 +65,11 @@ impl MlsGroupConfig {
         self.use_ratchet_tree_extension
     }
 
+    /// Get the [`MlsGroupConfig`] sender ratchet configuration.
+    pub fn sender_ratchet_configuration(&self) -> &SenderRatchetConfiguration {
+        &self.sender_ratchet_configuration
+    }
+
     #[cfg(any(feature = "test-utils", test))]
     pub fn test_default() -> Self {
         Self::builder()
@@ -79,6 +88,7 @@ impl Default for MlsGroupConfig {
             number_of_resumption_secrets: 0,
             use_ratchet_tree_extension: false,
             required_capabilities: RequiredCapabilitiesExtension::default(),
+            sender_ratchet_configuration: SenderRatchetConfiguration::default(),
         }
     }
 }
@@ -136,6 +146,16 @@ impl MlsGroupConfigBuilder {
     /// Sets the `use_ratchet_tree_extension` property of the MlsGroupConfig.
     pub fn use_ratchet_tree_extension(mut self, use_ratchet_tree_extension: bool) -> Self {
         self.config.use_ratchet_tree_extension = use_ratchet_tree_extension;
+        self
+    }
+
+    /// Sets the `sender_ratchet_configuration` property of the MlsGroupConfig.
+    /// See [`SenderRatchetConfiguration`] for more information.
+    pub fn sender_ratchet_configuration(
+        mut self,
+        sender_ratchet_configuration: SenderRatchetConfiguration,
+    ) -> Self {
+        self.config.sender_ratchet_configuration = sender_ratchet_configuration;
         self
     }
 

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -25,8 +25,15 @@ impl MlsGroup {
         self.flag_state_change();
 
         // Parse the message
+        let sender_ratchet_configuration =
+            self.configuration().sender_ratchet_configuration().clone();
         self.group
-            .parse_message(message, &mut self.message_secrets_store, backend)
+            .parse_message(
+                message,
+                &mut self.message_secrets_store,
+                &sender_ratchet_configuration,
+                backend,
+            )
             .map_err(MlsGroupError::Group)
     }
 

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -7,7 +7,7 @@
 use crate::{
     ciphersuite::signable::Signable, config::*, credentials::*, framing::*, group::*,
     key_packages::*, messages::proposals::*, messages::public_group_state::*, messages::*,
-    schedule::*, test_utils::*, treesync::node::Node,
+    schedule::*, test_utils::*, tree::sender_ratchet::*, treesync::node::Node,
 };
 
 use openmls_rust_crypto::OpenMlsRustCrypto;
@@ -188,7 +188,11 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
         )
         .expect("An unexpected error occurred.");
     let verifiable_mls_plaintext_application = group
-        .decrypt(&mls_ciphertext_application, &crypto)
+        .decrypt(
+            &mls_ciphertext_application,
+            &crypto,
+            &SenderRatchetConfiguration::default(),
+        )
         .expect("An unexpected error occurred.");
     // Sets the context implicitly.
     let mls_plaintext_application = group

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -41,6 +41,9 @@ pub use crate::key_packages::*;
 // Key store
 pub use crate::key_store::*;
 
+// Tree
+pub use crate::tree::SenderRatchetConfiguration;
+
 // PSKs
 // TODO #141
 pub use crate::schedule::psk::{

--- a/openmls/src/tree/mod.rs
+++ b/openmls/src/tree/mod.rs
@@ -1,10 +1,15 @@
 use crate::ciphersuite::*;
 
 // Tree modules
+// Public
 pub mod errors;
+pub mod sender_ratchet;
+pub use sender_ratchet::SenderRatchetConfiguration;
+
+// Crate
 pub(crate) mod index;
 pub(crate) mod secret_tree;
-pub(crate) mod sender_ratchet;
+
 pub(crate) mod treemath;
 
 pub(crate) use errors::*;

--- a/openmls/src/tree/secret_tree.rs
+++ b/openmls/src/tree/secret_tree.rs
@@ -210,6 +210,7 @@ impl SecretTree {
         index: LeafIndex,
         secret_type: SecretType,
         generation: u32,
+        configuration: &SenderRatchetConfiguration,
     ) -> Result<RatchetSecrets, SecretTreeError> {
         log::debug!(
             "Generating {:?} decryption secret for {:?} in generation {} with {}",
@@ -226,7 +227,7 @@ impl SecretTree {
             self.initialize_sender_ratchets(ciphersuite, backend, index)?;
         }
         let sender_ratchet = self.ratchet_mut(index, secret_type);
-        sender_ratchet.secret_for_decryption(ciphersuite, backend, generation)
+        sender_ratchet.secret_for_decryption(ciphersuite, backend, generation, configuration)
     }
 
     /// Return the next RatchetSecrets that should be used for encryption and

--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -11,8 +11,47 @@ use crate::tree::{index::LeafIndex, secret_tree::*};
 use super::index::NodeIndex;
 use super::*;
 
-const OUT_OF_ORDER_TOLERANCE: u32 = 5;
-const MAXIMUM_FORWARD_DISTANCE: u32 = 1000;
+// TODO #265: This should disappear
+pub(crate) const OUT_OF_ORDER_TOLERANCE: u32 = 5;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SenderRatchetConfiguration {
+    out_of_order_tolerance: u32,
+    maximum_forward_distance: u32,
+}
+
+impl SenderRatchetConfiguration {
+    /// Create a new configuration with the following parameters:
+    ///  - out_of_order_tolerance:
+    /// This parameter defines a window for which decryption secrets are kept.
+    /// This is useful in case the DS cannot guarantee that all application messages have total order within an epoch.
+    /// Use this carefully, since keeping decryption secrets affects forward secrecy within an epoch.
+    /// The dafault value is 0.
+    ///  - maximum_forward_distance:
+    /// This parameter defines how many incoming messages can be skipped. This is useful if the DS
+    /// drops application messages.
+    pub fn new(out_of_order_tolerance: u32, maximum_forward_distance: u32) -> Self {
+        Self {
+            out_of_order_tolerance,
+            maximum_forward_distance,
+        }
+    }
+    /// Get a reference to the sender ratchet configuration's out of order tolerance.
+    pub fn out_of_order_tolerance(&self) -> u32 {
+        self.out_of_order_tolerance
+    }
+
+    /// Get a reference to the sender ratchet configuration's maximum forward distance.
+    pub fn maximum_forward_distance(&self) -> u32 {
+        self.maximum_forward_distance
+    }
+}
+
+impl Default for SenderRatchetConfiguration {
+    fn default() -> Self {
+        Self::new(5, 1000)
+    }
+}
 
 pub type RatchetSecrets = (AeadKey, AeadNonce);
 
@@ -40,13 +79,15 @@ impl SenderRatchet {
         ciphersuite: &Ciphersuite,
         backend: &impl OpenMlsCryptoProvider,
         generation: u32,
+        configuration: &SenderRatchetConfiguration,
     ) -> Result<RatchetSecrets, SecretTreeError> {
         // If generation is too distant in the future
-        if generation > (self.generation + MAXIMUM_FORWARD_DISTANCE) {
+        if generation > (self.generation + configuration.maximum_forward_distance()) {
             return Err(SecretTreeError::TooDistantInTheFuture);
         }
         // If generation id too distant in the past
-        if generation < self.generation && (self.generation - generation) >= OUT_OF_ORDER_TOLERANCE
+        if generation < self.generation
+            && (self.generation - generation) >= configuration.out_of_order_tolerance()
         {
             return Err(SecretTreeError::TooDistantInThePast);
         }
@@ -64,7 +105,7 @@ impl SenderRatchet {
         // If generation is in the future
         } else {
             for _ in 0..(generation - self.generation) {
-                if self.past_secrets.len() == OUT_OF_ORDER_TOLERANCE as usize {
+                if self.past_secrets.len() == configuration.out_of_order_tolerance() as usize {
                     self.past_secrets.remove(0);
                 }
                 // We can return a library error here, because there must be a mistake in the implementation

--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -14,6 +14,18 @@ use super::*;
 // TODO #265: This should disappear
 pub(crate) const OUT_OF_ORDER_TOLERANCE: u32 = 5;
 
+/// Stores the configuration parameters for sender ratchets.
+///
+/// **Parameters**
+///
+///  - out_of_order_tolerance:
+/// This parameter defines a window for which decryption secrets are kept.
+/// This is useful in case the DS cannot guarantee that all application messages have total order within an epoch.
+/// Use this carefully, since keeping decryption secrets affects forward secrecy within an epoch.
+/// The default value is 0.
+///  - maximum_forward_distance:
+/// This parameter defines how many incoming messages can be skipped. This is useful if the DS
+/// drops application messages. The default value is 1000.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SenderRatchetConfiguration {
     out_of_order_tolerance: u32,
@@ -21,15 +33,7 @@ pub struct SenderRatchetConfiguration {
 }
 
 impl SenderRatchetConfiguration {
-    /// Create a new configuration with the following parameters:
-    ///  - out_of_order_tolerance:
-    /// This parameter defines a window for which decryption secrets are kept.
-    /// This is useful in case the DS cannot guarantee that all application messages have total order within an epoch.
-    /// Use this carefully, since keeping decryption secrets affects forward secrecy within an epoch.
-    /// The default value is 0.
-    ///  - maximum_forward_distance:
-    /// This parameter defines how many incoming messages can be skipped. This is useful if the DS
-    /// drops application messages. The default value is 1000.
+    /// Create a new configuration
     pub fn new(out_of_order_tolerance: u32, maximum_forward_distance: u32) -> Self {
         Self {
             out_of_order_tolerance,

--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -26,7 +26,7 @@ impl SenderRatchetConfiguration {
     /// This parameter defines a window for which decryption secrets are kept.
     /// This is useful in case the DS cannot guarantee that all application messages have total order within an epoch.
     /// Use this carefully, since keeping decryption secrets affects forward secrecy within an epoch.
-    /// The dafault value is 0.
+    /// The default value is 0.
     ///  - maximum_forward_distance:
     /// This parameter defines how many incoming messages can be skipped. This is useful if the DS
     /// drops application messages. The default value is 1000.

--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -29,7 +29,7 @@ impl SenderRatchetConfiguration {
     /// The dafault value is 0.
     ///  - maximum_forward_distance:
     /// This parameter defines how many incoming messages can be skipped. This is useful if the DS
-    /// drops application messages.
+    /// drops application messages. The default value is 1000.
     pub fn new(out_of_order_tolerance: u32, maximum_forward_distance: u32) -> Self {
         Self {
             out_of_order_tolerance,

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -87,7 +87,10 @@ use crate::{
     messages::proposals::Proposal,
     schedule::{EncryptionSecret, MembershipKey, SenderDataSecret},
     test_utils::*,
-    tree::secret_tree::{SecretTree, SecretType},
+    tree::{
+        secret_tree::{SecretTree, SecretType},
+        sender_ratchet::SenderRatchetConfiguration,
+    },
     utils::random_u64,
 };
 
@@ -351,6 +354,7 @@ pub fn generate_test_vector(
                     leaf.into(),
                     SecretType::ApplicationSecret,
                     generation,
+                    &SenderRatchetConfiguration::default(),
                 )
                 .expect("Error getting decryption secret");
             let application_key_string = bytes_to_hex(application_secret_key.as_slice());
@@ -373,6 +377,7 @@ pub fn generate_test_vector(
                     leaf.into(),
                     SecretType::HandshakeSecret,
                     generation,
+                    &SenderRatchetConfiguration::default(),
                 )
                 .expect("Error getting decryption secret");
             let handshake_key_string = bytes_to_hex(handshake_secret_key.as_slice());
@@ -514,6 +519,7 @@ pub fn run_test_vector(
                     leaf_index.into(),
                     SecretType::ApplicationSecret,
                     generation,
+                    &SenderRatchetConfiguration::default(),
                 )
                 .expect("Error getting decryption secret");
             log::debug!(
@@ -563,7 +569,12 @@ pub fn run_test_vector(
 
             // Decrypt and check application message
             let mls_plaintext_application = mls_ciphertext_application
-                .to_plaintext(ciphersuite, backend, group.message_secrets_mut())
+                .to_plaintext(
+                    ciphersuite,
+                    backend,
+                    group.message_secrets_mut(),
+                    &SenderRatchetConfiguration::default(),
+                )
                 .expect("Error decrypting MlsCiphertext");
             if hex_to_bytes(&application.plaintext)
                 != mls_plaintext_application
@@ -589,6 +600,7 @@ pub fn run_test_vector(
                     leaf_index.into(),
                     SecretType::HandshakeSecret,
                     generation,
+                    &SenderRatchetConfiguration::default(),
                 )
                 .expect("Error getting decryption secret");
             if hex_to_bytes(&handshake.key) != handshake_secret_key.as_slice() {
@@ -620,7 +632,12 @@ pub fn run_test_vector(
 
             // Decrypt and check message
             let mls_plaintext_handshake = mls_ciphertext_handshake
-                .to_plaintext(ciphersuite, backend, group.message_secrets_mut())
+                .to_plaintext(
+                    ciphersuite,
+                    backend,
+                    group.message_secrets_mut(),
+                    &SenderRatchetConfiguration::default(),
+                )
                 .expect("Error decrypting MlsCiphertext");
             if hex_to_bytes(&handshake.plaintext)
                 != mls_plaintext_handshake
@@ -646,6 +663,7 @@ pub fn run_test_vector(
                     leaf_index.into(),
                     SecretType::HandshakeSecret,
                     generation,
+                    &SenderRatchetConfiguration::default(),
                 )
                 .expect("Error getting decryption secret");
             if hex_to_bytes(&handshake.key) != handshake_secret_key.as_slice() {
@@ -673,7 +691,12 @@ pub fn run_test_vector(
 
             // Decrypt and check message
             let mls_plaintext_handshake = mls_ciphertext_handshake
-                .to_plaintext(ciphersuite, backend, group.message_secrets_mut())
+                .to_plaintext(
+                    ciphersuite,
+                    backend,
+                    group.message_secrets_mut(),
+                    &SenderRatchetConfiguration::default(),
+                )
                 .expect("Error decrypting MLSCiphertext");
             if hex_to_bytes(&handshake.plaintext)
                 != mls_plaintext_handshake

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_sender_ratchet.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_sender_ratchet.rs
@@ -1,29 +1,99 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
 
 use crate::{
-    ciphersuite::Secret, config::Config, test_utils::*, tree::sender_ratchet::SenderRatchet,
+    ciphersuite::Secret, config::Config, test_utils::*, tree::secret_tree::SecretTreeError,
+    tree::sender_ratchet::*,
 };
 
+// Test the maximum forward ratcheting
 #[apply(ciphersuites_and_backends)]
-fn test_ratchet_generations(
+fn test_max_forward_distance(
     ciphersuite: &'static Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) {
-    let leaf0 = 0u32.into();
+    let configuration = &SenderRatchetConfiguration::default();
+    let leaf = 0u32.into();
     let secret = Secret::random(ciphersuite, backend, Config::supported_versions()[0])
         .expect("Not enough randomness.");
-    let mut linear_ratchet = SenderRatchet::new(leaf0, &secret);
-    let mut testratchet = SenderRatchet::new(leaf0, &secret);
+    let mut ratchet1 = SenderRatchet::new(leaf, &secret);
+    let mut ratchet2 = SenderRatchet::new(leaf, &secret);
 
-    let _ = linear_ratchet.secret_for_decryption(ciphersuite, backend, 0);
-    let _ = linear_ratchet.secret_for_decryption(ciphersuite, backend, 1);
-    let secret = linear_ratchet
-        .secret_for_decryption(ciphersuite, backend, 2)
-        .expect("Could not derive the secret.");
-    // jump 2 generations instead of going one by one
-    let secret2 = testratchet
-        .secret_for_decryption(ciphersuite, backend, 2)
-        .expect("Could not derive the secret.");
-    /* We should have the same secret */
-    assert_eq!(secret, secret2);
+    // We expect this to still work
+    let _secret = ratchet1
+        .secret_for_decryption(
+            ciphersuite,
+            backend,
+            configuration.maximum_forward_distance(),
+            configuration,
+        )
+        .expect("Expected decryption secret.");
+
+    // We expect this to return an error
+    let err = ratchet2
+        .secret_for_decryption(
+            ciphersuite,
+            backend,
+            configuration.maximum_forward_distance() + 1,
+            configuration,
+        )
+        .expect_err("Expected error.");
+
+    assert_eq!(err, SecretTreeError::TooDistantInTheFuture);
 }
+
+// Test out-of-order generations
+#[apply(ciphersuites_and_backends)]
+fn test_out_of_order_generations(
+    ciphersuite: &'static Ciphersuite,
+    backend: &impl OpenMlsCryptoProvider,
+) {
+    let configuration = &SenderRatchetConfiguration::default();
+    let leaf = 0u32.into();
+    let secret = Secret::random(ciphersuite, backend, Config::supported_versions()[0])
+        .expect("Not enough randomness.");
+    let mut ratchet1 = SenderRatchet::new(leaf, &secret);
+
+    // Ratchet forward twice the size of the window
+    for i in 0..configuration.out_of_order_tolerance() * 2 {
+        let _secret = ratchet1
+            .secret_for_decryption(ciphersuite, backend, i, configuration)
+            .expect("Expected decryption secret.");
+    }
+
+    // Check that secrets from before th window are not accessible anymore
+    let err = ratchet1
+        .secret_for_decryption(
+            ciphersuite,
+            backend,
+            configuration.out_of_order_tolerance() - 1,
+            configuration,
+        )
+        .expect_err("Expected error.");
+
+    assert_eq!(err, SecretTreeError::TooDistantInThePast);
+
+    // Check that all secrets within the window are accessible
+    for i in configuration.out_of_order_tolerance()..configuration.out_of_order_tolerance() * 2 {
+        let _secret = ratchet1
+            .secret_for_decryption(ciphersuite, backend, i, configuration)
+            .expect("Expected decryption secret.");
+    }
+}
+/*
+TODO: This currently blocked by #265
+// Test forward secrecy
+#[apply(ciphersuites_and_backends)]
+fn test_forward_secrecy(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+    let leaf = 0u32.into();
+    let secret = Secret::random(ciphersuite, backend, Config::supported_versions()[0])
+        .expect("Not enough randomness.");
+    let mut ratchet1 = SenderRatchet::new(leaf, &secret);
+
+    // Generate an encryption secret
+    let (generation, _encryption_secret) = ratchet1.secret_for_encryption(ciphersuite, backend);
+
+    let err = ratchet1
+        .secret_for_decryption(ciphersuite, backend, generation)
+        .expect_err("Expected error.");
+}
+*/

--- a/openmls/tests/test_group.rs
+++ b/openmls/tests/test_group.rs
@@ -299,6 +299,7 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
     let group_aad = b"Alice's test group";
     // Framing parameters
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
+    let sender_ratchet_configuration = SenderRatchetConfiguration::default();
 
     // Define credential bundles
     let alice_credential_bundle = CredentialBundle::new(
@@ -414,7 +415,11 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
     let mls_ciphertext_alice = group_alice
         .create_application_message(&[], &message_alice, &alice_credential_bundle, 0, backend)
         .expect("An unexpected error occurred.");
-    let mls_plaintext_bob = match group_bob.decrypt(&mls_ciphertext_alice, backend) {
+    let mls_plaintext_bob = match group_bob.decrypt(
+        &mls_ciphertext_alice,
+        backend,
+        &sender_ratchet_configuration,
+    ) {
         Ok(mls_plaintext) => group_bob
             .verify(mls_plaintext, backend)
             .expect("Error verifying plaintext"),
@@ -718,13 +723,21 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
             backend,
         )
         .expect("An unexpected error occurred.");
-    let mls_plaintext_alice = match group_alice.decrypt(&mls_ciphertext_charlie.clone(), backend) {
+    let mls_plaintext_alice = match group_alice.decrypt(
+        &mls_ciphertext_charlie.clone(),
+        backend,
+        &sender_ratchet_configuration,
+    ) {
         Ok(mls_plaintext) => group_alice
             .verify(mls_plaintext, backend)
             .expect("Error verifying plaintext"),
         Err(e) => panic!("Error decrypting MlsCiphertext: {:?}", e),
     };
-    let mls_plaintext_bob = match group_bob.decrypt(&mls_ciphertext_charlie, backend) {
+    let mls_plaintext_bob = match group_bob.decrypt(
+        &mls_ciphertext_charlie,
+        backend,
+        &sender_ratchet_configuration,
+    ) {
         Ok(mls_plaintext) => group_bob
             .verify(mls_plaintext, backend)
             .expect("Error verifying plaintext"),


### PR DESCRIPTION
This PR introduces a configuration for sender ratchet parameters:

 - The parameters can be set with `SenderRatcherConfiguration` in `MlsGroupConfig`
 - The default values will be more conservative once #265 and #243 are addressed
 - The unit tests now better cover the sender ratchet
 
Fixes #457.