### PR TITLE
Drop local dependencies in crates

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,9 +13,9 @@ pretty_env_logger = "0.4"
 termion = "1.5"
 tls_codec = "0.2.0-pre.4"
 
-openmls = {features = ["test-utils"], version = "0.4.0-pre.1" }
-openmls_traits = "0.1.0-pre.1" 
-openmls_rust_crypto = "0.1.0-pre.1"
+openmls = {features = ["test-utils"], version = "0.4.0-pre.2" }
+openmls_traits = "0.1.0-pre.2" 
+openmls_rust_crypto = "0.1.0-pre.2"
 
 ds-lib = { path = "../delivery-service/ds-lib/" }
 
@@ -23,3 +23,4 @@ ds-lib = { path = "../delivery-service/ds-lib/" }
 openmls = { path = "../openmls" }
 openmls_traits = { path = "../traits" }
 openmls_rust_crypto = { path = "../openmls_rust_crypto" }
+openmls_memory_keystore = { path = "../memory_keystore" }

--- a/delivery-service/ds-lib/Cargo.toml
+++ b/delivery-service/ds-lib/Cargo.toml
@@ -7,11 +7,12 @@ description = "Types to interact with the OpenMLS DS."
 
 [dependencies]
 tls_codec = "0.2.0-pre.4"
-openmls = {features = ["test-utils"], version = "0.4.0-pre.1" }
-openmls_traits = "0.1.0-pre.1" 
-openmls_rust_crypto = "0.1.0-pre.1"
+openmls = {features = ["test-utils"], version = "0.4.0-pre.2" }
+openmls_traits = "0.1.0-pre.2" 
+openmls_rust_crypto = "0.1.0-pre.2"
 
 [patch.crates-io]
 openmls = { path = "../../openmls" }
 openmls_traits = { path = "../../traits" }
 openmls_rust_crypto = { path = "../../openmls_rust_crypto" }
+openmls_memory_keystore = { path = "../../memory_keystore" }

--- a/delivery-service/ds/Cargo.toml
+++ b/delivery-service/ds/Cargo.toml
@@ -20,9 +20,9 @@ clap = "2.33"
 base64 = "0.13"
 tls_codec = "0.2.0-pre.4"
 
-openmls = {features = ["test-utils"], version = "0.4.0-pre.1" }
-openmls_traits = "0.1.0-pre.1" 
-openmls_rust_crypto = "0.1.0-pre.1"
+openmls = {features = ["test-utils"], version = "0.4.0-pre.2" }
+openmls_traits = "0.1.0-pre.2" 
+openmls_rust_crypto = "0.1.0-pre.2"
 
 ds-lib = { path = "../ds-lib/" }
 
@@ -30,3 +30,4 @@ ds-lib = { path = "../ds-lib/" }
 openmls = { path = "../../openmls" }
 openmls_traits = { path = "../../traits" }
 openmls_rust_crypto = { path = "../../openmls_rust_crypto" }
+openmls_memory_keystore = { path = "../../memory_keystore" }

--- a/evercrypt_backend/Cargo.toml
+++ b/evercrypt_backend/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/openmls/openmls/tree/main/evercrypt_backend"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { version = "0.1.0-pre.1", path = "../traits" }
+openmls_traits = { version = "0.1.0-pre.1" }
 evercrypt = { version = "0.0.10", features = ["serialization"] }
-memory_keystore = { version = "0.1.0-pre.1", path = "../memory_keystore", package = "openmls_memory_keystore" }
+openmls_memory_keystore = { version = "0.1.0-pre.1" }
 rand = "0.8"
 rand_chacha = { version = "0.3" }
 hpke = { version = "0.1.0-pre.2", package = "hpke-rs", features = ["hazmat", "serialization"] }

--- a/evercrypt_backend/Cargo.toml
+++ b/evercrypt_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openmls_evercrypt"
 authors = ["OpenMLS Authors"]
-version = "0.1.0-pre.1"
+version = "0.1.0-pre.2"
 edition = "2018"
 description = "A crypto backend for OpenMLS implementing openmls_traits using HACL/Evercrypt."
 license = "MIT"
@@ -10,12 +10,16 @@ repository = "https://github.com/openmls/openmls/tree/main/evercrypt_backend"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { version = "0.1.0-pre.1" }
+openmls_traits = { version = "0.1.0-pre.2" }
 evercrypt = { version = "0.0.10", features = ["serialization"] }
