### PR TITLE
Refactor proposal queues

### DIFF
--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -335,7 +335,7 @@ impl User {
             .borrow()
             .create_add_proposal(framing_parameters, credentials, key_package, &self.crypto)
             .expect("Could not create proposal.");
-        let proposal_store = ProposalStore::from_staged_proposal(
+        let proposal_store = ProposalStore::from_queued_proposal(
             QueuedProposal::from_mls_plaintext(
                 Config::ciphersuite(CIPHERSUITE).map_err(|e| format!("{}", e))?,
                 &self.crypto,

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -213,7 +213,7 @@ impl User {
                             let mut proposal_store = ProposalStore::new();
                             for proposal in &group.pending_proposals {
                                 proposal_store.add(
-                                    StagedProposal::from_mls_plaintext(
+                                    QueuedProposal::from_mls_plaintext(
                                         Config::ciphersuite(CIPHERSUITE)
                                             .map_err(|e| format!("{}", e))?,
                                         &self.crypto,
@@ -336,7 +336,7 @@ impl User {
             .create_add_proposal(framing_parameters, credentials, key_package, &self.crypto)
             .expect("Could not create proposal.");
         let proposal_store = ProposalStore::from_staged_proposal(
-            StagedProposal::from_mls_plaintext(
+            QueuedProposal::from_mls_plaintext(
                 Config::ciphersuite(CIPHERSUITE).map_err(|e| format!("{}", e))?,
                 &self.crypto,
                 add_proposal.clone(),

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -217,7 +217,7 @@ async fn test_group() {
         )
         .unwrap();
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(
             Config::ciphersuite(group_ciphersuite).expect("Unsupported ciphersuite."),
             crypto,

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -218,12 +218,12 @@ async fn test_group() {
         .unwrap();
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(
+        QueuedProposal::from_mls_plaintext(
             Config::ciphersuite(group_ciphersuite).expect("Unsupported ciphersuite."),
             crypto,
             client2_add_proposal,
         )
-        .expect("Could not create StagedProposal."),
+        .expect("Could not create QueuedProposal."),
     );
     let params = CreateCommitParams::builder()
         .framing_parameters(framing_parameters)

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -853,7 +853,7 @@ impl MlsClient for MlsClientImpl {
 
         let mut proposal_store = ProposalStore::new();
         for proposal in proposal_plaintexts {
-            if let Ok(staging_proposal) = StagedProposal::from_mls_plaintext(
+            if let Ok(staging_proposal) = QueuedProposal::from_mls_plaintext(
                 interop_group.group.ciphersuite(),
                 &self.crypto_provider,
                 proposal,
@@ -970,7 +970,7 @@ impl MlsClient for MlsClientImpl {
         let mut proposal_store = ProposalStore::new();
         for proposal in &proposal_plaintexts {
             proposal_store.add(
-                StagedProposal::from_mls_plaintext(
+                QueuedProposal::from_mls_plaintext(
                     interop_group.group.ciphersuite(),
                     &self.crypto_provider,
                     proposal.clone(),

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -150,8 +150,8 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
         .expect("Could not create proposal.");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -234,7 +234,7 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
         .expect("Could not create proposal.");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create staged proposal."),
     );
 

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -149,7 +149,7 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
         )
         .expect("Could not create proposal.");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );
@@ -233,7 +233,7 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
         )
         .expect("Could not create proposal.");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create staged proposal."),
     );

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -4,7 +4,7 @@ use crate::{
     framing::*,
     group::core_group::{
         create_commit_params::CreateCommitParams,
-        proposals::{ProposalStore, StagedProposal},
+        proposals::{ProposalStore, QueuedProposal},
     },
     key_packages::KeyPackageBundle,
     tree::sender_ratchet::SenderRatchetConfiguration,
@@ -397,8 +397,8 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
         .expect("Could not create proposal.");
 
     let mut proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -431,7 +431,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, charlie_add_proposal)
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, charlie_add_proposal)
             .expect("Could not create staged proposal."),
     );
 
@@ -469,7 +469,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_remove_proposal)
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_remove_proposal)
             .expect("Could not create staged proposal."),
     );
 
@@ -641,8 +641,8 @@ fn confirmation_tag_presence(
         .expect("Could not create proposal.");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -725,8 +725,8 @@ fn invalid_plaintext_signature(
         .expect("Could not create proposal.");
 
     let mut proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal.clone())
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal.clone())
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -841,7 +841,7 @@ fn invalid_plaintext_signature(
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal.clone())
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal.clone())
             .expect("Could not create staged proposal."),
     );
 
@@ -878,7 +878,7 @@ fn invalid_plaintext_signature(
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create staged proposal."),
     );
 

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -396,7 +396,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
         )
         .expect("Could not create proposal.");
 
-    let mut proposal_store = ProposalStore::from_staged_proposal(
+    let mut proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );
@@ -640,7 +640,7 @@ fn confirmation_tag_presence(
         )
         .expect("Could not create proposal.");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );
@@ -724,7 +724,7 @@ fn invalid_plaintext_signature(
         )
         .expect("Could not create proposal.");
 
-    let mut proposal_store = ProposalStore::from_staged_proposal(
+    let mut proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal.clone())
             .expect("Could not create QueuedProposal."),
     );

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -35,7 +35,7 @@
 //! ```
 
 use crate::{schedule::MessageSecrets, tree::sender_ratchet::SenderRatchetConfiguration};
-use core_group::{proposals::StagedProposal, staged_commit::StagedCommit};
+use core_group::{proposals::QueuedProposal, staged_commit::StagedCommit};
 use openmls_traits::OpenMlsCryptoProvider;
 
 use crate::ciphersuite::signable::Verifiable;
@@ -327,11 +327,11 @@ impl VerifiedExternalMessage {
 }
 
 /// Message that contains messages that are syntactically and semantically correct.
-/// [StagedCommit] and [StagedProposal] can be inspected for authorization purposes.
+/// [StagedCommit] and [QueuedProposal] can be inspected for authorization purposes.
 #[derive(Debug)]
 pub enum ProcessedMessage {
     ApplicationMessage(ApplicationMessage),
-    ProposalMessage(Box<StagedProposal>),
+    ProposalMessage(Box<QueuedProposal>),
     StagedCommitMessage(Box<StagedCommit>),
 }
 

--- a/openmls/src/group/core_group/apply_proposals.rs
+++ b/openmls/src/group/core_group/apply_proposals.rs
@@ -11,10 +11,7 @@ use crate::{
     treesync::{diff::TreeSyncDiff, node::leaf_node::LeafNode},
 };
 
-use super::{
-    proposals::{CreationProposalQueue, StagedProposalQueue},
-    CoreGroup,
-};
+use super::{proposals::ProposalQueue, CoreGroup};
 
 /// This struct contain the return values of the `apply_proposals()` function
 pub struct ApplyProposalsValues {
@@ -51,7 +48,7 @@ impl CoreGroup {
         &self,
         diff: &mut TreeSyncDiff,
         backend: &impl OpenMlsCryptoProvider,
-        proposal_queue: &CreationProposalQueue,
+        proposal_queue: &ProposalQueue,
         key_package_bundles: &[KeyPackageBundle],
     ) -> Result<ApplyProposalsValues, CoreGroupError> {
         log::debug!("Applying proposal");
@@ -165,132 +162,6 @@ impl CoreGroup {
             invitation_list,
             presharedkeys,
             external_init_secret_option,
-        })
-    }
-
-    /// Applies a list of staged proposals from a Commit to the tree.
-    /// `proposal_queue` is the queue of proposals received or sent in the
-    /// current epoch `updates_key_package_bundles` is the list of own
-    /// KeyPackageBundles corresponding to updates or commits sent in the
-    /// current epoch
-    pub(crate) fn apply_staged_proposals(
-        &self,
-        diff: &mut TreeSyncDiff,
-        backend: &impl OpenMlsCryptoProvider,
-        proposal_queue: &StagedProposalQueue,
-        key_package_bundles: &[KeyPackageBundle],
-    ) -> Result<ApplyProposalsValues, CoreGroupError> {
-        log::debug!("Applying proposal");
-        let mut has_updates = false;
-        let mut has_removes = false;
-        let mut self_removed = false;
-        let mut external_init_secret_option = None;
-
-        // Process updates first
-        for queued_proposal in proposal_queue.filtered_by_type(ProposalType::Update) {
-            has_updates = true;
-            // Unwrapping here is safe because we know the proposal type
-            let update_proposal = &queued_proposal.proposal().as_update().unwrap();
-            // Check if this is our own update.
-            let sender_index = queued_proposal.sender().to_leaf_index();
-            let leaf_node: LeafNode = if sender_index == self.tree.own_leaf_index() {
-                let own_kpb = match key_package_bundles
-                    .iter()
-                    .find(|&kpb| kpb.key_package() == update_proposal.key_package())
-                {
-                    Some(kpb) => kpb,
-                    // We lost the KeyPackageBundle apparently
-                    None => return Err(CoreGroupError::MissingKeyPackageBundle),
-                };
-                own_kpb.clone().into()
-            } else {
-                update_proposal.key_package().clone().into()
-            };
-            diff.update_leaf(leaf_node, queued_proposal.sender().to_leaf_index())?;
-        }
-
-        // Process removes
-        for queued_proposal in proposal_queue.filtered_by_type(ProposalType::Remove) {
-            has_removes = true;
-            // Unwrapping here is safe because we know the proposal type
-            let remove_proposal = &queued_proposal.proposal().as_remove().unwrap();
-            // Check if we got removed from the group
-            if remove_proposal.removed() == self.treesync().own_leaf_index() {
-                self_removed = true;
-            }
-            // Blank the direct path of the removed member
-            diff.blank_leaf(remove_proposal.removed())?;
-        }
-
-        // Process external init proposals
-        for queued_proposal in proposal_queue.filtered_by_type(ProposalType::ExternalInit) {
-            // If we are the originator of the external init, we don't need to
-            // get the init secret from the proposal. This branching will not be
-            // necessary after #617.
-            if queued_proposal.sender().to_leaf_index() != self.treesync().own_leaf_index() {
-                // We know the proposal type, so this should not fail
-                let external_init_proposal = &queued_proposal
-                    .proposal()
-                    .as_external_init()
-                    .ok_or(CoreGroupError::LibraryError)?;
-                // Decrypt the context an derive the external init.
-                let external_priv = self
-                    .group_epoch_secrets()
-                    .external_secret()
-                    .derive_external_keypair(backend.crypto(), self.ciphersuite())
-                    .private
-                    .into();
-                external_init_secret_option = Some(InitSecret::from_kem_output(
-                    backend,
-                    self.ciphersuite(),
-                    self.mls_version,
-                    &external_priv,
-                    external_init_proposal.kem_output(),
-                )?);
-                // Ignore every external init beyond the first one.
-                break;
-            }
-        }
-
-        // Process adds
-        let add_proposals: Vec<AddProposal> = proposal_queue
-            .filtered_by_type(ProposalType::Add)
-            .map(|queued_proposal| {
-                let proposal = &queued_proposal.proposal();
-                // Unwrapping here is safe because we know the proposal type
-                proposal.as_add().unwrap()
-            })
-            .collect();
-
-        // Extract KeyPackages from proposals
-        let mut invitation_list = Vec::new();
-        for add_proposal in &add_proposals {
-            let leaf_index = diff.add_leaf(add_proposal.key_package().clone())?;
-            invitation_list.push((leaf_index, add_proposal.clone()))
-        }
-
-        // Process PSK proposals
-        let psks: Vec<PreSharedKeyId> = proposal_queue
-            .filtered_by_type(ProposalType::Presharedkey)
-            .map(|queued_proposal| {
-                // FIXME: remove unwrap
-                // Unwrapping here is safe because we know the proposal type
-                let psk_proposal = queued_proposal.proposal().as_presharedkey().unwrap();
-                psk_proposal.into_psk_id()
-            })
-            .collect();
-
-        let presharedkeys = PreSharedKeys { psks: psks.into() };
-
-        // Determine if Commit needs a path field
-        let path_required = has_updates || has_removes || external_init_secret_option.is_some();
-
-        Ok(ApplyProposalsValues {
-            path_required,
-            self_removed,
-            invitation_list,
-            external_init_secret_option,
-            presharedkeys,
         })
     }
 }

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -283,7 +283,7 @@ impl CoreGroup {
             provisional_interim_transcript_hash,
             diff.into_staged_diff(backend, ciphersuite)?,
         );
-        let staged_commit = StagedCommit::new(proposal_queue.into(), Some(staged_commit_state));
+        let staged_commit = StagedCommit::new(proposal_queue, Some(staged_commit_state));
 
         Ok(CreateCommitResult {
             commit: mls_plaintext,

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use super::{
     create_commit_params::{CommitType, CreateCommitParams},
-    proposals::CreationProposalQueue,
+    proposals::ProposalQueue,
     staged_commit::{StagedCommit, StagedCommitState},
 };
 
@@ -46,7 +46,7 @@ impl CoreGroup {
         };
 
         // Filter proposals
-        let (proposal_queue, contains_own_updates) = CreationProposalQueue::filter_proposals(
+        let (proposal_queue, contains_own_updates) = ProposalQueue::filter_proposals(
             ciphersuite,
             backend,
             sender_type,

--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::{
     create_commit_params::{CommitType, CreateCommitParams},
-    proposals::{ProposalStore, StagedProposal},
+    proposals::{ProposalStore, QueuedProposal},
     CoreGroup,
 };
 use crate::group::core_group::*;
@@ -114,7 +114,7 @@ impl CoreGroup {
         let mut proposal_store = ProposalStore::default();
         for proposal in proposals_by_reference {
             let staged_proposal =
-                StagedProposal::from_mls_plaintext(ciphersuite, backend, proposal.clone())?;
+                QueuedProposal::from_mls_plaintext(ciphersuite, backend, proposal.clone())?;
             proposal_store.add(staged_proposal)
         }
 

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -1,4 +1,4 @@
-use core_group::{proposals::StagedProposal, staged_commit::StagedCommit};
+use core_group::{proposals::QueuedProposal, staged_commit::StagedCommit};
 
 use crate::tree::secret_tree::SecretTreeError;
 
@@ -163,7 +163,7 @@ impl CoreGroup {
                     }
                     MlsPlaintextContentType::Proposal(_proposal) => {
                         ProcessedMessage::ProposalMessage(Box::new(
-                            StagedProposal::from_mls_plaintext(
+                            QueuedProposal::from_mls_plaintext(
                                 self.ciphersuite(),
                                 backend,
                                 verified_member_message.take_plaintext(),

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -349,10 +349,8 @@ impl ProposalQueue {
 
         // Aggregate both proposal types to a common iterator
         // We checked earlier that only proposals can end up here
-        let mut queued_proposal_list: Vec<QueuedProposal> = proposal_store
-            .proposals()
-            .map(|queued_proposal| queued_proposal.clone())
-            .collect();
+        let mut queued_proposal_list: Vec<QueuedProposal> =
+            proposal_store.proposals().cloned().collect();
 
         queued_proposal_list.extend(
             inline_proposals

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -478,7 +478,7 @@ impl ProposalQueue {
     }
 }
 
-/// A staged Add proposal
+/// A queued Add proposal
 pub struct QueuedAddProposal<'a> {
     add_proposal: &'a AddProposal,
     sender: &'a Sender,
@@ -496,7 +496,7 @@ impl<'a> QueuedAddProposal<'a> {
     }
 }
 
-/// A staged Remove proposal
+/// A queued Remove proposal
 pub struct QueuedRemoveProposal<'a> {
     remove_proposal: &'a RemoveProposal,
     sender: &'a Sender,
@@ -514,7 +514,7 @@ impl<'a> QueuedRemoveProposal<'a> {
     }
 }
 
-/// A staged Update proposal
+/// A queued Update proposal
 pub struct QueuedUpdateProposal<'a> {
     update_proposal: &'a UpdateProposal,
     sender: &'a Sender,
@@ -532,7 +532,7 @@ impl<'a> QueuedUpdateProposal<'a> {
     }
 }
 
-/// A staged PresharedKey proposal
+/// A queued PresharedKey proposal
 pub struct QueuedPskProposal<'a> {
     psk_proposal: &'a PreSharedKeyProposal,
     sender: &'a Sender,

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -238,8 +238,8 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         )
         .expect("Could not create proposal.");
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
     let params = CreateCommitParams::builder()
         .framing_parameters(framing_parameters)
@@ -300,8 +300,8 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         )
         .expect("Could not create proposal.");
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_bob)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_bob)
+            .expect("Could not create QueuedProposal."),
     );
     let params = CreateCommitParams::builder()
         .framing_parameters(framing_parameters)
@@ -464,12 +464,12 @@ fn test_psks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProv
         .expect("Could not create proposal");
 
     let mut proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, psk_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, psk_proposal)
+            .expect("Could not create QueuedProposal."),
     );
     log::info!(" >>> Creating commit ...");
     let params = CreateCommitParams::builder()
@@ -520,8 +520,8 @@ fn test_psks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProv
         )
         .expect("Could not create proposal.");
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_bob)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_bob)
+            .expect("Could not create QueuedProposal."),
     );
     let params = CreateCommitParams::builder()
         .framing_parameters(framing_parameters)
@@ -593,8 +593,8 @@ fn test_staged_commit_creation(
         )
         .expect("Could not create proposal.");
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
     let params = CreateCommitParams::builder()
         .framing_parameters(framing_parameters)

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -237,7 +237,7 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
             backend,
         )
         .expect("Could not create proposal.");
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );
@@ -299,7 +299,7 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
             backend,
         )
         .expect("Could not create proposal.");
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_bob)
             .expect("Could not create QueuedProposal."),
     );
