### PR TITLE
Move message_secrets_store into CoreGroup

### DIFF
--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -234,8 +234,17 @@ fn wire_format_checks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
 
     message_secrets.replace_secret_tree(orig_secret_tree);
 
+    let sender_data = ciphertext
+        .sender_data(&mut message_secrets, backend, ciphersuite)
+        .expect("Could not decrypt sender data.");
     let verifiable_plaintext = ciphertext
-        .to_plaintext(ciphersuite, backend, &mut message_secrets, configuration)
+        .to_plaintext(
+            ciphersuite,
+            backend,
+            &mut message_secrets,
+            configuration,
+            sender_data,
+        )
         .expect("Could not decrypt MlsCiphertext.");
 
     assert_eq!(
@@ -249,7 +258,7 @@ fn wire_format_checks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
 
     assert_eq!(
         ciphertext
-            .to_plaintext(ciphersuite, backend, &mut message_secrets, configuration)
+            .sender_data(&mut message_secrets, backend, ciphersuite)
             .expect_err("Could decrypt despite wrong wire format."),
         MlsCiphertextError::WrongWireFormat
     );
@@ -522,7 +531,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
             epoch: group_alice.context().epoch(),
             sender: 1u32,
         },
-        group_alice.message_secrets_mut(),
+        group_alice.message_secrets_test_mut(),
         0,
     )
     .expect("Encryption error");
@@ -561,7 +570,7 @@ fn unknown_sender(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
             epoch: group_alice.context().epoch(),
             sender: 1u32,
         },