-openmls_memory_keystore = { version = "0.1.0-pre.1" }
+openmls_memory_keystore = { version = "0.1.0-pre.2" }
 rand = "0.8"
 rand_chacha = { version = "0.3" }
 hpke = { version = "0.1.0-pre.2", package = "hpke-rs", features = ["hazmat", "serialization"] }
 log = { version = "0.4", features = ["std"] }
 hpke-rs-crypto = { version = "0.1.1-pre.2" }
 hpke-rs-evercrypt = { version = "0.1.1-pre.2" }
+
+[patch.crates-io]
+openmls_traits = { path = "../traits" }
+openmls_memory_keystore = { path = "../memory_keystore" }

--- a/evercrypt_backend/src/lib.rs
+++ b/evercrypt_backend/src/lib.rs
@@ -1,4 +1,4 @@
-use memory_keystore::MemoryKeyStore;
+use openmls_memory_keystore::MemoryKeyStore;
 use openmls_traits::OpenMlsCryptoProvider;
 
 mod provider;

--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openmls = {features = ["test-utils"], version = "0.4.0-pre.1" }
-openmls_traits = "0.1.0-pre.1" 
-openmls_rust_crypto = "0.1.0-pre.1"
+openmls = {features = ["test-utils"], version = "0.4.0-pre.2" }
+openmls_traits = "0.1.0-pre.2" 
+openmls_rust_crypto = "0.1.0-pre.2"
 tonic = "0.3"
 prost = "0.6"
 tokio = { version = "0.2", features = ["macros",  "net"] }
@@ -27,3 +27,4 @@ tonic-build = "0.3"
 openmls = { path = "../openmls" }
 openmls_traits = { path = "../traits" }
 openmls_rust_crypto = { path = "../openmls_rust_crypto" }
+openmls_memory_keystore = { path = "../memory_keystore" }

--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openmls = { path = "../openmls", features = ["test-utils"]}
+openmls = {features = ["test-utils"], version = "0.4.0-pre.1" }
+openmls_traits = "0.1.0-pre.1" 
+openmls_rust_crypto = "0.1.0-pre.1"
 tonic = "0.3"
 prost = "0.6"
 tokio = { version = "0.2", features = ["macros",  "net"] }
@@ -17,8 +19,11 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tls_codec = { version = "0.2.0-pre.4", features = ["derive", "serde_serialize"] }
 pretty_env_logger = "0.4"
-openmls_rust_crypto = { path = "../openmls_rust_crypto" }
-openmls_traits = { path = "../traits" }
 
 [build-dependencies]
 tonic-build = "0.3"
+
+[patch.crates-io]
+openmls = { path = "../openmls" }
+openmls_traits = { path = "../traits" }
+openmls_rust_crypto = { path = "../openmls_rust_crypto" }

--- a/memory_keystore/Cargo.toml
+++ b/memory_keystore/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/openmls/openmls/tree/main/memory_keystore"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { version = "0.1.0-pre.1", path = "../traits" }
+openmls_traits = { version = "0.1.0-pre.1" }

--- a/memory_keystore/Cargo.toml
+++ b/memory_keystore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openmls_memory_keystore"
 authors = ["OpenMLS Authors"]
-version = "0.1.0-pre.1"
+version = "0.1.0-pre.2"
 edition = "2018"
 description = "A very basic key store for OpenMLS implementing openmls_traits."
 license = "MIT"
@@ -10,4 +10,7 @@ repository = "https://github.com/openmls/openmls/tree/main/memory_keystore"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { version = "0.1.0-pre.1" }
+openmls_traits = { version = "0.1.0-pre.2" }
+
+[patch.crates-io]
+openmls_traits = { path = "../traits" }

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/openmls/openmls/"
 readme = "../README.md"
 
 [dependencies]
-openmls_traits = { version = "0.1.0-pre.1", path = "../traits" }
+openmls_traits = { version = "0.1.0-pre.1" }
 uuid = { version = "0.8", features = ["v4"] }
 lazy_static = "1.4"
 serde = { version = "^1.0", features = ["derive"] }