@@ -463,7 +463,7 @@ fn test_psks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProv
         )
         .expect("Could not create proposal");
 
-    let mut proposal_store = ProposalStore::from_staged_proposal(
+    let mut proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );
@@ -519,7 +519,7 @@ fn test_psks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProv
             backend,
         )
         .expect("Could not create proposal.");
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_bob)
             .expect("Could not create QueuedProposal."),
     );
@@ -592,7 +592,7 @@ fn test_staged_commit_creation(
             backend,
         )
         .expect("Could not create proposal.");
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );

--- a/openmls/src/group/core_group/test_duplicate_extension.rs
+++ b/openmls/src/group/core_group/test_duplicate_extension.rs
@@ -73,7 +73,7 @@ fn duplicate_ratchet_tree_extension(
         )
         .expect("Could not create proposal.");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create StagingProposal"),
     );

--- a/openmls/src/group/core_group/test_duplicate_extension.rs
+++ b/openmls/src/group/core_group/test_duplicate_extension.rs
@@ -74,7 +74,7 @@ fn duplicate_ratchet_tree_extension(
         .expect("Could not create proposal.");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create StagingProposal"),
     );
 

--- a/openmls/src/group/core_group/test_external_init.rs
+++ b/openmls/src/group/core_group/test_external_init.rs
@@ -75,7 +75,7 @@ fn test_external_init(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
             backend,
         )
         .expect("Could not create proposal.");
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );

