### PR TITLE
rename tree::index types

### DIFF
--- a/openmls/src/schedule/message_secrets.rs
+++ b/openmls/src/schedule/message_secrets.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 #[cfg(test)]
-use crate::tree::index::LeafIndex;
+use crate::tree::index::SecretTreeLeafIndex;
 /// Combined message secrets that need to be stored for later decryption/verification
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MessageSecrets {
@@ -79,7 +79,7 @@ impl MessageSecrets {
                 .expect("Not enough randomness."),
             secret_tree: SecretTree::new(
                 EncryptionSecret::random(ciphersuite, backend),
-                LeafIndex(10),
+                SecretTreeLeafIndex(10),
             ),
         }
     }

--- a/openmls/src/tree/index.rs
+++ b/openmls/src/tree/index.rs
@@ -20,9 +20,9 @@ use super::*;
     TlsDeserialize,
     TlsSize,
 )]
-pub struct NodeIndex(u32);
+pub struct SecretTreeNodeIndex(u32);
 
-impl NodeIndex {
+impl SecretTreeNodeIndex {
     pub fn as_u32(self) -> u32 {
         self.0
     }
@@ -37,21 +37,21 @@ impl NodeIndex {
     }
 }
 
-impl From<u32> for NodeIndex {
-    fn from(i: u32) -> NodeIndex {
-        NodeIndex(i)
+impl From<u32> for SecretTreeNodeIndex {
+    fn from(i: u32) -> SecretTreeNodeIndex {
+        SecretTreeNodeIndex(i)
     }
 }
 
-impl From<usize> for NodeIndex {
-    fn from(i: usize) -> NodeIndex {
-        NodeIndex(i as u32)
+impl From<usize> for SecretTreeNodeIndex {
+    fn from(i: usize) -> SecretTreeNodeIndex {
+        SecretTreeNodeIndex(i as u32)
     }
 }
 
-impl From<LeafIndex> for NodeIndex {
-    fn from(node_index: LeafIndex) -> NodeIndex {
-        NodeIndex(node_index.as_u32() * 2)
+impl From<SecretTreeLeafIndex> for SecretTreeNodeIndex {
+    fn from(node_index: SecretTreeLeafIndex) -> SecretTreeNodeIndex {
+        SecretTreeNodeIndex(node_index.as_u32() * 2)
     }
 }
 
@@ -72,9 +72,9 @@ impl From<LeafIndex> for NodeIndex {
     TlsSerialize,
     TlsSize,
 )]
-pub struct LeafIndex(pub(crate) u32);
+pub struct SecretTreeLeafIndex(pub(crate) u32);
 
-impl LeafIndex {
+impl SecretTreeLeafIndex {
     pub fn as_u32(self) -> u32 {
         self.0
     }
@@ -83,39 +83,39 @@ impl LeafIndex {
     }
 }
 
-impl From<u32> for LeafIndex {
-    fn from(i: u32) -> LeafIndex {
-        LeafIndex(i)
+impl From<u32> for SecretTreeLeafIndex {
+    fn from(i: u32) -> SecretTreeLeafIndex {
+        SecretTreeLeafIndex(i)
     }
 }
 
-impl From<usize> for LeafIndex {
-    fn from(i: usize) -> LeafIndex {
-        LeafIndex(i as u32)
+impl From<usize> for SecretTreeLeafIndex {
+    fn from(i: usize) -> SecretTreeLeafIndex {
+        SecretTreeLeafIndex(i as u32)
     }
 }
 
-impl From<LeafIndex> for u32 {
-    fn from(i: LeafIndex) -> u32 {
+impl From<SecretTreeLeafIndex> for u32 {
+    fn from(i: SecretTreeLeafIndex) -> u32 {
         i.as_u32()
     }
 }
 
-impl From<LeafIndex> for usize {
-    fn from(i: LeafIndex) -> usize {
+impl From<SecretTreeLeafIndex> for usize {
+    fn from(i: SecretTreeLeafIndex) -> usize {
         i.as_usize()
     }
 }
 
-impl TryFrom<NodeIndex> for LeafIndex {
+impl TryFrom<SecretTreeNodeIndex> for SecretTreeLeafIndex {
     type Error = &'static str;
-    fn try_from(node_index: NodeIndex) -> Result<Self, Self::Error> {
+    fn try_from(node_index: SecretTreeNodeIndex) -> Result<Self, Self::Error> {
         // A node with an odd index must be a parent node and therefore cannot be
         // converted to a leaf node
         if node_index.is_parent() {
             Err("Cannot convert a parent node index to a leaf node index.")
         } else {
-            Ok(LeafIndex((node_index.as_u32() + 1) / 2))
+            Ok(SecretTreeLeafIndex((node_index.as_u32() + 1) / 2))
         }
     }
 }

--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -6,9 +6,9 @@
 //! error, will still return a `Result` since they may throw a `LibraryError`.
 
 use crate::ciphersuite::{AeadNonce, *};
-use crate::tree::{index::LeafIndex, secret_tree::*};
+use crate::tree::{index::SecretTreeLeafIndex, secret_tree::*};
 
-use super::index::NodeIndex;
+use super::index::SecretTreeNodeIndex;
 use super::*;
 
 /// Stores the configuration parameters for sender ratchets.
@@ -59,14 +59,14 @@ pub type RatchetSecrets = (AeadKey, AeadNonce);
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(any(feature = "test-utils", test), derive(PartialEq))]
 pub struct SenderRatchet {
-    index: LeafIndex,
+    index: SecretTreeLeafIndex,
     generation: u32,
     past_secrets: Vec<Secret>,
 }
 
 impl SenderRatchet {
     /// Creates e new SenderRatchet
-    pub fn new(index: LeafIndex, secret: &Secret) -> Self {
+    pub fn new(index: SecretTreeLeafIndex, secret: &Secret) -> Self {
         Self {
             index,
             generation: 0,
@@ -166,7 +166,7 @@ impl SenderRatchet {
         derive_tree_secret(
             secret,
             "secret",
-            NodeIndex::from(self.index).as_u32(),
+            SecretTreeNodeIndex::from(self.index).as_u32(),
             self.generation,
             ciphersuite.hash_length(),
             backend,
@@ -180,7 +180,7 @@ impl SenderRatchet {
         secret: &Secret,
         generation: u32,
     ) -> RatchetSecrets {
-        let tree_index = NodeIndex::from(self.index).as_u32();
+        let tree_index = SecretTreeNodeIndex::from(self.index).as_u32();
         let nonce = derive_tree_secret(
             secret,
             "nonce",

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_secret_tree.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_secret_tree.rs
@@ -5,7 +5,7 @@ use crate::{
     config::{Config, ProtocolVersion},
     schedule::EncryptionSecret,
     test_utils::*,
-    tree::{index::LeafIndex, secret_tree::*, *},
+    tree::{index::SecretTreeLeafIndex, secret_tree::*, *},
 };
 use std::collections::HashMap;
 
@@ -14,13 +14,13 @@ use std::collections::HashMap;
 fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     let configuration = &SenderRatchetConfiguration::default();
     let encryption_secret = EncryptionSecret::random(ciphersuite, backend);
-    let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(2u32));
+    let mut secret_tree = SecretTree::new(encryption_secret, SecretTreeLeafIndex::from(2u32));
     let secret_type = SecretType::ApplicationSecret;
     assert!(secret_tree
         .secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(0u32),
+            SecretTreeLeafIndex::from(0u32),
             secret_type,
             0,
             configuration
@@ -30,7 +30,7 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         .secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(1u32),
+            SecretTreeLeafIndex::from(1u32),
             secret_type,
             0,
             configuration
@@ -40,7 +40,7 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         .secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(0u32),
+            SecretTreeLeafIndex::from(0u32),
             secret_type,
             1,
             configuration
@@ -50,7 +50,7 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         .secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(0u32),
+            SecretTreeLeafIndex::from(0u32),
             secret_type,
             1_000,
             configuration,
@@ -60,7 +60,7 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         secret_tree.secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(1u32),
+            SecretTreeLeafIndex::from(1u32),
             secret_type,
             1001,
             configuration,
@@ -71,7 +71,7 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         .secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(0u32),
+            SecretTreeLeafIndex::from(0u32),
             secret_type,
             996,
             configuration,
@@ -81,7 +81,7 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         secret_tree.secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(0u32),
+            SecretTreeLeafIndex::from(0u32),
             secret_type,
             995,
             configuration,
@@ -92,7 +92,7 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         secret_tree.secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(2u32),
+            SecretTreeLeafIndex::from(2u32),
             secret_type,
             0,
             configuration,
@@ -100,12 +100,12 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         Err(SecretTreeError::IndexOutOfBounds)
     );
     let encryption_secret = EncryptionSecret::random(ciphersuite, backend);
-    let mut largetree = SecretTree::new(encryption_secret, LeafIndex::from(100_000u32));
+    let mut largetree = SecretTree::new(encryption_secret, SecretTreeLeafIndex::from(100_000u32));
     assert!(largetree
         .secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(0u32),
+            SecretTreeLeafIndex::from(0u32),
             secret_type,
             0,
             configuration
@@ -115,7 +115,7 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         .secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(99_999u32),
+            SecretTreeLeafIndex::from(99_999u32),
             secret_type,
             0,
             configuration,
@@ -125,7 +125,7 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         .secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(99_999u32),
+            SecretTreeLeafIndex::from(99_999u32),
             secret_type,
             1_000,
             configuration,
@@ -135,7 +135,7 @@ fn test_boundaries(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         largetree.secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(100_000u32),
+            SecretTreeLeafIndex::from(100_000u32),
             secret_type,
             0,
             configuration,
@@ -153,14 +153,21 @@ fn increment_generation(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
 
     let mut unique_values: HashMap<Vec<u8>, bool> = HashMap::new();
     let encryption_secret = EncryptionSecret::random(ciphersuite, backend);
-    let mut secret_tree = SecretTree::new(encryption_secret, LeafIndex::from(SIZE as u32));
+    let mut secret_tree =
+        SecretTree::new(encryption_secret, SecretTreeLeafIndex::from(SIZE as u32));
     for i in 0..SIZE {
         assert_eq!(
-            secret_tree.generation(LeafIndex::from(i as u32), SecretType::HandshakeSecret),
+            secret_tree.generation(
+                SecretTreeLeafIndex::from(i as u32),
+                SecretType::HandshakeSecret
+            ),
             0
         );
         assert_eq!(
-            secret_tree.generation(LeafIndex::from(i as u32), SecretType::ApplicationSecret),
+            secret_tree.generation(
+                SecretTreeLeafIndex::from(i as u32),
+                SecretType::ApplicationSecret
+            ),
             0
         );
     }
@@ -170,7 +177,7 @@ fn increment_generation(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
                 .secret_for_encryption(
                     ciphersuite,
                     backend,
-                    LeafIndex::from(j as u32),
+                    SecretTreeLeafIndex::from(j as u32),
                     SecretType::HandshakeSecret,
                 )
                 .expect("Index out of bounds.");
@@ -185,7 +192,7 @@ fn increment_generation(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
                 .secret_for_encryption(
                     ciphersuite,
                     backend,
-                    LeafIndex::from(j as u32),
+                    SecretTreeLeafIndex::from(j as u32),
                     SecretType::ApplicationSecret,
                 )
                 .expect("Index out of bounds.");
@@ -215,14 +222,14 @@ fn secret_tree(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoPr
             ProtocolVersion::default(),
             ciphersuite,
         ),
-        LeafIndex::from(n_leaves),
+        SecretTreeLeafIndex::from(n_leaves),
     );
     println!("Secret tree: {:?}", secret_tree);
     let (application_secret_key, application_secret_nonce) = secret_tree
         .secret_for_decryption(
             ciphersuite,
             backend,
-            LeafIndex::from(leaf_index),
+            SecretTreeLeafIndex::from(leaf_index),
             SecretType::ApplicationSecret,
             generation,
             configuration,


### PR DESCRIPTION
Renaming tree::index::LeafIndex and tree::index::NodeIndex to
SecretTreeLeafIndex and SecretTreeNodeIndex resp.