@@ -25,8 +25,8 @@ rand = { version = "0.8", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
 # Crypto backends required for KAT and testing - "test-utils" feature
 itertools = { version = "0.10", optional = true }
-openmls_rust_crypto = { version = "0.1.0-pre.1", path = "../openmls_rust_crypto", optional = true }
-evercrypt_backend = { version = "0.1.0-pre.1", path = "../evercrypt_backend", package = "openmls_evercrypt", optional = true }
+openmls_rust_crypto = { version = "0.1.0-pre.1", optional = true }
+openmls_evercrypt = { version = "0.1.0-pre.1", optional = true }
 rstest = {version = "^0.12", optional = true}
 rstest_reuse = {version = "^0.1", optional = true}
 rayon = "^1.5.0"
@@ -36,7 +36,7 @@ thiserror = "^1.0"
 default = []
 crypto-subtle = [] # Enable subtle crypto APIs that have to be used with care.
 test-utils = ["itertools", "openmls_rust_crypto", "rand", "rstest", "rstest_reuse"]
-evercrypt = ["evercrypt_backend"] # Evercrypt needs to be enabled individually
+evercrypt = ["openmls_evercrypt"] # Evercrypt needs to be enabled individually
 crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
 

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openmls"
-version = "0.4.0-pre.1"
+version = "0.4.0-pre.2"
 authors = ["OpenMLS Authors"]
 edition = "2021"
 description = "This is a WIP Rust implementation of the Messaging Layer Security (MLS) protocol based on draft 9+."
@@ -10,7 +10,7 @@ repository = "https://github.com/openmls/openmls/"
 readme = "../README.md"
 
 [dependencies]
-openmls_traits = { version = "0.1.0-pre.1" }
+openmls_traits = { version = "0.1.0-pre.2" }
 uuid = { version = "0.8", features = ["v4"] }
 lazy_static = "1.4"
 serde = { version = "^1.0", features = ["derive"] }
@@ -25,8 +25,8 @@ rand = { version = "0.8", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
 # Crypto backends required for KAT and testing - "test-utils" feature
 itertools = { version = "0.10", optional = true }
-openmls_rust_crypto = { version = "0.1.0-pre.1", optional = true }
-openmls_evercrypt = { version = "0.1.0-pre.1", optional = true }
+openmls_rust_crypto = { version = "0.1.0-pre.2", optional = true }
+openmls_evercrypt = { version = "0.1.0-pre.2", optional = true }
 rstest = {version = "^0.12", optional = true}
 rstest_reuse = {version = "^0.1", optional = true}
 rayon = "^1.5.0"
@@ -58,3 +58,9 @@ features = ["test-utils", "evercrypt"]
 [[bench]]
 name = "benchmark"
 harness = false
+
+[patch.crates-io]
+openmls_traits = { path = "../traits" }
+openmls_rust_crypto = { path = "../openmls_rust_crypto" }
+openmls_evercrypt = { path = "../evercrypt_backend" }
+openmls_memory_keystore = { path = "../memory_keystore" }

--- a/openmls/benches/benchmark.rs
+++ b/openmls/benches/benchmark.rs
@@ -49,7 +49,7 @@ fn kp_bundle_rust_crypto(c: &mut Criterion) {
 
 #[cfg(feature = "evercrypt")]
 fn kp_bundle_evercrypt(c: &mut Criterion) {
-    use evercrypt_backend::OpenMlsEvercrypt;
+    use openmls_evercrypt::OpenMlsEvercrypt;
     let backend = &OpenMlsEvercrypt::default();
     println!("Backend: Evercrypt");
     criterion_kp_bundle(c, backend);

--- a/openmls/fuzz/Cargo.toml
+++ b/openmls/fuzz/Cargo.toml
@@ -41,3 +41,9 @@ name = "proposal_decode"
 path = "fuzz_targets/proposal_decode.rs"
 test = false
 doc = false
+
+[patch.crates-io]
+openmls_traits = { path = "../../traits" }
+openmls_rust_crypto = { path = "../../openmls_rust_crypto" }
+openmls_evercrypt = { path = "../../evercrypt_backend" }
+openmls_memory_keystore = { path = "../../memory_keystore" }

--- a/openmls/src/test_utils/mod.rs
+++ b/openmls/src/test_utils/mod.rs
@@ -84,7 +84,7 @@ pub fn hex_to_bytes_option(hex: Option<String>) -> Vec<u8> {
     not(target_family = "wasm"),
     feature = "evercrypt",
 ))]
-pub use evercrypt_backend::OpenMlsEvercrypt;
+pub use openmls_evercrypt::OpenMlsEvercrypt;
 
 // This backend is currently used on all platforms
 pub use openmls_rust_crypto::OpenMlsRustCrypto;
@@ -115,7 +115,7 @@ pub fn backends(backend: &impl OpenMlsCryptoProvider) {}
 #[template]
 #[rstest(backend,
     case::rust_crypto(&OpenMlsRustCrypto::default()),
-    case::evercrypt(&evercrypt_backend::OpenMlsEvercrypt::default()),
+    case::evercrypt(&openmls_evercrypt::OpenMlsEvercrypt::default()),
   )
 ]
 pub fn backends(backend: &impl OpenMlsCryptoProvider) {}