--- a/openmls/src/group/core_group/test_external_init.rs
+++ b/openmls/src/group/core_group/test_external_init.rs
@@ -15,7 +15,7 @@ use tls_codec::{Deserialize, Serialize};
 
 use super::{
     create_commit_params::CreateCommitParams,
-    proposals::{ProposalStore, StagedProposal},
+    proposals::{ProposalStore, QueuedProposal},
     CoreGroup,
 };
 
@@ -76,8 +76,8 @@ fn test_external_init(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
         )
         .expect("Could not create proposal.");
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
     let params = CreateCommitParams::builder()
         .framing_parameters(framing_parameters)

--- a/openmls/src/group/core_group/test_proposals.rs
+++ b/openmls/src/group/core_group/test_proposals.rs
@@ -142,7 +142,7 @@ fn proposal_queue_functions(
     )
     .expect("Could not create proposal.");
 
-    let mut proposal_store = ProposalStore::from_staged_proposal(
+    let mut proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, mls_plaintext_add_alice1)
             .expect("Could not create QueuedProposal."),
     );
@@ -254,7 +254,7 @@ fn proposal_queue_order(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
     .expect("Could not create proposal.");
 
     // This should set the order of the proposals.
-    let mut proposal_store = ProposalStore::from_staged_proposal(
+    let mut proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, mls_plaintext_add_alice1)
             .expect("Could not create QueuedProposal."),
     );
