### PR TITLE
Remove unnecessary `KeyPackageBundle` return during commit processing

### DIFF
--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -876,10 +876,6 @@ impl MlsClient for MlsClientImpl {
             .create_commit(params, &self.crypto_provider)
             .map_err(into_status)?;
 
-        if let Some(kpb) = create_commit_results.key_package_bundle_option {
-            interop_group.own_kpbs.push(kpb)
-        }
-
         let commit = match interop_group.wire_format {
             WireFormat::MlsCiphertext => interop_group
                 .group

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -26,7 +26,6 @@ struct PathProcessingResult {
     commit_secret: Option<CommitSecret>,
     encrypted_path: Option<UpdatePath>,
     plain_path: Option<Vec<PlainUpdatePathNode>>,
-    key_package_bundle: Option<KeyPackageBundle>,
 }
 
 impl CoreGroup {
@@ -93,7 +92,7 @@ impl CoreGroup {
 
                 // Derive and apply an update path based on the previously
                 // generated KeyPackageBundle.
-                let (key_package_bundle, plain_path, commit_secret) = diff.apply_own_update_path(
+                let (key_package, plain_path, commit_secret) = diff.apply_own_update_path(
                     backend,
                     ciphersuite,
                     key_package_bundle_payload,
@@ -107,13 +106,12 @@ impl CoreGroup {
                     &plain_path,
                     &serialized_group_context,
                     &apply_proposals_values.exclusion_list(),
-                    key_package_bundle.key_package(),
+                    &key_package,
                 )?;
                 PathProcessingResult {
                     commit_secret: Some(commit_secret),
                     encrypted_path: Some(encrypted_path),
                     plain_path: Some(plain_path),
-                    key_package_bundle: Some(key_package_bundle),
                 }
             } else {
                 // If path is not needed, return empty path processing results
@@ -286,7 +284,6 @@ impl CoreGroup {
         Ok(CreateCommitResult {
             commit: mls_plaintext,
             welcome_option,
-            key_package_bundle_option: path_processing_result.key_package_bundle,
             staged_commit,
         })
     }

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -106,7 +106,7 @@ impl CoreGroup {
                     &plain_path,
                     &serialized_group_context,
                     &apply_proposals_values.exclusion_list(),
-                    &key_package,
+                    key_package,
                 )?;
                 PathProcessingResult {
                     commit_secret: Some(commit_secret),

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -73,7 +73,6 @@ use super::{
 pub struct CreateCommitResult {
     pub commit: MlsPlaintext,
     pub welcome_option: Option<Welcome>,
-    pub key_package_bundle_option: Option<KeyPackageBundle>,
     pub staged_commit: StagedCommit,
 }
 

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -255,7 +255,7 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         MlsPlaintextContentType::Commit(commit) => commit,
         _ => panic!("Wrong content type"),
     };
-    assert!(!commit.has_path() && create_commit_result.key_package_bundle_option.is_none());
+    assert!(!commit.has_path());
     // Check that the function returned a Welcome message
     assert!(create_commit_result.welcome_option.is_some());
 
@@ -674,14 +674,7 @@ fn test_own_commit_processing(
 
     // Alice attempts to process her own commit
     let error = alice_group
-        .stage_commit(
-            &create_commit_result.commit,
-            &proposal_store,
-            &[create_commit_result
-                .key_package_bundle_option
-                .expect("no kpb in create commit result")],
-            backend,
-        )
+        .stage_commit(&create_commit_result.commit, &proposal_store, &[], backend)
         .expect_err("no error while processing own commit");
     assert_eq!(error, CoreGroupError::OwnCommitError);
 }

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -65,11 +65,6 @@ impl MlsGroup {
             }
         };
 
-        // If it was a full Commit, we have to save the KeyPackageBundle for later
-        if let Some(kpb) = create_commit_result.key_package_bundle_option {
-            self.own_kpbs.push(kpb);
-        }
-
         // Convert MlsPlaintext messages to MLSMessage and encrypt them if required by
         // the configuration
         let mls_messages = self.plaintext_to_mls_message(create_commit_result.commit, backend)?;
@@ -127,15 +122,6 @@ impl MlsGroup {
             .inline_proposals(inline_proposals)
             .build();
         let create_commit_result = self.group.create_commit(params, backend)?;
-
-        // It has to be a full Commit and we have to save the KeyPackageBundle for later
-        if let Some(kpb) = create_commit_result.key_package_bundle_option {
-            self.own_kpbs.push(kpb);
-        } else {
-            return Err(MlsGroupError::LibraryError(
-                "We didn't get a key package for a full commit.".into(),
-            ));
-        }
 
         // Convert MlsPlaintext messages to MLSMessage and encrypt them if required by
         // the configuration

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -81,8 +81,9 @@ pub struct MlsGroup {
     // A [MessageSecretsStore] that stores message secrets from past epochs in order to be able to decrypt
     // application messages from previous epochs.
     message_secrets_store: MessageSecretsStore,
-    // Own `KeyPackageBundle`s that were created for update proposals or commits. The vector is
-    // emptied after every epoch change.
+    // Own `KeyPackageBundle`s that were created for update proposals and that
+    // are needed in case an update proposal is commited by another group
+    // member. The vector is emptied after every epoch change.
     own_kpbs: Vec<KeyPackageBundle>,
     // The AAD that is used for all outgoing handshake messages. The AAD can be set through
     // `set_aad()`.

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -91,11 +91,6 @@ impl MlsGroup {
             .build();
         let create_commit_result = self.group.create_commit(params, backend)?;
 
-        // If it was a full Commit, we have to save the KeyPackageBundle for later
-        if let Some(kpb) = create_commit_result.key_package_bundle_option {
-            self.own_kpbs.push(kpb);
-        }
-
         // Convert MlsPlaintext messages to MLSMessage and encrypt them if required by
         // the configuration
         let mls_message = self.plaintext_to_mls_message(create_commit_result.commit, backend)?;

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -50,17 +50,6 @@ impl MlsGroup {
             }
         };
 
-        // Take the new KeyPackageBundle and save it for later
-        let kpb = create_commit_result
-            .key_package_bundle_option
-            .ok_or_else(|| {
-                MlsGroupError::LibraryError(
-                    "We didn't get a key package for a full commit on self update.".into(),
-                )
-            })?;
-
-        self.own_kpbs.push(kpb);
-
         // Convert MlsPlaintext messages to MLSMessage and encrypt them if required by
         // the configuration
         let mls_message = self.plaintext_to_mls_message(create_commit_result.commit, backend)?;

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -40,12 +40,12 @@ use crate::{
     ciphersuite::{signable::Signable, Ciphersuite, HpkePrivateKey, HpkePublicKey, Secret},
     credentials::{CredentialBundle, CredentialError},
     extensions::ExtensionType,
-    key_packages::{KeyPackage, KeyPackageBundle, KeyPackageBundlePayload},
+    key_packages::{KeyPackage, KeyPackageBundlePayload},
     messages::{PathSecret, PathSecretError},
     schedule::CommitSecret,
 };
 
-pub(crate) type UpdatePathResult = (KeyPackageBundle, Vec<PlainUpdatePathNode>, CommitSecret);
+pub(crate) type UpdatePathResult = (KeyPackage, Vec<PlainUpdatePathNode>, CommitSecret);
 
 /// The [`StagedTreeSyncDiff`] can be created from a [`TreeSyncDiff`], examined
 /// and later merged into a [`TreeSync`] instance.
@@ -258,11 +258,12 @@ impl<'a> TreeSyncDiff<'a> {
         key_package_bundle_payload.update_parent_hash(&parent_hash);
         let key_package_bundle = key_package_bundle_payload.sign(backend, credential_bundle)?;
 
-        let node = Node::LeafNode(key_package_bundle.clone().into());
+        let key_package = key_package_bundle.key_package().clone();
+        let node = Node::LeafNode(key_package_bundle.into());
 
         // Replace the leaf.
         self.diff.replace_leaf(self.own_leaf_index, node.into())?;
-        Ok((key_package_bundle, update_path_nodes, commit_secret))
+        Ok((key_package, update_path_nodes, commit_secret))
     }
 
     /// Set the given path as the direct path of the `sender_leaf_index` and

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -235,11 +235,8 @@ impl<'a> TreeSyncDiff<'a> {
     /// apply it to this diff. The given [`CredentialBundle`] reference is used
     /// to sign the [`KeyPackageBundlePayload`] after updating its parent hash.
     ///
-    /// Returns the resulting [`KeyPackageBundle`] for later use with
-    /// [`Self::re_apply_own_update_path()`], as well as the [`CommitSecret`]
-    /// and the path resulting from the path derivation. FIXME: There is no need
-    /// to return a KPB here, as we're either going to merge the commit or drop
-    /// it entirely.
+    /// Returns the [`CommitSecret`] and the path resulting from the path
+    /// derivation, as well as the [`KeyPackage`].
     pub(crate) fn apply_own_update_path(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -43,7 +43,7 @@ impl<'a> TreeSyncDiff<'a> {
         path: &[PlainUpdatePathNode],
         group_context: &[u8],
         exclusion_list: &HashSet<&LeafIndex>,
-        key_package: &KeyPackage,
+        key_package: KeyPackage,
     ) -> Result<UpdatePath, TreeKemError> {
         let copath_resolutions = self.copath_resolutions(self.own_leaf_index(), exclusion_list)?;
 
@@ -60,7 +60,7 @@ impl<'a> TreeSyncDiff<'a> {
             .collect::<Vec<UpdatePathNode>>();
 
         Ok(UpdatePath {
-            leaf_key_package: key_package.clone(),
+            leaf_key_package: key_package,
             nodes: update_path_nodes.into(),
         })
     }

--- a/openmls/tests/test_group.rs
+++ b/openmls/tests/test_group.rs
@@ -89,14 +89,15 @@ fn create_commit_optional_path(
         .credential_bundle(&alice_credential_bundle)
         .proposal_store(&proposal_store)
         .build();
-    let create_commit_result = group_alice
-        .create_commit(params, backend)
-        .expect("error creating commit");
+    let create_commit_result =
+        match group_alice.create_commit(params /* No PSK fetcher */, backend) {
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => Some(commit),
-        _ => None,
-    }
-    .expect("error getting commit content from create_commit_result");
+        MlsPlaintextContentType::Commit(commit) => commit,
+        _ => panic!(),
+    };
     assert!(commit.has_path());
 
     // Alice adds Bob without forced self-update
@@ -124,14 +125,14 @@ fn create_commit_optional_path(
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = group_alice
-        .create_commit(params, backend)
-        .expect("error creating commit");
+    let create_commit_result = match group_alice.create_commit(params, backend) {
+        Ok(c) => c,
+        Err(e) => panic!("Error creating commit: {:?}", e),
+    };
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => Some(commit),
-        _ => None,
-    }
-    .expect("error getting commit content from create_commit_result");
+        MlsPlaintextContentType::Commit(commit) => commit,
+        _ => panic!(),
+    };
     assert!(!commit.has_path());
 
     // Alice applies the Commit without the forced self-update
@@ -181,14 +182,14 @@ fn create_commit_optional_path(
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = group_alice
-        .create_commit(params, backend)
-        .expect("error creating commit");
+    let create_commit_result = match group_alice.create_commit(params, backend) {
+        Ok(c) => c,
+        Err(e) => panic!("Error creating commit: {:?}", e),
+    };
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => Some(commit),
-        _ => None,
-    }
-    .expect("error getting commit content from create_commit_result");
+        MlsPlaintextContentType::Commit(commit) => commit,
+        _ => panic!(),
+    };
     assert!(commit.has_path());
 
     // Apply UpdateProposal
@@ -262,9 +263,10 @@ fn basic_group_setup(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCr
         .credential_bundle(&alice_credential_bundle)
         .proposal_store(&proposal_store)
         .build();
-    let _create_commit_result = group_alice
-        .create_commit(params, backend)
-        .expect("error creating commit");
+    let _commit = match group_alice.create_commit(params /* PSK fetcher */, backend) {
+        Ok(c) => c,
+        Err(e) => panic!("Error creating commit: {:?}", e),
+    };
 }
 
 /// This test simulates various group operations like Add, Update, Remove in a
@@ -360,10 +362,9 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .create_commit(params, backend)
         .expect("Error creating commit");
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => Some(commit),
-        _ => None,
-    }
-    .expect("error getting commit content from create_commit_result");
+        MlsPlaintextContentType::Commit(commit) => commit,
+        _ => panic!("Wrong content type"),
+    };
     assert!(!commit.has_path());
     // Check that the function returned a Welcome message
     assert!(create_commit_result.welcome_option.is_some());
@@ -447,16 +448,16 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = group_bob
-        .create_commit(params, backend)
-        .expect("error creating commit");
+    let create_commit_result = match group_bob.create_commit(params, backend) {
+        Ok(c) => c,
+        Err(e) => panic!("Error creating commit: {:?}", e),
+    };
 
     // Check that there is a path
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => Some(commit),
-        _ => None,
-    }
-    .expect("error getting commit content from create_commit_result");
+        MlsPlaintextContentType::Commit(commit) => commit,
+        _ => panic!("Wrong content type"),
+    };
     assert!(commit.has_path());
     // Check there is no Welcome message
     assert!(create_commit_result.welcome_option.is_none());
@@ -508,9 +509,11 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = group_alice
-        .create_commit(params, backend)
-        .expect("error creating commit");
+    let create_commit_result =
+        match group_alice.create_commit(params /* PSK fetcher */, backend) {
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
 
     // Check that there is a path
     assert!(commit.has_path());
@@ -561,9 +564,10 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = group_alice
-        .create_commit(params, backend)
-        .expect("error creating commit");
+    let create_commit_result = match group_alice.create_commit(params, backend) {
+        Ok(c) => c,
+        Err(e) => panic!("Error creating commit: {:?}", e),
+    };
 
     // Check that there is a path
     assert!(commit.has_path());
@@ -634,17 +638,17 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = group_bob
-        .create_commit(params, backend)
-        .expect("error creating commit");
+    let create_commit_result = match group_bob.create_commit(params, backend) {
+        Ok(c) => c,
+        Err(e) => panic!("Error creating commit: {:?}", e),
+    };
 
     // Check there is no path since there are only Add Proposals and no forced
     // self-update
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => Some(commit),
-        _ => None,
-    }
-    .expect("error getting commit content from create_commit_result");
+        MlsPlaintextContentType::Commit(commit) => commit,
+        _ => panic!("Wrong content type"),
+    };
     assert!(!commit.has_path());
     // Make sure the is a Welcome message for Charlie
     assert!(create_commit_result.welcome_option.is_some());
@@ -756,16 +760,16 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = group_charlie
-        .create_commit(params, backend)
-        .expect("error creating commit");
+    let create_commit_result = match group_charlie.create_commit(params, backend) {
+        Ok(c) => c,
+        Err(e) => panic!("Error creating commit: {:?}", e),
+    };
 
     // Check that there is a new KeyPackageBundle
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => Some(commit),
-        _ => None,
-    }
-    .expect("error getting commit content from create_commit_result");
+        MlsPlaintextContentType::Commit(commit) => commit,
+        _ => panic!("Wrong content type"),
+    };
     assert!(commit.has_path());
 
     let staged_commit = group_alice
@@ -816,9 +820,11 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = group_charlie
-        .create_commit(params, backend)
-        .expect("error creating commit");
+    let create_commit_result =
+        match group_charlie.create_commit(params /* PSK fetcher */, backend) {
+            Ok(c) => c,
+            Err(e) => panic!("Error creating commit: {:?}", e),
+        };
 
     // Check that there is a new KeyPackageBundle
     assert!(commit.has_path());

--- a/openmls/tests/test_group.rs
+++ b/openmls/tests/test_group.rs
@@ -89,15 +89,14 @@ fn create_commit_optional_path(
         .credential_bundle(&alice_credential_bundle)
         .proposal_store(&proposal_store)
         .build();
-    let create_commit_result =
-        match group_alice.create_commit(params /* No PSK fetcher */, backend) {
-            Ok(c) => c,
-            Err(e) => panic!("Error creating commit: {:?}", e),
-        };
+    let create_commit_result = group_alice
+        .create_commit(params, backend)
+        .expect("error creating commit");
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => commit,
-        _ => panic!(),
-    };
+        MlsPlaintextContentType::Commit(commit) => Some(commit),
+        _ => None,
+    }
+    .expect("error getting commit content from create_commit_result");
     assert!(commit.has_path());
 
     // Alice adds Bob without forced self-update
@@ -125,14 +124,14 @@ fn create_commit_optional_path(
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = match group_alice.create_commit(params, backend) {
-        Ok(c) => c,
-        Err(e) => panic!("Error creating commit: {:?}", e),
-    };
+    let create_commit_result = group_alice
+        .create_commit(params, backend)
+        .expect("error creating commit");
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => commit,
-        _ => panic!(),
-    };
+        MlsPlaintextContentType::Commit(commit) => Some(commit),
+        _ => None,
+    }
+    .expect("error getting commit content from create_commit_result");
     assert!(!commit.has_path());
 
     // Alice applies the Commit without the forced self-update
