### PR TITLE
Introduce missing public docs linting

### DIFF
--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -20,6 +20,7 @@
 //! [MLS RFC]: https://datatracker.ietf.org/doc/draft-ietf-mls-protocol/
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), forbid(unsafe_code))]
+#![cfg_attr(not(feature = "test-utils"), warn(missing_docs))]
 
 // === Testing ===
 


### PR DESCRIPTION
This PR enables clippy linting for missing documentation on public types.
We should have done this a long time ago.