### PR TITLE
Reduce visibility

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,9 +38,7 @@ jobs:
           version: latest
       - name: Fuzz Welcome
         run: cargo fuzz run welcome_decode -- -runs=100000
-      - name: Fuzz MLSCiphertext
-        run: cargo fuzz run mls_ciphertext_decode -- -runs=100000
-      - name: Fuzz MLSPlaintext
-        run: cargo fuzz run mls_plaintext_decode -- -runs=100000
+      - name: Fuzz MLSMessageIn
+        run: cargo fuzz run mls_message_decode -- -runs=100000
       - name: Fuzz Proposal
         run: cargo fuzz run proposal_decode -- -runs=100000

--- a/openmls/fuzz/Cargo.toml
+++ b/openmls/fuzz/Cargo.toml
@@ -31,14 +31,8 @@ test = false
 doc = false
 
 [[bin]]
-name = "mls_plaintext_decode"
-path = "fuzz_targets/mls_plaintext_decode.rs"
-test = false
-doc = false
-
-[[bin]]
-name = "mls_ciphertext_decode"
-path = "fuzz_targets/mls_ciphertext_decode.rs"
+name = "mls_message_decode"
+path = "fuzz_targets/mls_message_decode.rs"
 test = false
 doc = false
 

--- a/openmls/fuzz/fuzz_targets/mls_message_decode.rs
+++ b/openmls/fuzz/fuzz_targets/mls_message_decode.rs
@@ -4,5 +4,5 @@ use libfuzzer_sys::fuzz_target;
 use openmls::prelude::*;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = MlsCiphertext::tls_deserialize(&mut &data[..]);
+    let _ = MlsMessageIn::try_from_bytes(data);
 });

--- a/openmls/fuzz/fuzz_targets/mls_plaintext_decode.rs
+++ b/openmls/fuzz/fuzz_targets/mls_plaintext_decode.rs
@@ -1,8 +1,0 @@
-#![no_main]
-use libfuzzer_sys::fuzz_target;
-
-use openmls::prelude::*;
-
-fuzz_target!(|data: &[u8]| {
-    let _ = VerifiableMlsPlaintext::tls_deserialize(&mut &data[..]);
-});

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -130,7 +130,6 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
 
     let config = CoreGroupConfig {
         add_ratchet_tree_extension: true,
-        ..CoreGroupConfig::default()
     };
 
     // === Alice creates a group with the ratchet tree extension ===
@@ -212,7 +211,6 @@ fn ratchet_tree_extension(ciphersuite: &'static Ciphersuite, backend: &impl Open
 
     let config = CoreGroupConfig {
         add_ratchet_tree_extension: false,
-        ..CoreGroupConfig::default()
     };
 
     let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)

--- a/openmls/src/framing/ciphertext.rs
+++ b/openmls/src/framing/ciphertext.rs
@@ -12,7 +12,7 @@ use super::*;
 /// This message format is meant to be sent to and received from the Delivery
 /// Service.
 #[derive(Debug, PartialEq, Clone, TlsSerialize, TlsSize)]