-        group_alice.message_secrets_mut(),
+        group_alice.message_secrets_test_mut(),
         0,
     )
     .expect("Encryption error");

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -75,11 +75,13 @@ impl DecryptedMessage {
     ) -> Result<Self, ValidationError> {
         // This will be refactored with #265.
         if let MlsMessage::Ciphertext(ciphertext) = inbound_message.mls_message {
+            let sender_data = ciphertext.sender_data(message_secrets, backend, ciphersuite)?;
             let plaintext = ciphertext.to_plaintext(
                 ciphersuite,
                 backend,
                 message_secrets,
                 sender_ratchet_configuration,
+                sender_data,
             )?;
             Self::from_plaintext(plaintext)
         } else {

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -42,7 +42,7 @@ use crate::{
     messages::{proposals::*, *},
     schedule::psk::*,
     schedule::*,
-    tree::sender_ratchet::*,
+    tree::{secret_tree::SecretTreeError, sender_ratchet::*},
     treesync::{node::Node, *},
 };
 
@@ -63,7 +63,7 @@ use std::io::{Error, Read, Write};
 
 use tls_codec::Serialize as TlsSerializeTrait;
 
-use self::staged_commit::StagedCommit;
+use self::{past_secrets::MessageSecretsStore, staged_commit::StagedCommit};
 
 use super::{
     errors::{CoreGroupError, ExporterError, FramingValidationError, ProposalValidationError},
@@ -82,7 +82,6 @@ pub struct CoreGroup {
     ciphersuite: &'static Ciphersuite,
     group_context: GroupContext,
     group_epoch_secrets: GroupEpochSecrets,
-    message_secrets: MessageSecrets,
     tree: TreeSync,
     interim_transcript_hash: Vec<u8>,
     // Group config.
@@ -91,17 +90,24 @@ pub struct CoreGroup {
     use_ratchet_tree_extension: bool,
     // The MLS protocol version used in this group.
     mls_version: ProtocolVersion,
+    /// A [`MessageSecretsStore`] that stores message secrets.
+    /// By default this store has the length of 1, i.e. only the [`MessageSecrets`]
+    /// of the current epoch is kept.
+    /// If more secrets should from past epochs should be kept in order to be
+    /// able to decrypt application messages from previous epochs, the size of
+    /// the store must be increased through [`max_past_epochs()`].
+    message_secrets_store: MessageSecretsStore,
 }
 
 implement_persistence!(
     CoreGroup,
     group_context,
     group_epoch_secrets,
-    message_secrets,
     tree,
     interim_transcript_hash,
     use_ratchet_tree_extension,
-    mls_version
+    mls_version,
+    message_secrets_store
 );
 
 /// Builder for [`CoreGroup`].
@@ -112,6 +118,7 @@ pub struct CoreGroupBuilder {
     psk_ids: Vec<PreSharedKeyId>,
     version: Option<ProtocolVersion>,
     required_capabilities: Option<RequiredCapabilitiesExtension>,
+    max_past_epochs: usize,
 }
 
 impl CoreGroupBuilder {
@@ -124,6 +131,7 @@ impl CoreGroupBuilder {
             psk_ids: vec![],
             version: None,
             required_capabilities: None,
+            max_past_epochs: 0,
         }
     }
     /// Set the [`CoreGroupConfig`] of the [`CoreGroup`].
@@ -149,6 +157,11 @@ impl CoreGroupBuilder {
         required_capabilities: RequiredCapabilitiesExtension,
     ) -> Self {
         self.required_capabilities = Some(required_capabilities);
+        self
+    }
+    /// Set the number of past epochs the group should keep secrets.
+    pub fn with_max_past_epoch_secrets(mut self, max_past_epochs: usize) -> Self {
+        self.max_past_epochs = max_past_epochs;
         self
     }
 
@@ -198,6 +211,8 @@ impl CoreGroupBuilder {
 
         let (group_epoch_secrets, message_secrets) =
             epoch_secrets.split_secrets(serialized_group_context, 1u32);
+        let message_secrets_store =
+            MessageSecretsStore::new_with_secret(self.max_past_epochs, message_secrets);
 
         let interim_transcript_hash = vec![];
 
@@ -205,11 +220,11 @@ impl CoreGroupBuilder {
             ciphersuite,
             group_context,
             group_epoch_secrets,
-            message_secrets,
             tree,
             interim_transcript_hash,
             use_ratchet_tree_extension: config.add_ratchet_tree_extension,
             mls_version: version,
+            message_secrets_store,
         })
     }
 }
@@ -424,7 +439,7 @@ impl CoreGroup {
                 epoch: self.context().epoch(),
                 sender: self.sender_index(),
             },
-            self.message_secrets_mut(),
+            self.message_secrets_mut(mls_plaintext.epoch())?,
             padding_size,
         )
         .map_err(CoreGroupError::MlsCiphertextError)
@@ -438,11 +453,15 @@ impl CoreGroup {
         backend: &impl OpenMlsCryptoProvider,
         sender_ratchet_configuration: &SenderRatchetConfiguration,
     ) -> Result<VerifiableMlsPlaintext, CoreGroupError> {
+        let ciphersuite = self.ciphersuite();
+        let message_secrets = self.message_secrets_test_mut();
+        let sender_data = mls_ciphertext.sender_data(message_secrets, backend, ciphersuite)?;
         Ok(mls_ciphertext.to_plaintext(
-            self.ciphersuite(),
+            ciphersuite,
             backend,
-            &mut self.message_secrets,
+            message_secrets,
             sender_ratchet_configuration,
+            sender_data,
         )?)
     }
 
@@ -613,12 +632,37 @@ impl CoreGroup {
 
     /// Get a reference to the message secrets from a group
     pub(crate) fn message_secrets(&self) -> &MessageSecrets {
-        &self.message_secrets
+        self.message_secrets_store.message_secrets()
     }
 
-    /// Get a mutable reference to the message secrets from a group
-    pub(crate) fn message_secrets_mut(&mut self) -> &mut MessageSecrets {
-        &mut self.message_secrets
+    /// Sets the size of the [`MessageSecretsStore`], i.e. the number of past
+    /// epochs to keep.
+    /// This allows application messages from previous epochs to be decrypted.
+    pub(crate) fn set_max_past_epochs(&mut self, max_past_epochs: usize) {
+        self.message_secrets_store.resize(max_past_epochs);
+    }
+
+    /// Get the message secrets. Either from the secrets store or from the group.
+    pub(super) fn message_secrets_mut<'secret, 'group: 'secret>(
+        &'group mut self,
+        epoch: GroupEpoch,
+    ) -> Result<&'secret mut MessageSecrets, CoreGroupError> {
+        if epoch < self.context().epoch() {
+            self.message_secrets_store
+                .secrets_for_epoch_mut(epoch)
+                .ok_or_else(|| {
+                    CoreGroupError::MlsCiphertextError(MlsCiphertextError::SecretTreeError(
+                        SecretTreeError::TooDistantInThePast,
+                    ))
+                })
+        } else {
+            Ok(self.message_secrets_store.message_secrets_mut())
+        }
+    }
+
+    #[cfg(any(feature = "test-utils", test))]
+    pub(crate) fn message_secrets_test_mut(&mut self) -> &mut MessageSecrets {
+        self.message_secrets_store.message_secrets_mut()
     }
 
     /// Current interim transcript hash of the group

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -93,7 +93,7 @@ pub struct CoreGroup {
     /// A [`MessageSecretsStore`] that stores message secrets.
     /// By default this store has the length of 1, i.e. only the [`MessageSecrets`]
     /// of the current epoch is kept.
-    /// If more secrets should from past epochs should be kept in order to be
+    /// If more secrets from past epochs should be kept in order to be
     /// able to decrypt application messages from previous epochs, the size of
     /// the store must be increased through [`max_past_epochs()`].
     message_secrets_store: MessageSecretsStore,

--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -91,6 +91,7 @@ impl CoreGroup {
             group_context.tls_serialize_detached()?,
             treesync.leaf_count()?,
         );
+        let message_secrets_store = MessageSecretsStore::new_with_secret(0, message_secrets);
 
         // Prepare interim transcript hash
         let group = CoreGroup {
@@ -101,7 +102,7 @@ impl CoreGroup {
             use_ratchet_tree_extension: enable_ratchet_tree_extension,
             mls_version: pgs.version,
             group_epoch_secrets,
-            message_secrets,
+            message_secrets_store,
         };
 
         let external_init_proposal = Proposal::ExternalInit(ExternalInitProposal::from(kem_output));

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -157,15 +157,17 @@ impl CoreGroup {
             log_crypto!(trace, "  Expected: {:x?}", group_info.confirmation_tag());
             Err(WelcomeError::ConfirmationTagMismatch)
         } else {
+            let message_secrets_store = MessageSecretsStore::new_with_secret(0, message_secrets);
+
             Ok(CoreGroup {
                 ciphersuite,
                 group_context,
                 group_epoch_secrets,
-                message_secrets,
                 tree,
                 interim_transcript_hash,
                 use_ratchet_tree_extension: enable_ratchet_tree_extension,
                 mls_version,
+                message_secrets_store,
             })
         }
     }

--- a/openmls/src/group/core_group/past_secrets.rs
+++ b/openmls/src/group/core_group/past_secrets.rs
@@ -6,6 +6,7 @@ use super::*;
 
 // Internal helper struct
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 struct EpochTree {
     epoch: u64,
     message_secrets: MessageSecrets,
@@ -14,47 +15,92 @@ struct EpochTree {
 /// Can store message secrets for up to `max_epochs`. The trees are added with [`self::add()`] and can be queried
 /// with [`Self::get_epoch()`].
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct MessageSecretsStore {
+    // Maximum size of the `past_epoch_trees` list.
     max_epochs: usize,
-    epoch_trees: VecDeque<EpochTree>,
+    // Past message secrets.
+    past_epoch_trees: VecDeque<EpochTree>,
+    // The message secrets of the current epoch.
+    message_secrets: MessageSecrets,
 }
 
 impl MessageSecretsStore {
-    /// Create a new store that can hold up to `max_epochs` message secrets.
-    /// If `max_epochs` is 0, no secret trees will be stored.
-    pub fn new(max_epochs: usize) -> Self {
+    /// Create a new store that can hold up to `max_past_epochs` message secrets.
+    /// If `max_past_epochs` is 0, only the current epoch is being stored.
+    pub(crate) fn new_with_secret(max_epochs: usize, message_secrets: MessageSecrets) -> Self {
         Self {
             max_epochs,
-            epoch_trees: VecDeque::new(),
+            past_epoch_trees: VecDeque::new(),
+            message_secrets,
+        }
+    }
+
+    /// Resize the store.
+    pub(crate) fn resize(&mut self, max_past_epochs: usize) {
+        self.max_epochs = max_past_epochs;
+        while self.past_epoch_trees.len() > self.max_epochs {
+            self.past_epoch_trees.pop_front();
         }
     }
 
     /// Add a secret tree for a given epoch `group_epoch`.
+    /// Note that this does not take the epoch into account and pops out the
+    /// oldest element.
     pub fn add(&mut self, group_epoch: GroupEpoch, message_secrets: MessageSecrets) {
         // Don't store the tree if it's not intended
         if self.max_epochs == 0 {
             return;
         }
-        let GroupEpoch(epoch) = group_epoch;
-        let epoch_tree = EpochTree {
-            epoch,
-            message_secrets,
-        };
-        while self.epoch_trees.len() >= self.max_epochs {
-            self.epoch_trees.pop_front();
+        while self.past_epoch_trees.len() >= self.max_epochs {
+            self.past_epoch_trees.pop_front();
         }
-        self.epoch_trees.push_back(epoch_tree);
+        self.past_epoch_trees.push_back(EpochTree {
+            epoch: group_epoch.0,
+            message_secrets,
+        });
+        debug_assert!(
+            self.max_epochs >= self.past_epoch_trees.len(),
+            "Only {} past secrets must be stored but we found {}",
+            self.max_epochs,
+            self.past_epoch_trees.len()
+        );
     }
 
     /// Get a mutable reference to a secret tree for a given epoch `group_epoch`.
     /// If no message secrets are found for that epoch, `None` is returned.
-    pub fn secrets_for_epoch(&mut self, group_epoch: GroupEpoch) -> Option<&mut MessageSecrets> {
+    pub fn secrets_for_epoch_mut(
+        &mut self,
+        group_epoch: GroupEpoch,
+    ) -> Option<&mut MessageSecrets> {
         let GroupEpoch(epoch) = group_epoch;
-        for epoch_tree in self.epoch_trees.iter_mut() {
+        for epoch_tree in self.past_epoch_trees.iter_mut() {
             if epoch_tree.epoch == epoch {
                 return Some(&mut epoch_tree.message_secrets);
             }
         }
         None
+    }
+
+    /// Get a reference to a secret tree for a given epoch `group_epoch`.
+    /// If no message secrets are found for that epoch, `None` is returned.
+    pub fn secrets_for_epoch(&self, group_epoch: GroupEpoch) -> Option<&MessageSecrets> {
+        let GroupEpoch(epoch) = group_epoch;
+        for epoch_tree in self.past_epoch_trees.iter() {
+            if epoch_tree.epoch == epoch {
+                return Some(&epoch_tree.message_secrets);
+            }
+        }
+        None
+    }
+
+    /// Get a mutable reference to the message secrets of the current epoch.
+    pub(crate) fn message_secrets_mut(&mut self) -> &mut MessageSecrets {
+        &mut self.message_secrets
+    }
+
+    /// Get a reference to the message secrets of the current epoch.
+    pub(crate) fn message_secrets(&self) -> &MessageSecrets {
+        &self.message_secrets
     }
 }

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -1,8 +1,6 @@
 use core_group::{proposals::QueuedProposal, staged_commit::StagedCommit};
 
-use crate::tree::secret_tree::SecretTreeError;
-
-use super::{past_secrets::MessageSecretsStore, proposals::ProposalStore, *};
+use super::{proposals::ProposalStore, *};
 
 impl CoreGroup {
     /// This function is used to parse messages from the DS.
@@ -21,7 +19,6 @@ impl CoreGroup {
     pub fn parse_message<'a>(
         &mut self,
         message: MlsMessageIn,
-        message_secrets_store: impl Into<Option<&'a mut MessageSecretsStore>>,
         sender_ratchet_configuration: &SenderRatchetConfiguration,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<UnverifiedMessage, CoreGroupError> {
@@ -36,28 +33,8 @@ impl CoreGroup {
             WireFormat::MlsPlaintext => DecryptedMessage::from_inbound_plaintext(message)?,
             WireFormat::MlsCiphertext => {
                 // If the message is older than the current epoch, we need to fetch the correct secret tree first
-                let ciphersuite = self.ciphersuite().clone();
-                let message_secrets = if message.epoch() < self.context().epoch() {
-                    if let Some(store) = message_secrets_store.into() {
-                        if let Some(message_secrets) = store.secrets_for_epoch(message.epoch()) {
-                            message_secrets
-                        } else {
-                            return Err(CoreGroupError::MlsCiphertextError(
-                                MlsCiphertextError::SecretTreeError(
-                                    SecretTreeError::TooDistantInThePast,
-                                ),
-                            ));
-                        }
-                    } else {
-                        return Err(CoreGroupError::MlsCiphertextError(
-                            MlsCiphertextError::SecretTreeError(
-                                SecretTreeError::TooDistantInThePast,
-                            ),
-                        ));
-                    }
-                } else {
-                    self.message_secrets_mut()
-                };
+                let ciphersuite = self.ciphersuite();
+                let message_secrets = self.message_secrets_mut(message.epoch())?;
                 DecryptedMessage::from_inbound_ciphertext(
                     message,
                     &ciphersuite,
@@ -114,30 +91,12 @@ impl CoreGroup {
         unverified_message: UnverifiedMessage,
         signature_key: Option<&SignaturePublicKey>,
         proposal_store: &ProposalStore,
-        message_secrets_store: impl Into<Option<&'a mut MessageSecretsStore>>,
         own_kpbs: &[KeyPackageBundle],
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<ProcessedMessage, CoreGroupError> {
         // Add the context to the message and verify the membership tag if necessary.
         // If the message is older than the current epoch, we need to fetch the correct secret tree first.
-        let message_secrets = if unverified_message.epoch() < self.context().epoch() {
-            let message_secrets = if let Some(store) = message_secrets_store.into() {
-                if let Some(message_secrets) = store.secrets_for_epoch(unverified_message.epoch()) {
-                    message_secrets
-                } else {
-                    return Err(CoreGroupError::MlsCiphertextError(
-                        MlsCiphertextError::SecretTreeError(SecretTreeError::TooDistantInThePast),
-                    ));
-                }
-            } else {
-                return Err(CoreGroupError::MlsCiphertextError(
-                    MlsCiphertextError::SecretTreeError(SecretTreeError::TooDistantInThePast),
-                ));
-            };
-            message_secrets
-        } else {
-            self.message_secrets()
-        };
+        let message_secrets = self.message_secrets_mut(unverified_message.epoch())?;
 
         // Checks the following semantic validation:
         //  - ValSem8
@@ -214,14 +173,13 @@ impl CoreGroup {
         &mut self,
         staged_commit: StagedCommit,
         proposal_store: &mut ProposalStore,
-        message_secrets_store: &mut MessageSecretsStore,
     ) -> Result<(), CoreGroupError> {
         // Save the past epoch
         let past_epoch = self.context().epoch();
         // Merge the staged commit into the group state and store the secret tree from the
         // previous epoch in the message secrets store.
         if let Some(message_secrets) = self.merge_commit_take_message_secrets(staged_commit)? {
-            message_secrets_store.add(past_epoch, message_secrets);
+            self.message_secrets_store.add(past_epoch, message_secrets);
         }
         // Empty the proposal store
         proposal_store.empty();

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -290,7 +290,8 @@ impl CoreGroup {
         if let Some(state) = staged_commit.state {
             self.group_context = state.group_context;
             self.group_epoch_secrets = state.group_epoch_secrets;
-            self.message_secrets = state.message_secrets;
+            self.message_secrets_store =
+                MessageSecretsStore::new_with_secret(0, state.message_secrets);
             self.interim_transcript_hash = state.interim_transcript_hash;
             self.tree.merge_diff(state.staged_diff)?;
         };
@@ -312,7 +313,10 @@ impl CoreGroup {
 
             // Replace the previous message secrets with the new ones and return the previous message secrets
             let mut message_secrets = state.message_secrets;
-            mem::swap(&mut message_secrets, &mut self.message_secrets);
+            mem::swap(
+                &mut message_secrets,
+                self.message_secrets_store.message_secrets_mut(),
+            );
 
             self.interim_transcript_hash = state.interim_transcript_hash;
 

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -365,7 +365,7 @@ fn test_update_path(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         .set_membership_tag(
             backend,
             serialized_context,
-            group_bob.message_secrets.membership_key(),
+            group_bob.message_secrets().membership_key(),
         )
         .expect("Could not add membership key");
 

--- a/openmls/src/group/core_group/test_past_secrets.rs
+++ b/openmls/src/group/core_group/test_past_secrets.rs
@@ -8,7 +8,8 @@ use crate::{
 #[apply(ciphersuites_and_backends)]
 fn test_secret_tree_store(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     // Create a store that keeps up to 3 epochs
-    let mut message_secrets_store = MessageSecretsStore::new(3);
+    let mut message_secrets_store =
+        MessageSecretsStore::new_with_secret(3, MessageSecrets::random(ciphersuite, backend));
 
     // Add message secrets to the store
     message_secrets_store.add(GroupEpoch(0), MessageSecrets::random(ciphersuite, backend));
@@ -55,7 +56,8 @@ fn test_empty_secret_tree_store(
     backend: &impl OpenMlsCryptoProvider,
 ) {
     // Create a store that keeps no epochs
-    let mut message_secrets_store = MessageSecretsStore::new(0);
+    let mut message_secrets_store =
+        MessageSecretsStore::new_with_secret(0, MessageSecrets::random(ciphersuite, backend));
 
     // Add message secrets to the store
     message_secrets_store.add(GroupEpoch(0), MessageSecrets::random(ciphersuite, backend));

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -36,7 +36,6 @@ pub use errors::{
 pub(crate) use resumption::ResumptionSecretStore;
 use ser::*;
 
-use super::past_secrets::MessageSecretsStore;
 use super::proposals::{ProposalStore, QueuedProposal};
 use super::staged_commit::StagedCommit;
 
@@ -160,9 +159,6 @@ pub struct MlsGroup {
     // A [ProposalStore] that stores incoming proposals from the DS within one epoch.
     // The store is emptied after every epoch change.
     proposal_store: ProposalStore,
-    // A [MessageSecretsStore] that stores message secrets from past epochs in order to be able to decrypt
-    // application messages from previous epochs.
-    message_secrets_store: MessageSecretsStore,
     // Own `KeyPackageBundle`s that were created for update proposals and that
     // are needed in case an update proposal is commited by another group
     // member. The vector is emptied after every epoch change.

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -30,12 +30,7 @@ impl MlsGroup {
         let sender_ratchet_configuration =
             self.configuration().sender_ratchet_configuration().clone();
         self.group
-            .parse_message(
-                message,
-                &mut self.message_secrets_store,
-                &sender_ratchet_configuration,
-                backend,
-            )
+            .parse_message(message, &sender_ratchet_configuration, backend)
             .map_err(MlsGroupError::Group)
     }
 
@@ -52,7 +47,6 @@ impl MlsGroup {
                 unverified_message,
                 signature_key,
                 &self.proposal_store,
-                &mut self.message_secrets_store,
                 &self.own_kpbs,
                 backend,
             )
@@ -125,11 +119,7 @@ impl MlsGroup {
 
         // Merge staged commit
         self.group
-            .merge_staged_commit(
-                staged_commit,
-                &mut self.proposal_store,
-                &mut self.message_secrets_store,
-            )
+            .merge_staged_commit(staged_commit, &mut self.proposal_store)
             .map_err(MlsGroupError::Group)?;
 
         // Extract and store the resumption secret for the current epoch

--- a/openmls/src/group/mls_group/ser.rs
+++ b/openmls/src/group/mls_group/ser.rs
@@ -9,7 +9,6 @@ pub struct SerializedMlsGroup {
     mls_group_config: MlsGroupConfig,
     group: CoreGroup,
     proposal_store: ProposalStore,
-    message_secrets_store: MessageSecretsStore,
     own_kpbs: Vec<KeyPackageBundle>,
     aad: Vec<u8>,
     resumption_secret_store: ResumptionSecretStore,
@@ -22,7 +21,6 @@ impl SerializedMlsGroup {
             mls_group_config: self.mls_group_config,
             group: self.group,
             proposal_store: self.proposal_store,
-            message_secrets_store: self.message_secrets_store,
             own_kpbs: self.own_kpbs,
             aad: self.aad,
             resumption_secret_store: self.resumption_secret_store,
@@ -41,7 +39,6 @@ impl Serialize for MlsGroup {
         state.serialize_field("mls_group_config", &self.mls_group_config)?;
         state.serialize_field("group", &self.group)?;
         state.serialize_field("proposal_store", &self.proposal_store)?;
-        state.serialize_field("message_secrets_store", &self.message_secrets_store)?;
         state.serialize_field("own_kpbs", &self.own_kpbs)?;
         state.serialize_field("aad", &self.aad)?;
         state.serialize_field("resumption_secret_store", &self.resumption_secret_store)?;

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -182,7 +182,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
         .welcome_option
         .expect("An unexpected error occurred.");
     // Clone the secret tree to bypass FS restrictions
-    let secret_tree = group.message_secrets_mut().secret_tree_mut().clone();
+    let secret_tree = group.message_secrets_test_mut().secret_tree_mut().clone();
     let mls_ciphertext_application = group
         .create_application_message(
             b"aad",
@@ -193,7 +193,9 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> MessagesTestVe
         )
         .expect("An unexpected error occurred.");
     // Replace the secret tree
-    group.message_secrets_mut().replace_secret_tree(secret_tree);
+    group
+        .message_secrets_test_mut()
+        .replace_secret_tree(secret_tree);
     let verifiable_mls_plaintext_application = group
         .decrypt(
             &mls_ciphertext_application,

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -7,10 +7,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use crate::{
-    credentials::*, framing::*, group::core_group::past_secrets::*, group::*, key_packages::*,
-    test_utils::*, *,
-};
+use crate::{credentials::*, framing::*, group::*, key_packages::*, test_utils::*, *};
 use ::rand::rngs::OsRng;
 use ::rand::RngCore;
 use openmls_traits::types::SignatureScheme;
@@ -227,11 +224,7 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
                 .expect("An unexpected error occurred.");
 
             core_group
-                .merge_staged_commit(
-                    create_commit_result.staged_commit,
-                    &mut proposal_store,
-                    &mut MessageSecretsStore::new(0),
-                )
+                .merge_staged_commit(create_commit_result.staged_commit, &mut proposal_store)
                 .expect("error merging own commits");
 
             // Distribute the Welcome message to the other members.


### PR DESCRIPTION
In order to use KeyPackageRefs we need to restructure the way the message
decryption works. This PR is a step in this direction by moving the
message_secrets_store into the CoreGroup and having one way of getting it.
This is not guaranteed to fully make the KeyPackageRef work but is a step in
this direction.

Other changes:
Derypting ciphertext is in two steps now, sender data and actual ciphertext.
This will make it again easier to use KeyPackageRef because the two
decryption steps (header and payload) are separated.