### PR TITLE
Improve FS when encrypting messages

### DIFF
--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -214,6 +214,8 @@ fn wire_format_checks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
 
     let mut message_secrets = MessageSecrets::random(ciphersuite, backend);
 
+    let orig_secret_tree = message_secrets.secret_tree_mut().clone();
+
     let mut ciphertext = MlsCiphertext::try_from_plaintext(
         &plaintext,
         ciphersuite,
@@ -229,6 +231,8 @@ fn wire_format_checks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
     .expect("Could not encrypt MlsPlaintext.");
 
     // Decrypt the ciphertext and expect the correct wire format
+
+    message_secrets.replace_secret_tree(orig_secret_tree);
 
     let verifiable_plaintext = ciphertext
         .to_plaintext(ciphersuite, backend, &mut message_secrets, configuration)

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -8,6 +8,7 @@ use crate::credentials::CredentialError;
 use crate::error::ErrorString;
 use crate::framing::MlsCiphertextError;
 use crate::framing::ValidationError;
+use crate::group::errors::QueuedProposalError;
 use crate::group::{CoreGroupError, CreateCommitError, ExporterError, StageCommitError};
 use crate::treesync::TreeSyncError;
 use openmls_traits::types::CryptoError;
@@ -48,6 +49,8 @@ implement_error! {
             TlsCodecError(TlsCodecError) = "An error occured during TLS encoding/decoding.",
             CryptoError(CryptoError) =
                 "See [`CryptoError`](openmls_traits::types::CryptoError) for details.",
+            QueuedProposalError(QueuedProposalError) =
+                "See [`QueuedProposalError`](crate::group::QueuedProposalError) for details.",
         }
     }
 }

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -174,6 +174,12 @@ impl MlsGroup {
             backend,
         )?;
 
+        self.proposal_store.add(QueuedProposal::from_mls_plaintext(
+            self.ciphersuite(),
+            backend,
+            add_proposal.clone(),
+        )?);
+
         let mls_message = self.plaintext_to_mls_message(add_proposal, backend)?;
 
         // Since the state of the group might be changed, arm the state flag
@@ -211,6 +217,12 @@ impl MlsGroup {
             backend,
         )?;
 
+        self.proposal_store.add(QueuedProposal::from_mls_plaintext(
+            self.ciphersuite(),
+            backend,
+            remove_proposal.clone(),
+        )?);
+
         let mls_message = self.plaintext_to_mls_message(remove_proposal, backend)?;
 
         // Since the state of the group might be changed, arm the state flag
@@ -240,6 +252,12 @@ impl MlsGroup {
             self.group.treesync().own_leaf_index(),
             backend,
         )?;
+
+        self.proposal_store.add(QueuedProposal::from_mls_plaintext(
+            self.ciphersuite(),
+            backend,
+            remove_proposal.clone(),
+        )?);
 
         self.plaintext_to_mls_message(remove_proposal, backend)
     }

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -106,6 +106,11 @@ impl MlsGroup {
         )?;
 
         self.own_kpbs.push(key_package_bundle);
+        self.proposal_store.add(QueuedProposal::from_mls_plaintext(
+            self.ciphersuite(),
+            backend,
+            update_proposal.clone(),
+        )?);
 
         let mls_message = self.plaintext_to_mls_message(update_proposal, backend)?;
 

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -181,6 +181,8 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
     let welcome = create_commit_result
         .welcome_option
         .expect("An unexpected error occurred.");
+    // Clone the secret tree to bypass FS restrictions
+    let secret_tree = group.message_secrets_mut().secret_tree_mut().clone();
     let mls_ciphertext_application = group
         .create_application_message(
             b"aad",
@@ -190,6 +192,8 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
             &crypto,
         )
         .expect("An unexpected error occurred.");
