### PR TITLE
Update codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,6 +32,4 @@ jobs:
           args: "--manifest-path openmls/Cargo.toml"
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
Updates to version v2, since v1 will be sunset on Feb 1, 2022.
Removes the token, which apparently is not needed for public repos and stops PRs from forks to work.