@@ -182,14 +181,14 @@ fn create_commit_optional_path(
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = match group_alice.create_commit(params, backend) {
-        Ok(c) => c,
-        Err(e) => panic!("Error creating commit: {:?}", e),
-    };
+    let create_commit_result = group_alice
+        .create_commit(params, backend)
+        .expect("error creating commit");
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => commit,
-        _ => panic!(),
-    };
+        MlsPlaintextContentType::Commit(commit) => Some(commit),
+        _ => None,
+    }
+    .expect("error getting commit content from create_commit_result");
     assert!(commit.has_path());
 
     // Apply UpdateProposal
@@ -263,10 +262,9 @@ fn basic_group_setup(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCr
         .credential_bundle(&alice_credential_bundle)
         .proposal_store(&proposal_store)
         .build();
-    let _commit = match group_alice.create_commit(params /* PSK fetcher */, backend) {
-        Ok(c) => c,
-        Err(e) => panic!("Error creating commit: {:?}", e),
-    };
+    let _create_commit_result = group_alice
+        .create_commit(params, backend)
+        .expect("error creating commit");
 }
 
 /// This test simulates various group operations like Add, Update, Remove in a
@@ -362,9 +360,10 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .create_commit(params, backend)
         .expect("Error creating commit");
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => commit,
-        _ => panic!("Wrong content type"),
-    };
+        MlsPlaintextContentType::Commit(commit) => Some(commit),
+        _ => None,
+    }
+    .expect("error getting commit content from create_commit_result");
     assert!(!commit.has_path());
     // Check that the function returned a Welcome message
     assert!(create_commit_result.welcome_option.is_some());