+    // Replace the secret tree
+    group.message_secrets_mut().replace_secret_tree(secret_tree);
     let verifiable_mls_plaintext_application = group
         .decrypt(
             &mls_ciphertext_application,

--- a/openmls/src/group/tests/test_validation.rs
+++ b/openmls/src/group/tests/test_validation.rs
@@ -444,7 +444,9 @@ fn test_valsem6(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
         .add_members(backend, &[bob_key_package])
         .expect("Could not add member.");
 
-    alice_group.merge_pending_commit();
+    alice_group
+        .merge_pending_commit()
+        .expect("An unexpected error occurred.");
 
     let message = alice_group
         .create_message(backend, &[1, 2, 3])

--- a/openmls/src/group/tests/test_validation.rs
+++ b/openmls/src/group/tests/test_validation.rs
@@ -440,9 +440,15 @@ fn test_valsem6(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
         bob_key_package,
     } = validation_test_setup(WireFormat::MlsCiphertext, ciphersuite, backend);
 
-    let (message, _welcome) = alice_group
+    let (_message, welcome) = alice_group
         .add_members(backend, &[bob_key_package])
         .expect("Could not add member.");
+
+    alice_group.merge_pending_commit();
+
+    let message = alice_group
+        .create_message(backend, &[1, 2, 3])
+        .expect("An unexpected error occurred.");
 
     let serialized_message = message
         .tls_serialize_detached()
@@ -457,7 +463,17 @@ fn test_valsem6(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     let message_in = MlsMessageIn::from(ciphertext);
 
-    let err = alice_group
+    let ratchet_tree = alice_group.export_ratchet_tree();
+
+    let mls_group_config = MlsGroupConfig::builder()
+        .wire_format(WireFormat::MlsCiphertext)
+        .build();
+
+    let mut bob_group =
+        MlsGroup::new_from_welcome(backend, &mls_group_config, welcome, Some(ratchet_tree))
+            .expect("An unexpected error occurred.");
+
+    let err = bob_group
         .parse_message(message_in, backend)
         .expect_err("Could parse message despite garbled ciphertext.");
 
@@ -469,7 +485,7 @@ fn test_valsem6(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
     );
 
     // Positive case
-    alice_group
+    bob_group
         .parse_message(MlsMessageIn::from(original_message), backend)
         .expect("Unexpected error.");
 }
@@ -532,7 +548,7 @@ fn test_valsem8(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoP
 
     // Alice can't process her own commits, so we'll have to add Bob.
     let (_message, welcome) = alice_group
-        .add_members(backend, &[bob_key_package.clone()])
+        .add_members(backend, &[bob_key_package])
         .expect("Could not add member.");
 
     alice_group

--- a/openmls/src/tree/secret_tree.rs
+++ b/openmls/src/tree/secret_tree.rs
@@ -71,13 +71,13 @@ pub struct TreeContext {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, TlsSerialize, TlsSize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(feature = "test-utils", test), derive(PartialEq))]
 pub(crate) struct SecretTreeNode {
     pub(crate) secret: Secret,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(feature = "test-utils", test), derive(PartialEq, Clone))]
 pub struct SecretTree {
     nodes: Vec<Option<SecretTreeNode>>,
     handshake_sender_ratchets: Vec<Option<SenderRatchet>>,

--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -94,6 +94,7 @@ impl SenderRatchet {
         }
         // If generation is potentially within the window
         if generation <= self.generation {
+            // If the requested generation is within the window of past secrets, we should get a positive index
             let window_index =
                 self.past_secrets.len() as i32 - ((self.generation - generation) as i32) - 1;
             // We might not have the key material (e.g. we might have discarded it when generating an encryption secret)

--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -11,9 +11,6 @@ use crate::tree::{index::LeafIndex, secret_tree::*};
 use super::index::NodeIndex;
 use super::*;
 
-// TODO #265: This should disappear
-pub(crate) const OUT_OF_ORDER_TOLERANCE: u32 = 5;
-
 /// Stores the configuration parameters for sender ratchets.
 ///
 /// **Parameters**
@@ -60,7 +57,7 @@ impl Default for SenderRatchetConfiguration {
 pub type RatchetSecrets = (AeadKey, AeadNonce);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(feature = "test-utils", test), derive(PartialEq))]
 pub struct SenderRatchet {
     index: LeafIndex,
     generation: u32,
@@ -95,14 +92,20 @@ impl SenderRatchet {
         {
             return Err(SecretTreeError::TooDistantInThePast);
         }
-        // If generation is within the window
+        // If generation is potentially within the window
         if generation <= self.generation {
             let window_index =
-                (self.past_secrets.len() as u32 - (self.generation - generation) - 1) as usize;
+                self.past_secrets.len() as i32 - ((self.generation - generation) as i32) - 1;
+            // We might not have the key material (e.g. we might have discarded it when generating an encryption secret)
+            let index = if window_index >= 0 {
+                window_index as usize
+            } else {
+                return Err(SecretTreeError::TooDistantInThePast);
+            };
             // We can return a library error here, because there must be a mistake in the implementation
             let secret = self
                 .past_secrets
-                .get(window_index)
+                .get(index)
                 .ok_or(SecretTreeError::LibraryError)?;
             let ratchet_secrets = self.derive_key_nonce(ciphersuite, backend, secret, generation);
             Ok(ratchet_secrets)
@@ -144,13 +147,8 @@ impl SenderRatchet {
         };
         let next_path_secret = self.ratchet_secret(ciphersuite, backend, &current_path_secret);
         let generation = self.generation;
-        // Check if we have too many secrets in `past_secrets`
-        if self.past_secrets.len() >= OUT_OF_ORDER_TOLERANCE as usize {
-            //Drain older secrets
-            let surplus = self.past_secrets.len() - OUT_OF_ORDER_TOLERANCE as usize + 1;
-            self.past_secrets.drain(0..surplus);
-        }
-        self.past_secrets.push(next_path_secret);
+        // We remove all past_secrets when encrypting so that we get immediate FS
+        self.past_secrets = vec![next_path_secret];
         self.generation += 1;
         (
             generation,

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_sender_ratchet.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_sender_ratchet.rs
@@ -79,11 +79,11 @@ fn test_out_of_order_generations(
             .expect("Expected decryption secret.");
     }
 }
-/*
-TODO: This currently blocked by #265
+
 // Test forward secrecy
 #[apply(ciphersuites_and_backends)]
 fn test_forward_secrecy(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+    let configuration = &SenderRatchetConfiguration::default();
     let leaf = 0u32.into();
     let secret = Secret::random(ciphersuite, backend, Config::supported_versions()[0])
         .expect("Not enough randomness.");
@@ -92,8 +92,10 @@ fn test_forward_secrecy(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
     // Generate an encryption secret
     let (generation, _encryption_secret) = ratchet1.secret_for_encryption(ciphersuite, backend);
 
+    // We expect this to fail, because we should no longer have the key material for this generation
     let err = ratchet1
-        .secret_for_decryption(ciphersuite, backend, generation)
+        .secret_for_decryption(ciphersuite, backend, generation, configuration)
         .expect_err("Expected error.");
+
+    assert_eq!(err, SecretTreeError::TooDistantInThePast);
 }
-*/


### PR DESCRIPTION
This PR enforces immediate forward secrecy when encrypting messages, i.e. the encryption key gets deleted right away.
It introduces automatic storing of standalone proposals in the `MlsGroup`'s proposal store, since we can no longer decrypt our own proposals.
The alternative would be to hand out the proposals in the same way we hand out our own commits and expect the consumer to manually store them in the proposal store once the DS signaled there are no conflicts.
That would be more in line with how we treat other messages. I went for the simpler option for now, because the alternative would lead to quite a few code changes. If we have consensus on the alternative I can change it.

Fixes #243.