-pub struct MlsCiphertext {
+pub(crate) struct MlsCiphertext {
     wire_format: WireFormat,
     group_id: GroupId,
     epoch: GroupEpoch,
@@ -263,7 +263,8 @@ impl MlsCiphertext {
     }
 
     /// Returns `true` if this is a handshake message and `false` otherwise.
-    pub fn is_handshake_message(&self) -> bool {
+    #[cfg(test)]
+    pub(crate) fn is_handshake_message(&self) -> bool {
         self.content_type.is_handshake_message()
     }
 
@@ -315,17 +316,18 @@ impl MlsCiphertext {
     }
 
     /// Get the `group_id` in the `MlsCiphertext`.
-    pub fn group_id(&self) -> &GroupId {
+    pub(crate) fn group_id(&self) -> &GroupId {
         &self.group_id
     }
 
     /// Get the cipher text bytes as slice.
-    pub fn ciphertext(&self) -> &[u8] {
+    #[cfg(test)]
+    pub(crate) fn ciphertext(&self) -> &[u8] {
         self.ciphertext.as_slice()
     }
 
     /// Get the `epoch` in the `MlsCiphertext`.
-    pub fn epoch(&self) -> GroupEpoch {
+    pub(crate) fn epoch(&self) -> GroupEpoch {
         self.epoch
     }
 
@@ -342,7 +344,7 @@ impl MlsCiphertext {
 
     /// Set the ciphertext.
     #[cfg(test)]
-    pub fn set_ciphertext(&mut self, ciphertext: Vec<u8>) {
+    pub(crate) fn set_ciphertext(&mut self, ciphertext: Vec<u8>) {
         self.ciphertext = ciphertext.into();
     }
 }
@@ -358,7 +360,7 @@ pub(crate) struct MlsSenderData {
 }
 
 impl MlsSenderData {
-    pub fn new(sender: LeafIndex, generation: u32, reuse_guard: ReuseGuard) -> Self {
+    pub(crate) fn new(sender: LeafIndex, generation: u32, reuse_guard: ReuseGuard) -> Self {
         MlsSenderData {
             sender,
             generation,

--- a/openmls/src/framing/mod.rs
+++ b/openmls/src/framing/mod.rs
@@ -20,20 +20,20 @@ pub(crate) mod message;
 pub(crate) mod plaintext;
 pub(crate) mod sender;
 pub(crate) mod validation;
+pub(crate) use ciphertext::*;
+pub(crate) use plaintext::*;
 
 // Crate
 pub(crate) use errors::*;
 pub(crate) use sender::*;
 
 // Public
-pub use ciphertext::*;
 pub use message::*;
-pub use plaintext::*;
 pub use validation::*;
 
+// Tests
 #[cfg(test)]
 mod test_framing;
-
 #[derive(
     PartialEq, Clone, Copy, Debug, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
@@ -46,19 +46,19 @@ pub enum WireFormat {
 /// This struct is used to group common framing parameters
 /// in order to reduce the number of arguments in function calls.
 #[derive(Clone, Copy, PartialEq, Debug)]
-pub struct FramingParameters<'a> {
+pub(crate) struct FramingParameters<'a> {
     aad: &'a [u8],
     wire_format: WireFormat,
 }
 
 impl<'a> FramingParameters<'a> {
-    pub fn new(aad: &'a [u8], wire_format: WireFormat) -> Self {
+    pub(crate) fn new(aad: &'a [u8], wire_format: WireFormat) -> Self {
         Self { aad, wire_format }
     }
-    pub fn aad(&self) -> &'a [u8] {
+    pub(crate) fn aad(&self) -> &'a [u8] {
         self.aad
     }
-    pub fn wire_format(&self) -> WireFormat {
+    pub(crate) fn wire_format(&self) -> WireFormat {
         self.wire_format
     }
 }

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -286,7 +286,7 @@ impl UnverifiedExternalMessage {
     ) -> Result<VerifiedExternalMessage, ValidationError> {
         // ValSem10
         match self.plaintext.verify_with_key(backend, signature_key) {
-            Ok(plaintext) => Ok(VerifiedExternalMessage { plaintext }),
+            Ok(_plaintext) => Ok(VerifiedExternalMessage { _plaintext }),
             Err(e) => Err(e.into()),
         }
     }
@@ -299,30 +299,31 @@ pub struct VerifiedMemberMessage {
 
 impl VerifiedMemberMessage {
     /// Returns a reference to the inner [MlsPlaintext].
-    pub fn plaintext(&self) -> &MlsPlaintext {
+    pub(crate) fn plaintext(&self) -> &MlsPlaintext {
         &self.plaintext
     }
 
     /// Consumes the message and returns the inner [MlsPlaintext].
-    pub fn take_plaintext(self) -> MlsPlaintext {
+    pub(crate) fn take_plaintext(self) -> MlsPlaintext {
         self.plaintext
     }
 }
 
 /// External message, where all semantic checks on the framing have been successfully performed.
+/// Note: External messages are not fully supported yet #106
 pub struct VerifiedExternalMessage {
-    plaintext: MlsPlaintext,
+    _plaintext: MlsPlaintext,
 }
 
 impl VerifiedExternalMessage {
     /// Returns a reference to the inner [MlsPlaintext].
-    pub fn plaintext(&self) -> &MlsPlaintext {
-        &self.plaintext
+    pub(crate) fn _plaintext(&self) -> &MlsPlaintext {
+        &self._plaintext
     }
 
     /// Consumes the message and returns the inner [MlsPlaintext].
-    pub fn take_plaintext(self) -> MlsPlaintext {
-        self.plaintext
+    pub(crate) fn _take_plaintext(self) -> MlsPlaintext {
+        self._plaintext
     }
 }
 

--- a/openmls/src/group/core_group/apply_proposals.rs
+++ b/openmls/src/group/core_group/apply_proposals.rs
@@ -14,7 +14,7 @@ use crate::{
 use super::{proposals::ProposalQueue, CoreGroup};
 
 /// This struct contain the return values of the `apply_proposals()` function
-pub struct ApplyProposalsValues {
+pub(crate) struct ApplyProposalsValues {
     pub(crate) path_required: bool,
     pub(crate) self_removed: bool,
     pub(crate) invitation_list: Vec<(LeafIndex, AddProposal)>,
@@ -26,7 +26,7 @@ impl ApplyProposalsValues {
     /// This function creates a `HashSet` of node indexes of the new nodes that
     /// were added to the tree. The `HashSet` will be querried by the
     /// `resolve()` function to filter out those nodes from the resolution.
-    pub fn exclusion_list(&self) -> HashSet<&LeafIndex> {
+    pub(crate) fn exclusion_list(&self) -> HashSet<&LeafIndex> {
         // Collect the new leaves' indexes so we can filter them out in the resolution
         // later
         let new_leaves_indexes: HashSet<&LeafIndex> = self

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -29,7 +29,7 @@ struct PathProcessingResult {
 }
 
 impl CoreGroup {
-    pub fn create_commit(
+    pub(crate) fn create_commit(
         &self,
         params: CreateCommitParams,
         backend: &impl OpenMlsCryptoProvider,

--- a/openmls/src/group/core_group/create_commit_params.rs
+++ b/openmls/src/group/core_group/create_commit_params.rs
@@ -4,12 +4,12 @@ use super::{proposals::ProposalStore, *};
 
 /// Can be used to denote the type of a commit.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
-pub enum CommitType {
+pub(crate) enum CommitType {
     External,
     Member,
 }
 
-pub struct CreateCommitParams<'a> {
+pub(crate) struct CreateCommitParams<'a> {
     framing_parameters: FramingParameters<'a>, // Mandatory
     credential_bundle: &'a CredentialBundle,   // Mandatory
     proposal_store: &'a ProposalStore,         // Mandatory
@@ -18,29 +18,32 @@ pub struct CreateCommitParams<'a> {
     commit_type: CommitType,                   // Optional (default is `Member`)
 }
 
-pub struct TempBuilderCCPM0 {}
+pub(crate) struct TempBuilderCCPM0 {}
 
-pub struct TempBuilderCCPM1<'a> {
+pub(crate) struct TempBuilderCCPM1<'a> {
     framing_parameters: FramingParameters<'a>,
 }
 
-pub struct TempBuilderCCPM2<'a> {
+pub(crate) struct TempBuilderCCPM2<'a> {
     framing_parameters: FramingParameters<'a>,
     credential_bundle: &'a CredentialBundle,
 }
 
-pub struct CreateCommitParamsBuilder<'a> {
+pub(crate) struct CreateCommitParamsBuilder<'a> {
     ccp: CreateCommitParams<'a>,
 }
 
 impl TempBuilderCCPM0 {
-    pub fn framing_parameters(self, framing_parameters: FramingParameters) -> TempBuilderCCPM1 {
+    pub(crate) fn framing_parameters(
+        self,
+        framing_parameters: FramingParameters,
+    ) -> TempBuilderCCPM1 {
         TempBuilderCCPM1 { framing_parameters }
     }
 }
 
 impl<'a> TempBuilderCCPM1<'a> {
-    pub fn credential_bundle(
+    pub(crate) fn credential_bundle(
         self,
         credential_bundle: &'a CredentialBundle,
     ) -> TempBuilderCCPM2<'a> {
@@ -52,7 +55,7 @@ impl<'a> TempBuilderCCPM1<'a> {
 }
 
 impl<'a> TempBuilderCCPM2<'a> {
-    pub fn proposal_store(
+    pub(crate) fn proposal_store(
         self,
         proposal_store: &'a ProposalStore,
     ) -> CreateCommitParamsBuilder<'a> {
@@ -70,44 +73,44 @@ impl<'a> TempBuilderCCPM2<'a> {
 }
 
 impl<'a> CreateCommitParamsBuilder<'a> {
-    pub fn inline_proposals(mut self, inline_proposals: Vec<Proposal>) -> Self {
+    pub(crate) fn inline_proposals(mut self, inline_proposals: Vec<Proposal>) -> Self {
         self.ccp.inline_proposals = inline_proposals;
         self
     }
-    #[cfg(any(feature = "test-utils", test))]
-    pub fn force_self_update(mut self, force_self_update: bool) -> Self {
+    #[cfg(test)]
+    pub(crate) fn force_self_update(mut self, force_self_update: bool) -> Self {
         self.ccp.force_self_update = force_self_update;
         self
     }
-    pub fn commit_type(mut self, commit_type: CommitType) -> Self {
+    pub(crate) fn commit_type(mut self, commit_type: CommitType) -> Self {
         self.ccp.commit_type = commit_type;
         self
     }
-    pub fn build(self) -> CreateCommitParams<'a> {
+    pub(crate) fn build(self) -> CreateCommitParams<'a> {
         self.ccp
     }
 }
 
 impl<'a> CreateCommitParams<'a> {
-    pub fn builder() -> TempBuilderCCPM0 {
+    pub(crate) fn builder() -> TempBuilderCCPM0 {
         TempBuilderCCPM0 {}
     }
-    pub fn framing_parameters(&self) -> &FramingParameters {
+    pub(crate) fn framing_parameters(&self) -> &FramingParameters {
         &self.framing_parameters
     }
-    pub fn credential_bundle(&self) -> &CredentialBundle {
+    pub(crate) fn credential_bundle(&self) -> &CredentialBundle {
         self.credential_bundle
     }
-    pub fn proposal_store(&self) -> &ProposalStore {
+    pub(crate) fn proposal_store(&self) -> &ProposalStore {
         self.proposal_store
     }
-    pub fn inline_proposals(&self) -> &[Proposal] {
+    pub(crate) fn inline_proposals(&self) -> &[Proposal] {
         &self.inline_proposals
     }
-    pub fn force_self_update(&self) -> bool {
+    pub(crate) fn force_self_update(&self) -> bool {
         self.force_self_update
     }
-    pub fn commit_type(&self) -> CommitType {
+    pub(crate) fn commit_type(&self) -> CommitType {
         self.commit_type
     }
 }

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -136,12 +136,6 @@ impl CoreGroupBuilder {
         self.psk_ids = psk_ids;
         self
     }
-    /// Set the [`ProtocolVersion`] of the [`CoreGroup`].
-    #[cfg(test)]
-    pub(crate) fn _with_version(mut self, version: ProtocolVersion) -> Self {
-        self.version = Some(version);
-        self
-    }
     /// Set the [`RequiredCapabilitiesExtension`] of the [`CoreGroup`].
     pub(crate) fn with_required_capabilities(
         mut self,

--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::group::core_group::*;
 
-pub type ExternalCommitResult = (CoreGroup, CreateCommitResult);
+pub(crate) type ExternalCommitResult = (CoreGroup, CreateCommitResult);
 
 impl CoreGroup {
     /// Join a group without the help of an internal member. This function
@@ -24,7 +24,7 @@ impl CoreGroup {
     ///
     /// Returns the new `CoreGroup` object, as well as the `MlsPlaintext`
     /// containing the commit.
-    pub fn join_by_external_commit(
+    pub(crate) fn join_by_external_commit(
         backend: &impl OpenMlsCryptoProvider,
         params: CreateCommitParams,
         tree_option: Option<&[Option<Node>]>,

--- a/openmls/src/group/core_group/past_secrets.rs
+++ b/openmls/src/group/core_group/past_secrets.rs
@@ -14,7 +14,7 @@ struct EpochTree {
 /// Can store message secrets for up to `max_epochs`. The trees are added with [`self::add()`] and can be queried
 /// with [`Self::get_epoch()`].
 #[derive(Debug, Serialize, Deserialize)]
-pub struct MessageSecretsStore {
+pub(crate) struct MessageSecretsStore {
     max_epochs: usize,
     epoch_trees: VecDeque<EpochTree>,
 }
@@ -22,7 +22,7 @@ pub struct MessageSecretsStore {
 impl MessageSecretsStore {
     /// Create a new store that can hold up to `max_epochs` message secrets.
     /// If `max_epochs` is 0, no secret trees will be stored.
-    pub fn new(max_epochs: usize) -> Self {
+    pub(crate) fn new(max_epochs: usize) -> Self {
         Self {
             max_epochs,
             epoch_trees: VecDeque::new(),
@@ -30,7 +30,7 @@ impl MessageSecretsStore {
     }
 
     /// Add a secret tree for a given epoch `group_epoch`.
-    pub fn add(&mut self, group_epoch: GroupEpoch, message_secrets: MessageSecrets) {
+    pub(crate) fn add(&mut self, group_epoch: GroupEpoch, message_secrets: MessageSecrets) {
         // Don't store the tree if it's not intended
         if self.max_epochs == 0 {
             return;
@@ -48,7 +48,10 @@ impl MessageSecretsStore {
 
     /// Get a mutable reference to a secret tree for a given epoch `group_epoch`.
     /// If no message secrets are found for that epoch, `None` is returned.
-    pub fn secrets_for_epoch(&mut self, group_epoch: GroupEpoch) -> Option<&mut MessageSecrets> {
+    pub(crate) fn secrets_for_epoch(
+        &mut self,
+        group_epoch: GroupEpoch,
+    ) -> Option<&mut MessageSecrets> {
         let GroupEpoch(epoch) = group_epoch;
         for epoch_tree in self.epoch_trees.iter_mut() {
             if epoch_tree.epoch == epoch {

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -18,7 +18,7 @@ impl CoreGroup {
     ///  - ValSem6
     ///  - ValSem7
     ///  - ValSem9
-    pub fn parse_message<'a>(
+    pub(crate) fn parse_message<'a>(
         &mut self,
         message: MlsMessageIn,
         message_secrets_store: impl Into<Option<&'a mut MessageSecretsStore>>,
@@ -109,7 +109,7 @@ impl CoreGroup {
     ///  - ValSem107
     ///  - ValSem109
     ///  - ValSem110
-    pub fn process_unverified_message<'a>(
+    pub(crate) fn process_unverified_message<'a>(
         &mut self,
         unverified_message: UnverifiedMessage,
         signature_key: Option<&SignaturePublicKey>,
@@ -210,7 +210,7 @@ impl CoreGroup {
     }
 
     /// Merge a [StagedCommit] into the group after inspection
-    pub fn merge_staged_commit(
+    pub(crate) fn merge_staged_commit(
         &mut self,
         staged_commit: StagedCommit,
         proposal_store: &mut ProposalStore,
@@ -220,7 +220,7 @@ impl CoreGroup {
         let past_epoch = self.context().epoch();
         // Merge the staged commit into the group state and store the secret tree from the
         // previous epoch in the message secrets store.
-        if let Some(message_secrets) = self.merge_commit_take_message_secrets(staged_commit)? {
+        if let Some(message_secrets) = self.merge_commit(staged_commit)? {
             message_secrets_store.add(past_epoch, message_secrets);
         }
         // Empty the proposal store

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -20,26 +20,27 @@ pub struct ProposalStore {
 }
 
 impl ProposalStore {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             queued_proposals: Vec::new(),
         }
     }
-    pub fn from_queued_proposal(queued_proposal: QueuedProposal) -> Self {
+    #[cfg(any(feature = "test-utils", test))]
+    pub(crate) fn from_queued_proposal(queued_proposal: QueuedProposal) -> Self {
         Self {
             queued_proposals: vec![queued_proposal],
         }
     }
-    pub fn add(&mut self, queued_proposal: QueuedProposal) {
+    pub(crate) fn add(&mut self, queued_proposal: QueuedProposal) {
         self.queued_proposals.push(queued_proposal);
     }
-    pub fn proposals(&self) -> impl Iterator<Item = &QueuedProposal> {
+    pub(crate) fn proposals(&self) -> impl Iterator<Item = &QueuedProposal> {
         self.queued_proposals.iter()
     }
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.queued_proposals.is_empty()
     }
-    pub fn empty(&mut self) {
+    pub(crate) fn empty(&mut self) {
         self.queued_proposals = Vec::new();
     }
 }
@@ -56,7 +57,7 @@ pub struct QueuedProposal {
 
 impl QueuedProposal {
     /// Creates a new [QueuedProposal] from an [MlsPlaintext]
-    pub fn from_mls_plaintext(
+    pub(crate) fn from_mls_plaintext(
         ciphersuite: &Ciphersuite,
         backend: &impl OpenMlsCryptoProvider,
         mls_plaintext: MlsPlaintext,
@@ -228,7 +229,7 @@ impl ProposalQueue {
 
     /// Returns an iterator over all Add proposals in the queue
     /// in the order of the the Commit message
-    pub fn add_proposals(&self) -> impl Iterator<Item = QueuedAddProposal> {
+    pub(crate) fn add_proposals(&self) -> impl Iterator<Item = QueuedAddProposal> {
         self.queued_proposals().filter_map(|queued_proposal| {
             if let Proposal::Add(add_proposal) = queued_proposal.proposal() {
                 let sender = queued_proposal.sender();
@@ -244,7 +245,7 @@ impl ProposalQueue {
 
     /// Returns an iterator over all Remove proposals in the queue
     /// in the order of the the Commit message
-    pub fn remove_proposals(&self) -> impl Iterator<Item = QueuedRemoveProposal> {
+    pub(crate) fn remove_proposals(&self) -> impl Iterator<Item = QueuedRemoveProposal> {
         self.queued_proposals().filter_map(|queued_proposal| {
             if let Proposal::Remove(remove_proposal) = queued_proposal.proposal() {
                 let sender = queued_proposal.sender();
@@ -260,7 +261,7 @@ impl ProposalQueue {
 
     /// Returns an iterator over all Update in the queue
     /// in the order of the the Commit message
-    pub fn update_proposals(&self) -> impl Iterator<Item = QueuedUpdateProposal> {
+    pub(crate) fn update_proposals(&self) -> impl Iterator<Item = QueuedUpdateProposal> {
         self.queued_proposals().filter_map(|queued_proposal| {
             if let Proposal::Update(update_proposal) = queued_proposal.proposal() {
                 let sender = queued_proposal.sender();
@@ -276,7 +277,7 @@ impl ProposalQueue {
 
     /// Returns an iterator over all PresharedKey proposals in the queue
     /// in the order of the the Commit message
-    pub fn psk_proposals(&self) -> impl Iterator<Item = QueuedPskProposal> {
+    pub(crate) fn psk_proposals(&self) -> impl Iterator<Item = QueuedPskProposal> {
         self.queued_proposals().filter_map(|queued_proposal| {
             if let Proposal::PreSharedKey(psk_proposal) = queued_proposal.proposal() {
                 let sender = queued_proposal.sender();

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -36,7 +36,7 @@ impl CoreGroup {
     ///  - ValSem205
     /// Returns an error if the given commit was sent by the owner of this
     /// group.
-    pub fn stage_commit(
+    pub(crate) fn stage_commit(
         &mut self,
         mls_plaintext: &MlsPlaintext,
         proposal_store: &ProposalStore,
@@ -281,28 +281,12 @@ impl CoreGroup {
         })
     }
 
-    /// Merges a [StagedCommit] into the group state.
-    ///
-    /// This function should not fail and only returns a [`Result`], because it
-    /// might throw a `LibraryError`.
-    #[cfg(any(feature = "test-utils", test))]
-    pub fn merge_commit(&mut self, staged_commit: StagedCommit) -> Result<(), CoreGroupError> {
-        if let Some(state) = staged_commit.state {
-            self.group_context = state.group_context;
-            self.group_epoch_secrets = state.group_epoch_secrets;
-            self.message_secrets = state.message_secrets;
-            self.interim_transcript_hash = state.interim_transcript_hash;
-            self.tree.merge_diff(state.staged_diff)?;
-        };
-        Ok(())
-    }
-
     /// Merges a [StagedCommit] into the group state and optionally return a [`SecretTree`]
     /// from the previous epoch. The secret tree is returned if the Commit does not contain a self removal.
     ///
     /// This function should not fail and only returns a [`Result`], because it
     /// might throw a `LibraryError`.
-    pub fn merge_commit_take_message_secrets(
+    pub(crate) fn merge_commit(
         &mut self,
         staged_commit: StagedCommit,
     ) -> Result<Option<MessageSecrets>, CoreGroupError> {

--- a/openmls/src/group/core_group/test_duplicate_extension.rs
+++ b/openmls/src/group/core_group/test_duplicate_extension.rs
@@ -53,7 +53,6 @@ fn duplicate_ratchet_tree_extension(
 
     let config = CoreGroupConfig {
         add_ratchet_tree_extension: true,
-        ..CoreGroupConfig::default()
     };
 
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);

--- a/openmls/src/group/core_group/validation.rs
+++ b/openmls/src/group/core_group/validation.rs
@@ -11,7 +11,7 @@ impl CoreGroup {
     /// Checks the following semantic validation:
     ///  - ValSem2
     ///  - ValSem3
-    pub fn validate_framing(&self, message: &MlsMessageIn) -> Result<(), CoreGroupError> {
+    pub(crate) fn validate_framing(&self, message: &MlsMessageIn) -> Result<(), CoreGroupError> {
         // ValSem2
         if message.group_id() != self.group_id() {
             return Err(FramingValidationError::WrongGroupId.into());
@@ -42,7 +42,7 @@ impl CoreGroup {
     ///  - ValSem5
     ///  - ValSem7
     ///  - ValSem9
-    pub fn validate_plaintext(
+    pub(crate) fn validate_plaintext(
         &self,
         plaintext: &VerifiableMlsPlaintext,
     ) -> Result<(), CoreGroupError> {
@@ -97,7 +97,7 @@ impl CoreGroup {
     ///  - ValSem104
     ///  - ValSem105
     ///  - TODO: ValSem106
-    pub fn validate_add_proposals(
+    pub(crate) fn validate_add_proposals(
         &self,
         proposal_queue: &ProposalQueue,
     ) -> Result<(), CoreGroupError> {
@@ -164,7 +164,7 @@ impl CoreGroup {
     /// Validate Remove proposals. This function implements the following checks:
     ///  - ValSem107
     ///  - ValSem108
-    pub fn validate_remove_proposals(
+    pub(crate) fn validate_remove_proposals(
         &self,
         proposal_queue: &ProposalQueue,
     ) -> Result<(), CoreGroupError> {
@@ -194,7 +194,7 @@ impl CoreGroup {
     /// Validate Update proposals. This function implements the following checks:
     ///  - ValSem109
     ///  - ValSem110
-    pub fn validate_update_proposals(
+    pub(crate) fn validate_update_proposals(
         &self,
         proposal_queue: &ProposalQueue,
         path_key_package: Option<(Sender, &KeyPackage)>,

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -327,8 +327,8 @@ impl MlsGroup {
     }
 
     /// Get the underlying [CoreGroup].
-    #[cfg(any(feature = "test-utils", test))]
-    pub fn group(&self) -> &CoreGroup {
+    #[cfg(test)]
+    pub(crate) fn group(&self) -> &CoreGroup {
         &self.group
     }
 }

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -32,6 +32,7 @@ pub mod errors;
 // Tests
 #[cfg(any(feature = "test-utils", test))]
 pub(crate) use create_commit_params::*;
+#[cfg(any(feature = "test-utils", test))]
 pub(crate) mod tests;
 #[cfg(any(feature = "test-utils", test))]
 use openmls_traits::random::OpenMlsRand;

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -18,8 +18,7 @@ use tls_codec::*;
 
 // Crate
 pub(crate) mod core_group;
-pub mod errors;
-pub use core_group::*;
+pub(crate) use core_group::*;
 pub(crate) use errors::{
     CoreGroupError, CreateCommitError, ExporterError, InterimTranscriptHashError, StageCommitError,
     WelcomeError,
@@ -28,12 +27,12 @@ pub(crate) use group_context::*;
 
 // Public
 pub use mls_group::*;
+pub mod errors;
 
 // Tests
 #[cfg(any(feature = "test-utils", test))]
+pub(crate) use create_commit_params::*;
 pub(crate) mod tests;
-#[cfg(any(feature = "test-utils", test))]
-pub use create_commit_params::*;
 #[cfg(any(feature = "test-utils", test))]
 use openmls_traits::random::OpenMlsRand;
 #[cfg(any(feature = "test-utils", test))]

--- a/openmls/src/group/tests/mod.rs
+++ b/openmls/src/group/tests/mod.rs
@@ -1,9 +1,9 @@
 //! Unit tests for the core group
 
-#[cfg(any(feature = "test-utils", test))]
+#[cfg(feature = "test-utils")]
 pub mod kat_messages;
 
-#[cfg(any(feature = "test-utils", test))]
+#[cfg(feature = "test-utils")]
 pub mod kat_transcripts;
 
 #[cfg(test)]

--- a/openmls/src/group/tests/mod.rs
+++ b/openmls/src/group/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Unit tests for the core group
 
+#[cfg(any(feature = "test-utils", test))]
 pub mod kat_messages;
 
 #[cfg(any(feature = "test-utils", test))]

--- a/openmls/src/group/tests/test_encoding.rs
+++ b/openmls/src/group/tests/test_encoding.rs
@@ -31,8 +31,6 @@ fn create_encoding_test_setup(backend: &impl OpenMlsCryptoProvider) -> TestSetup
             ciphersuite: *ciphersuite_name,
             config: CoreGroupConfig {
                 add_ratchet_tree_extension: true,
-                padding_block_size: 10,
-                additional_as_epochs: 0,
             },
             members: vec![alice_config.clone(), bob_config.clone()],
         };

--- a/openmls/src/group/tests/test_validation.rs
+++ b/openmls/src/group/tests/test_validation.rs
@@ -50,7 +50,6 @@ fn generate_key_package_bundle(
 }
 
 // Test setup values
-#[cfg(test)]
 struct ValidationTestSetup {
     alice_group: MlsGroup,
     _alice_credential: Credential,

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -379,7 +379,7 @@ pub struct GroupContextExtensionProposal {
 
 impl GroupContextExtensionProposal {
     /// Create a new [`GroupContextExtensionProposal`].
-    #[cfg(any(feature = "test-utils", test))]
+    #[cfg(test)]
     pub(crate) fn new(extensions: &[Extension]) -> Self {
         Self {
             extensions: extensions.into(),

--- a/openmls/src/prelude_test.rs
+++ b/openmls/src/prelude_test.rs
@@ -2,11 +2,7 @@
 //! Include this to get access to all necessary pub(crate) functions of OpenMLS testing.
 
 pub use crate::ciphersuite::{signable::Verifiable, *};
-pub use crate::framing::ciphertext::MlsCiphertext;
-pub use crate::framing::*;
-pub use crate::group::{
-    core_group::*, create_commit_params::CreateCommitParams, past_secrets::MessageSecretsStore,
-};
+pub use crate::framing::{plaintext::*, *};
 pub use crate::schedule::*;
 pub use crate::treesync::*;
 


### PR DESCRIPTION
This PR reduces the visibility of `MlsPlaintext` and `MlsCiphertext` to crate-only. As a consequence, `CoreGroup` could also now become crate-only as intended.
Unused functions are dropped and minor changes are made to accommodate the change.
This will need more work as outlined in #691, but I want to keep it simple for now.