@@ -448,16 +447,16 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = match group_bob.create_commit(params, backend) {
-        Ok(c) => c,
-        Err(e) => panic!("Error creating commit: {:?}", e),
-    };
+    let create_commit_result = group_bob
+        .create_commit(params, backend)
+        .expect("error creating commit");
 
     // Check that there is a path
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => commit,
-        _ => panic!("Wrong content type"),
-    };
+        MlsPlaintextContentType::Commit(commit) => Some(commit),
+        _ => None,
+    }
+    .expect("error getting commit content from create_commit_result");
     assert!(commit.has_path());
     // Check there is no Welcome message
     assert!(create_commit_result.welcome_option.is_none());
@@ -509,11 +508,9 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result =
-        match group_alice.create_commit(params /* PSK fetcher */, backend) {
-            Ok(c) => c,
-            Err(e) => panic!("Error creating commit: {:?}", e),
-        };
+    let create_commit_result = group_alice
+        .create_commit(params, backend)
+        .expect("error creating commit");
 
     // Check that there is a path
     assert!(commit.has_path());
@@ -564,10 +561,9 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = match group_alice.create_commit(params, backend) {
-        Ok(c) => c,
-        Err(e) => panic!("Error creating commit: {:?}", e),
-    };
+    let create_commit_result = group_alice
+        .create_commit(params, backend)
+        .expect("error creating commit");
 
     // Check that there is a path
     assert!(commit.has_path());
