### PR TITLE
Introduce byte buffers for messages

### DIFF
--- a/openmls/src/framing/codec.rs
+++ b/openmls/src/framing/codec.rs
@@ -260,16 +260,16 @@ impl MlsCiphertextContent {
     }
 }
 
-impl tls_codec::Serialize for MlsMessageIn {
+impl tls_codec::Serialize for MlsMessage {
     fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
         match self {
-            MlsMessageIn::Ciphertext(m) => m.tls_serialize(writer),
-            MlsMessageIn::Plaintext(m) => m.tls_serialize(writer),
+            MlsMessage::Ciphertext(m) => m.tls_serialize(writer),
+            MlsMessage::Plaintext(m) => m.tls_serialize(writer),
         }
     }
 }
 
-impl tls_codec::Deserialize for MlsMessageIn {
+impl tls_codec::Deserialize for MlsMessage {
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error> {
         // Determine the wire format by looking at the first byte
         let mut first_byte_buffer = [0u8];
@@ -283,11 +283,11 @@ impl tls_codec::Deserialize for MlsMessageIn {
                 match wire_format {
                     WireFormat::MlsPlaintext => {
                         let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut chain)?;
-                        Ok(MlsMessageIn::Plaintext(Box::new(plaintext)))
+                        Ok(MlsMessage::Plaintext(Box::new(plaintext)))
                     }
                     WireFormat::MlsCiphertext => {
                         let ciphertext = MlsCiphertext::tls_deserialize(&mut chain)?;
-                        Ok(MlsMessageIn::Ciphertext(Box::new(ciphertext)))
+                        Ok(MlsMessage::Ciphertext(Box::new(ciphertext)))
                     }
                 }
             }
@@ -296,33 +296,14 @@ impl tls_codec::Deserialize for MlsMessageIn {
     }
 }
 
-impl tls_codec::Size for MlsMessageIn {
+impl tls_codec::Size for MlsMessage {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
         match &self {
-            MlsMessageIn::Plaintext(plaintext) => {
+            MlsMessage::Plaintext(plaintext) => {
                 VerifiableMlsPlaintext::tls_serialized_len(plaintext)
             }
-            MlsMessageIn::Ciphertext(ciphertext) => MlsCiphertext::tls_serialized_len(ciphertext),
-        }
-    }
-}
-
-impl tls_codec::Serialize for MlsMessageOut {
-    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
-        match self {
-            MlsMessageOut::Ciphertext(m) => m.tls_serialize(writer),
-            MlsMessageOut::Plaintext(m) => m.tls_serialize(writer),
-        }
-    }
-}
-
-impl tls_codec::Size for MlsMessageOut {
-    #[inline]
-    fn tls_serialized_len(&self) -> usize {
-        match &self {
-            MlsMessageOut::Plaintext(plaintext) => MlsPlaintext::tls_serialized_len(plaintext),
-            MlsMessageOut::Ciphertext(ciphertext) => MlsCiphertext::tls_serialized_len(ciphertext),
+            MlsMessage::Ciphertext(ciphertext) => MlsCiphertext::tls_serialized_len(ciphertext),
         }
     }
 }

--- a/openmls/src/framing/errors.rs
+++ b/openmls/src/framing/errors.rs
@@ -76,3 +76,10 @@ implement_error! {
         }
     }
 }
+
+implement_error! {
+    pub enum MlsMessageError {
+        DecodingError = "The message could not be decoded.",
+        EncodingError = "The message could not be encoded.",
+    }
+}

--- a/openmls/src/framing/message.rs
+++ b/openmls/src/framing/message.rs
@@ -9,8 +9,6 @@
 //! Both messages have the same API. The framing part of the message can be inspected through it. In particular,
 //! it is important to look at [`MlsMessageIn::group_id()`] to determine in which [`MlsGroup`] it should be processed.
 
-use std::io::Cursor;
-
 use tls_codec::{Deserialize, Serialize};
 
 use super::*;
@@ -68,9 +66,8 @@ impl MlsMessage {
     }
 
     /// Tries to deserialize from a byte slice. Returns [`MlsMessageError::DecodingError`] on failure.
-    fn try_from_bytes(bytes: &[u8]) -> Result<Self, MlsMessageError> {
-        let mut reader = Cursor::new(bytes);
-        MlsMessage::tls_deserialize(&mut reader).map_err(|_| MlsMessageError::DecodingError)
+    fn try_from_bytes(mut bytes: &[u8]) -> Result<Self, MlsMessageError> {
+        MlsMessage::tls_deserialize(&mut bytes).map_err(|_| MlsMessageError::DecodingError)
     }
 
     /// Serializes the message to a byte vector. Returns [`MlsMessageError::EncodingError`] on failure.

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -382,11 +382,6 @@ impl MlsPlaintext {
         modified_signature[0] ^= 0xFF;
         self.signature.modify(&modified_signature);
     }
-
-    #[cfg(test)]
-    pub(crate) fn set_sender(&mut self, sender: Sender) {
-        self.sender = sender
-    }
 }
 
 // === Helper structs ===
@@ -494,7 +489,7 @@ impl<'a> MlsPlaintextTbmPayload<'a> {
 )]
 pub struct MembershipTag(pub(crate) Mac);
 