@@ -412,7 +412,7 @@ fn test_group_context_extensions(
         )
         .expect("Could not create proposal");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );
@@ -515,7 +515,7 @@ fn test_group_context_extension_proposal_fails(
         )
         .expect("Could not create proposal");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );
@@ -619,7 +619,7 @@ fn test_group_context_extension_proposal(
         )
         .expect("Could not create proposal");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );
@@ -668,7 +668,7 @@ fn test_group_context_extension_proposal(
         )
         .expect("Error creating gce proposal.");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, gce_proposal)
             .expect("Could not create QueuedProposal."),
     );

--- a/openmls/src/group/core_group/test_proposals.rs
+++ b/openmls/src/group/core_group/test_proposals.rs
@@ -12,7 +12,7 @@ use crate::{
     group::{
         create_commit_params::CreateCommitParams,
         errors::CoreGroupError,
-        proposals::{CreationProposalQueue, ProposalStore, StagedProposal, StagedProposalQueue},
+        proposals::{ProposalQueue, ProposalStore, QueuedProposal},
         GroupContext, GroupEpoch, GroupId,
     },
     key_packages::{KeyPackageBundle, KeyPackageError},
@@ -44,7 +44,7 @@ fn setup_client(
     (credential_bundle, key_package_bundle)
 }
 
-/// This test makes sure CreationProposalQueue works as intented. This functionality is
+/// This test makes sure ProposalQueue works as intented. This functionality is
 /// used in `create_commit` to filter the epoch proposals. Expected result:
 /// `filtered_queued_proposals` returns only proposals of a certain type
 #[apply(ciphersuites_and_backends)]
@@ -143,15 +143,15 @@ fn proposal_queue_functions(
     .expect("Could not create proposal.");
 
     let mut proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, mls_plaintext_add_alice1)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, mls_plaintext_add_alice1)
+            .expect("Could not create QueuedProposal."),
     );
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, mls_plaintext_add_alice2)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, mls_plaintext_add_alice2)
+            .expect("Could not create QueuedProposal."),
     );
 