@@ -638,17 +634,17 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = match group_bob.create_commit(params, backend) {
-        Ok(c) => c,
-        Err(e) => panic!("Error creating commit: {:?}", e),
-    };
+    let create_commit_result = group_bob
+        .create_commit(params, backend)
+        .expect("error creating commit");
 
     // Check there is no path since there are only Add Proposals and no forced
     // self-update
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => commit,
-        _ => panic!("Wrong content type"),
-    };
+        MlsPlaintextContentType::Commit(commit) => Some(commit),
+        _ => None,
+    }
+    .expect("error getting commit content from create_commit_result");
     assert!(!commit.has_path());
     // Make sure the is a Welcome message for Charlie
     assert!(create_commit_result.welcome_option.is_some());
@@ -760,16 +756,16 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result = match group_charlie.create_commit(params, backend) {
-        Ok(c) => c,
-        Err(e) => panic!("Error creating commit: {:?}", e),
-    };
+    let create_commit_result = group_charlie
+        .create_commit(params, backend)
+        .expect("error creating commit");
 
     // Check that there is a new KeyPackageBundle
     let commit = match create_commit_result.commit.content() {
-        MlsPlaintextContentType::Commit(commit) => commit,
-        _ => panic!("Wrong content type"),
-    };
+        MlsPlaintextContentType::Commit(commit) => Some(commit),
+        _ => None,
+    }
+    .expect("error getting commit content from create_commit_result");
     assert!(commit.has_path());
 
     let staged_commit = group_alice
