### PR TITLE
[Bug] treesync::node::Node is private but public API needs it

### DIFF
--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -53,11 +53,11 @@ pub mod key_packages;
 pub mod key_store;
 pub mod messages;
 pub mod schedule;
+pub mod treesync;
 
 // Private
 mod binary_tree;
 mod tree;
-mod treesync;
 
 /// Single place, re-exporting the most used public functions.
 pub mod prelude;

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -46,7 +46,7 @@ use self::{
 
 pub(crate) mod diff;
 mod hashes;
-pub(crate) mod node;
+pub mod node;
 pub(crate) mod treekem;
 pub(crate) mod treesync_node;
 


### PR DESCRIPTION
 #722 [Bug] treesync::node::Node is private but public API needs it
For now exposing treesync and node so that I can get unblocked.
