### PR TITLE
Make CoreGroup integration tests unit tests

### DIFF
--- a/openmls/src/group/tests/mod.rs
+++ b/openmls/src/group/tests/mod.rs
@@ -6,6 +6,14 @@ pub mod kat_messages;
 pub mod kat_transcripts;
 
 #[cfg(test)]
+mod test_encoding;
+#[cfg(test)]
+mod test_framing;
+#[cfg(test)]
+mod test_group;
+#[cfg(test)]
 mod test_past_secrets;
 #[cfg(test)]
 mod test_validation;
+#[cfg(test)]
+pub(crate) mod utils;

--- a/openmls/src/group/tests/test_encoding.rs
+++ b/openmls/src/group/tests/test_encoding.rs
@@ -1,8 +1,9 @@
-use openmls::{prelude::*, prelude_test::*, test_utils::*, *};
-pub mod utils;
+use super::utils::*;
+use crate::{
+    ciphersuite::signable::*, framing::*, group::*, key_packages::*, messages::*, test_utils::*, *,
+};
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use tls_codec::{Deserialize, Serialize};
-use utils::mls_utils::*;
 
 /// Creates a simple test setup for various encoding tests.
 fn create_encoding_test_setup(backend: &impl OpenMlsCryptoProvider) -> TestSetup {

--- a/openmls/src/group/tests/test_framing.rs
+++ b/openmls/src/group/tests/test_framing.rs
@@ -1,8 +1,6 @@
-use openmls::prelude::*;
-use openmls::prelude_test::*;
-mod utils;
-use openmls::{test_utils::*, *};
-use utils::mls_utils::*;
+use super::utils::*;
+use crate::{group::*, test_utils::*, *};
+use openmls_rust_crypto::OpenMlsRustCrypto;
 
 #[apply(backends)]
 fn padding(backend: &impl OpenMlsCryptoProvider) {

--- a/openmls/src/group/tests/test_group.rs
+++ b/openmls/src/group/tests/test_group.rs
@@ -1,9 +1,5 @@
-use openmls::prelude::*;
-use openmls::prelude_test::*;
+use crate::{credentials::*, framing::*, group::*, key_packages::*, test_utils::*, tree::*, *};
 use openmls_rust_crypto::OpenMlsRustCrypto;
-
-use openmls::test_utils::*;
-use openmls::*;
 
 #[apply(ciphersuites_and_backends)]
 fn create_commit_optional_path(

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -1,3 +1,4 @@
+//! A framework to create integration tests of the "raw" core_group API.
 //! # Test utils
 //!
 //! Most tests require to set up groups, clients, credentials, and identities.
@@ -6,11 +7,12 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
+use crate::{
+    credentials::*, framing::*, group::core_group::past_secrets::*, group::*, key_packages::*,
+    test_utils::*, *,
+};
 use ::rand::rngs::OsRng;
 use ::rand::RngCore;
-use openmls::prelude::*;
-use openmls::prelude_test::*;
-use openmls::{test_utils::*, *};
 use openmls_traits::types::SignatureScheme;
 use openmls_traits::OpenMlsCryptoProvider;
 

--- a/openmls/tests/test_decryption_key_index.rs
+++ b/openmls/tests/test_decryption_key_index.rs
@@ -8,9 +8,6 @@ use openmls::{
     *,
 };
 
-#[macro_use]
-mod utils;
-
 #[apply(ciphersuites)]
 fn decryption_key_index_computation(ciphersuite: &'static Ciphersuite) {
     println!("Testing ciphersuite {:?}", ciphersuite.name());

--- a/openmls/tests/test_interop_scenarios.rs
+++ b/openmls/tests/test_interop_scenarios.rs
@@ -5,9 +5,6 @@ use openmls::{
     *,
 };
 
-#[macro_use]
-mod utils;
-
 // The following tests correspond to the interop test scenarios detailed here:
 // https://github.com/mlswg/mls-implementations/blob/master/test-scenarios.md
 // The tests are conducted for every available ciphersuite, but currently only

--- a/openmls/tests/test_key_packages.rs
+++ b/openmls/tests/test_key_packages.rs
@@ -2,9 +2,6 @@
 
 use openmls::{prelude::*, test_utils::*, *};
 
-#[macro_use]
-mod utils;
-
 #[apply(ciphersuites_and_backends)]
 fn key_package_generation(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     println!("Testing ciphersuite {:?}", ciphersuite.name());

--- a/openmls/tests/test_managed_api.rs
+++ b/openmls/tests/test_managed_api.rs
@@ -5,8 +5,6 @@ use openmls::{
     *,
 };
 
-mod utils;
-
 #[apply(ciphersuites)]
 fn test_mls_group_api(ciphersuite: &'static Ciphersuite) {
     // Some basic setup functions for the MlsGroup.

--- a/openmls/tests/utils/mod.rs
+++ b/openmls/tests/utils/mod.rs
@@ -1,3 +1,0 @@
-//! A framework to create integration tests of the "raw" core_group API.
-
-pub mod mls_utils;


### PR DESCRIPTION
Fixes #644.

This PR moves previous `CoreGroup` integration tests so they become unit tests. The test utils they use are also moved.

Not sure how well GH will detect the move, but the only code changes that were made are to accommodate the new position of the tests.