@@ -820,11 +816,9 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .proposal_store(&proposal_store)
         .force_self_update(false)
         .build();
-    let create_commit_result =
-        match group_charlie.create_commit(params /* PSK fetcher */, backend) {
-            Ok(c) => c,
-            Err(e) => panic!("Error creating commit: {:?}", e),
-        };
+    let create_commit_result = group_charlie
+        .create_commit(params, backend)
+        .expect("error creating commit");
 
     // Check that there is a new KeyPackageBundle
     assert!(commit.has_path());

--- a/openmls/tests/test_group.rs
+++ b/openmls/tests/test_group.rs
@@ -99,7 +99,6 @@ fn create_commit_optional_path(
         _ => panic!(),
     };
     assert!(commit.has_path());
-    assert!(commit.has_path() && create_commit_result.key_package_bundle_option.is_some());
 
     // Alice adds Bob without forced self-update
     // Since there are only Add Proposals, this does not generate a path field on
@@ -134,7 +133,7 @@ fn create_commit_optional_path(
         MlsPlaintextContentType::Commit(commit) => commit,
         _ => panic!(),
     };
-    assert!(!commit.has_path() && create_commit_result.key_package_bundle_option.is_none());
+    assert!(!commit.has_path());
 
     // Alice applies the Commit without the forced self-update
     group_alice
