### PR TITLE
Review older PSK spec changes

### DIFF
--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -320,7 +320,7 @@ impl CoreGroup {
     // struct {
     //     PreSharedKeyID psk;
     // } PreSharedKey;
-    // TODO: #141
+    // TODO: #751
     #[cfg(test)]
     pub(crate) fn create_presharedkey_proposal(
         &self,

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -134,7 +134,7 @@ impl CoreGroup {
         )?;
 
         let serialized_group_context = group_context.tls_serialize_detached()?;
-        // TODO #141: Implement PSK
+        // TODO #751: Implement PSK
         key_schedule.add_context(backend, &serialized_group_context)?;
         let epoch_secrets = key_schedule.epoch_secrets(backend)?;
 

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -408,7 +408,7 @@ impl ProposalQueue {
                     proposal_pool.insert(queued_proposal.proposal_reference(), queued_proposal);
                 }
                 Proposal::ReInit(_) => {
-                    // TODO #141: Only keep one ReInit
+                    // TODO #751: Only keep one ReInit
                     proposal_pool.insert(queued_proposal.proposal_reference(), queued_proposal);
                 }
                 Proposal::ExternalInit(_) => {

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -18,7 +18,7 @@ impl MlsGroup {
         group_id: GroupId,
         key_package_hash: &[u8],
     ) -> Result<Self, MlsGroupError> {
-        // TODO #141
+        // TODO #751
         let kph = key_package_hash.to_vec();
         let key_package_bundle: KeyPackageBundle = backend
             .key_store()
@@ -72,7 +72,7 @@ impl MlsGroup {
                     .read(&egs.new_member.as_slice().to_vec())
             })
             .ok_or(MlsGroupError::NoMatchingKeyPackageBundle)?;
-        // TODO #141
+        // TODO #751
         let mut group =
             CoreGroup::new_from_welcome(welcome, ratchet_tree, key_package_bundle, backend)?;
         group.set_max_past_epochs(mls_group_config.max_past_epochs);

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -48,7 +48,7 @@ impl MlsGroup {
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all proposals
-        // TODO #141
+        // TODO #751
         let params = CreateCommitParams::builder()
             .framing_parameters(self.framing_parameters())
             .credential_bundle(&credential_bundle)
@@ -114,7 +114,7 @@ impl MlsGroup {
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all proposals
-        // TODO #141
+        // TODO #751
         let params = CreateCommitParams::builder()
             .framing_parameters(self.framing_parameters())
             .credential_bundle(&credential_bundle)

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -90,7 +90,7 @@ impl MlsGroup {
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all pending proposals
-        // TODO #141
+        // TODO #751
         let params = CreateCommitParams::builder()
             .framing_parameters(self.framing_parameters())
             .credential_bundle(&credential_bundle)

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -26,7 +26,7 @@ impl MlsGroup {
             .ok_or(MlsGroupError::NoMatchingCredentialBundle)?;
 
         // Create Commit over all proposals. If a `KeyPackageBundle` was passed
-        // in, use it to create an update proposal by value. TODO #141
+        // in, use it to create an update proposal by value. TODO #751
         let create_commit_result = match key_package_bundle_option {
             Some(kpb) => {
                 let update_proposal = Proposal::Update(UpdateProposal {

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -41,7 +41,7 @@ pub use crate::tree::SenderRatchetConfiguration;
 pub use crate::treesync::node::Node;
 
 // PSKs
-// TODO #141
+// TODO #751
 pub use crate::schedule::psk::{
     BranchPsk, ExternalPsk, PreSharedKeyId, PreSharedKeys, Psk, PskBundle, PskType, ReinitPsk,
 };

--- a/openmls/src/schedule/kat_key_schedule.rs
+++ b/openmls/src/schedule/kat_key_schedule.rs
@@ -34,7 +34,7 @@ struct Epoch {
     // Chosen by the generator
     tree_hash: String,
     commit_secret: String,
-    // XXX: PSK is not supported in OpenMLS yet #141
+    // XXX: PSK is not supported in OpenMLS yet #751
     psks: Vec<PskValue>,
     confirmed_transcript_hash: String,
 


### PR DESCRIPTION
I reviewed #141 and #284 and came to the conclusion that we already implemented all the changes. We even implemented some more recent changes regarding the PSK secrets and the key schedule.
The only part that is left is a public API to use PSKs with `MlsGroup`. I have created #751 for that and this is now mentioned in the code.

Fixes #141.
Fixes #284.