### PR TITLE
Error cleanup 2

### DIFF
--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -44,8 +44,7 @@ fn codec_plaintext(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCryp
             .expect("An unexpected error occurred."),
     ));
     let group_context =
-        GroupContext::new(GroupId::random(backend), GroupEpoch(1), vec![], vec![], &[])
-            .expect("An unexpected error occurred.");
+        GroupContext::new(GroupId::random(backend), GroupEpoch(1), vec![], vec![], &[]);
 
     let serialized_context = group_context
         .tls_serialize_detached()
@@ -101,8 +100,7 @@ fn codec_ciphertext(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCry
         vec![],
         vec![],
         &[],
-    )
-    .expect("An unexpected error occurred.");
+    );
 
     let serialized_context = group_context
         .tls_serialize_detached()
@@ -188,8 +186,7 @@ fn wire_format_checks(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsC
         vec![],
         vec![],
         &[],
-    )
-    .expect("An unexpected error occurred.");
+    );
 
     let serialized_context = group_context
         .tls_serialize_detached()
@@ -330,8 +327,7 @@ fn membership_tag(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
     )
     .expect("An unexpected error occurred.");
     let group_context =
-        GroupContext::new(GroupId::random(backend), GroupEpoch(1), vec![], vec![], &[])
-            .expect("An unexpected error occurred.");
+        GroupContext::new(GroupId::random(backend), GroupEpoch(1), vec![], vec![], &[]);
     let membership_key = MembershipKey::from_secret(
         Secret::random(ciphersuite, backend, None /* MLS version */)
             .expect("Not enough randomness."),

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -222,7 +222,7 @@ impl CoreGroup {
             tree_hash.clone(),
             confirmed_transcript_hash.clone(),
             self.group_context.extensions(),
-        )?;
+        );
 
         let joiner_secret = JoinerSecret::new(
             backend,

--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -30,10 +30,11 @@ impl CoreGroup {
         params: CreateCommitParams,
         tree_option: Option<&[Option<Node>]>,
         verifiable_public_group_state: VerifiablePublicGroupState,
-    ) -> Result<ExternalCommitResult, CoreGroupError> {
-        let ciphersuite = Config::ciphersuite(verifiable_public_group_state.ciphersuite())?;
+    ) -> Result<ExternalCommitResult, ExternalCommitError> {
+        let ciphersuite = Config::ciphersuite(verifiable_public_group_state.ciphersuite())
+            .map_err(|_| ExternalCommitError::UnsupportedCiphersuite)?;
         if !Config::supported_versions().contains(&verifiable_public_group_state.version()) {
-            return Err(ExternalCommitError::UnsupportedMlsVersion.into());
+            return Err(ExternalCommitError::UnsupportedMlsVersion);
         }
 
         // Build the ratchet tree
@@ -45,22 +46,35 @@ impl CoreGroup {
         let extension_tree_option = try_nodes_from_extensions(
             verifiable_public_group_state.other_extensions(),
             backend.crypto(),
-        )?;
+        )
+        .map_err(|e| match e {
+            ExtensionError::DuplicateRatchetTreeExtension => {
+                ExternalCommitError::DuplicateRatchetTreeExtension
+            }
+            _ => LibraryError::custom("Unexpected extension error").into(),
+        })?;
         let (nodes, enable_ratchet_tree_extension) = match extension_tree_option {
             Some(nodes) => (nodes, true),
             None => match tree_option {
                 Some(n) => (n.into(), false),
-                None => return Err(ExternalCommitError::MissingRatchetTree.into()),
+                None => return Err(ExternalCommitError::MissingRatchetTree),
             },
         };
 
         // Create a RatchetTree from the given nodes. We have to do this before
         // verifying the PGS, since we need to find the Credential to verify the
         // signature against.
-        let treesync = TreeSync::from_nodes_without_leaf(backend, ciphersuite, nodes)?;
+        let treesync = TreeSync::from_nodes_without_leaf(backend, ciphersuite, nodes).map_err(
+            |e| match e {
+                TreeSyncFromNodesError::LibraryError(e) => e.into(),
+                TreeSyncFromNodesError::PublicTreeError(e) => {
+                    ExternalCommitError::PublicTreeError(e)
+                }
+            },
+        )?;
 
         if treesync.tree_hash() != verifiable_public_group_state.tree_hash() {
-            return Err(ExternalCommitError::TreeHashMismatch.into());
+            return Err(ExternalCommitError::TreeHashMismatch);
         }
 
         // FIXME #680: Validation of external commits
@@ -69,10 +83,12 @@ impl CoreGroup {
             .ok_or(ExternalCommitError::UnknownSender)?
             .key_package()
             .credential();
-        let pgs: PublicGroupState =
-            verifiable_public_group_state.verify(backend, pgs_signer_credential)?;
+        let pgs: PublicGroupState = verifiable_public_group_state
+            .verify(backend, pgs_signer_credential)
+            .map_err(|_| ExternalCommitError::InvalidPublicGroupStateSignature)?;
 
-        let (init_secret, kem_output) = InitSecret::from_public_group_state(backend, &pgs)?;
+        let (init_secret, kem_output) = InitSecret::from_public_group_state(backend, &pgs)
+            .map_err(|_| ExternalCommitError::UnsupportedCiphersuite)?;
 
         let group_context = GroupContext::new(
             pgs.group_id,
@@ -80,15 +96,20 @@ impl CoreGroup {
             pgs.tree_hash.as_slice().to_vec(),
             pgs.confirmed_transcript_hash.into(),
             pgs.group_context_extensions.as_slice(),
-        )?;
+        );
 
         // The `EpochSecrets` we create here are essentially zero, with the
         // exception of the `InitSecret`, which is all we need here for the
         // external commit.
-        let epoch_secrets = EpochSecrets::with_init_secret(backend, init_secret)?;
+        let epoch_secrets = EpochSecrets::with_init_secret(backend, init_secret)
+            .map_err(LibraryError::unexpected_crypto_error)?;
         let (group_epoch_secrets, message_secrets) = epoch_secrets.split_secrets(
-            group_context.tls_serialize_detached()?,
-            treesync.leaf_count()?,
+            group_context
+                .tls_serialize_detached()
+                .map_err(LibraryError::missing_bound_check)?,
+            treesync
+                .leaf_count()
+                .map_err(|_| LibraryError::custom("The tree was too big"))?,
             // We use a fake own index of 0 here, as we're not going to use the
             // tree for encryption until after the first commit. This issue is
             // tracked in #767.

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -25,14 +25,15 @@ impl CoreGroup {
         }
 
         let ciphersuite_name = welcome.ciphersuite();
-        let ciphersuite = Config::ciphersuite(ciphersuite_name)?;
+        let ciphersuite = Config::ciphersuite(ciphersuite_name)
+            .map_err(|_| WelcomeError::UnsupportedCiphersuite)?;
 
         // Find key_package in welcome secrets
         let egs = if let Some(egs) = Self::find_key_package_from_welcome_secrets(
             key_package_bundle.key_package(),
             welcome.secrets(),
             backend,
-        )? {
+        ) {
             egs
         } else {
             return Err(WelcomeError::JoinerSecretNotFound);
@@ -43,32 +44,45 @@ impl CoreGroup {
             return Err(e);
         }
 
-        let group_secrets_bytes = backend.crypto().hpke_open(
-            ciphersuite.hpke_config(),
-            &egs.encrypted_group_secrets,
-            key_package_bundle.private_key().as_slice(),
-            &[],
-            &[],
-        )?;
-        let group_secrets = GroupSecrets::tls_deserialize(&mut group_secrets_bytes.as_slice())?
+        let group_secrets_bytes = backend
+            .crypto()
+            .hpke_open(
+                ciphersuite.hpke_config(),
+                &egs.encrypted_group_secrets,
+                key_package_bundle.private_key().as_slice(),
+                &[],
+                &[],
+            )
+            .map_err(|_| WelcomeError::CouldNotDecrypt)?;
+        let group_secrets = GroupSecrets::tls_deserialize(&mut group_secrets_bytes.as_slice())
+            .map_err(|_| WelcomeError::MalformedWelcomeMessage)?
             .config(ciphersuite, mls_version);
         let joiner_secret = group_secrets.joiner_secret;
 
         // Prepare the PskSecret
-        let psk_secret = PskSecret::new(ciphersuite, backend, group_secrets.psks.psks())?;
+        let psk_secret = PskSecret::new(ciphersuite, backend, group_secrets.psks.psks()).map_err(
+            |e| match e {
+                PskSecretError::LibraryError(e) => e.into(),
+                PskSecretError::TooManyKeys => WelcomeError::PskTooManyKeys,
+                PskSecretError::KeyNotFound => WelcomeError::PskNotFound,
+            },
+        )?;
 
         // Create key schedule
         let mut key_schedule = KeySchedule::init(ciphersuite, backend, joiner_secret, psk_secret)?;
 
         // Derive welcome key & nonce from the key schedule
         let (welcome_key, welcome_nonce) = key_schedule
-            .welcome(backend)?
-            .derive_welcome_key_nonce(backend)?;
+            .welcome(backend)
+            .map_err(|_| LibraryError::custom("Using the key schedule in the wrong state"))?
+            .derive_welcome_key_nonce(backend)
+            .map_err(LibraryError::unexpected_crypto_error)?;
 
         let group_info_bytes = welcome_key
             .aead_open(backend, welcome.encrypted_group_info(), &[], &welcome_nonce)
             .map_err(|_| WelcomeError::GroupInfoDecryptionFailure)?;
-        let group_info = GroupInfo::tls_deserialize(&mut group_info_bytes.as_slice())?;
+        let group_info = GroupInfo::tls_deserialize(&mut group_info_bytes.as_slice())
+            .map_err(|_| WelcomeError::MalformedWelcomeMessage)?;
 
         // Make sure that we can support the required capabilities in the group info.
         let group_context_extensions = group_info.group_context_extensions();
@@ -76,14 +90,17 @@ impl CoreGroup {
             .iter()
             .find(|&extension| extension.extension_type() == ExtensionType::RequiredCapabilities);
         if let Some(required_capabilities) = required_capabilities {
-            let required_capabilities =
-                required_capabilities.as_required_capabilities_extension()?;
-            check_required_capabilities_support(required_capabilities)?;
+            let required_capabilities = required_capabilities
+                .as_required_capabilities_extension()
+                .map_err(|_| LibraryError::custom("Expected required capabilities extension"))?;
+            check_required_capabilities_support(required_capabilities)
+                .map_err(|_| WelcomeError::UnsupportedCapability)?;
             // Also check that our key package actually supports the extensions.
             // Per spec the sender must have checked this. But you never know.
             key_package_bundle
                 .key_package()
-                .check_extension_support(required_capabilities.extensions())?
+                .check_extension_support(required_capabilities.extensions())
+                .map_err(|_| WelcomeError::UnsupportedExtensions)?
         }
 
         let path_secret_option = group_secrets.path_secret;
@@ -95,7 +112,13 @@ impl CoreGroup {
         // this group. Note that this is not strictly necessary. But there's
         // currently no other mechanism to enable the extension.
         let (nodes, enable_ratchet_tree_extension) =
-            match try_nodes_from_extensions(group_info.other_extensions(), backend.crypto())? {
+            match try_nodes_from_extensions(group_info.other_extensions(), backend.crypto())
+                .map_err(|e| match e {
+                    ExtensionError::DuplicateRatchetTreeExtension => {
+                        WelcomeError::DuplicateRatchetTreeExtension
+                    }
+                    _ => LibraryError::custom("Unexpected extension error").into(),
+                })? {
                 Some(nodes) => (nodes, true),
                 None => match nodes_option {
                     Some(n) => (n, false),
@@ -112,7 +135,11 @@ impl CoreGroup {
             group_info.signer(),
             path_secret_option,
             key_package_bundle,
-        )?;
+        )
+        .map_err(|e| match e {
+            TreeSyncFromNodesError::LibraryError(e) => e.into(),
+            TreeSyncFromNodesError::PublicTreeError(e) => WelcomeError::PublicTreeError(e),
+        })?;
 
         let signer_key_package = tree
             .leaf_from_id(group_info.signer())
@@ -131,22 +158,30 @@ impl CoreGroup {
             tree.tree_hash().to_vec(),
             group_info.confirmed_transcript_hash().to_vec(),
             group_context_extensions,
-        )?;
+        );
 
-        let serialized_group_context = group_context.tls_serialize_detached()?;
+        let serialized_group_context = group_context
+            .tls_serialize_detached()
+            .map_err(LibraryError::missing_bound_check)?;
         // TODO #751: Implement PSK
-        key_schedule.add_context(backend, &serialized_group_context)?;
-        let epoch_secrets = key_schedule.epoch_secrets(backend)?;
+        key_schedule
+            .add_context(backend, &serialized_group_context)
+            .map_err(|_| LibraryError::custom("Using the key schedule in the wrong state"))?;
+        let epoch_secrets = key_schedule
+            .epoch_secrets(backend)
+            .map_err(|_| LibraryError::custom("Using the key schedule in the wrong state"))?;
 
         let (group_epoch_secrets, message_secrets) = epoch_secrets.split_secrets(
             serialized_group_context,
-            tree.leaf_count()?,
+            tree.leaf_count()
+                .map_err(|_| LibraryError::custom("The tree was too big"))?,
             tree.own_leaf_index(),
         );
 
         let confirmation_tag = message_secrets
             .confirmation_key()
-            .tag(backend, group_context.confirmed_transcript_hash())?;
+            .tag(backend, group_context.confirmed_transcript_hash())
+            .map_err(LibraryError::unexpected_crypto_error)?;
         let interim_transcript_hash = update_interim_transcript_hash(
             ciphersuite,
             backend,
@@ -182,12 +217,14 @@ impl CoreGroup {
         key_package: &KeyPackage,
         welcome_secrets: &[EncryptedGroupSecrets],
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<Option<EncryptedGroupSecrets>, KeyPackageError> {
+    ) -> Option<EncryptedGroupSecrets> {
         for egs in welcome_secrets {
-            if key_package.hash_ref(backend.crypto())?.as_slice() == egs.new_member.as_slice() {
-                return Ok(Some(egs.clone()));
+            if let Ok(hash_ref) = key_package.hash_ref(backend.crypto()) {
+                if hash_ref == egs.new_member {
+                    return Some(egs.clone());
+                }
             }
         }
-        Ok(None)
+        None
     }
 }

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -253,7 +253,7 @@ impl CoreGroup {
             diff.compute_tree_hashes(backend, ciphersuite)?,
             confirmed_transcript_hash.clone(),
             self.group_context.extensions(),
-        )?;
+        );
 
         // Prepare the PskSecret
         let psk_secret = PskSecret::new(

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -182,7 +182,7 @@ fn test_failed_groupinfo_decryption(
         let error = CoreGroup::new_from_welcome(broken_welcome, None, key_package_bundle, backend)
             .expect_err("Creation of core group from a broken Welcome was successful.");
 
-        assert_eq!(error, WelcomeError::CouldNotDecrypt)
+        assert_eq!(error, WelcomeError::UnableToDecrypt)
     }
 }
 

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -17,7 +17,7 @@ use crate::{
     messages::*,
     schedule::psk::*,
     test_utils::*,
-    treesync::{diff::TreeSyncDiffError, treekem::TreeKemError},
+    treesync::{errors::TreeSyncDiffError, treekem::TreeKemError},
 };
 
 #[apply(ciphersuites_and_backends)]
@@ -182,10 +182,7 @@ fn test_failed_groupinfo_decryption(
         let error = CoreGroup::new_from_welcome(broken_welcome, None, key_package_bundle, backend)
             .expect_err("Creation of core group from a broken Welcome was successful.");
 
-        assert_eq!(
-            error,
-            WelcomeError::CryptoError(CryptoError::HpkeDecryptionError)
-        )
+        assert_eq!(error, WelcomeError::CouldNotDecrypt)
     }
 }
 

--- a/openmls/src/group/core_group/test_duplicate_extension.rs
+++ b/openmls/src/group/core_group/test_duplicate_extension.rs
@@ -103,7 +103,6 @@ fn duplicate_ratchet_tree_extension(
         welcome.secrets(),
         backend,
     )
-    .expect("Could not hash KeyPackage.")
     .expect("JoinerSecret not found");
 
     let group_secrets_bytes = backend
@@ -172,6 +171,6 @@ fn duplicate_ratchet_tree_extension(
     // We expect an error because the ratchet tree is duplicated
     assert_eq!(
         error.expect("We expected an error"),
-        WelcomeError::ExtensionError(ExtensionError::DuplicateRatchetTreeExtension)
+        WelcomeError::DuplicateRatchetTreeExtension
     );
 }

--- a/openmls/src/group/core_group/test_duplicate_extension.rs
+++ b/openmls/src/group/core_group/test_duplicate_extension.rs
@@ -99,9 +99,11 @@ fn duplicate_ratchet_tree_extension(
 
     // Find key_package in welcome secrets
     let egs = CoreGroup::find_key_package_from_welcome_secrets(
-        bob_key_package_bundle.key_package(),
+        bob_key_package_bundle
+            .key_package()
+            .hash_ref(backend.crypto())
+            .expect("An unexpected error occurred."),
         welcome.secrets(),
-        backend,
     )
     .expect("JoinerSecret not found");
 

--- a/openmls/src/group/core_group/test_proposals.rs
+++ b/openmls/src/group/core_group/test_proposals.rs
@@ -95,8 +95,7 @@ fn proposal_queue_functions(
     assert!(alice_update_key_package.verify(backend).is_ok());
 
     let group_context =
-        GroupContext::new(GroupId::random(backend), GroupEpoch(0), vec![], vec![], &[])
-            .expect("Could not create new GroupContext");
+        GroupContext::new(GroupId::random(backend), GroupEpoch(0), vec![], vec![], &[]);
 
     // Let's create some proposals
     let add_proposal_alice1 = AddProposal {
@@ -247,8 +246,7 @@ fn proposal_queue_order(ciphersuite: &'static Ciphersuite, backend: &impl OpenMl
     assert!(alice_update_key_package.verify(backend).is_ok());
 
     let group_context =
-        GroupContext::new(GroupId::random(backend), GroupEpoch(0), vec![], vec![], &[])
-            .expect("An unexpected error occurred.");
+        GroupContext::new(GroupId::random(backend), GroupEpoch(0), vec![], vec![], &[]);
 
     // Let's create some proposals
     let add_proposal_alice1 = AddProposal {

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -108,7 +108,7 @@ pub enum WelcomeError {
     #[error("Malformed Welcome message.")]
     MalformedWelcomeMessage,
     #[error("Could not decrypt the Welcome message.")]
-    CouldNotDecrypt,
+    UnableToDecrypt,
     #[error("Unsupported extensions found in the KeyPackage of another member.")]
     UnsupportedExtensions,
     #[error("A duplicate ratchet tree was found.")]
@@ -282,14 +282,14 @@ pub enum ExternalCommitValidationError {
     MultipleExternalInitProposals,
     #[error("Found inline Add or Update proposals.")]
     InvalidInlineProposals,
-    // FIXME: this seems unused
+    // TODO #803: this seems unused
     #[error("Found multiple inline Remove proposals.")]
     MultipleRemoveProposals,
     #[error("Remove proposal targets the wrong group member.")]
     InvalidRemoveProposal,
     #[error("Found an ExternalInit proposal among the referenced proposals.")]
     ReferencedExternalInitProposal,
-    // FIXME: this seems unused
+    // TODO #803: this seems unused
     #[error("External Commit has to contain a path.")]
     NoPath,
     #[error("The remove proposal referenced a non-existing member.")]

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -161,9 +161,9 @@ pub enum StageCommitError {
     PathKeyPackageVerificationFailure,
     #[error("Unable to determine commit path.")]
     RequiredPathNotFound,
-    #[error("Confirmation Tag is missing.")]
+    #[error("The confirmation Tag is missing.")]
     ConfirmationTagMissing,
-    #[error("Confirmation tag is invalid.")]
+    #[error("The confirmation tag is invalid.")]
     ConfirmationTagMismatch,
     #[error("The proposal queue is missing a proposal for the commit.")]
     MissingProposal,

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -8,269 +8,232 @@ use crate::{
     credentials::CredentialError,
     error::LibraryError,
     extensions::errors::ExtensionError,
-    framing::errors::{
-        MlsCiphertextError, MlsPlaintextError, SenderError, ValidationError, VerificationError,
-    },
+    framing::errors::{MlsCiphertextError, MlsPlaintextError, SenderError, ValidationError},
     key_packages::KeyPackageError,
     schedule::{KeyScheduleError, PskSecretError},
-    treesync::{diff::TreeSyncDiffError, treekem::TreeKemError, TreeSyncError},
+    treesync::{errors::*, treekem::TreeKemError, TreeSyncError},
 };
 use openmls_traits::types::CryptoError;
+use thiserror::Error;
 use tls_codec::Error as TlsCodecError;
 
-use thiserror::Error;
+// === Public errors ===
 
-implement_error! {
-    pub enum CoreGroupError {
-        Simple {
-            MissingKeyPackageBundle =
-                "Couldn't find KeyPackageBundle corresponding to own update proposal.",
-            NoSignatureKey = "No signature key was found.",
-            OwnCommitError = "Can't process a commit created by the owner of the group. Please merge the [`StagedCommit`] returned by `create_commit` instead.",
-        }
-        Complex {
-            LibraryError(LibraryError) = "A LibraryError occurred.",
-            MlsCiphertextError(MlsCiphertextError) =
-                "See [`MlsCiphertextError`](`crate::framing::errors::MlsCiphertextError`) for details.",
-            MlsPlaintextError(MlsPlaintextError) =
-                "See [`MlsPlaintextError`](`crate::framing::errors::MlsPlaintextError`) for details.",
-            WelcomeError(WelcomeError) =
-                "See [`WelcomeError`](`WelcomeError`) for details.",
-            ExternalCommitError(ExternalCommitError) =
-                "See [`Externaallow(lint)`](`ExternalInitError`) for details.",
-            StageCommitError(StageCommitError) =
-                "See [`StageCommitError`](`StageCommitError`) for details.",
-            CreateCommitError(CreateCommitError) =
-                "See [`CreateCommitError`](`CreateCommitError`) for details.",
-            ConfigError(ConfigError) =
-                "See [`ConfigError`](`crate::config::ConfigError`) for details.",
-            ExporterError(ExporterError) =
-                "See [`ExporterError`](`ExporterError`) for details.",
-            ProposalQueueError(ProposalQueueError) =
-                "See [`ProposalQueueError`](`crate::messages::errors::ProposalQueueError`) for details.",
-            CodecError(TlsCodecError) =
-                "TLS (de)serialization error occurred.",
-            KeyScheduleError(KeyScheduleError) =
-                "An error occurred in the key schedule.",
-            PskSecretError(PskSecretError) =
-                "A PskSecret error occurred.",
-            CredentialError(CredentialError) =
-                "See [`CredentialError`](crate::credentials::CredentialError) for details.",
-            TreeSyncError(TreeSyncError) =
-                "An error occurred during an operation on the tree underlying the group.",
-            TreeSyncDiffError(TreeSyncDiffError) =
-                "An error occurred during an operation on the tree underlying the group.",
-            TreeKemError(TreeKemError) =
-                "An error occurred during an operation on the tree underlying the group.",
-            KeyPackageError(KeyPackageError) =
-                "See [`KeyPackageError`] for details.",
-            ExtensionError(ExtensionError) =
-                "See [`ExtensionError`] for details.",
-            ValidationError(ValidationError) =
-                "See [`ValidationError`](crate::framing::ValidationError) for details.",
-            FramingValidationError(FramingValidationError) =
-                "See [`FramingValidationError`](crate::group::FramingValidationError) for details.",
-            ProposalValidationError(ProposalValidationError) =
-                "See [`ProposalValidationError`](crate::group::ProposalValidationError) for details.",
-            ExternalCommitValidationError(ExternalCommitValidationError) =
-                "See [`ProposalValidationError`](crate::group::ProposalValidationError) for details.",
-            CryptoError(CryptoError) =
-                "See [`CryptoError`](openmls_traits::types::CryptoError) for details.",
-            InterimTranscriptHashError(InterimTranscriptHashError) =
-                "See [`InterimTranscriptHashError`](crate::group::InterimTranscriptHashError) for details.",
-            SenderError(SenderError) =
-                "Sender error",
-        }
-    }
+/// CoreGroup error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum CoreGroupError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("Couldn't find KeyPackageBundle corresponding to own update proposal.")]
+    MissingKeyPackageBundle,
+    #[error("No signature key was found.")]
+    NoSignatureKey,
+    #[error(transparent)]
+    MlsCiphertextError(#[from] MlsCiphertextError),
+    #[error(transparent)]
+    MlsPlaintextError(#[from] MlsPlaintextError),
+    #[error(transparent)]
+    WelcomeError(#[from] WelcomeError),
+    #[error(transparent)]
+    ExternalCommitError(#[from] ExternalCommitError),
+    #[error(transparent)]
+    StageCommitError(#[from] StageCommitError),
+    #[error(transparent)]
+    CreateCommitError(#[from] CreateCommitError),
+    #[error(transparent)]
+    ConfigError(#[from] ConfigError),
+    #[error(transparent)]
+    ExporterError(#[from] ExporterError),
+    #[error(transparent)]
+    ProposalQueueError(#[from] ProposalQueueError),
+    #[error(transparent)]
+    CodecError(#[from] TlsCodecError),
+    #[error(transparent)]
+    KeyScheduleError(#[from] KeyScheduleError),
+    #[error(transparent)]
+    PskSecretError(#[from] PskSecretError),
+    #[error(transparent)]
+    CredentialError(#[from] CredentialError),
+    #[error(transparent)]
+    TreeSyncError(#[from] TreeSyncError),
+    #[error(transparent)]
+    TreeSyncDiffError(#[from] TreeSyncDiffError),
+    #[error(transparent)]
+    TreeKemError(#[from] TreeKemError),
+    #[error(transparent)]
+    KeyPackageError(#[from] KeyPackageError),
+    #[error(transparent)]
+    ExtensionError(#[from] ExtensionError),
+    #[error(transparent)]
+    ValidationError(#[from] ValidationError),
+    #[error(transparent)]
+    FramingValidationError(#[from] FramingValidationError),
+    #[error(transparent)]
+    ProposalValidationError(#[from] ProposalValidationError),
+    #[error(transparent)]
+    ExternalCommitValidationError(#[from] ExternalCommitValidationError),
+    #[error(transparent)]
+    CryptoError(#[from] CryptoError),
+    #[error(transparent)]
+    SenderError(#[from] SenderError),
 }
 
-implement_error! {
-    pub enum WelcomeError {
-        Simple {
-            CiphersuiteMismatch =
-                "Ciphersuites in the Welcome message and the corresponding key package bundle don't match.",
-            JoinerSecretNotFound =
-                "No joiner secret found in the Welcome message.",
-            MissingRatchetTree =
-                "No ratchet tree available to build initial tree after receiving a Welcome message.",
-            TreeHashMismatch =
-                "The computed tree hash does not match the one in the GroupInfo.",
-            ConfirmationTagMismatch =
-                "The computed confirmation tag does not match the expected one.",
-            InvalidGroupInfoSignature =
-                "The signature on the GroupInfo is not valid.",
-            GroupInfoDecryptionFailure =
-                "Unable to decrypt the GroupInfo.",
-            UnsupportedMlsVersion =
-                "The Welcome message uses an unsupported MLS version.",
-            MissingKeyPackage =
-                "The sender key package is missing.",
-            UnknownError =
-                "An unknown error occurred.",
-            UnknownSender =
-                "Sender not found in tree.",
-            LibraryError = "An unrecoverable error has occurred due to a bug in the implementation.",
-            }
-        Complex {
-            ConfigError(ConfigError) =
-                "See [`ConfigError`](`crate::config::ConfigError`) for details.",
-            CodecError(TlsCodecError) =
-                "Tls (de)serialization error occurred.",
-            KeyScheduleError(KeyScheduleError) =
-                "An error occurred in the key schedule.",
-            PskSecretError(PskSecretError) =
-                "A PskSecret error occured.",
-            TreeSyncError(TreeSyncError) =
-                "An error occurred while importing the new tree.",
-            ExtensionError(ExtensionError) =
-                "See [`ExtensionError`] for details.",
-            KeyPackageError(KeyPackageError) =
-                "See [`KeyPackageError`] for details.",
-            InterimTranscriptHashError(InterimTranscriptHashError) =
-                "See [`InterimTranscriptHashError`] for details.",
-            CryptoError(CryptoError) =
-                "See [`CryptoError`](openmls_traits::types::CryptoError) for details.",
-        }
-    }
+/// Welcome error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum WelcomeError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error(
+        "Ciphersuites in the Welcome message and the corresponding key package bundle don't match."
+    )]
+    CiphersuiteMismatch,
+    #[error("No joiner secret found in the Welcome message.")]
+    JoinerSecretNotFound,
+    #[error("No ratchet tree available to build initial tree after receiving a Welcome message.")]
+    MissingRatchetTree,
+    #[error("The computed confirmation tag does not match the expected one.")]
+    ConfirmationTagMismatch,
+    #[error("The signature on the GroupInfo is not valid.")]
+    InvalidGroupInfoSignature,
+    #[error("Unable to decrypt the GroupInfo.")]
+    GroupInfoDecryptionFailure,
+    #[error("We don't support the version of the group we are trying to join.")]
+    UnsupportedMlsVersion,
+    #[error("We don't support the ciphersuite of the group we are trying to join.")]
+    UnsupportedCiphersuite,
+    #[error("We don't support all capabilities of the group.")]
+    UnsupportedCapability,
+    #[error("Sender not found in tree.")]
+    UnknownSender,
+    #[error("Malformed Welcome message.")]
+    MalformedWelcomeMessage,
+    #[error("Could not decrypt the Welcome message.")]
+    CouldNotDecrypt,
+    #[error("Unsupported extensions found in the KeyPackage of another member.")]
+    UnsupportedExtensions,
+    #[error("A duplicate ratchet tree was found.")]
+    DuplicateRatchetTreeExtension,
+    #[error("More than 2^16 PSKs were provided.")]
+    PskTooManyKeys,
+    #[error("The PSK could not be found in the key store.")]
+    PskNotFound,
+    /// This error indicates the public tree is invalid. See [`PublicTreeError`] for more details.
+    #[error(transparent)]
+    PublicTreeError(#[from] PublicTreeError),
 }
 
-implement_error! {
-    pub enum ExternalCommitError {
-        Simple {
-            MissingRatchetTree =
-                "No ratchet tree available to build initial tree.",
-            TreeHashMismatch =
-                "The computed tree hash does not match the one in the GroupInfo.",
-            UnsupportedMlsVersion =
-                "We don't support the version of the group we are trying to join.",
-            UnknownSender =
-                "Sender not found in tree.",
-            InvalidPublicGroupStateSignature =
-                "The signature over the given public group state is invalid.",
-            LibraryError = "An unrecoverable error has occurred due to a bug in the implementation.",
-            CommitError =
-                "Error creating external commit.",
-            }
-        Complex {
-            VerificationError(CredentialError) =
-                "Error verifying `PublicGroupState`.",
-            ConfigError(ConfigError) =
-                "See [`ConfigError`](`crate::config::ConfigError`) for details.",
-            CodecError(TlsCodecError) =
-                "Tls (de)serialization error occurred.",
-            KeyScheduleError(KeyScheduleError) =
-                "An error occurred in the key schedule.",
-            TreeSyncError(TreeSyncError) =
-                "An error occurred while importing the new tree.",
-            TreeSyncDiffError(TreeSyncDiffError) =
-                "An error occurred while adding our own leaf to the new tree.",
-            ExtensionError(ExtensionError) =
-                "See [`ExtensionError`] for details.",
-            KeyPackageError(KeyPackageError) =
-                "See [`KeyPackageError`] for details.",
-            CryptoError(CryptoError) =
-                "See [`CryptoError`](openmls_traits::types::CryptoError) for details.",
-        }
-    }
+/// External Commit error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum ExternalCommitError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("No ratchet tree available to build initial tree.")]
+    MissingRatchetTree,
+    #[error("The computed tree hash does not match the one in the GroupInfo.")]
+    TreeHashMismatch,
+    #[error("We don't support the version of the group we are trying to join.")]
+    UnsupportedMlsVersion,
+    #[error("We don't support the ciphersuite of the group we are trying to join.")]
+    UnsupportedCiphersuite,
+    #[error("Sender not found in tree.")]
+    UnknownSender,
+    #[error("The signature over the given public group state is invalid.")]
+    InvalidPublicGroupStateSignature,
+    #[error("A duplicate ratchet tree was found.")]
+    DuplicateRatchetTreeExtension,
+    #[error("Error creating external commit.")]
+    CommitError,
+    /// This error indicates the public tree is invalid. See [`PublicTreeError`] for more details.
+    #[error(transparent)]
+    PublicTreeError(#[from] PublicTreeError),
 }
 
-implement_error! {
-    pub enum StageCommitError {
-        Simple {
-            EpochMismatch =
-                "Couldn't stage Commit. The epoch of the group context and MlsPlaintext didn't match.",
-            WrongPlaintextContentType =
-                "stage_commit was called with an MlsPlaintext that is not a Commit.",
-            SelfRemoved =
-                "Tried to stage a commit to a group we are not a part of.",
-            PathKeyPackageVerificationFailure =
-                "Unable to verify the key package signature.",
-            NoParentHashExtension =
-                "Parent hash extension is missing.",
-            ParentHashMismatch =
-                "Parent hash values don't match.",
-            RequiredPathNotFound =
-                "Unable to determine commit path.",
-            ConfirmationTagMissing =
-                "Confirmation Tag is missing.",
-            ConfirmationTagMismatch =
-                "Confirmation tag is invalid.",
-            MissingOwnKeyPackage =
-                "No key package provided to apply own commit.",
-            MissingProposal =
-                "The proposal queue is missing a proposal for the commit.",
-            OwnKeyNotFound =
-                "Missing own key to apply proposal.",
-            InconsistentSenderIndex =
-                "External Committer used the wrong index.",
-            LibraryError =
-                "An unrecoverable error has occurred due to a bug in the implementation.",
-        }
-        Complex {
-            PlaintextSignatureFailure(VerificationError) =
-                "MlsPlaintext signature is invalid.",
-            CodecError(TlsCodecError) =
-                "Tls (de)serialization error occurred.",
-            KeyScheduleError(KeyScheduleError) =
-                "An error occurred in the key schedule.",
-        }
-    }
+/// Stage Commit error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum StageCommitError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("The epoch of the group context and MlsPlaintext didn't match.")]
+    EpochMismatch,
+    #[error("stage_commit was called with an MlsPlaintext that is not a Commit.")]
+    WrongPlaintextContentType,
+    #[error("Unable to verify the key package signature.")]
+    PathKeyPackageVerificationFailure,
+    #[error("Unable to determine commit path.")]
+    RequiredPathNotFound,
+    #[error("Confirmation Tag is missing.")]
+    ConfirmationTagMissing,
+    #[error("Confirmation tag is invalid.")]
+    ConfirmationTagMismatch,
+    #[error("The proposal queue is missing a proposal for the commit.")]
+    MissingProposal,
+    #[error("Missing own key to apply proposal.")]
+    OwnKeyNotFound,
+    #[error("External Committer used the wrong index.")]
+    InconsistentSenderIndex,
 }
 
-implement_error! {
-    pub enum CreateCommitError {
-        CannotRemoveSelf =
-            "The Commit tried to remove self from the group. This is not possible.",
-        OwnKeyNotFound =
-            "Couldn't create the commit because there's no key to apply the proposals.",
-    }
+// === Crate errors ===
+
+/// Create commit error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum CreateCommitError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("The Commit tried to remove self from the group. This is not possible.")]
+    CannotRemoveSelf,
 }
 
-implement_error! {
-    pub enum ExporterError {
-        KeyLengthTooLong =
-            "The requested key length is not supported (too large).",
-    }
+/// Exporter error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum ExporterError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("The requested key length is not supported (too large).")]
+    KeyLengthTooLong,
 }
 
-implement_error! {
-    pub enum ProposalQueueError {
-        Simple {
-            ProposalNotFound = "Not all proposals in the Commit were found locally.",
-            SelfRemoval = "The sender of a Commit tried to remove themselves.",
-            ArchitectureError = "Couldn't fit a `u32` into a `usize`.",
-            RemovedNotFound = "Couldn't find the member to remove.",
-        }
-        Complex {
-            LibraryError(LibraryError) = "Library error",
-            SenderError(SenderError) = "Sender error",
-        }
-    }
+/// Proposal queue error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum ProposalQueueError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("Not all proposals in the Commit were found locally.")]
+    ProposalNotFound,
+    #[error("The sender of a Commit tried to remove themselves.")]
+    SelfRemoval,
+    #[error(transparent)]
+    SenderError(#[from] SenderError),
 }
 
-implement_error! {
-    pub enum CreationProposalQueueError {
-        Simple {
-            ProposalNotFound = "Not all proposals in the Commit were found locally.",
-            ArchitectureError = "Couldn't fit a `u32` into a `usize`.",
-        }
-        Complex {
-            LibraryError(LibraryError) = "A LibraryError occurred.",
-            SenderError(SenderError) = "Sender error",
-        }
-    }
+/// Creation proposal queue error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub(crate) enum CreationProposalQueueError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error(transparent)]
+    SenderError(#[from] SenderError),
 }
 
-implement_error! {
-    pub enum FramingValidationError {
-        WrongGroupId = "Message group ID differs from the group's group ID.",
-        WrongEpoch = "Message epoch differs from the group's epoch.",
-        UnknownMember = "The sender could not be matched to a member of the group.",
-        UnencryptedApplicationMessage = "Application messages must always be encrypted.",
-        NonMemberApplicationMessage = "An application message was sent from an external sender.",
-        MissingMembershipTag = "Membership tag is missing.",
-        MissingConfirmationTag = "Confirmation tag is missing.",
-    }
+/// Framing validaton error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum FramingValidationError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("Message group ID differs from the group's group ID.")]
+    WrongGroupId,
+    #[error("Message epoch differs from the group's epoch.")]
+    WrongEpoch,
+    #[error("The sender could not be matched to a member of the group.")]
+    UnknownMember,
+    #[error("Application messages must always be encrypted.")]
+    UnencryptedApplicationMessage,
+    #[error("An application message was sent from an external sender.")]
+    NonMemberApplicationMessage,
+    #[error("Membership tag is missing.")]
+    MissingMembershipTag,
+    #[error("Confirmation tag is missing.")]
+    MissingConfirmationTag,
 }
 
 /// Proposal validation error
@@ -308,28 +271,27 @@ pub enum ProposalValidationError {
     CommitterIncludedOwnUpdate,
 }
 
-implement_error! {
-    pub enum ExternalCommitValidationError {
-        NoExternalInitProposals = "No ExternalInit proposal found.",
-        MultipleExternalInitProposals = "Multiple ExternalInit proposal found.",
-        InvalidInlineProposals = "Found inline Add or Update proposals.",
-        MultipleRemoveProposals = "Found multiple inline Remove proposals.",
-        InvalidRemoveProposal = "Remove proposal targets the wrong group member.",
-        ReferencedExternalInitProposal = "Found an ExternalInit proposal among the referenced proposals.",
-        NoPath = "External Commit has to contain a path.",
-        NoCommit = "A Message sent by a sender with type NewMember can only be a Commit.",
-        UnknownMemberRemoval = "The remove proposal referenced a non-existing member.",
-    }
-}
-
-implement_error! {
-    pub enum InterimTranscriptHashError {
-        Simple {}
-        Complex {
-            CodecError(TlsCodecError) =
-                "TLS (de)serialization error occurred.",
-            CryptoError(CryptoError) =
-                "See [`CryptoError`](openmls_traits::types::CryptoError) for details.",
-        }
-    }
+/// External Commit validaton error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum ExternalCommitValidationError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("No ExternalInit proposal found.")]
+    NoExternalInitProposals,
+    #[error("Multiple ExternalInit proposal found.")]
+    MultipleExternalInitProposals,
+    #[error("Found inline Add or Update proposals.")]
+    InvalidInlineProposals,
+    // FIXME: this seems unused
+    #[error("Found multiple inline Remove proposals.")]
+    MultipleRemoveProposals,
+    #[error("Remove proposal targets the wrong group member.")]
+    InvalidRemoveProposal,
+    #[error("Found an ExternalInit proposal among the referenced proposals.")]
+    ReferencedExternalInitProposal,
+    // FIXME: this seems unused
+    #[error("External Commit has to contain a path.")]
+    NoPath,
+    #[error("The remove proposal referenced a non-existing member.")]
+    UnknownMemberRemoval,
 }

--- a/openmls/src/group/group_context.rs
+++ b/openmls/src/group/group_context.rs
@@ -24,29 +24,29 @@ impl GroupContext {
 
 impl GroupContext {
     /// Create a new group context
-    pub fn new(
+    pub(crate) fn new(
         group_id: GroupId,
         epoch: GroupEpoch,
         tree_hash: Vec<u8>,
         confirmed_transcript_hash: Vec<u8>,
         extensions: &[Extension],
-    ) -> Result<Self, tls_codec::Error> {
-        let group_context = GroupContext {
+    ) -> Self {
+        GroupContext {
             group_id,
             epoch,
             tree_hash: tree_hash.into(),
             confirmed_transcript_hash: confirmed_transcript_hash.into(),
             extensions: extensions.into(),
-        };
-        Ok(group_context)
+        }
     }
+
     /// Create the `GroupContext` needed upon creation of a new group.
-    pub fn create_initial_group_context(
+    pub(crate) fn create_initial_group_context(
         ciphersuite: &Ciphersuite,
         group_id: GroupId,
         tree_hash: Vec<u8>,
         extensions: &[Extension],
-    ) -> Result<Self, tls_codec::Error> {
+    ) -> Self {
         Self::new(
             group_id,
             GroupEpoch(0),
@@ -57,27 +57,31 @@ impl GroupContext {
     }
 
     /// Return the group ID
-    pub fn group_id(&self) -> &GroupId {
+    pub(crate) fn group_id(&self) -> &GroupId {
         &self.group_id
     }
+
     /// Return the epoch
-    pub fn epoch(&self) -> GroupEpoch {
+    pub(crate) fn epoch(&self) -> GroupEpoch {
         self.epoch
     }
+
     /// Return the extensions of the context
-    pub fn extensions(&self) -> &[Extension] {
+    pub(crate) fn extensions(&self) -> &[Extension] {
         self.extensions.as_slice()
     }
+
     /// Get the required capabilities extension.
-    pub fn required_capabilities(&self) -> Option<&RequiredCapabilitiesExtension> {
+    pub(crate) fn required_capabilities(&self) -> Option<&RequiredCapabilitiesExtension> {
         self.extensions
             .iter()
             .find(|e| e.extension_type() == ExtensionType::RequiredCapabilities)
             .map(|e| e.as_required_capabilities_extension().ok())
             .flatten()
     }
+
     /// Return the confirmed transcript hash
-    pub fn confirmed_transcript_hash(&self) -> &[u8] {
+    pub(crate) fn confirmed_transcript_hash(&self) -> &[u8] {
         self.confirmed_transcript_hash.as_slice()
     }
 }

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -1,5 +1,5 @@
 use crate::{
-    group::core_group::create_commit_params::CreateCommitParams,
+    group::{core_group::create_commit_params::CreateCommitParams, errors::ExternalCommitError},
     messages::VerifiablePublicGroupState,
 };
 
@@ -118,7 +118,7 @@ impl MlsGroup {
         aad: &[u8],
         credential_bundle: &CredentialBundle,
         proposal_store: ProposalStore,
-    ) -> Result<(Self, MlsMessageOut), MlsGroupError> {
+    ) -> Result<(Self, MlsMessageOut), ExternalCommitError> {
         let resumption_secret_store =
             ResumptionSecretStore::new(mls_group_config.number_of_resumption_secrets);
 

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -20,9 +20,9 @@ use tls_codec::*;
 pub(crate) mod core_group;
 pub(crate) use core_group::*;
 pub(crate) use errors::{
-    CoreGroupError, CreateCommitError, ExporterError, InterimTranscriptHashError, StageCommitError,
-    WelcomeError,
+    CoreGroupError, CreateCommitError, ExporterError, StageCommitError, WelcomeError,
 };
+#[cfg(not(any(feature = "test-utils", test)))]
 pub(crate) use group_context::*;
 
 // Public
@@ -36,6 +36,8 @@ pub use mls_group::*;
 pub(crate) use create_commit_params::*;
 #[cfg(any(feature = "test-utils", test))]
 pub(crate) mod tests;
+#[cfg(any(feature = "test-utils", test))]
+pub use group_context::GroupContext;
 #[cfg(any(feature = "test-utils", test))]
 use openmls_traits::random::OpenMlsRand;
 #[cfg(any(feature = "test-utils", test))]

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -75,8 +75,7 @@ pub fn generate_test_vector(ciphersuite: &'static Ciphersuite) -> TranscriptTest
         tree_hash_before.clone(),
         confirmed_transcript_hash_before.clone(),
         &[], // extensions
-    )
-    .expect("Error creating group context");
+    );
     let aad = crypto
         .rand()
         .random_vec(48)
@@ -227,8 +226,7 @@ pub fn run_test_vector(
         tree_hash_before,
         confirmed_transcript_hash_before,
         &[], // extensions
-    )
-    .expect("Error creating group context");
+    );
     let expected_group_context = hex_to_bytes(&test_vector.group_context);
     if context
         .tls_serialize_detached()

--- a/openmls/src/schedule/errors.rs
+++ b/openmls/src/schedule/errors.rs
@@ -30,14 +30,12 @@ pub enum KeyScheduleError {
 /// PSK secret error
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum PskSecretError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
     #[error("More than 2^16 PSKs were provided.")]
     TooManyKeys,
     #[error("The PSK could not be found in the key store.")]
     KeyNotFound,
-    #[error("Error serializing the PSK label.")]
-    EncodingError,
-    #[error(transparent)]
-    CryptoError(#[from] CryptoError),
 }
 
 #[cfg(any(feature = "test-utils", test))]

--- a/openmls/src/schedule/kat_key_schedule.rs
+++ b/openmls/src/schedule/kat_key_schedule.rs
@@ -145,8 +145,7 @@ fn generate(
         tree_hash.to_vec(),
         confirmed_transcript_hash.clone(),
         &[], // Extensions
-    )
-    .expect("An unexpected error occurred.");
+    );
 
     let serialized_group_context = group_context
         .tls_serialize_detached()
@@ -403,8 +402,7 @@ pub fn run_test_vector(
             tree_hash.to_vec(),
             confirmed_transcript_hash.clone(),
             &[], // Extensions
-        )
-        .expect("Error creating group context");
+        );
 
         let expected_group_context = hex_to_bytes(&epoch.group_context);
         let group_context_serialized = group_context

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -382,7 +382,7 @@ impl KeySchedule {
         backend: &impl OpenMlsCryptoProvider,
         joiner_secret: JoinerSecret,
         psk: impl Into<Option<PskSecret>>,
-    ) -> Result<Self, KeyScheduleError> {
+    ) -> Result<Self, LibraryError> {
         log::debug!(
             "Initializing the key schedule with {:?} ...",
             ciphersuite.name()
@@ -394,7 +394,8 @@ impl KeySchedule {
         );
         let psk = psk.into();
         log_crypto!(trace, "  {}", if psk.is_some() { "with PSK" } else { "" });
-        let intermediate_secret = IntermediateSecret::new(backend, &joiner_secret, psk)?;
+        let intermediate_secret = IntermediateSecret::new(backend, &joiner_secret, psk)
+            .map_err(LibraryError::unexpected_crypto_error)?;
         Ok(Self {
             ciphersuite,
             intermediate_secret: Some(intermediate_secret),

--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -172,7 +172,7 @@ impl DecryptionRatchet {
     pub fn new(secret: Secret) -> Self {
         Self {
             past_secrets: VecDeque::new(),
-            ratchet_head: RatchetSecret::initial_ratchet_secret(secret.clone()),
+            ratchet_head: RatchetSecret::initial_ratchet_secret(secret),
         }
     }
 

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -17,25 +17,25 @@
 //! functions that are not expected to fail and throw an error, will still
 //! return a [`Result`] since they may throw a
 //! [`LibraryError`](TreeSyncDiffError::LibraryError).
-use openmls_traits::{crypto::OpenMlsCrypto, types::CryptoError, OpenMlsCryptoProvider};
+use openmls_traits::{crypto::OpenMlsCrypto, OpenMlsCryptoProvider};
 use serde::{Deserialize, Serialize};
 
 use std::{collections::HashSet, convert::TryFrom};
 
 use super::{
+    errors::*,
     node::{
         leaf_node::LeafNode,
         parent_node::{ParentNode, PathDerivationResult, PlainUpdatePathNode},
-        {Node, NodeError},
+        Node,
     },
-    treesync_node::{TreeSyncNode, TreeSyncNodeError},
-    TreeSync,
+    treesync_node::TreeSyncNode,
+    TreeSync, TreeSyncParentHashError, TreeSyncSetPathError,
 };
 
 use crate::{
     binary_tree::{
-        array_representation::diff::NodeId, LeafIndex, MlsBinaryTreeDiff, MlsBinaryTreeDiffError,
-        MlsBinaryTreeError, StagedMlsBinaryTreeDiff,
+        array_representation::diff::NodeId, LeafIndex, MlsBinaryTreeDiff, StagedMlsBinaryTreeDiff,
     },
     ciphersuite::{
         hash_ref::KeyPackageRef, signable::Signable, Ciphersuite, HpkePrivateKey, HpkePublicKey,
@@ -45,7 +45,7 @@ use crate::{
     error::LibraryError,
     extensions::ExtensionType,
     key_packages::{KeyPackage, KeyPackageBundlePayload, KeyPackageError},
-    messages::{PathSecret, PathSecretError},
+    messages::PathSecret,
     schedule::CommitSecret,
 };
 
@@ -356,14 +356,24 @@ impl<'a> TreeSyncDiff<'a> {
         ciphersuite: &Ciphersuite,
         mut path_secret: PathSecret,
         sender_index: LeafIndex,
-    ) -> Result<CommitSecret, TreeSyncDiffError> {
-        let subtree_path = self.diff.subtree_path(self.own_leaf_index, sender_index)?;
+    ) -> Result<CommitSecret, TreeSyncSetPathError> {
+        // We assume both nodes are in the tree
+        let subtree_path = self
+            .diff
+            .subtree_path(self.own_leaf_index, sender_index)
+            .map_err(|_| LibraryError::custom("Expected both nodes to be in the tree"))?;
         for node_id in subtree_path {
-            let tsn = self.diff.node_mut(node_id)?;
+            // We know the node is in the diff, since it is in the subtree path
+            let tsn = self
+                .diff
+                .node_mut(node_id)
+                .map_err(|_| LibraryError::custom("Expected the node to be in the diff"))?;
             // We only care about non-blank nodes.
             if let Some(ref mut node) = tsn.node_mut() {
                 // This has to be a parent node.
-                let pn = node.as_parent_node_mut()?;
+                let pn = node
+                    .as_parent_node_mut()
+                    .map_err(|_| LibraryError::custom("Expected a parent node"))?;
                 // If our own leaf index is not in the list of unmerged leaves
                 // then we should have the secret for this node.
                 if !pn.unmerged_leaves().contains(&self.own_leaf_index) {
@@ -372,7 +382,7 @@ impl<'a> TreeSyncDiff<'a> {
                     // The derived public key should match the one in the node.
                     // If not, the tree is corrupt.
                     if pn.public_key() != &public_key {
-                        return Err(TreeSyncDiffError::PublicKeyMismatch);
+                        return Err(TreeSyncSetPathError::PublicKeyMismatch);
                     } else {
                         // If everything is ok, set the private key and derive
                         // the next path secret.
@@ -389,20 +399,31 @@ impl<'a> TreeSyncDiff<'a> {
 
     /// A helper function that filters the unmerged leaves of the given node
     /// from the given resolution.
+    ///
+    /// Returns a LibraryError when the ParentNode is not in the tree or
+    /// its unmerged leaves are not in the tree.
     fn filter_resolution(
         &self,
         parent_node: &ParentNode,
         resolution: &mut Vec<HpkePublicKey>,
-    ) -> Result<(), TreeSyncDiffError> {
+    ) -> Result<(), LibraryError> {
         for leaf_index in parent_node.unmerged_leaves() {
-            let leaf_id = self.diff.leaf(*leaf_index)?;
-            let leaf = self.diff.node(leaf_id)?;
+            let leaf_id = self
+                .diff
+                .leaf(*leaf_index)
+                .map_err(|_| LibraryError::custom("Unmerged leaf not in tree"))?;
+            let leaf = self
+                .diff
+                .node(leaf_id)
+                .map_err(|_| LibraryError::custom("Unmerged leaf not in tree"))?;
             // All unmerged leaves should be non-blank.
             let leaf_node = leaf
                 .node()
                 .as_ref()
                 .ok_or_else(|| LibraryError::custom("Node was empty."))?;
-            let leaf = leaf_node.as_leaf_node()?;
+            let leaf = leaf_node
+                .as_leaf_node()
+                .map_err(|_| LibraryError::custom("Unmerged leaf not a leaf"))?;
             if let Some(position) = resolution
                 .iter()
                 .position(|bytes| bytes == leaf.public_key())
@@ -466,13 +487,21 @@ impl<'a> TreeSyncDiff<'a> {
     /// Helper function computing the resolution of a node with the given index.
     /// If an exclusion list is given, do not add the public keys of the leaves
     /// given in the list.
+    ///
+    /// Returns The list of HPKE public keys.
+    /// In case node_id is not in the tree a LibraryError is returned.
     fn resolution(
         &self,
         node_id: NodeId,
         excluded_indices: &HashSet<&LeafIndex>,
-    ) -> Result<Vec<HpkePublicKey>, TreeSyncDiffError> {
+    ) -> Result<Vec<HpkePublicKey>, LibraryError> {
         // First, check if the node is blank or not.
-        if let Some(node) = self.diff.node(node_id)?.node() {
+        if let Some(node) = self
+            .diff
+            .node(node_id)
+            .map_err(|_| LibraryError::custom("Expected node to be in the tree"))?
+            .node()
+        {
             // If it's a full node, check if it's a leaf.
             if let Some(leaf_index) = self.diff.leaf_index(node_id) {
                 // If the node is a leaf, check if it is in the exclusion list.
@@ -487,16 +516,25 @@ impl<'a> TreeSyncDiff<'a> {
                 // as necessary and add their public keys to the resulting
                 // resolution.
                 let mut resolution = vec![node.public_key().clone()];
-                for leaf_index in node.as_parent_node()?.unmerged_leaves() {
+                for leaf_index in node
+                    .as_parent_node()
+                    .map_err(|_| LibraryError::custom("Expected a parent node"))?
+                    .unmerged_leaves()
+                {
                     if !excluded_indices.contains(leaf_index) {
-                        let leaf_id = self.diff.leaf(*leaf_index)?;
-                        let leaf = self.diff.node(leaf_id)?;
-                        // FIXME: Once we have the right checks in place, this could
-                        // turn into a libraryerror.
+                        let leaf_id = self
+                            .diff
+                            .leaf(*leaf_index)
+                            .map_err(|_| LibraryError::custom("Expected leaf to be in the tree"))?;
+                        let leaf = self
+                            .diff
+                            .node(leaf_id)
+                            .map_err(|_| LibraryError::custom("Expected node to be in the tree"))?;
+                        // TODO #800: unmerged leaves should be checked
                         let leaf_node = leaf
                             .node()
                             .as_ref()
-                            .ok_or(TreeSyncDiffError::BlankUnmergedLeaf)?;
+                            .ok_or_else(|| LibraryError::custom("Found a blank unmerged leaf"))?;
                         resolution.push(leaf_node.public_key().clone())
                     }
                 }
@@ -510,8 +548,14 @@ impl<'a> TreeSyncDiff<'a> {
             } else {
                 // If not, continue resolving down the tree.
                 let mut resolution = Vec::new();
-                let left_child = self.diff.left_child(node_id)?;
-                let right_child = self.diff.right_child(node_id)?;
+                let left_child = self
+                    .diff
+                    .left_child(node_id)
+                    .map_err(|_| LibraryError::custom("Expected a parent node"))?;
+                let right_child = self
+                    .diff
+                    .right_child(node_id)
+                    .map_err(|_| LibraryError::custom("Expected a parent node"))?;
                 resolution.append(&mut self.resolution(left_child, excluded_indices)?);
                 resolution.append(&mut self.resolution(right_child, excluded_indices)?);
                 Ok(resolution)
@@ -560,21 +604,39 @@ impl<'a> TreeSyncDiff<'a> {
 
     /// Verify the parent hashes of all nodes in the tree.
     ///
-    /// Returns an error if a mismatching parent hash is found.
+    /// Returns TreeSyncParentHashError::InvalidParentHash if a
+    /// mismatching parent hash is found or a LibraryError if the
+    /// tree is malformed.
     pub(crate) fn verify_parent_hashes(
         &self,
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: &Ciphersuite,
-    ) -> Result<(), TreeSyncDiffError> {
+    ) -> Result<(), TreeSyncParentHashError> {
         for node_id in self.diff.iter() {
             // Continue early if node is blank.
-            if let Some(Node::ParentNode(parent_node)) = self.diff.node(node_id)?.node() {
+            if let Some(Node::ParentNode(parent_node)) = self
+                .diff
+                .node(node_id)
+                .map_err(|_| LibraryError::custom("Node not in tree"))?
+                .node()
+            {
                 // We don't care about leaf nodes.
-                let left_child_id = self.diff.left_child(node_id)?;
-                let mut right_child_id = self.diff.right_child(node_id)?;
+                let left_child_id = self
+                    .diff
+                    .left_child(node_id)
+                    .map_err(|_| LibraryError::custom("Expected parent node"))?;
+                let mut right_child_id = self
+                    .diff
+                    .right_child(node_id)
+                    .map_err(|_| LibraryError::custom("Expected parent node"))?;
                 // If the left child is blank, we continue with the next step
                 // in the verification algorithm.
-                if let Some(left_child) = self.diff.node(left_child_id)?.node() {
+                if let Some(left_child) = self
+                    .diff
+                    .node(left_child_id)
+                    .map_err(|_| LibraryError::custom("Node not in tree"))?
+                    .node()
+                {
                     let mut right_child_resolution =
                         self.resolution(right_child_id, &HashSet::new())?;
                     // Filter unmerged leaves from resolution.
@@ -595,15 +657,28 @@ impl<'a> TreeSyncDiff<'a> {
 
                 // If the right child is blank, replace it with its left child
                 // until it's non-blank or a leaf.
-                while self.diff.node(right_child_id)?.node().is_none()
+                while self
+                    .diff
+                    .node(right_child_id)
+                    .map_err(|_| LibraryError::custom("Node not in tree"))?
+                    .node()
+                    .is_none()
                     && !self.diff.is_leaf(right_child_id)
                 {
-                    right_child_id = self.diff.left_child(right_child_id)?;
+                    right_child_id = self
+                        .diff
+                        .left_child(right_child_id)
+                        .map_err(|_| LibraryError::custom("Expected parent node"))?;
                 }
                 // If the "right child" is a non-blank node, we continue,
                 // otherwise it has to be a blank leaf node and the check
                 // fails.
-                if let Some(right_child) = self.diff.node(right_child_id)?.node() {
+                if let Some(right_child) = self
+                    .diff
+                    .node(right_child_id)
+                    .map_err(|_| LibraryError::custom("Node not in tree"))?
+                    .node()
+                {
                     // Perform the check with the parent hash of the "right
                     // child" and the left child resolution.
                     let mut left_child_resolution =
@@ -626,7 +701,7 @@ impl<'a> TreeSyncDiff<'a> {
                     // parent hash extension (the `None` case in the `if let`
                     // above), the verification fails.
                 }
-                return Err(TreeSyncDiffError::InvalidParentHash);
+                return Err(TreeSyncParentHashError::InvalidParentHash);
             } else {
                 continue;
             }
@@ -640,7 +715,7 @@ impl<'a> TreeSyncDiff<'a> {
         mut self,
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: &Ciphersuite,
-    ) -> Result<StagedTreeSyncDiff, TreeSyncDiffError> {
+    ) -> Result<StagedTreeSyncDiff, LibraryError> {
         let new_tree_hash = self.compute_tree_hashes(backend, ciphersuite)?;
         debug_assert!(self.verify_parent_hashes(backend, ciphersuite).is_ok());
         Ok(StagedTreeSyncDiff {
@@ -659,10 +734,13 @@ impl<'a> TreeSyncDiff<'a> {
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: &Ciphersuite,
         node_id: NodeId,
-    ) -> Result<Vec<u8>, TreeSyncDiffError> {
+    ) -> Result<Vec<u8>, LibraryError> {
         // Check if this is a leaf.
         if let Some(leaf_index) = self.diff.leaf_index(node_id) {
-            let leaf = self.diff.node_mut(node_id)?;
+            let leaf = self
+                .diff
+                .node_mut(node_id)
+                .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
             let tree_hash =
                 // Giving 0 as a node index here for now. See comment in the
                 // function for context.
@@ -670,18 +748,30 @@ impl<'a> TreeSyncDiff<'a> {
             return Ok(tree_hash);
         }
         // Return early if there's already a cached tree hash.
-        let node = self.diff.node(node_id)?;
+        let node = self
+            .diff
+            .node(node_id)
+            .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
         if let Some(tree_hash) = node.tree_hash() {
             return Ok(tree_hash.to_vec());
         }
         // Compute left hash.
-        let left_child = self.diff.left_child(node_id)?;
+        let left_child = self
+            .diff
+            .left_child(node_id)
+            .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
         let left_hash = self.compute_tree_hash(backend, ciphersuite, left_child)?;
         // Compute right hash.
-        let right_child = self.diff.right_child(node_id)?;
+        let right_child = self
+            .diff
+            .right_child(node_id)
+            .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
         let right_hash = self.compute_tree_hash(backend, ciphersuite, right_child)?;
 
-        let node = self.diff.node_mut(node_id)?;
+        let node = self
+            .diff
+            .node_mut(node_id)
+            .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
         let node_index = node_id.node_index();
         let tree_hash = node.compute_tree_hash(
             backend,
@@ -715,7 +805,7 @@ impl<'a> TreeSyncDiff<'a> {
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: &Ciphersuite,
-    ) -> Result<Vec<u8>, TreeSyncDiffError> {
+    ) -> Result<Vec<u8>, LibraryError> {
         self.compute_tree_hash(backend, ciphersuite, self.diff.root())
     }
 
@@ -805,30 +895,6 @@ impl<'a> TreeSyncDiff<'a> {
             Err(TreeSyncDiffError::LibraryError(LibraryError::custom(
                 "missing leaf node",
             )))
-        }
-    }
-}
-
-implement_error! {
-    pub enum TreeSyncDiffError {
-        Simple {
-            PathLengthError = "The given path does not have the length of the given leaf's direct path.",
-            MissingParentHash = "The given key package does not contain a parent hash extension.",
-            ParentHashMismatch = "The parent hash of the given key package is invalid.",
-            InvalidParentHash = "The parent hash of a node in the given tree is invalid.",
-            BlankUnmergedLeaf = "The leaf index in the unmerged leaves of a parent node point to a blank.",
-            PublicKeyMismatch = "The derived public key doesn't match the one in the tree.",
-            NoPrivateKeyFound = "Couldn't find a fitting private key in the filtered resolution of the given leaf index.",
-        }
-        Complex {
-            LibraryError(LibraryError) = "A LibraryError occurred.",
-            NodeTypeError(NodeError) = "We found a node with an unexpected type.",
-            TreeSyncNodeError(TreeSyncNodeError) = "Error computing tree hash.",
-            TreeDiffError(MlsBinaryTreeDiffError) = "An error occurred while operating on the diff.",
-            CryptoError(CryptoError) = "An error occurred during key derivation.",
-            DerivationError(PathSecretError) = "An error occurred during PathSecret derivation.",
-            CreationError(MlsBinaryTreeError) = "An error occurred while creating an empty diff.",
-            KeyPackageError(KeyPackageError) = "An error occurred while building the leaf node from a key package bundle.",
         }
     }
 }

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -350,6 +350,12 @@ impl<'a> TreeSyncDiff<'a> {
     ///
     /// Returns the `CommitSecret` derived from the path secret of the root
     /// node. Returns an error if the target leaf is outside of the tree.
+    ///
+    /// Returns TreeSyncSetPathError::PublicKeyMismatch if the derived keys don't
+    /// match with the existing ones.
+    ///
+    /// Returns TreeSyncSetPathError::LibraryError if the sender_index is not
+    /// in the tree.
     pub(super) fn set_path_secrets(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
@@ -357,7 +363,7 @@ impl<'a> TreeSyncDiff<'a> {
         mut path_secret: PathSecret,
         sender_index: LeafIndex,
     ) -> Result<CommitSecret, TreeSyncSetPathError> {
-        // We assume both nodes are in the tree
+        // We assume both nodes are in the tree, since the sender_index must be in the tree
         let subtree_path = self
             .diff
             .subtree_path(self.own_leaf_index, sender_index)

--- a/openmls/src/treesync/errors.rs
+++ b/openmls/src/treesync/errors.rs
@@ -1,0 +1,110 @@
+use thiserror::Error;
+
+use super::*;
+use crate::{binary_tree::MlsBinaryTreeDiffError, error::LibraryError};
+
+// === Public errors ===
+
+/// Public tree error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum PublicTreeError {
+    #[error("The derived public key doesn't match the one in the tree.")]
+    PublicKeyMismatch,
+    #[error("Found two KeyPackages with the same public key.")]
+    DuplicateKeyPackage,
+    #[error("Couldn't find our own key package in this tree.")]
+    MissingKeyPackage,
+    #[error("The tree is malformed.")]
+    MalformedTree,
+    #[error("A parent hash was invalid.")]
+    InvalidParentHash,
+}
+
+// === Crate errors ===
+
+/// TreeSync error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum TreeSyncError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("Found two KeyPackages with the same public key.")]
+    KeyPackageRefNotInTree,
+    #[error(transparent)]
+    SetPathError(#[from] TreeSyncSetPathError),
+    #[error(transparent)]
+    BinaryTreeError(#[from] MlsBinaryTreeError),
+    #[error(transparent)]
+    TreeSyncNodeError(#[from] TreeSyncNodeError),
+    #[error(transparent)]
+    NodeTypeError(#[from] NodeError),
+    #[error(transparent)]
+    TreeSyncDiffError(#[from] TreeSyncDiffError),
+    #[error(transparent)]
+    DerivationError(#[from] PathSecretError),
+    #[error(transparent)]
+    SenderError(#[from] SenderError),
+    #[error(transparent)]
+    CryptoError(#[from] CryptoError),
+}
+
+/// TreeSync set path error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum TreeSyncSetPathError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("The derived public key doesn't match the one in the tree.")]
+    PublicKeyMismatch,
+}
+
+/// TreeSync from nodes error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub(crate) enum TreeSyncFromNodesError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error(transparent)]
+    PublicTreeError(#[from] PublicTreeError),
+}
+
+/// TreeSync parent hash error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub(crate) enum TreeSyncParentHashError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("Parent hash mismatch.")]
+    InvalidParentHash,
+}
+
+/// TreeSync parent hash error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum TreeSyncDiffError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("The given path does not have the length of the given leaf's direct path.")]
+    PathLengthError,
+    #[error("The given key package does not contain a parent hash extension.")]
+    MissingParentHash,
+    #[error("The parent hash of the given key package is invalid.")]
+    ParentHashMismatch,
+    #[error("The parent hash of a node in the given tree is invalid.")]
+    InvalidParentHash,
+    #[error("The leaf index in the unmerged leaves of a parent node point to a blank.")]
+    BlankUnmergedLeaf,
+    #[error(
+        "Couldn't find a fitting private key in the filtered resolution of the given leaf index."
+    )]
+    NoPrivateKeyFound,
+    #[error(transparent)]
+    NodeTypeError(#[from] NodeError),
+    #[error(transparent)]
+    TreeSyncNodeError(#[from] TreeSyncNodeError),
+    #[error(transparent)]
+    TreeDiffError(#[from] MlsBinaryTreeDiffError),
+    #[error(transparent)]
+    CryptoError(#[from] CryptoError),
+    #[error(transparent)]
+    DerivationError(#[from] PathSecretError),
+    #[error(transparent)]
+    CreationError(#[from] MlsBinaryTreeError),
+    #[error(transparent)]
+    KeyPackageError(#[from] KeyPackageError),
+}

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -158,6 +158,9 @@ impl TreeSync {
     ///
     /// Returns the new [`TreeSync`] instance or an error if one of the
     /// invariants is not true (see [`TreeSync`]).
+    ///
+    /// Returns TreeSyncFromNodesError::LibraryError if the input parameters are
+    /// malformed.
     pub(crate) fn from_nodes_with_secrets(
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: &Ciphersuite,
@@ -221,10 +224,10 @@ impl TreeSync {
                         if leaf_node.public_key() == own_key_package.hpke_init_key() {
                             // Check if there's a duplicate
                             if let Some(private_key) = private_key.take() {
-                                own_index_option =
-                                    Some(u32::try_from(node_index / 2).map_err(|_| {
-                                        LibraryError::custom("Own leaf is outside of the tree")
-                                    })?);
+                                own_index_option = Some(
+                                    u32::try_from(node_index / 2)
+                                        .map_err(|_| LibraryError::custom("Architecture error"))?,
+                                );
                                 leaf_node.set_private_key(private_key);
                             } else {
                                 return Err(PublicTreeError::DuplicateKeyPackage.into());

--- a/openmls/src/treesync/treesync_node.rs
+++ b/openmls/src/treesync/treesync_node.rs
@@ -104,7 +104,7 @@ impl TreeSyncNode {
         node_index: LeafIndex,
         left_hash: Vec<u8>,
         right_hash: Vec<u8>,
-    ) -> Result<Vec<u8>, TreeSyncNodeError> {
+    ) -> Result<Vec<u8>, LibraryError> {
         // If there's a cached tree hash, use that one.
         if let Some(hash) = self.tree_hash() {
             return Ok(hash.clone());
@@ -113,7 +113,10 @@ impl TreeSyncNode {
         // Check if I'm a leaf node.
         let hash = if let Some(leaf_index) = leaf_index_option {
             let key_package_option = match self.node.as_ref() {
-                Some(node) => Some(node.as_leaf_node()?),
+                Some(node) => Some(
+                    node.as_leaf_node()
+                        .map_err(|_| LibraryError::custom("Expected a leaf node"))?,
+                ),
                 None => None,
             }
             .map(|leaf_node| leaf_node.key_package());
@@ -124,7 +127,10 @@ impl TreeSyncNode {
             hash_input.hash(ciphersuite, backend)?
         } else {
             let parent_node_option = match self.node.as_ref() {
-                Some(node) => Some(node.as_parent_node()?),
+                Some(node) => Some(
+                    node.as_parent_node()
+                        .map_err(|_| LibraryError::custom("Expected a parent node"))?,
+                ),
                 None => None,
             };
             // FIXME: After PR #507 of the spec is merged, this not include a


### PR DESCRIPTION
This PR continues with the error cleanup:

 - I wrote a [wiki article](https://github.com/openmls/openmls/wiki/Error-management-in-OpenMLS) explaining the overall error management strategy (will be part of the book later)
 - `WelcomeError`/`ExternalCommitError` are public and in near-final state (except for documentation)
 - Refactoring in TreeSync/TreeSyncDiff/ABinaryTree API to return LibraryError more often
 - more than 50% of the errors now use `thiserror`

Sorry for the large PR again, most of it should be easy to review though.