### PR TITLE
Use MlsGroup in interop client

### DIFF
--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -788,7 +788,7 @@ impl MlsClient for MlsClientImpl {
 
         // Proposals by value. These proposals are inline proposals. They should be converted into group operations.
 
-        // TODO: The interop client cannot process these proposals yet.
+        // TODO #692: The interop client cannot process these proposals yet.
 
         let (commit, welcome_option) = interop_group
             .group


### PR DESCRIPTION
This PR gets rid of `CoreGroup` in the interop client.

The functionality was not changed, however, I noticed by looking at the old code that the Commit checks (CommitRequest/CommitResponse) were probably not functional. This will have to be fixed when we work on the client again.

The client still uses the `test-utils` feature because it needs access to the KAT vectors. This can probably be changed at some point if we drop that feature and introduce a dedicated feature for the interop client. See  #691.

Fixes  #687.