### PR TITLE
Introduce RemoveOperation

### DIFF
--- a/book/src/user_manual/processing.md
+++ b/book/src/user_manual/processing.md
@@ -57,3 +57,19 @@ Commit messages are returned as `StagedCommit` objects. The proposals they cover
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code.rs:inspect_staged_commit}}
 ```
+
+### Interpreting remove operations
+
+Remove operations can have different meanings, such as:
+
+- We left the group (by our own wish)
+- We were removed from the group (by another member or a pre-configured sender)
+- We removed another member from the group
+- Another member left the group (by its own wish)
+- Another member was removed from the group (by a member or a pre-configured sender, but not by us)
+
+Since all remove operations only appear as a `QueuedRemoveProposal`, the `RemoveOperation` enum can be constructed from the remove proposal and the current group state to refelect the different scenarios listed above.
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code.rs:remove_operation}}
+```

--- a/openmls/src/framing/mod.rs
+++ b/openmls/src/framing/mod.rs
@@ -28,6 +28,7 @@ pub(crate) use sender::*;
 
 // Public
 pub use message::*;
+pub use sender::*;
 pub use validation::*;
 
 // Tests

--- a/openmls/src/framing/sender.rs
+++ b/openmls/src/framing/sender.rs
@@ -114,6 +114,11 @@ impl Sender {
         self.sender_type == SenderType::NewMember
     }
 
+    /// Returns the [`SenderValue`]
+    pub fn sender_value(&self) -> &SenderValue {
+        &self.sender
+    }
+
     /// Get the sender a [`KeyPackageRef`].
     ///
     /// Returns a [`SenderError`] if this [`Sender`] is not a [`SenderType::Member`].

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -484,6 +484,7 @@ impl ProposalQueue {
 }
 
 /// A queued Add proposal
+#[derive(PartialEq, Debug)]
 pub struct QueuedAddProposal<'a> {
     add_proposal: &'a AddProposal,
     sender: &'a Sender,
@@ -502,6 +503,7 @@ impl<'a> QueuedAddProposal<'a> {
 }
 
 /// A queued Remove proposal
+#[derive(PartialEq, Debug)]
 pub struct QueuedRemoveProposal<'a> {
     remove_proposal: &'a RemoveProposal,
     sender: &'a Sender,
@@ -520,6 +522,7 @@ impl<'a> QueuedRemoveProposal<'a> {
 }
 
 /// A queued Update proposal
+#[derive(PartialEq, Debug)]
 pub struct QueuedUpdateProposal<'a> {
     update_proposal: &'a UpdateProposal,
     sender: &'a Sender,
@@ -538,6 +541,7 @@ impl<'a> QueuedUpdateProposal<'a> {
 }
 
 /// A queued PresharedKey proposal
+#[derive(PartialEq, Debug)]
 pub struct QueuedPskProposal<'a> {
     psk_proposal: &'a PreSharedKeyProposal,
     sender: &'a Sender,

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -16,6 +16,8 @@ use crate::{ciphersuite::hash_ref::KeyPackageRef, credentials::CredentialBundle}
 
 use openmls_traits::{key_store::OpenMlsKeyStore, OpenMlsCryptoProvider};
 