@@ -191,7 +190,7 @@ fn create_commit_optional_path(
         MlsPlaintextContentType::Commit(commit) => commit,
         _ => panic!(),
     };
-    assert!(commit.has_path() && create_commit_result.key_package_bundle_option.is_some());
+    assert!(commit.has_path());
 
     // Apply UpdateProposal
     group_alice
@@ -366,7 +365,7 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         MlsPlaintextContentType::Commit(commit) => commit,
         _ => panic!("Wrong content type"),
     };
-    assert!(!commit.has_path() && create_commit_result.key_package_bundle_option.is_none());
+    assert!(!commit.has_path());
     // Check that the function returned a Welcome message
     assert!(create_commit_result.welcome_option.is_some());
 
@@ -454,8 +453,12 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         Err(e) => panic!("Error creating commit: {:?}", e),
     };
 
-    // Check that there is a new KeyPackageBundle
-    assert!(create_commit_result.key_package_bundle_option.is_some());
+    // Check that there is a path
+    let commit = match create_commit_result.commit.content() {
+        MlsPlaintextContentType::Commit(commit) => commit,
+        _ => panic!("Wrong content type"),
+    };
+    assert!(commit.has_path());
     // Check there is no Welcome message
     assert!(create_commit_result.welcome_option.is_none());
 