-#[derive(Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct MlsPlaintextTbs {
     pub(super) serialized_context: Option<Vec<u8>>,
     pub(super) wire_format: WireFormat,
@@ -525,7 +520,7 @@ fn encode_tbs<'a>(
     Ok(out)
 }
 
-#[derive(Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct VerifiableMlsPlaintext {
     pub(super) tbs: MlsPlaintextTbs,
     pub(super) signature: Signature,
@@ -730,6 +725,13 @@ impl VerifiableMlsPlaintext {
     #[cfg(test)]
     pub(crate) fn set_signature(&mut self, signature: Signature) {
         self.signature = signature;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn invalidate_signature(&mut self) {
+        let mut modified_signature = self.signature().as_slice().to_vec();
+        modified_signature[0] ^= 0xFF;
+        self.signature.modify(&modified_signature);
     }
 }
 

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -57,7 +57,7 @@ impl DecryptedMessage {
     pub(crate) fn from_inbound_plaintext(
         inbound_message: MlsMessageIn,
     ) -> Result<Self, ValidationError> {
-        if let MlsMessageIn::Plaintext(plaintext) = inbound_message {
+        if let MlsMessage::Plaintext(plaintext) = inbound_message.mls_message {
             Self::from_plaintext(*plaintext)
         } else {
             Err(ValidationError::WrongWireFormat)
@@ -74,7 +74,7 @@ impl DecryptedMessage {
         sender_ratchet_configuration: &SenderRatchetConfiguration,
     ) -> Result<Self, ValidationError> {
         // This will be refactored with #265.
-        if let MlsMessageIn::Ciphertext(ciphertext) = inbound_message {
+        if let MlsMessage::Ciphertext(ciphertext) = inbound_message.mls_message {
             let plaintext = ciphertext.to_plaintext(
                 ciphersuite,
                 backend,

--- a/openmls/src/group/mls_group/application.rs
+++ b/openmls/src/group/mls_group/application.rs
@@ -40,6 +40,6 @@ impl MlsGroup {
         // Since the state of the group might be changed, arm the state flag
         self.flag_state_change();
 
-        Ok(MlsMessageOut::Ciphertext(Box::new(ciphertext)))
+        Ok(MlsMessageOut::from(ciphertext))
     }
 }

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -335,7 +335,7 @@ impl MlsGroup {
 
 // Private methods of MlsGroup
 impl MlsGroup {
-    /// Converts MlsPlaintext to MLSMessage. Depending on whether handshake
+    /// Converts MlsPlaintext to MlsMessageOut. Depending on whether handshake
     /// message should be encrypted, MlsPlaintext messages are encrypted to
     /// MlsCiphertext first.
     fn plaintext_to_mls_message(
@@ -344,12 +344,12 @@ impl MlsGroup {
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<MlsMessageOut, MlsGroupError> {
         let msg = match self.configuration().wire_format() {
-            WireFormat::MlsPlaintext => MlsMessageOut::Plaintext(Box::new(plaintext)),
+            WireFormat::MlsPlaintext => MlsMessageOut::from(plaintext),
             WireFormat::MlsCiphertext => {
                 let ciphertext =
                     self.group
                         .encrypt(plaintext, self.configuration().padding_size(), backend)?;
-                MlsMessageOut::Ciphertext(Box::new(ciphertext))
+                MlsMessageOut::from(ciphertext)
             }
         };
         Ok(msg)

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -380,7 +380,7 @@ fn test_invalid_plaintext(ciphersuite: &'static Ciphersuite) {
     // Right now the membership tag is verified first, wihich yields `VerificationError::InvalidMembershipTag`
     // error instead of a `CredentialError:InvalidSignature`.
     let mut msg_invalid_signature = mls_message.clone();
-    if let MlsMessageOut::Plaintext(ref mut pt) = msg_invalid_signature {
+    if let MlsMessage::Plaintext(ref mut pt) = msg_invalid_signature.mls_message {
         pt.invalidate_signature()
     };
 
@@ -401,12 +401,12 @@ fn test_invalid_plaintext(ciphersuite: &'static Ciphersuite) {
 
     // Tamper with the message such that sender lookup fails
     let mut msg_invalid_sender = mls_message;
-    match &mut msg_invalid_sender {
-        MlsMessageOut::Plaintext(pt) => pt.set_sender(Sender {
+    match &mut msg_invalid_sender.mls_message {
+        MlsMessage::Plaintext(pt) => pt.set_sender(Sender {
             sender_type: pt.sender().sender_type,
             sender: (group.members.len() as u32 + 1u32),
         }),
-        MlsMessageOut::Ciphertext(_) => panic!("This should be a plaintext!"),
+        MlsMessage::Ciphertext(_) => panic!("This should be a plaintext!"),
     };
 
     let error = setup


### PR DESCRIPTION
Fixes #265.

This PR introduces two opaque type for MLS messages: `MlsMessageIn` and `MlsMessageOut`. The types are identical, the distinction is for the added benefit of type safety.

While this doesn't change the current functionality, it is a step towards making `Mls(Plain|Cipher)text` messages crate-only in order to further restrict the public API.