+use super::proposals::{ProposalStore, QueuedProposal};
+use super::staged_commit::StagedCommit;
 use crate::{
     ciphersuite::signable::Signable,
     credentials::Credential,
@@ -27,18 +29,21 @@ use crate::{
     messages::{proposals::*, Welcome},
     schedule::ResumptionSecret,
 };
-
+use ser::*;
 use std::io::{Error, Read, Write};
 
-pub use config::*;
-pub use errors::{
-    EmptyInputError, InvalidMessageError, MlsGroupError, PendingProposalsError, UseAfterEviction,
-};
+// Crate exports
 pub(crate) use resumption::ResumptionSecretStore;
-use ser::*;
 
-use super::proposals::{ProposalStore, QueuedProposal};
-use super::staged_commit::StagedCommit;
+// Public exports
+pub use {
+    config::*,
+    errors::{
+        EmptyInputError, InvalidMessageError, MlsGroupError, PendingProposalsError,
+        UseAfterEviction,
+    },
+    membership::RemoveOperation,
+};
 
 /// Pending Commit state. Differentiates between Commits issued by group members
 /// and External Commits.

--- a/openmls/src/group/tests/mod.rs
+++ b/openmls/src/group/tests/mod.rs
@@ -21,6 +21,8 @@ mod test_past_secrets;
 #[cfg(test)]
 mod test_proposal_validation;
 #[cfg(test)]
+mod test_remove_operation;
+#[cfg(test)]
 mod test_wire_format_policy;
 #[cfg(test)]
 pub(crate) mod utils;

--- a/openmls/src/group/tests/test_remove_operation.rs
+++ b/openmls/src/group/tests/test_remove_operation.rs
@@ -1,0 +1,316 @@
+//! This module tests the classification of remove operations with RemoveOperation
+
+use super::utils::{generate_credential_bundle, generate_key_package_bundle};
+use crate::{credentials::*, framing::*, group::*, test_utils::*, *};
+use openmls_rust_crypto::OpenMlsRustCrypto;
+
+// Tests the differen variants of the RemoveOperation enum.
+#[apply(ciphersuites_and_backends)]
+fn test_remove_operation_variants(
+    ciphersuite: &'static Ciphersuite,
+    backend: &impl OpenMlsCryptoProvider,
+) {
+    // We define two test cases, one where the member is removed by another member
+    // and one where the member leaves the group on its own
+    enum TestCase {
+        Remove,
+        Leave,
+    }
+
+    for test_case in [TestCase::Remove, TestCase::Leave] {
+        let group_id = GroupId::from_slice(b"Test Group");
+
+        // Generate credential bundles
+        let alice_credential = generate_credential_bundle(
+            "Alice".into(),
+            CredentialType::Basic,
+            ciphersuite.signature_scheme(),
+            backend,
+        )
+        .expect("An unexpected error occurred.");
+
+        let bob_credential = generate_credential_bundle(
+            "Bob".into(),
+            CredentialType::Basic,
+            ciphersuite.signature_scheme(),
+            backend,
+        )
+        .expect("An unexpected error occurred.");
+
+        let charlie_credential = generate_credential_bundle(
+            "Charlie".into(),
+            CredentialType::Basic,
+            ciphersuite.signature_scheme(),
+            backend,
+        )
+        .expect("An unexpected error occurred.");
+
+        // Generate KeyPackages
+        let alice_key_package =
+            generate_key_package_bundle(&[ciphersuite.name()], &alice_credential, vec![], backend)
+                .expect("An unexpected error occurred.");
+        let bob_key_package =
+            generate_key_package_bundle(&[ciphersuite.name()], &bob_credential, vec![], backend)
+                .expect("An unexpected error occurred.");
+        let charlie_key_package = generate_key_package_bundle(
+            &[ciphersuite.name()],
+            &charlie_credential,
+            vec![],
+            backend,
+        )
+        .expect("An unexpected error occurred.");
+
+        // Define the MlsGroup configuration
+        let mls_group_config = MlsGroupConfig::default();
+
+        // === Alice creates a group ===
+        let mut alice_group = MlsGroup::new(
+            backend,
+            &mls_group_config,
+            group_id,
+            alice_key_package
+                .hash_ref(backend.crypto())
+                .expect("Could not hash KeyPackage.")
+                .as_slice(),
+        )
+        .expect("An unexpected error occurred.");
+
+        // === Alice adds Bob & Charlie ===
+
+        // The new members are added sequentially because that way we can use the same key store for them
+        let (_message, welcome) = alice_group
+            .add_members(backend, &[bob_key_package])
+            .expect("An unexpected error occurred.");
+        alice_group
+            .merge_pending_commit()
+            .expect("error merging pending commit");
+
+        let mut bob_group = MlsGroup::new_from_welcome(
+            backend,
+            &mls_group_config,
+            welcome,
+            Some(alice_group.export_ratchet_tree()),
+        )
+        .expect("Error creating group from Welcome");
+
+        let (message, welcome) = alice_group
+            .add_members(backend, &[charlie_key_package])
+            .expect("An unexpected error occurred.");
+        alice_group
+            .merge_pending_commit()
+            .expect("error merging pending commit");
+
+        let unverified_message = bob_group
+            .parse_message(message.into(), backend)
+            .expect("Could not parse message.");
+        let bob_processed_message = bob_group
+            .process_unverified_message(unverified_message, None, backend)
+            .expect("Could not process unverified message.");
+
+        match bob_processed_message {
+            ProcessedMessage::StagedCommitMessage(bob_staged_commit) => {
+                bob_group
+                    .merge_staged_commit(*bob_staged_commit)
+                    .expect("An unexpected error occurred.");
+            }
+            _ => unreachable!(),
+        }
+
+        let mut charlie_group = MlsGroup::new_from_welcome(
+            backend,
+            &mls_group_config,
+            welcome,
+            Some(alice_group.export_ratchet_tree()),
+        )
+        .expect("Error creating group from Welcome");
+
+        // === Remove operation ===
+
+        let alice_kpr = *alice_group
+            .key_package_ref()
+            .expect("An unexpected error occurred.");
+        let bob_kpr = *bob_group
+            .key_package_ref()
+            .expect("An unexpected error occurred.");
+
+        // We differentiate between th two test cases here
+        let (message, _welcome) = match test_case {
+            // Alice removes Bob
+            TestCase::Remove => alice_group
+                .remove_members(backend, &[bob_kpr])
+                .expect("Could not remove members."),
+            // Bob leaves
+            TestCase::Leave => {
+                // Bob leaves the group
+                let message = bob_group
+                    .leave_group(backend)
+                    .expect("Could not leave group.");
+
+                // Alice & Charlie store the pending proposal
+                for group in [&mut alice_group, &mut charlie_group] {
+                    let unverified_message = group
+                        .parse_message(message.clone().into(), backend)
+                        .expect("Could not parse message.");
+                    let processed_message = group
+                        .process_unverified_message(unverified_message, None, backend)
+                        .expect("Could not process unverified message.");
+
+                    match processed_message {
+                        ProcessedMessage::ProposalMessage(proposal) => {
+                            group.store_pending_proposal(*proposal);
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+
+                // Alice commits to Bob's proposal
+                alice_group
+                    .commit_to_pending_proposals(backend)
+                    .expect("An unexpected error occurred.")
+            }
+        };
+
+        // === Remove operation from Alice's perspective ===
+
+        let alice_staged_commit = alice_group.pending_commit().expect("No pending commit.");
+
+        let remove_proposal = alice_staged_commit
+            .remove_proposals()
+            .next()
+            .expect("An unexpected error occurred.");
+
+        let remove_operation = RemoveOperation::new(remove_proposal, &alice_group)
+            .expect("An unexpected Error occurred.");
+
+        match test_case {
+            TestCase::Remove => {
+                // We expect this variant, since Alice removed Bob
+                match remove_operation {
+                    RemoveOperation::WeRemovedThem(removed) => {
+                        // Check that it was indeed Bob who was removed
+                        assert_eq!(removed, bob_kpr);
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            TestCase::Leave => {
+                // We expect this variant, since Bob left
+                match remove_operation {
+                    RemoveOperation::TheyLeft(removed) => {
+                        // Check that it was indeed Bob who left
+                        assert_eq!(removed, bob_kpr);
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        // === Remove operation from Bob's perspective ===
+
+        let unverified_message = bob_group
+            .parse_message(message.clone().into(), backend)
+            .expect("Could not parse message.");
+        let bob_processed_message = bob_group
+            .process_unverified_message(unverified_message, None, backend)
+            .expect("Could not process unverified message.");
+
+        match bob_processed_message {
+            ProcessedMessage::StagedCommitMessage(bob_staged_commit) => {
+                let remove_proposal = bob_staged_commit
+                    .remove_proposals()
+                    .next()
+                    .expect("An unexpected error occurred.");
+
+                let remove_operation = RemoveOperation::new(remove_proposal, &bob_group)
+                    .expect("An unexpected Error occurred.");
+
+                match test_case {
+                    TestCase::Remove => {
+                        // We expect this variant, since Alice removed Bob
+                        match remove_operation {
+                            RemoveOperation::WeWereRemovedBy(sender) => {
+                                // Make sure Alice is indeed a member
+                                assert!(sender.is_member());
+                                // Check Bob was removed
+                                assert!(bob_staged_commit.self_removed());
+                                match sender.sender_value() {
+                                    SenderValue::Member(member) => {
+                                        // Check that it was Alice who removed Bob
+                                        assert_eq!(member, &alice_kpr);
+                                    }
+                                    _ => unreachable!(),
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                    TestCase::Leave => {
+                        // We expect this variant, since Bob left
+                        match remove_operation {
+                            RemoveOperation::WeLeft => {
+                                // Check that Bob is no longer part of the group
+                                assert!(bob_staged_commit.self_removed());
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        // === Remove operation from Charlie's perspective ===
+
+        let unverified_message = charlie_group
+            .parse_message(message.into(), backend)
+            .expect("Could not parse message.");
+        let charlie_processed_message = charlie_group
+            .process_unverified_message(unverified_message, None, backend)
+            .expect("Could not process unverified message.");
+
+        match charlie_processed_message {
+            ProcessedMessage::StagedCommitMessage(charlie_staged_commit) => {
+                let remove_proposal = charlie_staged_commit
+                    .remove_proposals()
+                    .next()
+                    .expect("An unexpected error occurred.");
+
+                let remove_operation = RemoveOperation::new(remove_proposal, &charlie_group)
+                    .expect("An unexpected Error occurred.");
+
+                match test_case {
+                    TestCase::Remove => {
+                        // We expect this variant, since Alice removed Bob
+                        match remove_operation {
+                            RemoveOperation::TheyWereRemovedBy((removed, sender)) => {
+                                // Make sure Alice is indeed a member
+                                assert!(sender.is_member());
+                                // Check that it was indeed Bob who was removed
+                                assert_eq!(removed, bob_kpr);
+                                match sender.sender_value() {
+                                    SenderValue::Member(member) => {
+                                        // Check that it was Alice who removed Bob
+                                        assert_eq!(member, &alice_kpr);
+                                    }
+                                    _ => unreachable!(),
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                    TestCase::Leave => {
+                        // We expect this variant, since Bob left
+                        match remove_operation {
+                            RemoveOperation::TheyLeft(removed) => {
+                                // Check that it was indeed Bob who left
+                                assert_eq!(removed, bob_kpr);
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/openmls/src/group/tests/test_remove_operation.rs
+++ b/openmls/src/group/tests/test_remove_operation.rs
@@ -133,7 +133,7 @@ fn test_remove_operation_variants(
             .key_package_ref()
             .expect("An unexpected error occurred.");
 
-        // We differentiate between th two test cases here
+        // We differentiate between the two test cases here
         let (message, _welcome) = match test_case {
             // Alice removes Bob
             TestCase::Remove => alice_group

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -26,7 +26,7 @@ pub use crate::config::*;
 pub use crate::extensions::*;
 
 // Framing
-pub use crate::framing::{message::*, validation::*};
+pub use crate::framing::{message::*, sender::*, validation::*};
 
 // Key packages
 pub use crate::key_packages::*;

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -642,8 +642,7 @@ fn book_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
 
     assert!(alice_members
         .iter()
-        .find(|&kp| kp.credential() == sender_credential)
-        .is_some());
+        .any(|kp| kp.credential() == sender_credential));
 
     assert_eq!(sender_credential, &charlie_credential);
 
@@ -698,29 +697,32 @@ fn book_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
         unreachable!("Expected a StagedCommit.");
     }
 
-    // Check that we receive the correct proposal for Alice
+    // Check that we receive the correct proposal for Bob
+    // ANCHOR: remove_operation
     if let ProcessedMessage::StagedCommitMessage(staged_commit) = bob_processed_message {
-        let remove = staged_commit
+        let remove_proposal = staged_commit
             .remove_proposals()
             .next()
-            .expect("Expected a proposal.");
-        // Check that Bob was removed
-        // TODO #575: Replace this with the adequate API call
-        assert_eq!(
-            remove.remove_proposal().removed(),
-            bob_group
-                .key_package_ref()
-                .expect("An unexpected error occurred.")
-        );
-        // Check that Charlie removed Bob
-        // TODO #575: Replace this with the adequate API call
-        assert_eq!(
-            remove
-                .sender()
-                .as_key_package_ref()
-                .expect("An unexpected error occurred."),
-            &charlies_old_kpr
-        );
+            .expect("An unexpected error occurred.");
+
+        // We construct a RemoveOperation enum to help us interpret the remove operation
+        let remove_operation = RemoveOperation::new(remove_proposal, &bob_group)
+            .expect("An unexpected Error occurred.");
+
+        match remove_operation {
+            RemoveOperation::WeLeft => unreachable!(),
+            // We expect this variant, since Bob was removed by Charlie
+            RemoveOperation::WeWereRemovedBy(member) => {
+                assert_eq!(
+                    member.sender_value(),
+                    &SenderValue::Member(charlies_old_kpr)
+                );
+            }
+            RemoveOperation::TheyLeft(_) => unreachable!(),
+            RemoveOperation::TheyWereRemovedBy(_) => unreachable!(),
+            RemoveOperation::WeRemovedThem(_) => unreachable!(),
+        }
+
         // Merge staged Commit
         bob_group
             .merge_staged_commit(*staged_commit)
@@ -728,6 +730,7 @@ fn book_operations(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
     } else {
         unreachable!("Expected a StagedCommit.");
     }
+    // ANCHOR_END: remove_operation
 
     // Check we didn't receive a Welcome message
     assert!(welcome_option.is_none());


### PR DESCRIPTION
This PR introduces the `RemoveOperation` `enum` that helps interpret the semantic value of a remove proposal when inspecting proposals that are covered by a Commit.

Fixes #623.