@@ -512,8 +515,8 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
             Err(e) => panic!("Error creating commit: {:?}", e),
         };
 
-    // Check that there is a new KeyPackageBundle
-    assert!(create_commit_result.key_package_bundle_option.is_some());
+    // Check that there is a path
+    assert!(commit.has_path());
 
     group_alice
         .merge_commit(create_commit_result.staged_commit)
@@ -566,8 +569,8 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         Err(e) => panic!("Error creating commit: {:?}", e),
     };
 
-    // Check that there is a new KeyPackageBundle
-    assert!(create_commit_result.key_package_bundle_option.is_some());
+    // Check that there is a path
+    assert!(commit.has_path());
 
     group_alice
         .merge_commit(create_commit_result.staged_commit)
@@ -640,9 +643,13 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         Err(e) => panic!("Error creating commit: {:?}", e),
     };
 
-    // Check there is no KeyPackageBundle since there are only Add Proposals and no
-    // forced self-update
-    assert!(create_commit_result.key_package_bundle_option.is_none());
+    // Check there is no path since there are only Add Proposals and no forced
+    // self-update
+    let commit = match create_commit_result.commit.content() {
+        MlsPlaintextContentType::Commit(commit) => commit,
+        _ => panic!("Wrong content type"),
+    };
+    assert!(!commit.has_path());
     // Make sure the is a Welcome message for Charlie
     assert!(create_commit_result.welcome_option.is_some());
 
@@ -759,7 +766,11 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
     };
 
     // Check that there is a new KeyPackageBundle
-    assert!(create_commit_result.key_package_bundle_option.is_some());
+    let commit = match create_commit_result.commit.content() {
+        MlsPlaintextContentType::Commit(commit) => commit,
+        _ => panic!("Wrong content type"),
+    };
+    assert!(commit.has_path());
 
     let staged_commit = group_alice
         .stage_commit(&create_commit_result.commit, &proposal_store, &[], backend)
@@ -816,7 +827,7 @@ fn group_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         };
 
     // Check that there is a new KeyPackageBundle
-    assert!(create_commit_result.key_package_bundle_option.is_some());
+    assert!(commit.has_path());
 
     let staged_commit = group_alice
         .stage_commit(&create_commit_result.commit, &proposal_store, &[], backend)


### PR DESCRIPTION
Since we're now relying on the stored `StagedCommit` to remember data from a commit, we don't need to return (and store in case of the `MlsGroup`) a `KeyPackageBundle` whenever we create a commit.

This PR removes the returned `KeyPackageBundle` throughout the `create_commit` chain of calls through the stack and thus fixes #673.