@@ -170,9 +170,9 @@ pub fn ciphersuites_and_backends(
     case::rust_crypto_MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519(Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519).expect("Ciphersuite not supported."), &OpenMlsRustCrypto::default()),
     case::rust_crypto_MLS10_128_DHKEMP256_AES128GCM_SHA256_P256(Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256).expect("Ciphersuite not supported."), &OpenMlsRustCrypto::default()),
     case::rust_crypto_MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519(Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519).expect("Ciphersuite not supported."), &OpenMlsRustCrypto::default()),
-    case::evercrypt_MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519(Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519).expect("Ciphersuite not supported."), &evercrypt_backend::OpenMlsEvercrypt::default()),
-    case::evercrypt_MLS10_128_DHKEMP256_AES128GCM_SHA256_P256(Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256).expect("Ciphersuite not supported."), &evercrypt_backend::OpenMlsEvercrypt::default()),
-    case::evercrypt_MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519(Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519).expect("Ciphersuite not supported."), &evercrypt_backend::OpenMlsEvercrypt::default()),
+    case::evercrypt_MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519(Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519).expect("Ciphersuite not supported."), &openmls_evercrypt::OpenMlsEvercrypt::default()),
+    case::evercrypt_MLS10_128_DHKEMP256_AES128GCM_SHA256_P256(Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256).expect("Ciphersuite not supported."), &openmls_evercrypt::OpenMlsEvercrypt::default()),
+    case::evercrypt_MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519(Config::ciphersuite(CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519).expect("Ciphersuite not supported."), &openmls_evercrypt::OpenMlsEvercrypt::default()),
   )
 ]
 pub fn ciphersuites_and_backends(ciphersuite: &Ciphersuite, backend: &impl OpenMlsCryptoProvider) {}

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openmls_rust_crypto"
 authors = ["OpenMLS Authors"]
-version = "0.1.0-pre.1"
+version = "0.1.0-pre.2"
 edition = "2018"
 description = "A crypto backend for OpenMLS implementing openmls_traits using RustCrypto primitives."
 license = "MIT"
@@ -10,8 +10,8 @@ repository = "https://github.com/openmls/openmls/tree/main/openmls_rust_crypto"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { version = "0.1.0-pre.1" }
-openmls_memory_keystore = { version = "0.1.0-pre.1" }
+openmls_traits = { version = "0.1.0-pre.2" }
+openmls_memory_keystore = { version = "0.1.0-pre.2" }
 # Rust Crypto dependencies
 sha2 = { version = "0.10" }
 aes-gcm = { version = "0.9" }
@@ -26,3 +26,7 @@ rand_chacha = { version = "0.3" }
 hpke = { version = "0.1.0-pre.2", package = "hpke-rs", default-features = false, features = ["hazmat", "serialization"] }
 hpke-rs-crypto = { version = "0.1.1-pre.2" }
 hpke-rs-rust-crypto = { version = "0.1.1-pre.2" }
+
+[patch.crates-io]
+openmls_traits = { path = "../traits" }
+openmls_memory_keystore = { path = "../memory_keystore" }

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/openmls/openmls/tree/main/openmls_rust_crypto"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { version = "0.1.0-pre.1", path = "../traits" }
-memory_keystore = { version = "0.1.0-pre.1", path = "../memory_keystore", package = "openmls_memory_keystore" }
+openmls_traits = { version = "0.1.0-pre.1" }
+openmls_memory_keystore = { version = "0.1.0-pre.1" }
 # Rust Crypto dependencies
 sha2 = { version = "0.10" }
 aes-gcm = { version = "0.9" }

--- a/openmls_rust_crypto/src/lib.rs
+++ b/openmls_rust_crypto/src/lib.rs
@@ -3,7 +3,7 @@
 //! This is an implementation of the [`OpenMlsCryptoProvider`] trait to use with
 //! OpenMLS.
 
-use memory_keystore::MemoryKeyStore;
+use openmls_memory_keystore::MemoryKeyStore;
 use openmls_traits::OpenMlsCryptoProvider;
 
 mod provider;

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openmls_traits"
-version = "0.1.0-pre.1"
+version = "0.1.0-pre.2"
 authors = ["OpenMLS Authors"]
 edition = "2018"
 description = "Traits used by OpenMLS"


### PR DESCRIPTION
This drops the local dependencies in various crates, which should fix a dependency issue when using the crates from crates.io.