### PR TITLE
use byte slice for key store key

### DIFF
--- a/cli/src/identity.rs
+++ b/cli/src/identity.rs
@@ -18,10 +18,11 @@ fn store_key_package_bundle_in_keystore(
     crypto_backend
         .key_store()
         .store(
-            &key_package_bundle
+            key_package_bundle
                 .key_package()
                 .hash_ref(crypto_backend.crypto())
-                .expect("Failed to hash KeyPackage."),
+                .expect("Failed to hash KeyPackage.")
+                .as_slice(),
             key_package_bundle,
         )
         .expect("Failed to store KeyPackage in keystore.");
@@ -36,7 +37,11 @@ fn store_credential_bundle_in_keystore(
     crypto_backend
         .key_store()
         .store(
-            &credential_bundle.credential().signature_key(),
+            &credential_bundle
+                .credential()
+                .signature_key()
+                .tls_serialize_detached()
+                .expect("Error serializing signature key"),
             credential_bundle,
         )
         .expect("Failed to store CredentialBundle in keystore.");

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -16,7 +16,13 @@ fn generate_credential(
     let credential = cb.credential().clone();
     crypto_backend
         .key_store()
-        .store(credential.signature_key(), &cb)
+        .store(
+            &credential
+                .signature_key()
+                .tls_serialize_detached()
+                .expect("Error serializing signature key"),
+            &cb,
+        )
         .expect("An unexpected error occurred.");
     Ok(credential)
 }
@@ -29,7 +35,12 @@ fn generate_key_package(
 ) -> Result<KeyPackage, KeyPackageError> {
     let credential_bundle = crypto_backend
         .key_store()
-        .read(credential.signature_key())
+        .read(
+            &credential
+                .signature_key()
+                .tls_serialize_detached()
+                .expect("Error serializing signature key"),
+        )
         .expect("An unexpected error occurred.");
     let kpb = KeyPackageBundle::new(ciphersuites, &credential_bundle, crypto_backend, extensions)?;
     let kp = kpb.key_package().clone();

--- a/memory_keystore/src/lib.rs
+++ b/memory_keystore/src/lib.rs
@@ -1,13 +1,9 @@
 use openmls_traits::key_store::{FromKeyStoreValue, OpenMlsKeyStore, ToKeyStoreValue};
-use std::{
-    collections::HashMap,
-    hash::{Hash, Hasher},
-    sync::RwLock,
-};
+use std::{collections::HashMap, sync::RwLock};
 
 #[derive(Debug, Default)]
 pub struct MemoryKeyStore {
-    values: RwLock<HashMap<u64, Vec<u8>>>,
+    values: RwLock<HashMap<Vec<u8>, Vec<u8>>>,
 }
 
 impl OpenMlsKeyStore for MemoryKeyStore {
@@ -18,10 +14,7 @@ impl OpenMlsKeyStore for MemoryKeyStore {
     /// serialization for ID `k`.
     ///
     /// Returns an error if storing fails.
-    fn store<K: Hash, V: ToKeyStoreValue>(&self, k: &K, v: &V) -> Result<(), Self::Error> {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        k.hash(&mut hasher);
-        let k = hasher.finish();
+    fn store<V: ToKeyStoreValue>(&self, k: &[u8], v: &V) -> Result<(), Self::Error> {
         let value = v
             .to_key_store_value()
             .map_err(|_| Error::SerializationError)?;
@@ -29,7 +22,7 @@ impl OpenMlsKeyStore for MemoryKeyStore {
         // lock on `credential_bundles`. It only holds the lock very briefly and
         // should not panic during that period.
         let mut values = self.values.write().unwrap();
-        values.insert(k, value);
+        values.insert(k.to_vec(), value);
         Ok(())
     }
 
@@ -37,16 +30,12 @@ impl OpenMlsKeyStore for MemoryKeyStore {
     /// [`KeyStoreValue`] trait for deserialization.
     ///
     /// Returns [`None`] if no value is stored for `k` or reading fails.
-    fn read<K: Hash, V: FromKeyStoreValue>(&self, k: &K) -> Option<V> {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        k.hash(&mut hasher);
-        let k = hasher.finish();
-
+    fn read<V: FromKeyStoreValue>(&self, k: &[u8]) -> Option<V> {
         // We unwrap here, because the two functions claiming a write lock on
         // `init_key_package_bundles` (this one and `generate_key_package_bundle`) only
         // hold the lock very briefly and should not panic during that period.
         let values = self.values.read().unwrap();
-        if let Some(value) = values.get(&k) {
+        if let Some(value) = values.get(k) {
             V::from_key_store_value(value).ok()
         } else {
             None
@@ -56,14 +45,10 @@ impl OpenMlsKeyStore for MemoryKeyStore {
     /// Delete a value stored for ID `k`.
     ///
     /// Returns an error if storing fails.
-    fn delete<K: Hash>(&self, k: &K) -> Result<(), Self::Error> {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        k.hash(&mut hasher);
-        let k = hasher.finish();
-
+    fn delete(&self, k: &[u8]) -> Result<(), Self::Error> {
         // We just delete both ...
         let mut values = self.values.write().unwrap();
-        values.remove(&k);
+        values.remove(k);
         Ok(())
     }
 }

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -446,7 +446,12 @@ fn test_psks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProv
     let psk_bundle = PskBundle::new(secret).expect("Could not create PskBundle.");
     backend
         .key_store()
-        .store(&preshared_key_id, &psk_bundle)
+        .store(
+            &preshared_key_id
+                .tls_serialize_detached()
+                .expect("Error serializing signature key."),
+            &psk_bundle,
+        )
         .expect("An unexpected error occured.");
     let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .with_psk(vec![preshared_key_id.clone()])

--- a/openmls/src/group/mls_group/application.rs
+++ b/openmls/src/group/mls_group/application.rs
@@ -1,3 +1,5 @@
+use tls_codec::Serialize;
+
 use super::*;
 
 impl MlsGroup {
@@ -26,7 +28,7 @@ impl MlsGroup {
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
-            .read(credential.signature_key())
+            .read(&credential.signature_key().tls_serialize_detached()?)
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         let ciphertext = self.group.create_application_message(

--- a/openmls/src/group/mls_group/exporting.rs
+++ b/openmls/src/group/mls_group/exporting.rs
@@ -1,3 +1,5 @@
+use tls_codec::Serialize;
+
 use crate::messages::PublicGroupState;
 
 use super::*;
@@ -40,7 +42,12 @@ impl MlsGroup {
     ) -> Result<PublicGroupState, MlsGroupError> {
         let credential_bundle: CredentialBundle = backend
             .key_store()
-            .read(self.credential()?.signature_key())
+            .read(
+                &self
+                    .credential()?
+                    .signature_key()
+                    .tls_serialize_detached()?,
+            )
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
         Ok(self
             .group

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -2,6 +2,7 @@
 use std::collections::BTreeMap;
 
 use core_group::create_commit_params::CreateCommitParams;
+use tls_codec::Serialize;
 
 use crate::ciphersuite::hash_ref::KeyPackageRef;
 
@@ -44,7 +45,7 @@ impl MlsGroup {
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
-            .read(credential.signature_key())
+            .read(&credential.signature_key().tls_serialize_detached()?)
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all proposals
@@ -110,7 +111,7 @@ impl MlsGroup {
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
-            .read(credential.signature_key())
+            .read(&credential.signature_key().tls_serialize_detached()?)
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all proposals
@@ -153,7 +154,7 @@ impl MlsGroup {
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
-            .read(credential.signature_key())
+            .read(&credential.signature_key().tls_serialize_detached()?)
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         let add_proposal = self.group.create_add_proposal(
@@ -190,7 +191,7 @@ impl MlsGroup {
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
-            .read(credential.signature_key())
+            .read(&credential.signature_key().tls_serialize_detached()?)
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         let remove_proposal = self.group.create_remove_proposal(
@@ -226,7 +227,7 @@ impl MlsGroup {
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
-            .read(credential.signature_key())
+            .read(&credential.signature_key().tls_serialize_detached()?)
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         let removed = self.group.key_package_ref().ok_or_else(|| {

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -4,6 +4,7 @@ use core_group::{
     create_commit_params::CreateCommitParams, proposals::QueuedProposal,
     staged_commit::StagedCommit,
 };
+use tls_codec::Serialize;
 
 use super::*;
 
@@ -86,7 +87,7 @@ impl MlsGroup {
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
-            .read(credential.signature_key())
+            .read(&credential.signature_key().tls_serialize_detached()?)
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all pending proposals

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -1,4 +1,5 @@
 use core_group::create_commit_params::CreateCommitParams;
+use tls_codec::Serialize;
 
 use super::*;
 
@@ -22,7 +23,7 @@ impl MlsGroup {
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
-            .read(credential.signature_key())
+            .read(&credential.signature_key().tls_serialize_detached()?)
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all proposals. If a `KeyPackageBundle` was passed
@@ -77,7 +78,7 @@ impl MlsGroup {
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
             .key_store()
-            .read(credential.signature_key())
+            .read(&credential.signature_key().tls_serialize_detached()?)
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         let tree = self.group.treesync();

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -82,7 +82,12 @@ fn validation_test_setup(
 
     let bob_credential_bundle = backend
         .key_store()
-        .read(bob_credential.signature_key())
+        .read(
+            &bob_credential
+                .signature_key()
+                .tls_serialize_detached()
+                .expect("Error serializing signature key."),
+        )
         .expect("An unexpected error occurred.");
 
     // Bob wants to commit externally.

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -2,6 +2,7 @@
 
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::{key_store::OpenMlsKeyStore, OpenMlsCryptoProvider};
+use tls_codec::Serialize;
 
 use rstest::*;
 use rstest_reuse::{self, *};
@@ -36,7 +37,13 @@ fn test_past_secrets_in_group(
         let alice_credential = alice_credential_bundle.credential().clone();
         backend
             .key_store()
-            .store(alice_credential.signature_key(), &alice_credential_bundle)
+            .store(
+                &alice_credential
+                    .signature_key()
+                    .tls_serialize_detached()
+                    .expect("Error serializing signature key."),
+                &alice_credential_bundle,
+            )
             .expect("An unexpected error occurred.");
 
         let bob_credential_bundle = CredentialBundle::new(
@@ -49,7 +56,13 @@ fn test_past_secrets_in_group(
         let bob_credential = bob_credential_bundle.credential().clone();
         backend
             .key_store()
-            .store(bob_credential.signature_key(), &bob_credential_bundle)
+            .store(
+                &bob_credential
+                    .signature_key()
+                    .tls_serialize_detached()
+                    .expect("Error serializing signature key."),
+                &bob_credential_bundle,
+            )
             .expect("An unexpected error occurred.");
 
         // Generate KeyPackages

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -6,6 +6,7 @@ use openmls_traits::{key_store::OpenMlsKeyStore, OpenMlsCryptoProvider};
 
 use rstest::*;
 use rstest_reuse::{self, *};
+use tls_codec::Serialize;
 
 use crate::{
     config::*,
@@ -33,7 +34,12 @@ fn generate_credential_bundle_and_key_package_bundle(
     .expect("Failed to generate CredentialBundle.");
     let credential_bundle = backend
         .key_store()
-        .read::<SignaturePublicKey, CredentialBundle>(credential.signature_key())
+        .read::<CredentialBundle>(
+            &credential
+                .signature_key()
+                .tls_serialize_detached()
+                .expect("Error serializing signature key."),
+        )
         .expect("An unexpected error occurred.");
 
     let key_package =

--- a/openmls/src/schedule/kat_key_schedule.rs
+++ b/openmls/src/schedule/kat_key_schedule.rs
@@ -110,7 +110,12 @@ fn generate(
         let psk_bundle = PskBundle::new(psk.secret().clone()).expect("Could not create PskBundle.");
         crypto
             .key_store()
-            .store(&psk_id, &psk_bundle)
+            .store(
+                &psk_id
+                    .tls_serialize_detached()
+                    .expect("Error serializing signature key."),
+                &psk_bundle,
+            )
             .expect("Could not store PskBundle in key store.");
     }
     let psk_secret =
@@ -351,7 +356,12 @@ pub fn run_test_vector(
             let psk_bundle = PskBundle::new(secret).expect("Could not create PskBundle.");
             backend
                 .key_store()
-                .store(&psk_id, &psk_bundle)
+                .store(
+                    &psk_id
+                        .tls_serialize_detached()
+                        .expect("Error serializing signature key."),
+                    &psk_bundle,
+                )
                 .expect("Could not store PskBundle in key store.");
         }
 

--- a/openmls/src/schedule/psk.rs
+++ b/openmls/src/schedule/psk.rs
@@ -300,7 +300,11 @@ impl PskSecret {
         // Fetch the PskBundles from the key store and make sure we have all of them
         let mut psk_bundles: Vec<PskBundle> = Vec::new();
         for psk_id in psk_ids {
-            if let Some(psk_bundle) = backend.key_store().read(&psk_id) {
+            if let Some(psk_bundle) = backend.key_store().read(
+                &psk_id
+                    .tls_serialize_detached()
+                    .map_err(|_| PskSecretError::EncodingError)?,
+            ) {
                 psk_bundles.push(psk_bundle);
             } else {
                 return Err(PskSecretError::KeyNotFound);

--- a/openmls/src/schedule/unit_tests.rs
+++ b/openmls/src/schedule/unit_tests.rs
@@ -4,6 +4,7 @@ use crate::test_utils::*;
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::key_store::OpenMlsKeyStore;
 use openmls_traits::{random::OpenMlsRand, OpenMlsCryptoProvider};
+use tls_codec::Serialize;
 
 use crate::{ciphersuite::Secret, config::Config, schedule::psk::PskBundle, schedule::psk::*};
 
@@ -39,7 +40,12 @@ fn test_psks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryptoProv
         let psk_bundle = PskBundle::new(secret).expect("Could not create PskBundle.");
         backend
             .key_store()
-            .store(&psk_id, &psk_bundle)
+            .store(
+                &psk_id
+                    .tls_serialize_detached()
+                    .expect("Error serializing signature key."),
+                &psk_bundle,
+            )
             .expect("An unexpected error occured.");
     }
 

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, sync::RwLock};
 
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::{key_store::OpenMlsKeyStore, OpenMlsCryptoProvider};
+use tls_codec::Serialize;
 
 use crate::{
     ciphersuite::*, credentials::*, extensions::*, framing::MlsMessageIn, framing::*, group::*,
@@ -48,7 +49,12 @@ impl Client {
         let credential_bundle: CredentialBundle = self
             .crypto
             .key_store()
-            .read(credential.signature_key())
+            .read(
+                &credential
+                    .signature_key()
+                    .tls_serialize_detached()
+                    .expect("Error serializing signature key."),
+            )
             .ok_or(ClientError::NoMatchingCredential)?;
         let kpb = KeyPackageBundle::new(
             ciphersuites,
@@ -83,7 +89,12 @@ impl Client {
         let credential_bundle: CredentialBundle = self
             .crypto
             .key_store()
-            .read(credential.signature_key())
+            .read(
+                &credential
+                    .signature_key()
+                    .tls_serialize_detached()
+                    .expect("Error serializing signature key."),
+            )
             .ok_or(ClientError::NoMatchingCredential)?;
         let kpb = KeyPackageBundle::new(
             &[ciphersuite.name()],

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -142,7 +142,13 @@ impl MlsGroupTestSetup {
                 let credential = cb.credential().clone();
                 crypto
                     .key_store()
-                    .store(cb.credential().signature_key(), &cb)
+                    .store(
+                        &cb.credential()
+                            .signature_key()
+                            .tls_serialize_detached()
+                            .expect("Error serializing signature key."),
+                        &cb,
+                    )
                     .expect("An unexpected error occurred.");
                 credentials.insert(*ciphersuite, credential);
             }

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -24,7 +24,13 @@ fn generate_credential_bundle(
     let credential = credential_bundle.credential().clone();
     backend
         .key_store()
-        .store(credential.signature_key(), &credential_bundle)
+        .store(
+            &credential
+                .signature_key()
+                .tls_serialize_detached()
+                .expect("Error serializing signature key."),
+            &credential_bundle,
+        )
         .expect("An unexpected error occurred.");
     // ANCHOR_END: store_credential_bundle
     Ok(credential)
@@ -44,7 +50,12 @@ fn generate_key_package_bundle(
     // Fetch the credential bundle from the key store
     let credential_bundle = backend
         .key_store()
-        .read(credential.signature_key())
+        .read(
+            &credential
+                .signature_key()
+                .tls_serialize_detached()
+                .expect("Error serializing signature key."),
+        )
         .expect("An unexpected error occurred.");
 
     // Create the key package bundle

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -20,7 +20,13 @@ fn generate_credential_bundle(
     let credential = cb.credential().clone();
     backend
         .key_store()
-        .store(credential.signature_key(), &cb)
+        .store(
+            &credential
+                .signature_key()
+                .tls_serialize_detached()
+                .expect("Error serializing signature key."),
+            &cb,
+        )
         .expect("An unexpected error occurred.");
     Ok(credential)
 }
@@ -33,7 +39,12 @@ fn generate_key_package_bundle(
 ) -> Result<KeyPackage, KeyPackageError> {
     let credential_bundle = backend
         .key_store()
-        .read(credential.signature_key())
+        .read(
+            &credential
+                .signature_key()
+                .tls_serialize_detached()
+                .expect("Error serializing signature key."),
+        )
         .expect("An unexpected error occurred.");
     let kpb = KeyPackageBundle::new(ciphersuites, &credential_bundle, backend, extensions)?;
     let kp = kpb.key_package().clone();

--- a/traits/src/key_store.rs
+++ b/traits/src/key_store.rs
@@ -1,7 +1,6 @@
 //! # OpenMLS Key Store Trait
 
 use std::fmt::Debug;
-use std::hash::Hash;
 
 pub trait FromKeyStoreValue: Sized {
     type Error: Debug + Clone + PartialEq + Into<String>;
@@ -22,7 +21,7 @@ pub trait OpenMlsKeyStore: Send + Sync {
     /// serialization for ID `k`.
     ///
     /// Returns an error if storing fails.
-    fn store<K: Hash, V: ToKeyStoreValue>(&self, k: &K, v: &V) -> Result<(), Self::Error>
+    fn store<V: ToKeyStoreValue>(&self, k: &[u8], v: &V) -> Result<(), Self::Error>
     where
         Self: Sized;
 
@@ -30,12 +29,12 @@ pub trait OpenMlsKeyStore: Send + Sync {
     /// [`KeyStoreValue`] trait for deserialization.
     ///
     /// Returns [`None`] if no value is stored for `k` or reading fails.
-    fn read<K: Hash, V: FromKeyStoreValue>(&self, k: &K) -> Option<V>
+    fn read<V: FromKeyStoreValue>(&self, k: &[u8]) -> Option<V>
     where
         Self: Sized;
 
     /// Delete a value stored for ID `k`.
     ///
     /// Returns an error if storing fails.
-    fn delete<K: Hash>(&self, k: &K) -> Result<(), Self::Error>;
+    fn delete(&self, k: &[u8]) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
Note that the memory key store simply uses the provided bytes as key.
This is not recommended for production systems as this might get
large.

fixes #656