### PR TITLE
Enable processing of own external commits

### DIFF
--- a/openmls/src/group/core_group/create_commit_params.rs
+++ b/openmls/src/group/core_group/create_commit_params.rs
@@ -3,7 +3,7 @@
 use super::{proposals::ProposalStore, *};
 
 /// Can be used to denote the type of a commit.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub enum CommitType {
     External,
     Member,

--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -1,7 +1,5 @@
 use crate::{
     ciphersuite::signable::Verifiable,
-    credentials::CredentialBundle,
-    framing::plaintext::MlsPlaintext,
     group::errors::ExternalCommitError,
     messages::{
         proposals::{ExternalInitProposal, Proposal},
@@ -11,7 +9,6 @@ use crate::{
 
 use super::{
     create_commit_params::{CommitType, CreateCommitParams},
-    proposals::{ProposalStore, QueuedProposal},
     CoreGroup,
 };
 use crate::group::core_group::*;
@@ -29,16 +26,13 @@ impl CoreGroup {
     /// containing the commit.
     pub fn join_by_external_commit(
         backend: &impl OpenMlsCryptoProvider,
-        framing_parameters: FramingParameters,
+        params: CreateCommitParams,
         tree_option: Option<&[Option<Node>]>,
-        credential_bundle: &CredentialBundle,
-        proposals_by_reference: &[MlsPlaintext],
-        proposals_by_value: &[Proposal],
         verifiable_public_group_state: VerifiablePublicGroupState,
     ) -> Result<ExternalCommitResult, CoreGroupError> {
         let ciphersuite = Config::ciphersuite(verifiable_public_group_state.ciphersuite())?;
         if !Config::supported_versions().contains(&verifiable_public_group_state.version()) {
-            Err(ExternalCommitError::UnsupportedMlsVersion)?;
+            return Err(ExternalCommitError::UnsupportedMlsVersion.into());
         }
 
         // Build the ratchet tree
@@ -53,7 +47,7 @@ impl CoreGroup {
             Some(ref nodes) => (nodes, true),
             None => match tree_option.as_ref() {
                 Some(n) => (n, false),
-                None => Err(ExternalCommitError::MissingRatchetTree)?,
+                None => return Err(ExternalCommitError::MissingRatchetTree.into()),
             },
         };
 
@@ -63,7 +57,7 @@ impl CoreGroup {
         let treesync = TreeSync::from_nodes_without_leaf(backend, ciphersuite, nodes)?;
 
         if treesync.tree_hash() != verifiable_public_group_state.tree_hash() {
-            Err(ExternalCommitError::TreeHashMismatch)?;
+            return Err(ExternalCommitError::TreeHashMismatch.into());
         }
 
         // FIXME #680: Validation of external commits
@@ -73,9 +67,8 @@ impl CoreGroup {
             .ok_or(ExternalCommitError::UnknownSender)?
             .key_package()
             .credential();
-        let pgs: PublicGroupState = verifiable_public_group_state
-            .verify(backend, pgs_signer_credential)
-            .map_err(|_| ExternalCommitError::InvalidPublicGroupStateSignature)?;
+        let pgs: PublicGroupState =
+            verifiable_public_group_state.verify(backend, pgs_signer_credential)?;
 
         let (init_secret, kem_output) = InitSecret::from_public_group_state(backend, &pgs)?;
 
@@ -113,20 +106,14 @@ impl CoreGroup {
 
         let external_init_proposal = Proposal::ExternalInit(ExternalInitProposal::from(kem_output));
 
-        let mut proposal_store = ProposalStore::default();
-        for proposal in proposals_by_reference {
-            let staged_proposal =
-                QueuedProposal::from_mls_plaintext(ciphersuite, backend, proposal.clone())?;
-            proposal_store.add(staged_proposal)
-        }
-
-        let mut inline_proposals = proposals_by_value.to_vec();
-        inline_proposals.push(external_init_proposal);
+        // FIXME #682: Check if old self is in the group. If that is the case,
+        // add a remove proposal.
+        let inline_proposals = vec![external_init_proposal];
 
         let params = CreateCommitParams::builder()
-            .framing_parameters(framing_parameters)
-            .credential_bundle(credential_bundle)
-            .proposal_store(&proposal_store)
+            .framing_parameters(*params.framing_parameters())
+            .credential_bundle(params.credential_bundle())
+            .proposal_store(params.proposal_store())
             .inline_proposals(inline_proposals)
             .commit_type(CommitType::External)
             .build();

--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -35,10 +35,10 @@ impl CoreGroup {
         proposals_by_reference: &[MlsPlaintext],
         proposals_by_value: &[Proposal],
         verifiable_public_group_state: VerifiablePublicGroupState,
-    ) -> Result<ExternalInitResult, ExternalInitError> {
+    ) -> Result<ExternalInitResult, CoreGroupError> {
         let ciphersuite = Config::ciphersuite(verifiable_public_group_state.ciphersuite())?;
         if !Config::supported_versions().contains(&verifiable_public_group_state.version()) {
-            return Err(ExternalInitError::UnsupportedMlsVersion);
+            Err(ExternalInitError::UnsupportedMlsVersion)?;
         }
 
         // Build the ratchet tree
@@ -53,7 +53,7 @@ impl CoreGroup {
             Some(ref nodes) => (nodes, true),
             None => match tree_option.as_ref() {
                 Some(n) => (n, false),
-                None => return Err(ExternalInitError::MissingRatchetTree),
+                None => Err(ExternalInitError::MissingRatchetTree)?,
             },
         };
 
@@ -63,7 +63,7 @@ impl CoreGroup {
         let treesync = TreeSync::from_nodes_without_leaf(backend, ciphersuite, nodes)?;
 
         if treesync.tree_hash() != verifiable_public_group_state.tree_hash() {
-            return Err(ExternalInitError::TreeHashMismatch);
+            Err(ExternalInitError::TreeHashMismatch)?;
         }
 
         let pgs_signer_leaf = treesync.leaf(verifiable_public_group_state.signer_index())?;

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -147,6 +147,8 @@ impl CoreGroup {
             backend,
         )?;
 
+        // FIXME #680: Validation of external commits
+
         match context_plaintext {
             UnverifiedContextMessage::Member(member_message) => {
                 // Checks the following semantic validation:

--- a/openmls/src/group/core_group/test_external_init.rs
+++ b/openmls/src/group/core_group/test_external_init.rs
@@ -125,7 +125,7 @@ fn test_external_init(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
             .into();
     let nodes_option = group_alice.treesync().export_nodes();
 
-    let (_group_charly, create_commit_result) = CoreGroup::new_from_external_init(
+    let (mut group_charly, create_commit_result) = CoreGroup::new_from_external_init(
         backend,
         framing_parameters,
         Some(&nodes_option),
@@ -151,6 +151,20 @@ fn test_external_init(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
     group_bob
         .merge_commit(staged_commit)
         .expect("error merging commit");
+
+    group_charly
+        .merge_commit(create_commit_result.staged_commit)
+        .expect("error merging own external commit");
+
+    assert_eq!(
+        group_charly.export_secret(backend, "", &[], ciphersuite.hash_length()),
+        group_bob.export_secret(backend, "", &[], ciphersuite.hash_length())
+    );
+
+    assert_eq!(
+        group_charly.treesync().export_nodes(),
+        group_bob.treesync().export_nodes()
+    );
 
     // TODO: Charly cannot process their own commit yet. Before we can do that,
     // we'll have to refactor how own commits are processed.

--- a/openmls/src/group/core_group/test_external_init.rs
+++ b/openmls/src/group/core_group/test_external_init.rs
@@ -125,7 +125,7 @@ fn test_external_init(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
             .into();
     let nodes_option = group_alice.treesync().export_nodes();
 
-    let (mut group_charly, create_commit_result) = CoreGroup::new_from_external_init(
+    let (mut group_charly, create_commit_result) = CoreGroup::join_by_external_commit(
         backend,
         framing_parameters,
         Some(&nodes_option),
@@ -226,7 +226,7 @@ fn test_external_init_single_member_group(
             .into();
     let nodes_option = group_alice.treesync().export_nodes();
 
-    let (_charly_group, create_commit_result) = CoreGroup::new_from_external_init(
+    let (_charly_group, create_commit_result) = CoreGroup::join_by_external_commit(
         backend,
         framing_parameters,
         Some(&nodes_option),

--- a/openmls/src/group/core_group/test_external_init.rs
+++ b/openmls/src/group/core_group/test_external_init.rs
@@ -125,13 +125,16 @@ fn test_external_init(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
             .into();
     let nodes_option = group_alice.treesync().export_nodes();
 
+    let proposal_store = ProposalStore::new();
+    let params = CreateCommitParams::builder()
+        .framing_parameters(framing_parameters)
+        .credential_bundle(&charly_credential_bundle)
+        .proposal_store(&proposal_store)
+        .build();
     let (mut group_charly, create_commit_result) = CoreGroup::join_by_external_commit(
         backend,
-        framing_parameters,
+        params,
         Some(&nodes_option),
-        &charly_credential_bundle,
-        &[], // proposals by reference
-        &[], // proposals by value
         verifiable_public_group_state,
     )
     .expect("Error initializing group externally.");
@@ -223,13 +226,16 @@ fn test_external_init_single_member_group(
             .into();
     let nodes_option = group_alice.treesync().export_nodes();
 
+    let proposal_store = ProposalStore::new();
+    let params = CreateCommitParams::builder()
+        .framing_parameters(framing_parameters)
+        .credential_bundle(&charly_credential_bundle)
+        .proposal_store(&proposal_store)
+        .build();
     let (mut group_charly, create_commit_result) = CoreGroup::join_by_external_commit(
         backend,
-        framing_parameters,
+        params,
         Some(&nodes_option),
-        &charly_credential_bundle,
-        &[], // proposals by reference
-        &[], // proposals by value
         verifiable_public_group_state,
     )
     .expect("Error initializing group externally.");

--- a/openmls/src/group/core_group/validation.rs
+++ b/openmls/src/group/core_group/validation.rs
@@ -254,7 +254,7 @@ impl CoreGroup {
                 if public_key_set.contains(key_package.hpke_init_key().as_slice()) {
                     return Err(ProposalValidationError::ExistingPublicKeyUpdateProposal.into());
                 }
-                // TODO: Proper validation of external inits (#630). For now,
+                // TODO: Proper validation of external inits (#680). For now,
                 // this is changed such that it doesn't consider external
                 // senders as "Unknown".
             } else if sender.sender_type == SenderType::Member {

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -150,11 +150,13 @@ implement_error! {
                 "Sender not found in tree.",
             InvalidPublicGroupStateSignature =
                 "The signature over the given public group state is invalid.",
-            CommitError =
-                "Error creating external commit",
             LibraryError = "An unrecoverable error has occurred due to a bug in the implementation.",
+            CommitError =
+                "Error creating external commit.",
             }
         Complex {
+            VerificationError(CredentialError) =
+                "Error verifying `PublicGroupState`.",
             ConfigError(ConfigError) =
                 "See [`ConfigError`](`crate::config::ConfigError`) for details.",
             CodecError(TlsCodecError) =

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -33,6 +33,8 @@ implement_error! {
                 "See [`MlsPlaintextError`](`crate::framing::errors::MlsPlaintextError`) for details.",
             WelcomeError(WelcomeError) =
                 "See [`WelcomeError`](`WelcomeError`) for details.",
+            ExternalInitError(ExternalInitError) =
+                "See [`Externaallow(lint)`](`ExternalInitError`) for details.",
             StageCommitError(StageCommitError) =
                 "See [`StageCommitError`](`StageCommitError`) for details.",
             CreateCommitError(CreateCommitError) =

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -33,7 +33,7 @@ implement_error! {
                 "See [`MlsPlaintextError`](`crate::framing::errors::MlsPlaintextError`) for details.",
             WelcomeError(WelcomeError) =
                 "See [`WelcomeError`](`WelcomeError`) for details.",
-            ExternalInitError(ExternalInitError) =
+            ExternalInitError(ExternalCommitError) =
                 "See [`Externaallow(lint)`](`ExternalInitError`) for details.",
             StageCommitError(StageCommitError) =
                 "See [`StageCommitError`](`StageCommitError`) for details.",
@@ -138,7 +138,7 @@ implement_error! {
 }
 
 implement_error! {
-    pub enum ExternalInitError {
+    pub enum ExternalCommitError {
         Simple {
             MissingRatchetTree =
                 "No ratchet tree available to build initial tree.",

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -33,7 +33,7 @@ implement_error! {
                 "See [`MlsPlaintextError`](`crate::framing::errors::MlsPlaintextError`) for details.",
             WelcomeError(WelcomeError) =
                 "See [`WelcomeError`](`WelcomeError`) for details.",
-            ExternalInitError(ExternalCommitError) =
+            ExternalCommitError(ExternalCommitError) =
                 "See [`Externaallow(lint)`](`ExternalInitError`) for details.",
             StageCommitError(StageCommitError) =
                 "See [`StageCommitError`](`StageCommitError`) for details.",

--- a/openmls/src/group/mls_group/application.rs
+++ b/openmls/src/group/mls_group/application.rs
@@ -14,7 +14,7 @@ impl MlsGroup {
         backend: &impl OpenMlsCryptoProvider,
         message: &[u8],
     ) -> Result<MlsMessageOut, MlsGroupError> {
-        if !self.active {
+        if !self.is_active() {
             return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
         }
         if !self.proposal_store.is_empty() {

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -89,8 +89,8 @@ impl MlsGroup {
         Ok(mls_group)
     }
 
-    /// Creates a new group by joining an existing group through an External
-    /// Init. The resulting [`MlsGroup`] instance starts off with a pending
+    /// Join an existing group through an External Commit.
+    /// The resulting [`MlsGroup`] instance starts off with a pending
     /// commit (the external commit, which adds this client to the group).
     /// Merging this commit is necessary for this [`MlsGroup`] instance to
     /// function properly, as, for example, this client is not yet part of the

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -100,7 +100,7 @@ impl MlsGroup {
     /// created using this function based on the latest `ratchet_tree` and
     /// public group state. For more information on the external init process,
     /// please see Section 11.2.1 in the MLS specification.
-    pub fn new_from_external_init(
+    pub fn join_by_external_commit(
         backend: &impl OpenMlsCryptoProvider,
         mls_group_config: &MlsGroupConfig,
         ratchet_tree: Option<Vec<Option<Node>>>,
@@ -114,7 +114,7 @@ impl MlsGroup {
             ResumptionSecretStore::new(mls_group_config.number_of_resumption_secrets);
         let framing_parameters = FramingParameters::new(aad, mls_group_config.wire_format());
         let ratchet_tree: Option<&[Option<Node>]> = ratchet_tree.as_deref();
-        let (group, create_commit_result) = CoreGroup::new_from_external_init(
+        let (group, create_commit_result) = CoreGroup::join_by_external_commit(
             backend,
             framing_parameters,
             ratchet_tree,
@@ -122,9 +122,7 @@ impl MlsGroup {
             proposals_by_reference,
             proposals_by_value,
             verifiable_public_group_state,
-        )
-        //FIXME: change new_from_external_init such that it returns a CoreGroupError
-        .map_err(|_| MlsGroupError::LibraryError("".into()))?;
+        )?;
 
         let mls_group = MlsGroup {
             mls_group_config: mls_group_config.clone(),

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -1,4 +1,7 @@
-use crate::messages::VerifiablePublicGroupState;
+use crate::{
+    config::Config, group::core_group::create_commit_params::CreateCommitParams,
+    messages::VerifiablePublicGroupState,
+};
 
 use super::*;
 
@@ -102,25 +105,36 @@ impl MlsGroup {
     /// please see Section 11.2.1 in the MLS specification.
     pub fn join_by_external_commit(
         backend: &impl OpenMlsCryptoProvider,
+        tree_option: Option<&[Option<Node>]>,
+        verifiable_public_group_state: VerifiablePublicGroupState,
         mls_group_config: &MlsGroupConfig,
-        ratchet_tree: Option<Vec<Option<Node>>>,
+        aad: &[u8],
         credential_bundle: &CredentialBundle,
         proposals_by_reference: &[MlsPlaintext],
-        proposals_by_value: &[Proposal],
-        verifiable_public_group_state: VerifiablePublicGroupState,
-        aad: &[u8],
     ) -> Result<(Self, MlsMessageOut), MlsGroupError> {
         let resumption_secret_store =
             ResumptionSecretStore::new(mls_group_config.number_of_resumption_secrets);
+
+        // Prepare the commit parameters
         let framing_parameters = FramingParameters::new(aad, mls_group_config.wire_format());
-        let ratchet_tree: Option<&[Option<Node>]> = ratchet_tree.as_deref();
+        let ciphersuite = Config::ciphersuite(verifiable_public_group_state.ciphersuite())?;
+        let mut proposal_store = ProposalStore::new();
+        for proposal in proposals_by_reference {
+            let queued_proposal =
+                QueuedProposal::from_mls_plaintext(ciphersuite, backend, proposal.clone())
+                    .map_err(CoreGroupError::QueuedProposalError)?;
+            proposal_store.add(queued_proposal);
+        }
+
+        let params = CreateCommitParams::builder()
+            .framing_parameters(framing_parameters)
+            .credential_bundle(credential_bundle)
+            .proposal_store(&proposal_store)
+            .build();
         let (group, create_commit_result) = CoreGroup::join_by_external_commit(
             backend,
-            framing_parameters,
-            ratchet_tree,
-            credential_bundle,
-            proposals_by_reference,
-            proposals_by_value,
+            params,
+            tree_option,
             verifiable_public_group_state,
         )?;
 
@@ -132,9 +146,9 @@ impl MlsGroup {
             own_kpbs: vec![],
             aad: vec![],
             resumption_secret_store,
-            group_state: MlsGroupState::PendingCommit(PendingCommitState::External(
+            group_state: MlsGroupState::PendingCommit(Box::new(PendingCommitState::External(
                 create_commit_result.staged_commit,
-            )),
+            ))),
             state_changed: InnerState::Changed,
         };
 

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -22,6 +22,7 @@ implement_error! {
             NoSignatureKey = "No signature key was available to verify the message signature.",
             PendingCommitError = "Can't create a new commit while another commit is still pending. Please clear or merge the pending commit before creating a new one.",
             NoPendingCommit = "There is no pending commit that can be merged.",
+            ExternalCommitError = "Can't clear an external commit, as the group can't merge `Member` commits yet. If an external commit is rejected by the DS, a new external init must be performed. See the MLS spec for more information.",
             KeyStoreError = "Error performing key store operation.",
         }
         Complex {

--- a/openmls/src/group/mls_group/exporting.rs
+++ b/openmls/src/group/mls_group/exporting.rs
@@ -11,7 +11,7 @@ impl MlsGroup {
         context: &[u8],
         key_length: usize,
     ) -> Result<Vec<u8>, MlsGroupError> {
-        if self.active {
+        if self.is_active() {
             Ok(self
                 .group
                 .export_secret(backend, label, context, key_length)?)

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -76,9 +76,9 @@ impl MlsGroup {
 
         // Set the current group state to [`MlsGroupState::PendingCommit`],
         // storing the current [`StagedCommit`] from the commit results
-        self.group_state = MlsGroupState::PendingCommit(PendingCommitState::Member(
+        self.group_state = MlsGroupState::PendingCommit(Box::new(PendingCommitState::Member(
             create_commit_result.staged_commit,
-        ));
+        )));
 
         // Since the state of the group might be changed, arm the state flag
         self.flag_state_change();
@@ -146,9 +146,9 @@ impl MlsGroup {
 
         // Set the current group state to [`MlsGroupState::PendingCommit`],
         // storing the current [`StagedCommit`] from the commit results
-        self.group_state = MlsGroupState::PendingCommit(PendingCommitState::Member(
+        self.group_state = MlsGroupState::PendingCommit(Box::new(PendingCommitState::Member(
             create_commit_result.staged_commit,
-        ));
+        )));
 
         // Since the state of the group might be changed, arm the state flag
         self.flag_state_change();

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -74,8 +74,11 @@ impl MlsGroup {
         // the configuration
         let mls_messages = self.plaintext_to_mls_message(create_commit_result.commit, backend)?;
 
-        // Store the staged commit as the current `pending_commit`
-        self.pending_commit = Some(create_commit_result.staged_commit);
+        // Set the current group state to [`MlsGroupState::PendingCommit`],
+        // storing the current [`StagedCommit`] from the commit results
+        self.group_state = MlsGroupState::PendingCommit(PendingCommitState::Member(
+            create_commit_result.staged_commit,
+        ));
 
         // Since the state of the group might be changed, arm the state flag
         self.flag_state_change();
@@ -141,8 +144,11 @@ impl MlsGroup {
         // the configuration
         let mls_message = self.plaintext_to_mls_message(create_commit_result.commit, backend)?;
 
-        // Store the staged commit as the current `pending_commit`
-        self.pending_commit = Some(create_commit_result.staged_commit);
+        // Set the current group state to [`MlsGroupState::PendingCommit`],
+        // storing the current [`StagedCommit`] from the commit results
+        self.group_state = MlsGroupState::PendingCommit(PendingCommitState::Member(
+            create_commit_result.staged_commit,
+        ));
 
         // Since the state of the group might be changed, arm the state flag
         self.flag_state_change();
@@ -190,13 +196,7 @@ impl MlsGroup {
         backend: &impl OpenMlsCryptoProvider,
         member: LeafIndex,
     ) -> Result<MlsMessageOut, MlsGroupError> {
-        if !self.active {
-            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
-        }
-
-        if self.pending_commit.is_some() {
-            return Err(MlsGroupError::PendingCommitError);
-        }
+        self.pending_commit_or_inactive()?;
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -23,7 +23,7 @@ impl MlsGroup {
         backend: &impl OpenMlsCryptoProvider,
         key_packages: &[KeyPackage],
     ) -> Result<(MlsMessageOut, Welcome), MlsGroupError> {
-        self.pending_commit_or_inactive()?;
+        self.is_operational()?;
 
         if key_packages.is_empty() {
             return Err(MlsGroupError::EmptyInput(EmptyInputError::AddMembers));
@@ -99,7 +99,7 @@ impl MlsGroup {
         backend: &impl OpenMlsCryptoProvider,
         members: &[usize],
     ) -> Result<(MlsMessageOut, Option<Welcome>), MlsGroupError> {
-        self.pending_commit_or_inactive()?;
+        self.is_operational()?;
 
         if members.is_empty() {
             return Err(MlsGroupError::EmptyInput(EmptyInputError::RemoveMembers));
@@ -165,7 +165,7 @@ impl MlsGroup {
 
         key_package: &KeyPackage,
     ) -> Result<MlsMessageOut, MlsGroupError> {
-        self.pending_commit_or_inactive()?;
+        self.is_operational()?;
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
@@ -196,7 +196,7 @@ impl MlsGroup {
         backend: &impl OpenMlsCryptoProvider,
         member: LeafIndex,
     ) -> Result<MlsMessageOut, MlsGroupError> {
-        self.pending_commit_or_inactive()?;
+        self.is_operational()?;
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
@@ -226,7 +226,7 @@ impl MlsGroup {
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<MlsMessageOut, MlsGroupError> {
-        self.pending_commit_or_inactive()?;
+        self.is_operational()?;
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -40,6 +40,84 @@ use super::past_secrets::MessageSecretsStore;
 use super::proposals::{ProposalStore, QueuedProposal};
 use super::staged_commit::StagedCommit;
 
+#[derive(Debug, Serialize, Deserialize)]
+pub enum PendingCommitState {
+    Member(StagedCommit),
+    External(StagedCommit),
+}
+
+impl PendingCommitState {
+    /// Return a reference to the [`StagedCommit`] contained in the
+    /// [`PendingCommitState`] enum.
+    pub(crate) fn staged_commit(&self) -> &StagedCommit {
+        match self {
+            PendingCommitState::Member(pc) => pc,
+            PendingCommitState::External(pc) => pc,
+        }
+    }
+}
+
+impl From<PendingCommitState> for StagedCommit {
+    fn from(pcs: PendingCommitState) -> Self {
+        match pcs {
+            PendingCommitState::Member(pc) => pc,
+            PendingCommitState::External(pc) => pc,
+        }
+    }
+}
+
+/// [`MlsGroupState`] determines the state of an [`MlsGroup`]. The different
+/// states and their transitions are as follows:
+///
+/// * [`MlsGroupState::Operational`]: This is the main state of the group, which
+/// allows access to all of its functionality, (except merging pending commits,
+/// see the [`MlsGroupState::PendingCommit`] for more information) and it's the
+/// state the group starts in (except when created via
+/// [`MlsGroup::new_from_external_init()`], see the functions documentation for
+/// more information). From this `Operational`, the group state can either
+/// transition to [`MlsGroupState::Inactive`], when it processes a commit that
+/// removes this client from the group, or to [`MlsGroupState::PendingCommit`],
+/// when this client creates a commit.
+///
+/// * [`MlsGroupState::Inactive`]: A group can enter this state from any other
+/// state when it processes a commit that removes this client from the group.
+/// This is a terminal state that the group can not exit from. If the clients
+/// wants to re-join the group, it can either be added by a group member or it
+/// can join via external init.
+///
+/// * [`MlsGroupState:PendingCommit`]: This state is split into two possible
+/// sub-states, one for each
+/// [`CommitType`](crate::group::core_group::create_commit_params::CommitType):
+/// [`PendingCommitState::Member`] and [`PendingCommitState::Member`]:
+///
+///   * If the client creates a commit for this group, the `PendingCommit` state
+///   is entered with [`PendingCommitState::Member`] and with the [`StagedCommit`] as
+///   additional state variable. In this state, it can perform the same
+///   operations as in the [`MlsGroupState::Operational`], except that it cannot
+///   create proposals or commits. However, it can merge or clear the stored
+///   [`StagedCommit`], where both actions result in a transition to the
+///   [`MlsGroupState::Operational`]. Additionally, if a commit from another
+///   group member is processed, the own pending commit is also cleared and
+///   either the `Inactive` state is entered (if this client was removed from
+///   the group as part of the processed commit), or the `Operational` state is
+///   entered.
+///
+///   * A group can enter the [`PendingCommitState::External`] sub-state only as
+///   the initial state when the group is created via
+///   [`MlsGroup::new_from_external_init()`]. In contrast to the
+///   [`PendingCommitState::Member`] `PendingCommit` state, the only possible
+///   functionality that can be used is the [`MlsGroup::merge_pending_commit()`]
+///   function, which merges the pending external commit and transitions the
+///   state to [`MlsGroupState::PendingCommit`]. For more information on the
+///   external init process, see [`MlsGroup::new_from_external_init()`] or
+///   Section 11.2.1 of the MLS specification.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum MlsGroupState {
+    PendingCommit(PendingCommitState),
+    Operational,
+    Inactive,
+}
+
 /// A `MlsGroup` represents an [CoreGroup] with
 /// an easier, high-level API designed to be used in production. The API exposes
 /// high level functions to manage a group by adding/removing members, get the
@@ -68,6 +146,10 @@ use super::staged_commit::StagedCommit;
 ///
 /// Changes to the group state are dispatched as events through callback
 /// functions (see [`MlsGroupCallbacks`]).
+///
+/// An `MlsGroup` has an internal state variable determining if it is active or
+/// inactive, as well as if it has a pending commit. See [`MlsGroupState`] for
+/// more information.
 #[derive(Debug)]
 pub struct MlsGroup {
     // The group configuration. See `MlsGroupCongig` for more information.
@@ -89,16 +171,13 @@ pub struct MlsGroup {
     aad: Vec<u8>,
     // Resumption secret store. This is where the resumption secrets are kept in a rollover list.
     resumption_secret_store: ResumptionSecretStore,
-    // A flag that indicates if the current client is still a member of a group. The value is set
-    // to `true` upon group creation and is set to `false` when the client gets evicted from the
-    // group`.
-    active: bool,
+    // A variable that indicates the state of the group. See [`MlsGroupState`]
+    // for more information.
+    group_state: MlsGroupState,
     // A flag that indicates if the group state has changed and needs to be persisted again. The value
     // is set to `InnerState::Changed` whenever an the internal group state is change and is set to
     // `InnerState::Persisted` once the state has been persisted.
     state_changed: InnerState,
-    // This field is populated when a commit is created. It can be inspected or merged. If a commit is merged that does not correspond to the `StagedCommit` in this field, it is cleared.
-    pending_commit: Option<StagedCommit>,
 }
 
 impl MlsGroup {
@@ -140,7 +219,10 @@ impl MlsGroup {
     /// Returns whether the own client is still a member of the group or if it
     /// was already evicted
     pub fn is_active(&self) -> bool {
-        self.active
+        match self.group_state {
+            MlsGroupState::Inactive => false,
+            _ => true,
+        }
     }
 
     /// Returns own credential. If the group is inactive, it returns a
@@ -167,17 +249,35 @@ impl MlsGroup {
     /// commit. If there was no commit created in this epoch, either because
     /// this commit or another commit was merged, it returns `None`.
     pub fn pending_commit(&self) -> Option<&StagedCommit> {
-        self.pending_commit.as_ref()
+        match self.group_state {
+            MlsGroupState::PendingCommit(ref pending_commit_state) => {
+                Some(pending_commit_state.staged_commit())
+            }
+            MlsGroupState::Operational => None,
+            MlsGroupState::Inactive => None,
+        }
     }
 
-    /// Sets the `pending_commit` to `None`.
+    /// Sets the `group_state` to [`MlsGroupState::Operational`], thus clearing
+    /// any potentially pending commits.
+    ///
+    /// Returns an error if the group was created through an external init and
+    /// the resulting external commit has not been merged yet. For more
+    /// information, see [`MlsGroup::new_from_external_init()`].
     ///
     /// Use with caution! This function should only be used if it is clear that
     /// the pending commit will not be used in the group. In particular, if a
     /// pending commit is later accepted by the group, this client will lack the
     /// key material to encrypt or decrypt group messages.
-    pub fn clear_pending_commit(&mut self) {
-        self.pending_commit = None
+    pub fn clear_pending_commit(&mut self) -> Result<(), MlsGroupError> {
+        match self.group_state {
+            MlsGroupState::PendingCommit(ref pending_commit_state) => match pending_commit_state {
+                PendingCommitState::Member(_) => self.group_state = MlsGroupState::Operational,
+                PendingCommitState::External(_) => return Err(MlsGroupError::ExternalCommitError),
+            },
+            MlsGroupState::Operational | MlsGroupState::Inactive => (),
+        }
+        Ok(())
     }
 
     // === Load & save ===
@@ -265,15 +365,13 @@ impl MlsGroup {
 
     /// Check if the group is inactive or if there is a pending commit.
     fn pending_commit_or_inactive(&self) -> Result<(), MlsGroupError> {
-        if !self.active {
-            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
+        match self.group_state {
+            MlsGroupState::PendingCommit(_) => Err(MlsGroupError::PendingCommitError),
+            MlsGroupState::Inactive => {
+                Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error))
+            }
+            MlsGroupState::Operational => Ok(()),
         }
-
-        if self.pending_commit.is_some() {
-            return Err(MlsGroupError::PendingCommitError);
-        }
-
-        Ok(())
     }
 }
 

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -363,8 +363,9 @@ impl MlsGroup {
         FramingParameters::new(&self.aad, self.mls_group_config.wire_format)
     }
 
-    /// Check if the group is inactive or if there is a pending commit.
-    fn pending_commit_or_inactive(&self) -> Result<(), MlsGroupError> {
+    /// Check if the group is operational. Throws an error if the group is
+    /// inactive or if there is a pending commit.
+    fn is_operational(&self) -> Result<(), MlsGroupError> {
         match self.group_state {
             MlsGroupState::PendingCommit(_) => Err(MlsGroupError::PendingCommitError),
             MlsGroupState::Inactive => {

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -73,7 +73,7 @@ impl From<PendingCommitState> for StagedCommit {
 /// allows access to all of its functionality, (except merging pending commits,
 /// see the [`MlsGroupState::PendingCommit`] for more information) and it's the
 /// state the group starts in (except when created via
-/// [`MlsGroup::new_from_external_init()`], see the functions documentation for
+/// [`MlsGroup::join_by_external_commit()`], see the functions documentation for
 /// more information). From this `Operational`, the group state can either
 /// transition to [`MlsGroupState::Inactive`], when it processes a commit that
 /// removes this client from the group, or to [`MlsGroupState::PendingCommit`],
@@ -83,7 +83,7 @@ impl From<PendingCommitState> for StagedCommit {
 /// state when it processes a commit that removes this client from the group.
 /// This is a terminal state that the group can not exit from. If the clients
 /// wants to re-join the group, it can either be added by a group member or it
-/// can join via external init.
+/// can join via external commit.
 ///
 /// * [`MlsGroupState:PendingCommit`]: This state is split into two possible
 /// sub-states, one for each
@@ -104,12 +104,12 @@ impl From<PendingCommitState> for StagedCommit {
 ///
 ///   * A group can enter the [`PendingCommitState::External`] sub-state only as
 ///   the initial state when the group is created via
-///   [`MlsGroup::new_from_external_init()`]. In contrast to the
+///   [`MlsGroup::join_by_external_commit()`]. In contrast to the
 ///   [`PendingCommitState::Member`] `PendingCommit` state, the only possible
 ///   functionality that can be used is the [`MlsGroup::merge_pending_commit()`]
 ///   function, which merges the pending external commit and transitions the
 ///   state to [`MlsGroupState::PendingCommit`]. For more information on the
-///   external init process, see [`MlsGroup::new_from_external_init()`] or
+///   external commit process, see [`MlsGroup::join_by_external_commit()`] or
 ///   Section 11.2.1 of the MLS specification.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum MlsGroupState {
@@ -261,9 +261,9 @@ impl MlsGroup {
     /// Sets the `group_state` to [`MlsGroupState::Operational`], thus clearing
     /// any potentially pending commits.
     ///
-    /// Returns an error if the group was created through an external init and
+    /// Returns an error if the group was created through an external commit and
     /// the resulting external commit has not been merged yet. For more
-    /// information, see [`MlsGroup::new_from_external_init()`].
+    /// information, see [`MlsGroup::join_by_external_commit()`].
     ///
     /// Use with caution! This function should only be used if it is clear that
     /// the pending commit will not be used in the group. In particular, if a

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -104,9 +104,9 @@ impl MlsGroup {
 
         // Set the current group state to [`MlsGroupState::PendingCommit`],
         // storing the current [`StagedCommit`] from the commit results
-        self.group_state = MlsGroupState::PendingCommit(PendingCommitState::Member(
+        self.group_state = MlsGroupState::PendingCommit(Box::new(PendingCommitState::Member(
             create_commit_result.staged_commit,
-        ));
+        )));
 
         // Since the state of the group might be changed, arm the state flag
         self.flag_state_change();
@@ -158,7 +158,7 @@ impl MlsGroup {
             MlsGroupState::PendingCommit(_) => {
                 let old_state = mem::replace(&mut self.group_state, MlsGroupState::Operational);
                 if let MlsGroupState::PendingCommit(pending_commit_state) = old_state {
-                    self.merge_staged_commit(pending_commit_state.into())
+                    self.merge_staged_commit((*pending_commit_state).into())
                 } else {
                     // We should never reach this state, as we previously
                     // checked that there actually is a pending commit.

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -158,14 +158,9 @@ impl MlsGroup {
             MlsGroupState::PendingCommit(_) => {
                 let old_state = mem::replace(&mut self.group_state, MlsGroupState::Operational);
                 if let MlsGroupState::PendingCommit(pending_commit_state) = old_state {
-                    self.merge_staged_commit((*pending_commit_state).into())
-                } else {
-                    // We should never reach this state, as we previously
-                    // checked that there actually is a pending commit.
-                    Err(MlsGroupError::LibraryError(
-                        "Reached unreachable state during pending commit merge.".into(),
-                    ))
+                    self.merge_staged_commit((*pending_commit_state).into())?
                 }
+                Ok(())
             }
             MlsGroupState::Operational => Err(MlsGroupError::NoPendingCommit),
             MlsGroupState::Inactive => {

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -76,7 +76,7 @@ impl MlsGroup {
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<(MlsMessageOut, Option<Welcome>), MlsGroupError> {
-        self.pending_commit_or_inactive()?;
+        self.is_operational()?;
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend

--- a/openmls/src/group/mls_group/ser.rs
+++ b/openmls/src/group/mls_group/ser.rs
@@ -13,8 +13,7 @@ pub struct SerializedMlsGroup {
     own_kpbs: Vec<KeyPackageBundle>,
     aad: Vec<u8>,
     resumption_secret_store: ResumptionSecretStore,
-    active: bool,
-    pending_commit: Option<StagedCommit>,
+    group_state: MlsGroupState,
 }
 
 impl SerializedMlsGroup {
@@ -27,9 +26,8 @@ impl SerializedMlsGroup {
             own_kpbs: self.own_kpbs,
             aad: self.aad,
             resumption_secret_store: self.resumption_secret_store,
-            active: self.active,
+            group_state: self.group_state,
             state_changed: InnerState::Persisted,
-            pending_commit: self.pending_commit,
         }
     }
 }
@@ -47,7 +45,7 @@ impl Serialize for MlsGroup {
         state.serialize_field("own_kpbs", &self.own_kpbs)?;
         state.serialize_field("aad", &self.aad)?;
         state.serialize_field("resumption_secret_store", &self.resumption_secret_store)?;
-        state.serialize_field("active", &self.active)?;
+        state.serialize_field("group_state", &self.group_state)?;
         state.end()
     }
 }

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -547,7 +547,9 @@ fn test_pending_commit_logic(
     assert_eq!(error, MlsGroupError::PendingCommitError);
 
     // Clearing the pending commit should actually clear it.
-    alice_group.clear_pending_commit();
+    alice_group
+        .clear_pending_commit()
+        .expect("error clearing pending commit");
     assert!(alice_group.pending_commit().is_none());
 
     // Creating a new commit should commit the same proposals.

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -65,8 +65,11 @@ impl MlsGroup {
         // the configuration
         let mls_message = self.plaintext_to_mls_message(create_commit_result.commit, backend)?;
 
-        // Store the staged commit as the current `pending_commit`
-        self.pending_commit = Some(create_commit_result.staged_commit);
+        // Set the current group state to [`MlsGroupState::PendingCommit`],
+        // storing the current [`StagedCommit`] from the commit results
+        self.group_state = MlsGroupState::PendingCommit(PendingCommitState::Member(
+            create_commit_result.staged_commit,
+        ));
 
         // Since the state of the group might be changed, arm the state flag
         self.flag_state_change();

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -17,7 +17,7 @@ impl MlsGroup {
         backend: &impl OpenMlsCryptoProvider,
         key_package_bundle_option: Option<KeyPackageBundle>,
     ) -> Result<(MlsMessageOut, Option<Welcome>), MlsGroupError> {
-        self.pending_commit_or_inactive()?;
+        self.is_operational()?;
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
@@ -83,7 +83,7 @@ impl MlsGroup {
         backend: &impl OpenMlsCryptoProvider,
         key_package_bundle_option: Option<KeyPackageBundle>,
     ) -> Result<MlsMessageOut, MlsGroupError> {
-        self.pending_commit_or_inactive()?;
+        self.is_operational()?;
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -67,9 +67,9 @@ impl MlsGroup {
 
         // Set the current group state to [`MlsGroupState::PendingCommit`],
         // storing the current [`StagedCommit`] from the commit results
-        self.group_state = MlsGroupState::PendingCommit(PendingCommitState::Member(
+        self.group_state = MlsGroupState::PendingCommit(Box::new(PendingCommitState::Member(
             create_commit_result.staged_commit,
-        ));
+        )));
 
         // Since the state of the group might be changed, arm the state flag
         self.flag_state_change();

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -147,7 +147,7 @@ impl Client {
         } else {
             if message.content_type() == ContentType::Commit {
                 // Clear any potential pending commits.
-                group_state.clear_pending_commit();
+                group_state.clear_pending_commit()?;
             }
             // Process the message.
             let unverified_message = group_state.parse_message(message.clone(), &self.crypto)?;


### PR DESCRIPTION
This PR allows clients that want to join a group via an External Init to process their own staged commit. This was already possible after #659, but this PR introduces proper state transitions in the `MlsGroup`.

This PR is part of the larger effort to enable the external init process, which is tracked in #630.