### PR TITLE
Fix bug in free leaf computation and add simple test

### DIFF
--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -155,7 +155,7 @@ impl<'a> TreeSyncDiff<'a> {
                 u32::try_from(leaf_index).map_err(|_| TreeSyncDiffError::LibraryError)?;
             if self.diff.node(*leaf_id)?.node().is_none() {
                 leaf_index_option = Some(leaf_index);
-                continue;
+                break;
             }
         }
         // If we found a free leaf, replace it with the new one, otherwise

--- a/openmls/src/treesync/tests_and_kats.rs
+++ b/openmls/src/treesync/tests_and_kats.rs
@@ -1,2 +1,4 @@
 #[cfg(any(feature = "test-utils", test))]
 pub mod kats;
+#[cfg(test)]
+mod tests;

--- a/openmls/src/treesync/tests_and_kats/tests.rs
+++ b/openmls/src/treesync/tests_and_kats/tests.rs
@@ -1,0 +1,1 @@
+mod test_diff;

--- a/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
+++ b/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
@@ -12,6 +12,7 @@ use crate::{
 
 use openmls_rust_crypto::OpenMlsRustCrypto;
 
+// Verifies that when we add a leaf to a tree with blank leaf nodes, the leaf will be added at the leftmost free leaf index
 #[apply(ciphersuites_and_backends)]
 fn test_free_leaf_computation(
     ciphersuite: &'static Ciphersuite,
@@ -38,7 +39,7 @@ fn test_free_leaf_computation(
     let kpb_3 = KeyPackageBundle::new(&[ciphersuite.name()], &cb_3, backend, vec![])
         .expect("error creating kpb");
 
-    // Build a rudimentary tree with two empty leaf nodes.
+    // Build a rudimentary tree with two populated and two empty leaf nodes.
     let nodes: Vec<Option<Node>> = vec![
         Some(Node::LeafNode(kpb_0.key_package().clone().into())), // Leaf 0
         None,

--- a/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
+++ b/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
@@ -1,0 +1,72 @@
+use openmls_traits::OpenMlsCryptoProvider;
+use rstest::*;
+use rstest_reuse::apply;
+
+use crate::{
+    ciphersuite::CiphersuiteName,
+    config::Config,
+    credentials::{CredentialBundle, CredentialType},
+    prelude::KeyPackageBundle,
+    prelude_test::{node::Node, Ciphersuite, TreeSync},
+};
+
+use openmls_rust_crypto::OpenMlsRustCrypto;
+
+#[apply(ciphersuites_and_backends)]
+fn test_free_leaf_computation(
+    ciphersuite: &'static Ciphersuite,
+    backend: &impl OpenMlsCryptoProvider,
+) {
+    let cb_0 = CredentialBundle::new(
+        "leaf0".as_bytes().to_vec(),
+        CredentialType::Basic,
+        ciphersuite.signature_scheme(),
+        backend,
+    )
+    .expect("error creating credential_bundle");
+
+    let kpb_0 = KeyPackageBundle::new(&[ciphersuite.name()], &cb_0, backend, vec![])
+        .expect("error creating kpb");
+
+    let cb_3 = CredentialBundle::new(
+        "leaf3".as_bytes().to_vec(),
+        CredentialType::Basic,
+        ciphersuite.signature_scheme(),
+        backend,
+    )
+    .expect("error creating credential_bundle");
+    let kpb_3 = KeyPackageBundle::new(&[ciphersuite.name()], &cb_3, backend, vec![])
+        .expect("error creating kpb");
+
+    // Build a rudimentary tree with two empty leaf nodes.
+    let nodes: Vec<Option<Node>> = vec![
+        Some(Node::LeafNode(kpb_0.key_package().clone().into())), // Leaf 0
+        None,
+        None, // Leaf 1
+        None,
+        None, // Leaf 2
+        None,
+        Some(Node::LeafNode(kpb_3.key_package().clone().into())), // Leaf 3
+    ];
+    let tree =
+        TreeSync::from_nodes(backend, ciphersuite, &nodes, kpb_0).expect("error generating tree");
+
+    // Create and add a new leaf. It should go to leaf index 1
+
+    let cb_2 = CredentialBundle::new(
+        "leaf2".as_bytes().to_vec(),
+        CredentialType::Basic,
+        ciphersuite.signature_scheme(),
+        backend,
+    )
+    .expect("error creating credential_bundle");
+    let kpb_2 = KeyPackageBundle::new(&[ciphersuite.name()], &cb_2, backend, vec![])
+        .expect("error creating kpb");
+
+    let mut diff = tree.empty_diff().expect("error creating empty diff");
+    let free_leaf_index = diff
+        .add_leaf(kpb_2.key_package().clone())
+        .expect("error adding leaf");
+
+    assert_eq!(free_leaf_index, 1u32);
+}


### PR DESCRIPTION
This fixes the bug found by @franziskuskiefer in the process of reviewing #634, where instead of adding a leaf in the first blank position, it instead adds it in the last. The test is very minimal and only tests the exact conditions under which the bug occurs. More expansive tests and proper test utils will be added in the course of #625 and #624.