### PR TITLE
Fix most clippy warnings

### DIFF
--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -48,7 +48,7 @@ impl CoreGroup {
         // this group. Note that this is not strictly necessary. But there's
         // currently no other mechanism to enable the extension.
         let extension_tree_option =
-            try_nodes_from_extensions(&verifiable_public_group_state.other_extensions())?;
+            try_nodes_from_extensions(verifiable_public_group_state.other_extensions())?;
         let (nodes, enable_ratchet_tree_extension) = match extension_tree_option {
             Some(ref nodes) => (nodes, true),
             None => match tree_option.as_ref() {

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -94,7 +94,7 @@ impl CoreGroup {
         // this group. Note that this is not strictly necessary. But there's
         // currently no other mechanism to enable the extension.
         let (nodes, enable_ratchet_tree_extension) =
-            match try_nodes_from_extensions(&group_info.other_extensions())? {
+            match try_nodes_from_extensions(group_info.other_extensions())? {
                 Some(nodes) => (nodes, true),
                 None => match nodes_option.as_ref() {
                     Some(n) => (n.as_slice(), false),

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -216,7 +216,7 @@ impl From<Secret> for InitSecret {
 /// the `init_secret` when creating or processing a commit with an external init
 /// proposal. TODO: #628.
 fn hpke_info_from_version(version: ProtocolVersion) -> &'static str {
-    &match version {
+    match version {
         ProtocolVersion::Reserved => "Reserved external init",
         ProtocolVersion::Mls10 => "MLS 1.0 external init",
         ProtocolVersion::Mls10Draft11 => "MLS 1.0 Draft 11 external init",


### PR DESCRIPTION
This fixes some of the clippy warnings that snuck in while the clippy CI was broken. I'm still not sure what to do about the number `decrypt_path` inputs. I'm tempted to put this off until we got rid of the explicit `version` handling.