### PR TITLE
Fix clippy errors

### DIFF
--- a/openmls/src/binary_tree/array_representation/treemath.rs
+++ b/openmls/src/binary_tree/array_representation/treemath.rs
@@ -72,7 +72,7 @@ pub(super) fn parent_step(x: NodeIndex) -> NodeIndex {
 
 // This function is only safe to use if index <= size.
 // If this is not checked before calling the function, `parent` should be used.
-fn unsafe_parent(index: NodeIndex, size: NodeIndex) -> Result<NodeIndex, TreeMathError> {
+fn try_parent(index: NodeIndex, size: NodeIndex) -> Result<NodeIndex, TreeMathError> {
     let x = index;
     let n = size;
     if index == root(size) {
@@ -91,7 +91,7 @@ fn unsafe_parent(index: NodeIndex, size: NodeIndex) -> Result<NodeIndex, TreeMat
 
 pub(super) fn sibling(index: NodeIndex, size: NodeIndex) -> Result<NodeIndex, TreeMathError> {
     node_in_tree(index, size)?;
-    let p = unsafe_parent(index, size)?;
+    let p = try_parent(index, size)?;
     match index.cmp(&p) {
         Ordering::Less => right(p, size),
         Ordering::Greater => left(p),
@@ -124,7 +124,7 @@ pub(super) fn direct_path(
     let mut d = vec![];
     let mut x = node_index;
     while x != r {
-        x = unsafe_parent(x, size)?;
+        x = try_parent(x, size)?;
         d.push(x);
     }
     Ok(d)
@@ -150,7 +150,7 @@ pub(super) fn lowest_common_ancestor(x: NodeIndex, y: NodeIndex) -> NodeIndex {
 
 pub(super) fn parent(index: NodeIndex, size: NodeIndex) -> Result<NodeIndex, TreeMathError> {
     node_in_tree(index, size)?;
-    unsafe_parent(index, size)
+    try_parent(index, size)
 }
 
 #[cfg(any(feature = "test-utils", test))]

--- a/openmls/src/binary_tree/test_binary_tree.rs
+++ b/openmls/src/binary_tree/test_binary_tree.rs
@@ -25,11 +25,10 @@ fn test_tree_basics() {
 
     // Test tree creation: Too many nodes (only in cases where usize is 64 bit).
     #[cfg(target_pointer_width = "64")]
-    unsafe {
+    {
         let len = NodeIndex::MAX as usize + 2;
-        let mut nodes: Vec<u32> = Vec::new();
-
-        nodes.set_len(len);
+        // This allocation should get optimized away by the compiler
+        let nodes = vec![0u32; len];
 
         assert_eq!(
             MlsBinaryTree::new(nodes).expect_err("No error while creating too large tree."),
@@ -285,19 +284,18 @@ fn test_leaf_addition_and_removal_errors() {
     );
 
     // Let's test what happens when the tree is getting too large.
-    let mut nodes: Vec<u32> = Vec::new();
+    let len = NodeIndex::MAX as usize;
+    // This allocation should get optimized away by the compiler
+    let nodes: Vec<u32> = vec![0; len];
 
-    unsafe {
-        nodes.set_len(NodeIndex::MAX as usize);
+    let tree = MlsBinaryTree::new(nodes).expect("error creating tree");
+    let mut diff = tree.empty_diff().expect("error creating empty diff");
 
-        let tree = MlsBinaryTree::new(nodes).expect("error creating tree");
-        let mut diff = tree.empty_diff().expect("error creating empty diff");
-        assert_eq!(
-            diff.add_leaf(666, 667)
-                .expect_err("no error adding beyond u32 max"),
-            MlsBinaryTreeDiffError::TreeTooLarge
-        )
-    }
+    assert_eq!(
+        diff.add_leaf(666, 667)
+            .expect_err("no error adding beyond u32 max"),
+        MlsBinaryTreeDiffError::TreeTooLarge
+    )
 }
 
 #[test]

--- a/openmls/src/binary_tree/test_binary_tree.rs
+++ b/openmls/src/binary_tree/test_binary_tree.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::mem::MaybeUninit;
 
 use crate::binary_tree::{MlsBinaryTree, MlsBinaryTreeDiffError, MlsBinaryTreeError};
 
@@ -26,9 +25,11 @@ fn test_tree_basics() {
 
     // Test tree creation: Too many nodes (only in cases where usize is 64 bit).
     #[cfg(target_pointer_width = "64")]
+    // We allow uninitialized vectors because we don't want to allocate so much memory
+    #[allow(clippy::uninit_vec)]
     unsafe {
         let len = NodeIndex::MAX as usize + 2;
-        let mut nodes: Vec<MaybeUninit<u32>> = Vec::with_capacity(len);
+        let mut nodes: Vec<u32> = Vec::new();
 
         nodes.set_len(len);
 
@@ -286,18 +287,18 @@ fn test_leaf_addition_and_removal_errors() {
     );
 
     // Let's test what happens when the tree is getting too large.
-    let len = NodeIndex::MAX as usize;
-    let mut nodes: Vec<MaybeUninit<u32>> = Vec::with_capacity(len);
+    let mut nodes: Vec<u32> = Vec::new();
 
+    // We allow uninitialized vectors because we don't want to allocate so much memory
+    #[allow(clippy::uninit_vec)]
     unsafe {
         nodes.set_len(NodeIndex::MAX as usize);
 
         let tree = MlsBinaryTree::new(nodes).expect("error creating tree");
         let mut diff = tree.empty_diff().expect("error creating empty diff");
-        let new_leaves: Vec<MaybeUninit<u32>> = vec![MaybeUninit::new(666), MaybeUninit::new(667)];
 
         assert_eq!(
-            diff.add_leaf(new_leaves[0], new_leaves[1])
+            diff.add_leaf(666, 667)
                 .expect_err("no error adding beyond u32 max"),
             MlsBinaryTreeDiffError::TreeTooLarge
         )

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -1,4 +1,4 @@
-use crate::treesync::diff::StagedTreeSyncDiff;
+use crate::treesync::{diff::StagedTreeSyncDiff, treekem::DecryptPathParams};
 
 use super::proposals::{ProposalQueue, ProposalStore, QueuedProposal};
 
@@ -174,15 +174,15 @@ impl CoreGroup {
             }
 
             // Decrypt the UpdatePath
-            let (plain_path, commit_secret) = diff.decrypt_path(
-                backend,
-                ciphersuite,
-                self.mls_version,
-                update_path_nodes,
-                sender,
-                &apply_proposals_values.exclusion_list(),
-                &serialized_context,
-            )?;
+            let decrypt_path_params = DecryptPathParams {
+                version: self.mls_version,
+                update_path: update_path_nodes,
+                sender_leaf_index: sender,
+                exclusion_list: &apply_proposals_values.exclusion_list(),
+                group_context: &serialized_context,
+            };
+            let (plain_path, commit_secret) =
+                diff.decrypt_path(backend, ciphersuite, decrypt_path_params)?;
 
             diff.apply_received_update_path(backend, ciphersuite, sender, key_package, plain_path)?;
             commit_secret

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -122,7 +122,7 @@ fn validation_test_setup(
         alice_group,
         bob_credential_bundle,
         plaintext: message,
-        original_plaintext: original_plaintext,
+        original_plaintext,
     }
 }
 

--- a/openmls/src/tree/treemath.rs
+++ b/openmls/src/tree/treemath.rs
@@ -83,7 +83,7 @@ pub(crate) fn parent_step(x: usize) -> usize {
 
 // This function is only safe to use if index <= size.
 // If this is not checked before calling the function, `parent` should be used.
-fn unsafe_parent(
+fn try_parent(
     index: SecretTreeNodeIndex,
     size: SecretTreeLeafIndex,
 ) -> Result<SecretTreeNodeIndex, TreeMathError> {
@@ -131,7 +131,7 @@ pub(crate) fn leaf_direct_path(
     let mut d = vec![];
     let mut x = node_index;
     while x != r {
-        x = unsafe_parent(x, size)?;
+        x = try_parent(x, size)?;
         d.push(x);
     }
     Ok(d)
@@ -144,7 +144,7 @@ pub(crate) fn leaf_direct_path(
 fn invalid_inputs() {
     assert_eq!(
         Err(TreeMathError::InvalidInput),
-        unsafe_parent(1000u32.into(), 100u32.into())
+        try_parent(1000u32.into(), 100u32.into())
     );
 }
 

--- a/openmls/src/treesync/tests_and_kats/kats/kat_tree_kem.rs
+++ b/openmls/src/treesync/tests_and_kats/kats/kat_tree_kem.rs
@@ -24,6 +24,9 @@ use crate::{
     treesync::{node::Node, treekem::UpdatePath, TreeSync},
 };
 
+#[cfg(any(feature = "test-utils", test))]
+use crate::treesync::treekem::DecryptPathParams;
+
 use openmls_traits::OpenMlsCryptoProvider;
 use serde::{self, Deserialize, Serialize};
 use std::{collections::HashSet, convert::TryFrom};
@@ -170,16 +173,15 @@ pub fn run_test_vector(
     let (key_package, update_path_nodes) = update_path.into_parts();
 
     // Decrypt update path
+    let decrypt_path_params = DecryptPathParams {
+        version: ProtocolVersion::default(),
+        update_path: update_path_nodes,
+        sender_leaf_index: test_vector.update_sender,
+        exclusion_list: &HashSet::new(),
+        group_context: &group_context,
+    };
     let (path, commit_secret) = diff
-        .decrypt_path(
-            backend,
-            ciphersuite,
-            ProtocolVersion::default(),
-            update_path_nodes,
-            test_vector.update_sender,
-            &HashSet::new(),
-            &group_context,
-        )
+        .decrypt_path(backend, ciphersuite, decrypt_path_params)
         .expect("error decrypting update path");
     diff.apply_received_update_path(
         backend,

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -77,19 +77,17 @@ impl<'a> TreeSyncDiff<'a> {
         &self,
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: &'static Ciphersuite,
-        version: ProtocolVersion,
-        update_path: Vec<UpdatePathNode>,
-        sender_leaf_index: LeafIndex,
-        exclusion_list: &HashSet<&LeafIndex>,
-        group_context: &[u8],
+        params: DecryptPathParams,
     ) -> Result<(Vec<ParentNode>, CommitSecret), TreeKemError> {
-        let path_position = self.subtree_root_position(sender_leaf_index, self.own_leaf_index())?;
-        let update_path_node = update_path
+        let path_position =
+            self.subtree_root_position(params.sender_leaf_index, self.own_leaf_index())?;
+        let update_path_node = params
+            .update_path
             .get(path_position)
             .ok_or(TreeKemError::UpdatePathNodeNotFound)?;
 
         let (decryption_key, resolution_position) =
-            self.decryption_key(sender_leaf_index, exclusion_list)?;
+            self.decryption_key(params.sender_leaf_index, params.exclusion_list)?;
         let ciphertext = update_path_node
             .encrypted_path_secrets(resolution_position)
             .ok_or(TreeKemError::EncryptedCiphertextNotFound)?;
@@ -97,18 +95,19 @@ impl<'a> TreeSyncDiff<'a> {
         let path_secret = PathSecret::decrypt(
             backend,
             ciphersuite,
-            version,
+            params.version,
             ciphertext,
             decryption_key,
-            group_context,
+            params.group_context,
         )?;
 
-        let remaining_path_length = update_path.len() - path_position;
+        let remaining_path_length = params.update_path.len() - path_position;
         let (mut derived_path, _plain_update_path, commit_secret) =
             ParentNode::derive_path(backend, ciphersuite, path_secret, remaining_path_length)?;
         // We now check that the public keys in the update path and in the
         // derived path match up.
-        for (update_parent_node, derived_parent_node) in update_path
+        for (update_parent_node, derived_parent_node) in params
+            .update_path
             .iter()
             .skip(path_position)
             .zip(derived_path.iter())
@@ -120,9 +119,10 @@ impl<'a> TreeSyncDiff<'a> {
 
         // Finally, we append the derived path to the part of the update path
         // below the first node that we have a private key for.
-        let _update_path_len = update_path.len();
+        let _update_path_len = params.update_path.len();
 
-        let mut path: Vec<ParentNode> = update_path
+        let mut path: Vec<ParentNode> = params
+            .update_path
             .into_iter()
             .take(path_position)
             .map(|update_path_node| update_path_node.public_key.into())
@@ -133,6 +133,14 @@ impl<'a> TreeSyncDiff<'a> {
 
         Ok((path, commit_secret))
     }
+}
+
+pub(crate) struct DecryptPathParams<'a> {
+    pub(crate) version: ProtocolVersion,
+    pub(crate) update_path: Vec<UpdatePathNode>,
+    pub(crate) sender_leaf_index: LeafIndex,
+    pub(crate) exclusion_list: &'a HashSet<&'a LeafIndex>,
+    pub(crate) group_context: &'a [u8],
 }
 
 /// 7.7. Update Paths


### PR DESCRIPTION
This PR does the following:
 - Fixes clippy errors in the binary tree tests by suppressing it 
 - Fixes clippy warnings
 - Renames functions that were prefixed with `unsafe_` (but that were actually not unsafe) to avoid any confusion in the future