-    let (proposal_queue, own_update) = CreationProposalQueue::filter_proposals(
+    let (proposal_queue, own_update) = ProposalQueue::filter_proposals(
         ciphersuite,
         backend,
         SenderType::Member,
@@ -185,7 +185,7 @@ fn proposal_queue_functions(
     }
 }
 
-/// Test, that we StagedProposalQueue is iterated in the right order.
+/// Test, that we QueuedProposalQueue is iterated in the right order.
 #[apply(ciphersuites_and_backends)]
 fn proposal_queue_order(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     // Framing parameters
@@ -255,12 +255,12 @@ fn proposal_queue_order(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
 
     // This should set the order of the proposals.
     let mut proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, mls_plaintext_add_alice1)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, mls_plaintext_add_alice1)
+            .expect("Could not create QueuedProposal."),
     );
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, mls_plaintext_add_bob1)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, mls_plaintext_add_bob1)
+            .expect("Could not create QueuedProposal."),
     );
 
     let proposal_or_refs = vec![
@@ -276,7 +276,7 @@ fn proposal_queue_order(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
     // And the same should go for proposal queues built from committed
     // proposals. The order here should be dictated by the proposals passed
     // as ProposalOrRefs.
-    let proposal_queue = StagedProposalQueue::from_committed_proposals(
+    let proposal_queue = ProposalQueue::from_committed_proposals(
         ciphersuite,
         backend,
         proposal_or_refs,
@@ -285,7 +285,7 @@ fn proposal_queue_order(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
     )
     .expect("An unexpected error occurred.");
 
-    let proposal_collection: Vec<&StagedProposal> =
+    let proposal_collection: Vec<&QueuedProposal> =
         proposal_queue.filtered_by_type(ProposalType::Add).collect();
 
     assert_eq!(proposal_collection[0].proposal(), &proposal_add_bob1);
@@ -413,8 +413,8 @@ fn test_group_context_extensions(
         .expect("Could not create proposal");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
     log::info!(" >>> Creating commit ...");
     let params = CreateCommitParams::builder()
@@ -516,8 +516,8 @@ fn test_group_context_extension_proposal_fails(
         .expect("Could not create proposal");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
     log::info!(" >>> Creating commit ...");
     let params = CreateCommitParams::builder()
@@ -620,8 +620,8 @@ fn test_group_context_extension_proposal(
         .expect("Could not create proposal");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
     log::info!(" >>> Creating commit ...");
     let params = CreateCommitParams::builder()
@@ -669,8 +669,8 @@ fn test_group_context_extension_proposal(
         .expect("Error creating gce proposal.");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, gce_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, gce_proposal)
+            .expect("Could not create QueuedProposal."),
     );
     log::info!(" >>> Creating commit ...");
     let params = CreateCommitParams::builder()

--- a/openmls/src/group/core_group/validation.rs
+++ b/openmls/src/group/core_group/validation.rs
@@ -99,9 +99,9 @@ impl CoreGroup {
     ///  - TODO: ValSem106
     pub fn validate_add_proposals(
         &self,
-        staged_proposal_queue: &ProposalQueue,
+        proposal_queue: &ProposalQueue,
     ) -> Result<(), CoreGroupError> {
-        let add_proposals = staged_proposal_queue.add_proposals();
+        let add_proposals = proposal_queue.add_proposals();
 
         let mut identity_set = HashSet::new();
         let mut signature_key_set = HashSet::new();
@@ -166,9 +166,9 @@ impl CoreGroup {
     ///  - ValSem108
     pub fn validate_remove_proposals(
         &self,
-        staged_proposal_queue: &ProposalQueue,
+        proposal_queue: &ProposalQueue,
     ) -> Result<(), CoreGroupError> {
-        let remove_proposals = staged_proposal_queue.remove_proposals();
+        let remove_proposals = proposal_queue.remove_proposals();
 
         let mut removes_set = HashSet::new();
         let tree = &self.treesync();
@@ -196,7 +196,7 @@ impl CoreGroup {
     ///  - ValSem110
     pub fn validate_update_proposals(
         &self,
-        staged_proposal_queue: &ProposalQueue,
+        proposal_queue: &ProposalQueue,
         path_key_package: Option<(Sender, &KeyPackage)>,
     ) -> Result<(), CoreGroupError> {
         let mut public_key_set = HashSet::new();
@@ -206,7 +206,7 @@ impl CoreGroup {
         }
 
         // Check the update proposals from the proposal queue first
-        let update_proposals = staged_proposal_queue.update_proposals();
+        let update_proposals = proposal_queue.update_proposals();
         let tree = &self.treesync();
 
         for update_proposal in update_proposals {

--- a/openmls/src/group/core_group/validation.rs
+++ b/openmls/src/group/core_group/validation.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 
-use super::{proposals::StagedProposalQueue, *};
+use super::{proposals::ProposalQueue, *};
 
 impl CoreGroup {
     // === Messages ===
@@ -99,7 +99,7 @@ impl CoreGroup {
     ///  - TODO: ValSem106
     pub fn validate_add_proposals(
         &self,
-        staged_proposal_queue: &StagedProposalQueue,
+        staged_proposal_queue: &ProposalQueue,
     ) -> Result<(), CoreGroupError> {
         let add_proposals = staged_proposal_queue.add_proposals();
 
@@ -166,7 +166,7 @@ impl CoreGroup {
     ///  - ValSem108
     pub fn validate_remove_proposals(
         &self,
-        staged_proposal_queue: &StagedProposalQueue,
+        staged_proposal_queue: &ProposalQueue,
     ) -> Result<(), CoreGroupError> {
         let remove_proposals = staged_proposal_queue.remove_proposals();
 
@@ -196,7 +196,7 @@ impl CoreGroup {
     ///  - ValSem110
     pub fn validate_update_proposals(
         &self,
-        staged_proposal_queue: &StagedProposalQueue,
+        staged_proposal_queue: &ProposalQueue,
         path_key_package: Option<(Sender, &KeyPackage)>,
     ) -> Result<(), CoreGroupError> {
         let mut public_key_set = HashSet::new();

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -10,7 +10,7 @@ use crate::framing::errors::{
     MlsCiphertextError, MlsPlaintextError, ValidationError, VerificationError,
 };
 use crate::key_packages::KeyPackageError;
-use crate::messages::errors::{ProposalError, ProposalQueueError};
+use crate::messages::errors::ProposalError;
 use crate::schedule::errors::{KeyScheduleError, PskSecretError};
 use crate::tree::{ParentHashError, TreeError};
 use crate::treesync::{diff::TreeSyncDiffError, treekem::TreeKemError, TreeSyncError};
@@ -44,8 +44,6 @@ implement_error! {
                 "See [`ExporterError`](`ExporterError`) for details.",
             ProposalQueueError(ProposalQueueError) =
                 "See [`ProposalQueueError`](`crate::messages::errors::ProposalQueueError`) for details.",
-            CreationProposalQueueError(CreationProposalQueueError) =
-                "See [`CreationProposalQueueError`](`crate::group::errors::CreationProposalQueueError`) for details.",
             CodecError(TlsCodecError) =
                 "TLS (de)serialization error occurred.",
             KeyScheduleError(KeyScheduleError) =
@@ -76,8 +74,8 @@ implement_error! {
                 "See [`CryptoError`](openmls_traits::types::CryptoError) for details.",
             InterimTranscriptHashError(InterimTranscriptHashError) =
                 "See [`InterimTranscriptHashError`](crate::group::InterimTranscriptHashError) for details.",
-            StagedProposalError(StagedProposalError) =
-                "See [`StagedProposalError`](crate::group::StagedProposalError) for details.",
+            QueuedProposalError(QueuedProposalError) =
+                "See [`QueuedProposalError`](crate::group::QueuedProposalError) for details.",
         }
     }
 }
@@ -132,8 +130,8 @@ implement_error! {
                 "See [`InterimTranscriptHashError`] for details.",
             CryptoError(CryptoError) =
                 "See [`CryptoError`](openmls_traits::types::CryptoError) for details.",
-            ProposalError(StagedProposalError) =
-                "See [`StagedProposalError`] for details.",
+            ProposalError(QueuedProposalError) =
+                "See [`QueuedProposalError`] for details.",
         }
     }
 }
@@ -172,8 +170,8 @@ implement_error! {
                 "See [`KeyPackageError`] for details.",
             CryptoError(CryptoError) =
                 "See [`CryptoError`](openmls_traits::types::CryptoError) for details.",
-            ProposalError(StagedProposalError) =
-                "See [`StagedProposalError`] for details.",
+            ProposalError(QueuedProposalError) =
+                "See [`QueuedProposalError`] for details.",
         }
     }
 }
@@ -236,7 +234,7 @@ implement_error! {
 }
 
 implement_error! {
-    pub enum StagedProposalError {
+    pub enum QueuedProposalError {
         Simple {
             WrongContentType = "API misuse. Only proposals can end up in the proposal queue",
         }
@@ -248,25 +246,14 @@ implement_error! {
 }
 
 implement_error! {
-    pub enum StagedProposalQueueError {
+    pub enum ProposalQueueError {
         Simple {
             ProposalNotFound = "Not all proposals in the Commit were found locally.",
             SelfRemoval = "The sender of a Commit tried to remove themselves.",
-        }
-        Complex {
-            NotAProposal(StagedProposalError) = "The given MLS Plaintext was not a Proposal.",
-        }
-    }
-}
-
-implement_error! {
-    pub enum CreationProposalQueueError {
-        Simple {
-            ProposalNotFound = "Not all proposals in the Commit were found locally.",
             ArchitectureError = "Couldn't fit a `u32` into a `usize`.",
         }
         Complex {
-            NotAProposal(StagedProposalError) = "The given MLS Plaintext was not a Proposal.",
+            NotAProposal(QueuedProposalError) = "The given MLS Plaintext was not a Proposal.",
         }
     }
 }

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -37,7 +37,7 @@ pub(crate) use resumption::ResumptionSecretStore;
 use ser::*;
 
 use super::past_secrets::MessageSecretsStore;
-use super::proposals::{ProposalStore, StagedProposal};
+use super::proposals::{ProposalStore, QueuedProposal};
 
 /// A `MlsGroup` represents an [CoreGroup] with
 /// an easier, high-level API designed to be used in production. The API exposes
@@ -156,7 +156,7 @@ impl MlsGroup {
     }
 
     /// Returns an `Iterator` over staged proposals.
-    pub fn pending_proposals(&self) -> impl Iterator<Item = &StagedProposal> {
+    pub fn pending_proposals(&self) -> impl Iterator<Item = &QueuedProposal> {
         self.proposal_store.proposals()
     }
 

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -1,5 +1,5 @@
 use core_group::{
-    create_commit_params::CreateCommitParams, proposals::StagedProposal,
+    create_commit_params::CreateCommitParams, proposals::QueuedProposal,
     staged_commit::StagedCommit,
 };
 
@@ -58,7 +58,7 @@ impl MlsGroup {
     }
 
     /// Stores a standalone proposal in the internal [ProposalStore]
-    pub fn store_pending_proposal(&mut self, proposal: StagedProposal) {
+    pub fn store_pending_proposal(&mut self, proposal: QueuedProposal) {
         // Store the proposal in in the internal ProposalStore
         self.proposal_store.add(proposal);
 

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -270,7 +270,7 @@ fn remover(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvid
         // TODO #541: Replace this with the adequate API call
         assert_eq!(staged_proposal.sender().to_leaf_index(), 0u32);
     } else {
-        unreachable!("Expected a StagedProposal.");
+        unreachable!("Expected a QueuedProposal.");
     }
 
     // Charlie commits

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -160,7 +160,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
         )
         .expect("An unexpected error occurred.");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, &crypto, add_proposal_pt.clone())
             .expect("An unexpected error occurred."),
     );

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -161,7 +161,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
         .expect("An unexpected error occurred.");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, &crypto, add_proposal_pt.clone())
+        QueuedProposal::from_mls_plaintext(ciphersuite, &crypto, add_proposal_pt.clone())
             .expect("An unexpected error occurred."),
     );
     let params = CreateCommitParams::builder()

--- a/openmls/src/messages/errors.rs
+++ b/openmls/src/messages/errors.rs
@@ -14,17 +14,6 @@ implement_error! {
 }
 
 implement_error! {
-    pub enum ProposalQueueError {
-        Simple {
-            ProposalNotFound = "Not all proposals in the Commit were found locally.",
-        }
-        Complex {
-            NotAProposal(QueuedProposalError) = "The given MLS Plaintext was not a Proposal.",
-        }
-    }
-}
-
-implement_error! {
     pub enum ProposalOrRefTypeError {
         UnknownValue = "Invalid value for ProposalOrRefType was found.",
     }
@@ -33,16 +22,5 @@ implement_error! {
 impl From<ProposalOrRefTypeError> for tls_codec::Error {
     fn from(e: ProposalOrRefTypeError) -> Self {
         tls_codec::Error::DecodingError(format!("{:?}", e))
-    }
-}
-
-implement_error! {
-    pub enum QueuedProposalError {
-        Simple {
-            WrongContentType = "API misuse. Only proposals can end up in the proposal queue",
-        }
-        Complex {
-            TlsCodecError(TlsCodecError) = "Error serializing",
-        }
     }
 }

--- a/openmls/src/messages/tests/test_pgs.rs
+++ b/openmls/src/messages/tests/test_pgs.rs
@@ -60,7 +60,7 @@ fn test_pgs(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvi
         )
         .expect("Could not create proposal.");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );

--- a/openmls/src/messages/tests/test_pgs.rs
+++ b/openmls/src/messages/tests/test_pgs.rs
@@ -61,8 +61,8 @@ fn test_pgs(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvi
         .expect("Could not create proposal.");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
     let params = CreateCommitParams::builder()
         .framing_parameters(framing_parameters)

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -3,7 +3,7 @@
 
 // MlsGroup
 pub use crate::group::{
-    proposals::{ProposalStore, StagedProposal},
+    proposals::{ProposalStore, QueuedProposal},
     EmptyInputError, GroupEpoch, GroupId, InnerState, InvalidMessageError, MlsGroup,
     MlsGroupConfig, MlsGroupError,
 };

--- a/openmls/tests/test_encoding.rs
+++ b/openmls/tests/test_encoding.rs
@@ -314,16 +314,16 @@ fn test_commit_encoding(backend: &impl OpenMlsCryptoProvider) {
             .expect("Could not create proposal.");
 
         let mut proposal_store = ProposalStore::from_staged_proposal(
-            StagedProposal::from_mls_plaintext(group_state.ciphersuite(), backend, add)
-                .expect("Could not create StagedProposal."),
+            QueuedProposal::from_mls_plaintext(group_state.ciphersuite(), backend, add)
+                .expect("Could not create QueuedProposal."),
         );
         proposal_store.add(
-            StagedProposal::from_mls_plaintext(group_state.ciphersuite(), backend, remove)
-                .expect("Could not create StagedProposal."),
+            QueuedProposal::from_mls_plaintext(group_state.ciphersuite(), backend, remove)
+                .expect("Could not create QueuedProposal."),
         );
         proposal_store.add(
-            StagedProposal::from_mls_plaintext(group_state.ciphersuite(), backend, update)
-                .expect("Could not create StagedProposal."),
+            QueuedProposal::from_mls_plaintext(group_state.ciphersuite(), backend, update)
+                .expect("Could not create QueuedProposal."),
         );
 
         let params = CreateCommitParams::builder()
@@ -387,8 +387,8 @@ fn test_welcome_message_encoding(backend: &impl OpenMlsCryptoProvider) {
             .expect("Could not create proposal.");
 
         let proposal_store = ProposalStore::from_staged_proposal(
-            StagedProposal::from_mls_plaintext(group_state.ciphersuite(), backend, add)
-                .expect("Could not create StagedProposal."),
+            QueuedProposal::from_mls_plaintext(group_state.ciphersuite(), backend, add)
+                .expect("Could not create QueuedProposal."),
         );
 
         let params = CreateCommitParams::builder()

--- a/openmls/tests/test_encoding.rs
+++ b/openmls/tests/test_encoding.rs
@@ -313,7 +313,7 @@ fn test_commit_encoding(backend: &impl OpenMlsCryptoProvider) {
             .create_remove_proposal(framing_parameters, alice_credential_bundle, 2u32, backend)
             .expect("Could not create proposal.");
 
-        let mut proposal_store = ProposalStore::from_staged_proposal(
+        let mut proposal_store = ProposalStore::from_queued_proposal(
             QueuedProposal::from_mls_plaintext(group_state.ciphersuite(), backend, add)
                 .expect("Could not create QueuedProposal."),
         );
@@ -386,7 +386,7 @@ fn test_welcome_message_encoding(backend: &impl OpenMlsCryptoProvider) {
             )
             .expect("Could not create proposal.");
 
-        let proposal_store = ProposalStore::from_staged_proposal(
+        let proposal_store = ProposalStore::from_queued_proposal(
             QueuedProposal::from_mls_plaintext(group_state.ciphersuite(), backend, add)
                 .expect("Could not create QueuedProposal."),
         );

--- a/openmls/tests/test_group.rs
+++ b/openmls/tests/test_group.rs
@@ -79,7 +79,7 @@ fn create_commit_optional_path(
         )
         .expect("Could not create proposal.");
 
-    let mut proposal_store = ProposalStore::from_staged_proposal(
+    let mut proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );
@@ -268,7 +268,7 @@ fn basic_group_setup(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCr
         )
         .expect("Could not create proposal.");
 
-    let proposal_store = ProposalStore::from_staged_proposal(
+    let proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );
@@ -362,7 +362,7 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         )
         .expect("Could not create proposal.");
 
-    let mut proposal_store = ProposalStore::from_staged_proposal(
+    let mut proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
             .expect("Could not create QueuedProposal."),
     );

--- a/openmls/tests/test_group.rs
+++ b/openmls/tests/test_group.rs
@@ -80,8 +80,8 @@ fn create_commit_optional_path(
         .expect("Could not create proposal.");
 
     let mut proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -116,8 +116,8 @@ fn create_commit_optional_path(
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -176,8 +176,8 @@ fn create_commit_optional_path(
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, alice_update_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, alice_update_proposal)
+            .expect("Could not create QueuedProposal."),
     );
 
     // Only UpdateProposal
@@ -269,8 +269,8 @@ fn basic_group_setup(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCr
         .expect("Could not create proposal.");
 
     let proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -363,8 +363,8 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .expect("Could not create proposal.");
 
     let mut proposal_store = ProposalStore::from_staged_proposal(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, bob_add_proposal)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -456,8 +456,8 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_bob)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_bob)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -522,8 +522,8 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_alice)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_alice)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -587,8 +587,8 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_bob)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_bob)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -665,8 +665,8 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, add_charlie_proposal_bob)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, add_charlie_proposal_bob)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -786,8 +786,8 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_charlie)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, update_proposal_charlie)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()
@@ -852,8 +852,8 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
 
     proposal_store.empty();
     proposal_store.add(
-        StagedProposal::from_mls_plaintext(ciphersuite, backend, remove_bob_proposal_charlie)
-            .expect("Could not create StagedProposal."),
+        QueuedProposal::from_mls_plaintext(ciphersuite, backend, remove_bob_proposal_charlie)
+            .expect("Could not create QueuedProposal."),
     );
 
     let params = CreateCommitParams::builder()

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -321,14 +321,14 @@ fn mls_group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
             // TODO #575: Replace this with the adequate API call
             assert_eq!(staged_proposal.sender().to_leaf_index(), 0u32);
         } else {
-            unreachable!("Expected a StagedProposal.");
+            unreachable!("Expected a QueuedProposal.");
         }
 
         // Merge Commit
         if let ProcessedMessage::ProposalMessage(staged_proposal) = bob_processed_message {
             bob_group.store_pending_proposal(*staged_proposal);
         } else {
-            unreachable!("Expected a StagedProposal.");
+            unreachable!("Expected a QueuedProposal.");
         }
 
         let (queued_message, _welcome_option) =
@@ -694,7 +694,7 @@ fn mls_group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
             // TODO #575: Replace this with the adequate API call
             assert_eq!(staged_proposal.sender().to_leaf_index(), 0u32);
         } else {
-            unreachable!("Expected a StagedProposal.");
+            unreachable!("Expected a QueuedProposal.");
         }
 
         let unverified_message = charlie_group
@@ -720,7 +720,7 @@ fn mls_group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
             // TODO #575: Replace this with the adequate API call
             assert_eq!(staged_proposal.sender().to_leaf_index(), 0u32);
         } else {
-            unreachable!("Expected a StagedProposal.");
+            unreachable!("Expected a QueuedProposal.");
         }
 
         // Create AddProposal and process it
@@ -749,7 +749,7 @@ fn mls_group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
             // Store proposal
             alice_group.store_pending_proposal(*staged_proposal);
         } else {
-            unreachable!("Expected a StagedProposal.");
+            unreachable!("Expected a QueuedProposal.");
         }
 
         let unverified_message = charlie_group
@@ -774,7 +774,7 @@ fn mls_group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
             // Store proposal
             charlie_group.store_pending_proposal(*staged_proposal);
         } else {
-            unreachable!("Expected a StagedProposal.");
+            unreachable!("Expected a QueuedProposal.");
         }
 
         // Commit to the proposals and process it
@@ -899,7 +899,7 @@ fn mls_group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
             // Store proposal
             alice_group.store_pending_proposal(*staged_proposal);
         } else {
-            unreachable!("Expected a StagedProposal.");
+            unreachable!("Expected a QueuedProposal.");
         }
 
         // Store proposal
@@ -907,7 +907,7 @@ fn mls_group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
             // Store proposal
             bob_group.store_pending_proposal(*staged_proposal);
         } else {
-            unreachable!("Expected a StagedProposal.");
+            unreachable!("Expected a QueuedProposal.");
         }
 
         // Should fail because you cannot remove yourself from a group

--- a/openmls/tests/utils/mls_utils/mod.rs
+++ b/openmls/tests/utils/mls_utils/mod.rs
@@ -203,7 +203,7 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
             let mut proposal_store = ProposalStore::new();
             for proposal in proposal_list {
                 proposal_store.add(
-                    StagedProposal::from_mls_plaintext(
+                    QueuedProposal::from_mls_plaintext(
                         &Ciphersuite::new(group_config.ciphersuite)
                             .expect("Could not create ciphersuite."),
                         backend,


### PR DESCRIPTION
This PR refactors proposal queues and in the process
 - gets rid of the `CreationProposalQueue` and the associated implementations and structs
 - gets rid of the `apply_proposal` function (thus fixing #565)
 - Removes the `Staged...` prefix whenever it's followed by `Proposal...`, as these structs are now used both for creation and staging

The advantage of the `CreationProposalQueue` was that it relied on references rather than full `Proposal` structs. However, in the course of #617 we started returning a `StagedProposalQueue` at the end of `create_commit`, so the cloning was taking place in any case.

This PR is mostly renaming an code removal with the exception of `filter_proposals`, where I had to clone a proposal where previously a reference was created.