### PR TITLE
Error cleanup 3

### DIFF
--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -10,7 +10,7 @@ use openmls::{prelude::*, prelude_test::*};
 use openmls_traits::key_store::OpenMlsKeyStore;
 use openmls_traits::OpenMlsCryptoProvider;
 use serde::{self, Serialize};
-use std::{collections::HashMap, convert::TryFrom, fs::File, io::Write, sync::Mutex};
+use std::{collections::HashMap, convert::TryFrom, fmt::Display, fs::File, io::Write, sync::Mutex};
 use tonic::{transport::Server, Request, Response, Status};
 
 use openmls_rust_crypto::OpenMlsRustCrypto;
@@ -77,7 +77,7 @@ impl MlsClientImpl {
     }
 }
 
-fn into_status(e: MlsGroupError) -> Status {
+fn into_status<E: Display>(e: E) -> Status {
     let message = "mls group error ".to_string() + &e.to_string();
     tonic::Status::new(tonic::Code::Aborted, message)
 }

--- a/openmls/src/binary_tree/array_representation/diff.rs
+++ b/openmls/src/binary_tree/array_representation/diff.rs
@@ -182,12 +182,12 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
 
     /// Returns references to the leaves of the diff in order from left to
     /// right. This function should not throw an error. However, it might throw
-    /// an LibraryError error if there is a bug in the implementation.
+    /// a [`LibraryError`] error if there is a bug in the implementation.
     pub(crate) fn leaves(&self) -> Result<Vec<NodeId>, LibraryError> {
         let mut leaf_references = Vec::new();
         for leaf_index in 0..self.leaf_count() {
             let node_index = to_node_index(leaf_index);
-            // The node reference must be valid, since it is a vlaid leaf
+            // The node reference must be valid, since it is a valid leaf
             let node_ref = NodeId::try_from_node_index(self, node_index)
                 .map_err(|_| LibraryError::custom("Expected a valid node reference"))?;
             leaf_references.push(node_ref);

--- a/openmls/src/binary_tree/array_representation/diff.rs
+++ b/openmls/src/binary_tree/array_representation/diff.rs
@@ -182,12 +182,14 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
 
     /// Returns references to the leaves of the diff in order from left to
     /// right. This function should not throw an error. However, it might throw
-    /// an [`ABinaryTreeDiffError::OutOfBounds`] error if there is a bug in the implementation.
-    pub(crate) fn leaves(&self) -> Result<Vec<NodeId>, ABinaryTreeDiffError> {
+    /// an LibraryError error if there is a bug in the implementation.
+    pub(crate) fn leaves(&self) -> Result<Vec<NodeId>, LibraryError> {
         let mut leaf_references = Vec::new();
         for leaf_index in 0..self.leaf_count() {
             let node_index = to_node_index(leaf_index);
-            let node_ref = NodeId::try_from_node_index(self, node_index)?;
+            // The node reference must be valid, since it is a vlaid leaf
+            let node_ref = NodeId::try_from_node_index(self, node_index)
+                .map_err(|_| LibraryError::custom("Expected a valid node reference"))?;
             leaf_references.push(node_ref);
         }
         Ok(leaf_references)

--- a/openmls/src/binary_tree/test_binary_tree.rs
+++ b/openmls/src/binary_tree/test_binary_tree.rs
@@ -2,9 +2,7 @@ use std::collections::HashSet;
 
 use crate::binary_tree::{MlsBinaryTree, MlsBinaryTreeDiffError, MlsBinaryTreeError};
 
-use super::array_representation::tree::NodeIndex;
-
-use super::array_representation::treemath::TreeMathError;
+use super::array_representation::{tree::NodeIndex, treemath::TreeMathError};
 
 #[test]
 fn test_tree_basics() {

--- a/openmls/src/framing/message.rs
+++ b/openmls/src/framing/message.rs
@@ -13,6 +13,8 @@ use tls_codec::{Deserialize, Serialize};
 
 use super::*;
 
+use crate::error::LibraryError;
+
 /// Unified message type for MLS messages.
 /// /// This is only used internally, externally we use either [`MlsMessageIn`] or
 /// [`MlsMessageOut`], depending on the context.
@@ -67,13 +69,14 @@ impl MlsMessage {
 
     /// Tries to deserialize from a byte slice. Returns [`MlsMessageError::DecodingError`] on failure.
     fn try_from_bytes(mut bytes: &[u8]) -> Result<Self, MlsMessageError> {
-        MlsMessage::tls_deserialize(&mut bytes).map_err(|_| MlsMessageError::DecodingError)
+        MlsMessage::tls_deserialize(&mut bytes).map_err(|_| MlsMessageError::UnableToDecode)
     }
 
     /// Serializes the message to a byte vector. Returns [`MlsMessageError::EncodingError`] on failure.
     fn to_bytes(&self) -> Result<Vec<u8>, MlsMessageError> {
-        self.tls_serialize_detached()
-            .map_err(|_| MlsMessageError::EncodingError)
+        Ok(self
+            .tls_serialize_detached()
+            .map_err(LibraryError::missing_bound_check)?)
     }
 }
 

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -18,6 +18,7 @@ use crate::{
             create_commit_params::CreateCommitParams,
             proposals::{ProposalStore, QueuedProposal},
         },
+        errors::StageCommitError,
         tests::tree_printing::print_tree,
     },
     key_packages::KeyPackageBundle,
@@ -700,10 +701,7 @@ fn confirmation_tag_presence(
         .stage_commit(&create_commit_result.commit, &proposal_store, &[], backend)
         .expect_err("No error despite missing confirmation tag.");
 
-    assert_eq!(
-        err,
-        CoreGroupError::StageCommitError(StageCommitError::ConfirmationTagMissing)
-    );
+    assert_eq!(err, StageCommitError::ConfirmationTagMissing);
 }
 
 #[apply(ciphersuites_and_backends)]

--- a/openmls/src/group/core_group/apply_proposals.rs
+++ b/openmls/src/group/core_group/apply_proposals.rs
@@ -4,6 +4,7 @@ use openmls_traits::OpenMlsCryptoProvider;
 
 use crate::{
     binary_tree::LeafIndex,
+    error::LibraryError,
     framing::{Sender, SenderError},
     group::CoreGroupError,
     key_packages::KeyPackageBundle,
@@ -151,7 +152,9 @@ impl CoreGroup {
         // Extract KeyPackages from proposals
         let mut invitation_list = Vec::new();
         for add_proposal in add_proposals {
-            let leaf_index = diff.add_leaf(add_proposal.key_package().clone(), backend.crypto())?;
+            let leaf_index = diff
+                .add_leaf(add_proposal.key_package().clone(), backend.crypto())
+                .map_err(|_| LibraryError::custom("Tree full: cannot add more members"))?;
             invitation_list.push((leaf_index, add_proposal.clone()))
         }
 

--- a/openmls/src/group/core_group/apply_proposals.rs
+++ b/openmls/src/group/core_group/apply_proposals.rs
@@ -154,6 +154,7 @@ impl CoreGroup {
         for add_proposal in add_proposals {
             let leaf_index = diff
                 .add_leaf(add_proposal.key_package().clone(), backend.crypto())
+                // TODO #810
                 .map_err(|_| LibraryError::custom("Tree full: cannot add more members"))?;
             invitation_list.push((leaf_index, add_proposal.clone()))
         }

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -404,7 +404,8 @@ impl CoreGroup {
                 vec![],
             )?;
 
-            diff.add_leaf(key_package_bundle.key_package().clone(), backend.crypto())?;
+            diff.add_leaf(key_package_bundle.key_package().clone(), backend.crypto())
+                .map_err(|_| LibraryError::custom("Tree full: cannot add more members"))?;
             diff.own_leaf()?.key_package()
         } else {
             self.treesync().own_leaf_node()?.key_package()

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -65,9 +65,9 @@ impl CoreGroup {
         // Prepare the PskSecret
         let psk_secret = PskSecret::new(ciphersuite, backend, group_secrets.psks.psks()).map_err(
             |e| match e {
-                PskSecretError::LibraryError(e) => e.into(),
-                PskSecretError::TooManyKeys => WelcomeError::PskTooManyKeys,
-                PskSecretError::KeyNotFound => WelcomeError::PskNotFound,
+                PskError::LibraryError(e) => e.into(),
+                PskError::TooManyKeys => WelcomeError::PskTooManyKeys,
+                PskError::KeyNotFound => WelcomeError::PskNotFound,
             },
         )?;
 

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -100,7 +100,10 @@ impl CoreGroup {
         // If the message is older than the current epoch, we need to fetch the correct secret tree first.
         let message_secrets = self
             .message_secrets_mut(unverified_message.epoch())
-            .map_err(|_| UnverifiedMessageError::NoPastEpochData)?;
+            .map_err(|e| match e {
+                SecretTreeError::TooDistantInThePast => UnverifiedMessageError::NoPastEpochData,
+                _ => LibraryError::custom("Unexpected return value").into(),
+            })?;
 
         // Checks the following semantic validation:
         //  - ValSem008

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -1,5 +1,7 @@
 use core_group::{proposals::QueuedProposal, staged_commit::StagedCommit};
 
+use crate::group::mls_group::errors::UnverifiedMessageError;
+
 use super::{proposals::ProposalStore, *};
 
 impl CoreGroup {
@@ -93,10 +95,12 @@ impl CoreGroup {
         proposal_store: &ProposalStore,
         own_kpbs: &[KeyPackageBundle],
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<ProcessedMessage, CoreGroupError> {
+    ) -> Result<ProcessedMessage, UnverifiedMessageError> {
         // Add the context to the message and verify the membership tag if necessary.
         // If the message is older than the current epoch, we need to fetch the correct secret tree first.
-        let message_secrets = self.message_secrets_mut(unverified_message.epoch())?;
+        let message_secrets = self
+            .message_secrets_mut(unverified_message.epoch())
+            .map_err(|_| UnverifiedMessageError::NoPastEpochData)?;
 
         // Checks the following semantic validation:
         //  - ValSem008
@@ -104,14 +108,16 @@ impl CoreGroup {
             unverified_message,
             message_secrets,
             backend,
-        )?;
+        )
+        .map_err(|_| UnverifiedMessageError::InvalidMembershipTag)?;
 
         match context_plaintext {
             UnverifiedContextMessage::Group(unverified_message) => {
                 // Checks the following semantic validation:
                 //  - ValSem010
-                let verified_member_message =
-                    unverified_message.into_verified(backend, signature_key)?;
+                let verified_member_message = unverified_message
+                    .into_verified(backend, signature_key)
+                    .map_err(|_| UnverifiedMessageError::InvalidSignature)?;
 
                 Ok(match verified_member_message.plaintext().content() {
                     MlsPlaintextContentType::Application(application_message) => {
@@ -155,10 +161,11 @@ impl CoreGroup {
             UnverifiedContextMessage::Preconfigured(external_message) => {
                 // Signature verification
                 if let Some(signature_public_key) = signature_key {
-                    let _verified_external_message =
-                        external_message.into_verified(backend, signature_public_key)?;
+                    let _verified_external_message = external_message
+                        .into_verified(backend, signature_public_key)
+                        .map_err(|_| UnverifiedMessageError::InvalidSignature)?;
                 } else {
-                    return Err(CoreGroupError::NoSignatureKey);
+                    return Err(UnverifiedMessageError::MissingSignatureKey);
                 }
 
                 // We don't support external messages from preconfigured senders yet

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -182,7 +182,7 @@ fn test_failed_groupinfo_decryption(
         let error = CoreGroup::new_from_welcome(broken_welcome, None, key_package_bundle, backend)
             .expect_err("Creation of core group from a broken Welcome was successful.");
 
-        assert_eq!(error, WelcomeError::CouldNotDecrypt)
+        assert_eq!(error, WelcomeError::UnableToDecrypt)
     }
 }
 

--- a/openmls/src/group/core_group/test_duplicate_extension.rs
+++ b/openmls/src/group/core_group/test_duplicate_extension.rs
@@ -99,9 +99,11 @@ fn duplicate_ratchet_tree_extension(
 
     // Find key_package in welcome secrets
     let egs = CoreGroup::find_key_package_from_welcome_secrets(
-        bob_key_package_bundle.key_package(),
+        bob_key_package_bundle
+            .key_package()
+            .hash_ref(backend.crypto())
+            .expect("An unexpected error occurred."),
         welcome.secrets(),
-        backend,
     )
     .expect("JoinerSecret not found");
 

--- a/openmls/src/group/core_group/validation.rs
+++ b/openmls/src/group/core_group/validation.rs
@@ -281,19 +281,19 @@ impl CoreGroup {
         key_package: &KeyPackage,
         public_key_set: HashSet<Vec<u8>>,
         proposal_sender: &Sender,
-    ) -> Result<(), CoreGroupError> {
+    ) -> Result<(), ProposalValidationError> {
         let indexed_key_packages = self.treesync().full_leaves()?;
         if let Some(existing_key_package) = indexed_key_packages.get(&sender) {
             // ValSem109
             if key_package.credential().identity() != existing_key_package.credential().identity() {
-                return Err(ProposalValidationError::UpdateProposalIdentityMismatch.into());
+                return Err(ProposalValidationError::UpdateProposalIdentityMismatch);
             }
             // ValSem110
             if public_key_set.contains(key_package.hpke_init_key().as_slice()) {
-                return Err(ProposalValidationError::ExistingPublicKeyUpdateProposal.into());
+                return Err(ProposalValidationError::ExistingPublicKeyUpdateProposal);
             }
         } else if proposal_sender.is_member() {
-            return Err(ProposalValidationError::UnknownMember.into());
+            return Err(ProposalValidationError::UnknownMember);
         }
         Ok(())
     }

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -108,7 +108,7 @@ pub enum WelcomeError {
     #[error("Malformed Welcome message.")]
     MalformedWelcomeMessage,
     #[error("Could not decrypt the Welcome message.")]
-    CouldNotDecrypt,
+    UnableToDecrypt,
     #[error("Unsupported extensions found in the KeyPackage of another member.")]
     UnsupportedExtensions,
     #[error("A duplicate ratchet tree was found.")]
@@ -282,14 +282,14 @@ pub enum ExternalCommitValidationError {
     MultipleExternalInitProposals,
     #[error("Found inline Add or Update proposals.")]
     InvalidInlineProposals,
-    // FIXME: this seems unused
+    // TODO #803: this seems unused
     #[error("Found multiple inline Remove proposals.")]
     MultipleRemoveProposals,
     #[error("Remove proposal targets the wrong group member.")]
     InvalidRemoveProposal,
     #[error("Found an ExternalInit proposal among the referenced proposals.")]
     ReferencedExternalInitProposal,
-    // FIXME: this seems unused
+    // TODO #803: this seems unused
     #[error("External Commit has to contain a path.")]
     NoPath,
     #[error("The remove proposal referenced a non-existing member.")]

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -8,10 +8,10 @@ use crate::{
     credentials::CredentialError,
     error::LibraryError,
     extensions::errors::ExtensionError,
-    framing::errors::{MlsCiphertextError, MlsPlaintextError, SenderError, ValidationError},
+    framing::errors::{MlsCiphertextError, SenderError, ValidationError},
     key_packages::KeyPackageError,
-    schedule::{KeyScheduleError, PskSecretError},
-    treesync::{errors::*, treekem::TreeKemError, TreeSyncError},
+    schedule::{KeyScheduleError, PskError},
+    treesync::errors::*,
 };
 use openmls_traits::types::CryptoError;
 use thiserror::Error;
@@ -31,8 +31,6 @@ pub enum CoreGroupError {
     #[error(transparent)]
     MlsCiphertextError(#[from] MlsCiphertextError),
     #[error(transparent)]
-    MlsPlaintextError(#[from] MlsPlaintextError),
-    #[error(transparent)]
     WelcomeError(#[from] WelcomeError),
     #[error(transparent)]
     ExternalCommitError(#[from] ExternalCommitError),
@@ -51,7 +49,7 @@ pub enum CoreGroupError {
     #[error(transparent)]
     KeyScheduleError(#[from] KeyScheduleError),
     #[error(transparent)]
-    PskSecretError(#[from] PskSecretError),
+    PskSecretError(#[from] PskError),
     #[error(transparent)]
     CredentialError(#[from] CredentialError),
     #[error(transparent)]
@@ -155,6 +153,8 @@ pub enum StageCommitError {
     LibraryError(#[from] LibraryError),
     #[error("The epoch of the group context and MlsPlaintext didn't match.")]
     EpochMismatch,
+    #[error("The Commit was created by this client.")]
+    OwnCommit,
     #[error("stage_commit was called with an MlsPlaintext that is not a Commit.")]
     WrongPlaintextContentType,
     #[error("Unable to verify the key package signature.")]
@@ -171,6 +171,18 @@ pub enum StageCommitError {
     OwnKeyNotFound,
     #[error("External Committer used the wrong index.")]
     InconsistentSenderIndex,
+    #[error("The sender is of type preconfigured, which is not valid.")]
+    SenderTypePreconfigured,
+    #[error("Too many new members: the tree is full.")]
+    TooManyNewMembers,
+    #[error(transparent)]
+    ProposalValidationError(#[from] ProposalValidationError),
+    #[error(transparent)]
+    PskError(#[from] PskError),
+    #[error(transparent)]
+    ExternalCommitValidation(#[from] ExternalCommitValidationError),
+    #[error(transparent)]
+    UpdatePathError(#[from] ApplyUpdatePathError),
 }
 
 // === Crate errors ===

--- a/openmls/src/group/mls_group/application.rs
+++ b/openmls/src/group/mls_group/application.rs
@@ -17,11 +17,13 @@ impl MlsGroup {
         message: &[u8],
     ) -> Result<MlsMessageOut, MlsGroupError> {
         if !self.is_active() {
-            return Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error));
+            return Err(MlsGroupError::GroupStateError(
+                MlsGroupStateError::UseAfterEviction,
+            ));
         }
         if !self.proposal_store.is_empty() {
-            return Err(MlsGroupError::PendingProposalsExist(
-                PendingProposalsError::Exists,
+            return Err(MlsGroupError::GroupStateError(
+                MlsGroupStateError::PendingProposal,
             ));
         }
 

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -6,102 +6,97 @@
 use crate::config::ConfigError;
 use crate::credentials::CredentialError;
 use crate::error::LibraryError;
-use crate::framing::MlsCiphertextError;
 use crate::framing::ValidationError;
+use crate::group::errors::StageCommitError;
 use crate::group::WelcomeError;
-use crate::group::{CoreGroupError, CreateCommitError, ExporterError, StageCommitError};
+use crate::group::{CoreGroupError, CreateCommitError, ExporterError};
 use crate::treesync::TreeSyncError;
 use openmls_traits::types::CryptoError;
+use thiserror::Error;
 use tls_codec::Error as TlsCodecError;
 
-implement_error! {
-    pub enum MlsGroupError {
-        Simple {
-            NoMatchingCredentialBundle = "Couldn't find a `CredentialBundle` in the `KeyStore` that matches the one in my leaf.",
-            NoMatchingKeyPackageBundle = "Couldn't find a `KeyPackageBundle` in the `KeyStore` that matches the given `KeyPackage` hash.",
-            PoisonedCredentialBundle = "Tried to access a poisoned `CredentialBundle`. See [`PoisonError`](`std::sync::PoisonError`) for details.",
-            NoSignatureKey = "No signature key was available to verify the message signature.",
-            PendingCommitError = "Can't create a new commit while another commit is still pending. Please clear or merge the pending commit before creating a new one.",
-            NoPendingCommit = "There is no pending commit that can be merged.",
-            ExternalCommitError = "Can't clear an external commit, as the group can't merge `Member` commits yet. If an external commit is rejected by the DS, a new external init must be performed. See the MLS spec for more information.",
-            KeyStoreError = "Error performing key store operation.",
-            IncompatibleWireFormat = "The incoming message's wire format was not compatible with the wire format policy for incoming messages.",
-        }
-        Complex {
-            LibraryError(LibraryError) =
-                "An internal library error occurred. Additional detail is provided.",
-            Config(ConfigError) =
-                "See [`ConfigError`](`crate::config::ConfigError`) for details",
-            Group(CoreGroupError) =
-                "See [`CoreGroupError`](`crate::group::CoreGroupError`) for details",
-            CreateCommit(CreateCommitError) =
-                "See [`CreateCommitError`](`crate::group::CreateCommitError`) for details",
-            UseAfterEviction(UseAfterEviction) =
-                "See [`UseAfterEviction`](`UseAfterEviction`) for details",
-            PendingProposalsExist(PendingProposalsError) =
-                "See [`PendingProposalsError`](`PendingProposalsError`) for details",
-            Exporter(ExporterError) =
-                "See [`ExporterError`](`crate::group::ExporterError`) for details",
-            EmptyInput(EmptyInputError) =
-                "Empty input. Additional detail is provided.",
-            InvalidMessage(InvalidMessageError) = "The message could not be processed.",
-            CredentialError(CredentialError) = "See [`CredentialError`](`crate::credentials::CredentialError`) for details",
-            TreeSyncError(TreeSyncError) = "An error occurred during an operation on the tree underlying the group.",
-            ValidationError(ValidationError) = "See [`ValidationError`](`crate::framing::ValidationError`) for details",
-            TlsCodecError(TlsCodecError) = "An error occured during TLS encoding/decoding.",
-            CryptoError(CryptoError) =
-                "See [`CryptoError`](openmls_traits::types::CryptoError) for details.",
-            WelcomeError(WelcomeError) = "See [`WelcomeError`] for details.",
-        }
-    }
+/// MlsGroup error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum MlsGroupError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error(
+        "Couldn't find a `CredentialBundle` in the `KeyStore` that matches the one in my leaf."
+    )]
+    NoMatchingCredentialBundle,
+    #[error("Couldn't find a `KeyPackageBundle` in the `KeyStore` that matches the given `KeyPackage` hash.")]
+    NoMatchingKeyPackageBundle,
+    #[error("Tried to access a poisoned `CredentialBundle`. See [`PoisonError`](`std::sync::PoisonError`) for details.")]
+    PoisonedCredentialBundle,
+    #[error("No signature key was available to verify the message signature.")]
+    NoSignatureKey,
+    #[error("Can't create a new commit while another commit is still pending. Please clear or merge the pending commit before creating a new one.")]
+    PendingCommitError,
+    #[error("There is no pending commit that can be merged.")]
+    NoPendingCommit,
+    #[error("Can't clear an external commit, as the group can't merge `Member` commits yet. If an external commit is rejected by the DS, a new external init must be performed. See the MLS spec for more information.")]
+    ExternalCommitError,
+    #[error("Error performing key store operation.")]
+    KeyStoreError,
+    #[error("The incoming message's wire format was not compatible with the wire format policy for incoming messages.")]
+    IncompatibleWireFormat,
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+    #[error(transparent)]
+    Group(#[from] CoreGroupError),
+    #[error(transparent)]
+    CreateCommit(#[from] CreateCommitError),
+    #[error(transparent)]
+    GroupStateError(#[from] MlsGroupStateError),
+    #[error(transparent)]
+    Exporter(#[from] ExporterError),
+    #[error(transparent)]
+    EmptyInput(#[from] EmptyInputError),
+    #[error(transparent)]
+    CredentialError(#[from] CredentialError),
+    #[error(transparent)]
+    TreeSyncError(#[from] TreeSyncError),
+    #[error(transparent)]
+    ValidationError(#[from] ValidationError),
+    #[error(transparent)]
+    TlsCodecError(#[from] TlsCodecError),
+    #[error(transparent)]
+    CryptoError(#[from] CryptoError),
+    #[error(transparent)]
+    WelcomeError(#[from] WelcomeError),
 }
 
-implement_error! {
-    pub enum EmptyInputError {
-        AddMembers = "An empty list of KeyPackages was provided.",
-        RemoveMembers = "An empty list of indexes was provided.",
-    }
+/// EmptyInput error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum EmptyInputError {
+    #[error("An empty list of KeyPackages was provided.")]
+    AddMembers,
+    #[error("An empty list of indexes was provided.")]
+    RemoveMembers,
 }
 
-implement_error! {
-    pub enum UseAfterEviction {
-        Error = "Tried to use a group after being evicted from it.",
-    }
+/// Group state error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum MlsGroupStateError {
+    #[error("Tried to use a group after being evicted from it.")]
+    UseAfterEviction,
+    #[error("Can't create message because a pending proposal exists.")]
+    PendingProposal,
 }
 
-implement_error! {
-    pub enum PendingProposalsError {
-        Exists = "Can't create message because a pending proposal exists.",
-    }
-}
-
-implement_error! {
-    pub enum InvalidMessageError {
-        Simple {
-            MissingMembershipTag =
-                "A message without a membership tag received.",
-            MembershipTagMismatch =
-                "A message with an invalid membership tag was received.",
-            UnknownSender =
-                "Could not retrieve credential for the given sender.",
-            InvalidProposal =
-                "The given proposal is invalid.",
-            CommitWithInvalidProposals =
-                "A commit contained an invalid proposal.",
-            InvalidApplicationMessage =
-                "The application message is invalid.",
-            WrongEpoch = "The epoch does not match the group's epoch.",
-            MissingConfirmationTag = "The confirmation tag is missing in the Commit message.",
-            InvalidSignature = "The message's signature is invalid.",
-            WrongGroupId = "Wrong group ID.",
-        }
-        Complex {
-            InvalidCiphertext(MlsCiphertextError) =
-                "An invalid ciphertext was provided. The error returns the associated data of the ciphertext.",
-            CommitError(StageCommitError) =
-                "See [`StageCommitError`](`crate::group::StageCommitError`) for details",
-            GroupError(CoreGroupError) =
-                "See [`CoreGroupError`](`crate::group::CoreGroupError`) for details",
-        }
-    }
+/// Unverified message error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum UnverifiedMessageError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("The message is from an epoch too far in the past.")]
+    NoPastEpochData,
+    #[error("The message's signature is invalid.")]
+    InvalidSignature,
+    #[error("The message's membership tag is invalid.")]
+    InvalidMembershipTag,
+    #[error("A signature key was not provided for a preconfigured message.")]
+    MissingSignatureKey,
+    #[error(transparent)]
+    InvalidCommit(#[from] StageCommitError),
 }

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -71,7 +71,7 @@ pub enum MlsGroupError {
 pub enum EmptyInputError {
     #[error("An empty list of KeyPackages was provided.")]
     AddMembers,
-    #[error("An empty list of indexes was provided.")]
+    #[error("An empty list of KeyPackage references was provided.")]
     RemoveMembers,
 }
 

--- a/openmls/src/group/mls_group/exporting.rs
+++ b/openmls/src/group/mls_group/exporting.rs
@@ -20,7 +20,9 @@ impl MlsGroup {
                 .group
                 .export_secret(backend, label, context, key_length)?)
         } else {
-            Err(MlsGroupError::UseAfterEviction(UseAfterEviction::Error))
+            Err(MlsGroupError::GroupStateError(
+                MlsGroupStateError::UseAfterEviction,
+            ))
         }
     }
 

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -410,11 +410,7 @@ fn test_invalid_plaintext(ciphersuite: &'static Ciphersuite, backend: &impl Open
         .expect_err("No error when distributing message with invalid signature.");
 
     assert_eq!(
-        ClientError::MlsGroupError(MlsGroupError::Group(CoreGroupError::ValidationError(
-            ValidationError::MlsPlaintextError(MlsPlaintextError::VerificationError(
-                VerificationError::InvalidMembershipTag
-            ))
-        ))),
+        ClientError::UnverifiedMessageError(UnverifiedMessageError::InvalidMembershipTag),
         error
     );
 

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -19,9 +19,7 @@ use tls_codec::*;
 // Crate
 pub(crate) mod core_group;
 pub(crate) use core_group::*;
-pub(crate) use errors::{
-    CoreGroupError, CreateCommitError, ExporterError, StageCommitError, WelcomeError,
-};
+pub(crate) use errors::{CoreGroupError, CreateCommitError, ExporterError, WelcomeError};
 #[cfg(not(any(feature = "test-utils", test)))]
 pub(crate) use group_context::*;
 

--- a/openmls/src/group/tests/test_encoding.rs
+++ b/openmls/src/group/tests/test_encoding.rs
@@ -195,13 +195,26 @@ fn test_add_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
         let add_encoded = add
             .tls_serialize_detached()
             .expect("Could not encode proposal.");
-        let add_decoded = match VerifiableMlsPlaintext::tls_deserialize(&mut add_encoded.as_slice())
-        {
-            Ok(a) => group_state
-                .verify(a, backend)
-                .expect("Error verifying MlsPlaintext"),
-            Err(err) => panic!("Error decoding MPLSPlaintext Add: {:?}", err),
-        };
+        let mut verifiable_plaintext =
+            VerifiableMlsPlaintext::tls_deserialize(&mut add_encoded.as_slice())
+                .expect("An unexpected error occurred.");
+
+        verifiable_plaintext.set_context(
+            group_state
+                .context()
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        );
+
+        let credential = group_state
+            .treesync()
+            .own_leaf_node()
+            .expect("An unexpected error occurred.")
+            .key_package()
+            .credential();
+        let add_decoded = verifiable_plaintext
+            .verify(backend, credential)
+            .expect("An unexpected error occurred.");
 
         assert_eq!(add, add_decoded);
     }
@@ -243,13 +256,26 @@ fn test_remove_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
         let remove_encoded = remove
             .tls_serialize_detached()
             .expect("Could not encode proposal.");
-        let remove_decoded =
-            match VerifiableMlsPlaintext::tls_deserialize(&mut remove_encoded.as_slice()) {
-                Ok(a) => group_state
-                    .verify(a, backend)
-                    .expect("Error verifying MlsPlaintext"),
-                Err(err) => panic!("Error decoding MPLSPlaintext Remove: {:?}", err),
-            };
+        let mut verifiable_plaintext =
+            VerifiableMlsPlaintext::tls_deserialize(&mut remove_encoded.as_slice())
+                .expect("An unexpected error occurred.");
+
+        verifiable_plaintext.set_context(
+            group_state
+                .context()
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        );
+
+        let credential = group_state
+            .treesync()
+            .own_leaf_node()
+            .expect("An unexpected error occurred.")
+            .key_package()
+            .credential();
+        let remove_decoded = verifiable_plaintext
+            .verify(backend, credential)
+            .expect("An unexpected error occurred.");
 
         assert_eq!(remove, remove_decoded);
     }
@@ -340,13 +366,27 @@ fn test_commit_encoding(backend: &impl OpenMlsCryptoProvider) {
             .commit
             .tls_serialize_detached()
             .expect("An unexpected error occurred.");
-        let commit_decoded =
-            match VerifiableMlsPlaintext::tls_deserialize(&mut commit_encoded.as_slice()) {
-                Ok(a) => group_state
-                    .verify(a, backend)
-                    .expect("Error verifying MlsPlaintext"),
-                Err(err) => panic!("Error decoding MPLSPlaintext Commit: {:?}", err),
-            };
+
+        let mut verifiable_plaintext =
+            VerifiableMlsPlaintext::tls_deserialize(&mut commit_encoded.as_slice())
+                .expect("An unexpected error occurred.");
+
+        verifiable_plaintext.set_context(
+            group_state
+                .context()
+                .tls_serialize_detached()
+                .expect("An unexpected error occurred."),
+        );
+
+        let credential = group_state
+            .treesync()
+            .own_leaf_node()
+            .expect("An unexpected error occurred.")
+            .key_package()
+            .credential();
+        let commit_decoded = verifiable_plaintext
+            .verify(backend, credential)
+            .expect("An unexpected error occurred.");
 
         assert_eq!(create_commit_result.commit, commit_decoded);
     }

--- a/openmls/src/group/tests/test_framing_validation.rs
+++ b/openmls/src/group/tests/test_framing_validation.rs
@@ -452,7 +452,7 @@ fn test_valsem006(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
     assert_eq!(
         err,
         MlsGroupError::Group(CoreGroupError::ValidationError(
-            ValidationError::MlsCiphertextError(MlsCiphertextError::DecryptionError)
+            ValidationError::UnableToDecrypt(MlsCiphertextError::DecryptionError)
         ))
     );
 
@@ -497,7 +497,7 @@ fn test_valsem007(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
     assert_eq!(
         err,
         MlsGroupError::Group(CoreGroupError::ValidationError(
-            ValidationError::MissingMembershipTag
+            ValidationError::VerificationError(VerificationError::MissingMembershipTag)
         ))
     );
 
@@ -568,14 +568,7 @@ fn test_valsem008(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
         .process_unverified_message(unverified_message, None, backend)
         .expect_err("Could process unverified message despite wrong membership tag.");
 
-    assert_eq!(
-        err,
-        MlsGroupError::Group(CoreGroupError::ValidationError(
-            ValidationError::MlsPlaintextError(MlsPlaintextError::VerificationError(
-                VerificationError::InvalidMembershipTag
-            ))
-        ))
-    );
+    assert_eq!(err, UnverifiedMessageError::InvalidMembershipTag);
 
     // Positive case
     let unverified_message = bob_group
@@ -727,12 +720,7 @@ fn test_valsem010(ciphersuite: &'static Ciphersuite, backend: &impl OpenMlsCrypt
         .process_unverified_message(unverified_message, None, backend)
         .expect_err("Could process unverified message despite wrong signature.");
 
-    assert_eq!(
-        err,
-        MlsGroupError::Group(CoreGroupError::ValidationError(
-            ValidationError::CredentialError(CredentialError::InvalidSignature)
-        ))
-    );
+    assert_eq!(err, UnverifiedMessageError::InvalidSignature);
 
     // Positive case
     let unverified_message = bob_group

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -193,7 +193,7 @@ fn test_past_secrets_in_group(
             assert_eq!(
                 err,
                 MlsGroupError::Group(CoreGroupError::ValidationError(
-                    ValidationError::MlsCiphertextError(MlsCiphertextError::DecryptionError),
+                    ValidationError::UnableToDecrypt(MlsCiphertextError::DecryptionError),
                 ))
             );
         }

--- a/openmls/src/schedule/errors.rs
+++ b/openmls/src/schedule/errors.rs
@@ -29,7 +29,7 @@ pub enum KeyScheduleError {
 
 /// PSK secret error
 #[derive(Error, Debug, PartialEq, Clone)]
-pub enum PskSecretError {
+pub enum PskError {
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
     #[error("More than 2^16 PSKs were provided.")]

--- a/openmls/src/schedule/psk.rs
+++ b/openmls/src/schedule/psk.rs
@@ -291,11 +291,11 @@ impl PskSecret {
         ciphersuite: &'static Ciphersuite,
         backend: &impl OpenMlsCryptoProvider,
         psk_ids: &[PreSharedKeyId],
-    ) -> Result<Self, PskSecretError> {
+    ) -> Result<Self, PskError> {
         // Check that we don't have too many PSKs
         let num_psks = psk_ids.len();
         if num_psks > u16::MAX as usize {
-            return Err(PskSecretError::TooManyKeys);
+            return Err(PskError::TooManyKeys);
         }
         let num_psks = num_psks as u16;
 
@@ -309,7 +309,7 @@ impl PskSecret {
             ) {
                 psk_bundles.push(psk_bundle);
             } else {
-                return Err(PskSecretError::KeyNotFound);
+                return Err(PskError::KeyNotFound);
             }
         }
 

--- a/openmls/src/test_utils/test_framework/errors.rs
+++ b/openmls/src/test_utils/test_framework/errors.rs
@@ -58,6 +58,8 @@ pub enum ClientError {
     #[error(transparent)]
     KeyPackageError(#[from] KeyPackageError),
     #[error(transparent)]
+    UnverifiedMessageError(#[from] UnverifiedMessageError),
+    #[error(transparent)]
     LibraryError(#[from] LibraryError),
     #[error("")]
     Unknown,

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -350,6 +350,12 @@ impl<'a> TreeSyncDiff<'a> {
     ///
     /// Returns the `CommitSecret` derived from the path secret of the root
     /// node. Returns an error if the target leaf is outside of the tree.
+    ///
+    /// Returns TreeSyncSetPathError::PublicKeyMismatch if the derived keys don't
+    /// match with the existing ones.
+    ///
+    /// Returns TreeSyncSetPathError::LibraryError if the sender_index is not
+    /// in the tree.
     pub(super) fn set_path_secrets(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
@@ -357,7 +363,7 @@ impl<'a> TreeSyncDiff<'a> {
         mut path_secret: PathSecret,
         sender_index: LeafIndex,
     ) -> Result<CommitSecret, TreeSyncSetPathError> {
-        // We assume both nodes are in the tree
+        // We assume both nodes are in the tree, since the sender_index must be in the tree
         let subtree_path = self
             .diff
             .subtree_path(self.own_leaf_index, sender_index)

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -44,7 +44,7 @@ use crate::{
     credentials::CredentialBundle,
     error::LibraryError,
     extensions::ExtensionType,
-    key_packages::{KeyPackage, KeyPackageBundlePayload, KeyPackageError},
+    key_packages::{KeyPackage, KeyPackageBundlePayload},
     messages::PathSecret,
     schedule::CommitSecret,
 };
@@ -143,14 +143,21 @@ impl<'a> TreeSyncDiff<'a> {
 
     /// Find and return the index of either the left-most blank leaf, or, if
     /// there are no blank leaves, the leaf count.
-    pub(crate) fn free_leaf_index(&self) -> Result<LeafIndex, TreeSyncDiffError> {
+    pub(crate) fn free_leaf_index(&self) -> Result<LeafIndex, LibraryError> {
         // Find a free leaf and fill it with the new key package.
         let leaf_ids = self.diff.leaves()?;
         let mut leaf_index_option = None;
         for (leaf_index, leaf_id) in leaf_ids.iter().enumerate() {
             let leaf_index: LeafIndex = u32::try_from(leaf_index)
                 .map_err(|_| LibraryError::custom("Could not convert index"))?;
-            if self.diff.node(*leaf_id)?.node().is_none() {
+            // The leaf ID must be valid, since it is one of the leaves of the tree
+            if self
+                .diff
+                .node(*leaf_id)
+                .map_err(|_| LibraryError::custom("Expected a valid leaf ID"))?
+                .node()
+                .is_none()
+            {
                 leaf_index_option = Some(leaf_index);
                 break;
             }
@@ -171,29 +178,39 @@ impl<'a> TreeSyncDiff<'a> {
         &mut self,
         leaf_node: KeyPackage,
         backend: &impl OpenMlsCrypto,
-    ) -> Result<LeafIndex, TreeSyncDiffError> {
-        let node = Node::LeafNode(LeafNode::new(leaf_node, backend).map_err(|e| {
-            if let KeyPackageError::CryptoError(e) = e {
-                TreeSyncDiffError::CryptoError(e)
-            } else {
-                TreeSyncDiffError::LibraryError(LibraryError::custom("key package error"))
-            }
-        })?);
+    ) -> Result<LeafIndex, TreeSyncAddLeaf> {
+        let node = Node::LeafNode(LeafNode::new(leaf_node, backend)?);
         // Find a free leaf and fill it with the new key package.
         let leaf_index = self.free_leaf_index()?;
         // If the free leaf index is within the tree, put the new leaf there,
         // otherwise extend the tree.
         if leaf_index < self.leaf_count() {
-            self.diff.replace_leaf(leaf_index, node.into())?;
+            self.diff
+                .replace_leaf(leaf_index, node.into())
+                .map_err(|_| LibraryError::custom("no parent hash extension"))?;
         } else {
-            self.diff.add_leaf(TreeSyncNode::blank(), node.into())?;
+            self.diff
+                .add_leaf(TreeSyncNode::blank(), node.into())
+                .map_err(|_| TreeSyncAddLeaf::TreeFull)?;
         }
         // Add new unmerged leaves entry to all nodes in direct path. Also, wipe
         // the cached tree hash.
-        for node_id in self.diff.direct_path(leaf_index)? {
-            let tsn = self.diff.node_mut(node_id)?;
+        for node_id in self
+            .diff
+            .direct_path(leaf_index)
+            // We checked the leaf index is in the tree
+            .map_err(|_| LibraryError::custom("Expected leaf index to be in tree"))?
+        {
+            // We know that the nodes from the direct path are in the tree
+            let tsn = self
+                .diff
+                .node_mut(node_id)
+                .map_err(|_| LibraryError::custom("Expected a node"))?;
             if let Some(ref mut node) = tsn.node_mut() {
-                let pn = node.as_parent_node_mut()?;
+                // We know that nodes in the direct path are always parent nodes
+                let pn = node
+                    .as_parent_node_mut()
+                    .map_err(|_| LibraryError::custom("Expected a parent node"))?;
                 pn.add_unmerged_leaf(leaf_index);
             }
             tsn.erase_tree_hash();
@@ -290,31 +307,27 @@ impl<'a> TreeSyncDiff<'a> {
         sender_leaf_index: LeafIndex,
         key_package: KeyPackage,
         path: Vec<ParentNode>,
-    ) -> Result<(), TreeSyncDiffError> {
+    ) -> Result<(), ApplyUpdatePathError> {
         let parent_hash =
             self.process_update_path(backend, ciphersuite, sender_leaf_index, path)?;
 
         // Verify the parent hash.
         let phe = key_package
             .extension_with_type(ExtensionType::ParentHash)
-            .ok_or(TreeSyncDiffError::MissingParentHash)?;
+            .ok_or(ApplyUpdatePathError::MissingParentHash)?;
         let key_package_parent_hash = phe
             .as_parent_hash_extension()
             .map_err(|_| LibraryError::custom("no parent hash extension"))?
             .parent_hash();
         if key_package_parent_hash != parent_hash {
-            return Err(TreeSyncDiffError::ParentHashMismatch);
+            return Err(ApplyUpdatePathError::ParentHashMismatch);
         };
 
         // Replace the leaf.
-        let node = Node::LeafNode(LeafNode::new(key_package, backend.crypto()).map_err(|e| {
-            if let KeyPackageError::CryptoError(e) = e {
-                TreeSyncDiffError::CryptoError(e)
-            } else {
-                TreeSyncDiffError::LibraryError(LibraryError::custom("key package error"))
-            }
-        })?);
-        self.diff.replace_leaf(sender_leaf_index, node.into())?;
+        let node = Node::LeafNode(LeafNode::new(key_package, backend.crypto())?);
+        self.diff
+            .replace_leaf(sender_leaf_index, node.into())
+            .map_err(|_| LibraryError::custom("Expected sender leaf to be in the tree"))?;
         Ok(())
     }
 
@@ -330,7 +343,7 @@ impl<'a> TreeSyncDiff<'a> {
         ciphersuite: &Ciphersuite,
         leaf_index: LeafIndex,
         mut path: Vec<ParentNode>,
-    ) -> Result<Vec<u8>, TreeSyncDiffError> {
+    ) -> Result<Vec<u8>, LibraryError> {
         // Compute the parent hash.
         let parent_hash = self.set_parent_hashes(backend, ciphersuite, &mut path, leaf_index)?;
         let direct_path: Vec<TreeSyncNode> = path
@@ -340,7 +353,9 @@ impl<'a> TreeSyncDiff<'a> {
 
         // Set the direct path. Note, that the nodes here don't have a tree hash
         // set.
-        self.diff.set_direct_path(leaf_index, direct_path)?;
+        self.diff
+            .set_direct_path(leaf_index, direct_path)
+            .map_err(|_| LibraryError::custom("Expected the leaf index to be in the tree"))?;
         Ok(parent_hash)
     }
 
@@ -452,7 +467,7 @@ impl<'a> TreeSyncDiff<'a> {
         ciphersuite: &Ciphersuite,
         path: &mut [ParentNode],
         leaf_index: LeafIndex,
-    ) -> Result<Vec<u8>, TreeSyncDiffError> {
+    ) -> Result<Vec<u8>, LibraryError> {
         // If the path is empty, return a zero-length string. This is the case
         // when the tree has only one leaf.
         if path.is_empty() {
@@ -464,9 +479,7 @@ impl<'a> TreeSyncDiff<'a> {
         let mut copath_resolutions = self.copath_resolutions(leaf_index, &HashSet::new())?;
         // There should be as many copath resolutions as nodes in the direct
         // path.
-        if path.len() != copath_resolutions.len() {
-            return Err(TreeSyncDiffError::PathLengthError);
-        }
+        debug_assert_eq!(path.len(), copath_resolutions.len());
         // We go through the nodes in the direct path in reverse order and get
         // the corresponding copath resolution for each node.
         let mut previous_parent_hash = vec![];
@@ -581,8 +594,11 @@ impl<'a> TreeSyncDiff<'a> {
         &self,
         leaf_index: LeafIndex,
         excluded_indices: &HashSet<&LeafIndex>,
-    ) -> Result<Vec<Vec<HpkePublicKey>>, TreeSyncDiffError> {
-        let leaf = self.diff.leaf(leaf_index)?;
+    ) -> Result<Vec<Vec<HpkePublicKey>>, LibraryError> {
+        let leaf = self
+            .diff
+            .leaf(leaf_index)
+            .map_err(|_| LibraryError::custom("Expected leaf to be in tree"))?;
 
         // If we're the only node in the tree, there's no copath.
         if leaf == self.diff.root() {
@@ -592,8 +608,13 @@ impl<'a> TreeSyncDiff<'a> {
         // We want the full path here, including the leaf itself, but not the
         // root.
         let mut full_path = vec![leaf];
-        let mut direct_path = self.diff.direct_path(leaf_index)?;
+        let mut direct_path = self
+            .diff
+            .direct_path(leaf_index)
+            // We know the leaf index is in the tree
+            .map_err(|_| LibraryError::custom("Expected leaf index to be in tree"))?;
         if !direct_path.is_empty() {
+            // Remove root
             direct_path.pop();
         }
         full_path.append(&mut direct_path);
@@ -601,7 +622,11 @@ impl<'a> TreeSyncDiff<'a> {
         let mut copath_resolutions = Vec::new();
         for node_id in &full_path {
             // If sibling is not a blank, return its HpkePublicKey.
-            let sibling_id = self.diff.sibling(*node_id)?;
+            let sibling_id = self
+                .diff
+                .sibling(*node_id)
+                // The root should not be there anymore, hence sibling cannot fail
+                .map_err(|_| LibraryError::custom("Expected root to be removed"))?;
             let resolution = self.resolution(sibling_id, excluded_indices)?;
             copath_resolutions.push(resolution);
         }

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -187,7 +187,8 @@ impl<'a> TreeSyncDiff<'a> {
         if leaf_index < self.leaf_count() {
             self.diff
                 .replace_leaf(leaf_index, node.into())
-                .map_err(|_| LibraryError::custom("no parent hash extension"))?;
+                // We know the leaf index is in the tree, so replacing it should not fail
+                .map_err(|_| LibraryError::custom("Could not replace the leaf"))?;
         } else {
             self.diff
                 .add_leaf(TreeSyncNode::blank(), node.into())
@@ -300,6 +301,7 @@ impl<'a> TreeSyncDiff<'a> {
     /// secrets.
     ///
     /// Returns an error if the `sender_leaf_index` is outside of the tree.
+    /// TODO #804
     pub(crate) fn apply_received_update_path(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
@@ -327,6 +329,7 @@ impl<'a> TreeSyncDiff<'a> {
         let node = Node::LeafNode(LeafNode::new(key_package, backend.crypto())?);
         self.diff
             .replace_leaf(sender_leaf_index, node.into())
+            // We assume the sender leaf is in the tree
             .map_err(|_| LibraryError::custom("Expected sender leaf to be in the tree"))?;
         Ok(())
     }
@@ -337,6 +340,7 @@ impl<'a> TreeSyncDiff<'a> {
     ///
     /// Returns the parent hash of the leaf at `leaf_index`. Returns an error if
     /// the target leaf is outside of the tree.
+    /// TODO #804
     fn process_update_path(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
@@ -352,6 +356,7 @@ impl<'a> TreeSyncDiff<'a> {
             .collect();
 
         // Set the direct path. Note, that the nodes here don't have a tree hash
+        // TODO #804
         // set.
         self.diff
             .set_direct_path(leaf_index, direct_path)

--- a/openmls/src/treesync/errors.rs
+++ b/openmls/src/treesync/errors.rs
@@ -2,6 +2,7 @@ use thiserror::Error;
 
 use super::*;
 use crate::{binary_tree::MlsBinaryTreeDiffError, error::LibraryError};
+use tls_codec::Error as TlsCodecError;
 
 // === Public errors ===
 
@@ -18,6 +19,21 @@ pub enum PublicTreeError {
     MalformedTree,
     #[error("A parent hash was invalid.")]
     InvalidParentHash,
+}
+
+/// Apply update path error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum ApplyUpdatePathError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("The received update path and the derived nodes are not identical.")]
+    PathMismatch,
+    #[error("The parent hash of the ney key package is invalid.")]
+    ParentHashMismatch,
+    #[error("The parent hash of the ney key package is missing.")]
+    MissingParentHash,
+    #[error("Unable to decrypt the path node.")]
+    UnableToDecrypt,
 }
 
 // === Crate errors ===
@@ -54,6 +70,15 @@ pub enum TreeSyncSetPathError {
     LibraryError(#[from] LibraryError),
     #[error("The derived public key doesn't match the one in the tree.")]
     PublicKeyMismatch,
+}
+
+/// TreeSync set path error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum TreeSyncAddLeaf {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("The tree is full, we cannot add any more leaves.")]
+    TreeFull,
 }
 
 /// TreeSync from nodes error
@@ -105,6 +130,27 @@ pub enum TreeSyncDiffError {
     DerivationError(#[from] PathSecretError),
     #[error(transparent)]
     CreationError(#[from] MlsBinaryTreeError),
+    #[error(transparent)]
+    KeyPackageError(#[from] KeyPackageError),
+}
+
+/// TreeKem error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum TreeKemError {
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    #[error("The given path to encrypt does not have the same length as the direct path.")]
+    PathLengthError,
+    #[error("Couldn't find the path secret to encrypt for one of the new members.")]
+    PathSecretNotFound,
+    #[error(transparent)]
+    TreeSyncError(#[from] TreeSyncError),
+    #[error(transparent)]
+    TreeSyncDiffError(#[from] TreeSyncDiffError),
+    #[error(transparent)]
+    PathSecretError(#[from] PathSecretError),
+    #[error(transparent)]
+    EncodingError(#[from] TlsCodecError),
     #[error(transparent)]
     KeyPackageError(#[from] KeyPackageError),
 }

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -158,6 +158,9 @@ impl TreeSync {
     ///
     /// Returns the new [`TreeSync`] instance or an error if one of the
     /// invariants is not true (see [`TreeSync`]).
+    ///
+    /// Returns TreeSyncFromNodesError::LibraryError if the input parameters are
+    /// malformed.
     pub(crate) fn from_nodes_with_secrets(
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: &Ciphersuite,
@@ -221,10 +224,10 @@ impl TreeSync {
                         if leaf_node.public_key() == own_key_package.hpke_init_key() {
                             // Check if there's a duplicate
                             if let Some(private_key) = private_key.take() {
-                                own_index_option =
-                                    Some(u32::try_from(node_index / 2).map_err(|_| {
-                                        LibraryError::custom("Own leaf is outside of the tree")
-                                    })?);
+                                own_index_option = Some(
+                                    u32::try_from(node_index / 2)
+                                        .map_err(|_| LibraryError::custom("Architecture error"))?,
+                                );
                                 leaf_node.set_private_key(private_key);
                             } else {
                                 return Err(PublicTreeError::DuplicateKeyPackage.into());

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -43,7 +43,6 @@ use crate::{
 
 use self::{
     diff::{StagedTreeSyncDiff, TreeSyncDiff},
-    errors::TreeSyncDiffError,
     node::{leaf_node::LeafNode, Node, NodeError},
     treesync_node::{TreeSyncNode, TreeSyncNodeError},
 };
@@ -93,15 +92,7 @@ impl TreeSync {
         let key_package = key_package_bundle.key_package();
         // We generate our own leaf without a private key for now. The private
         // key is set in the `from_nodes` constructor below.
-        let node = Node::LeafNode(
-            LeafNode::new(key_package.clone(), backend.crypto()).map_err(|e| {
-                if let KeyPackageError::CryptoError(e) = e {
-                    LibraryError::unexpected_crypto_error(e)
-                } else {
-                    LibraryError::custom("Unexpected error in KeyPackage")
-                }
-            })?,
-        );
+        let node = Node::LeafNode(LeafNode::new(key_package.clone(), backend.crypto())?);
         let path_secret: PathSecret = key_package_bundle.leaf_secret().clone().into();
         let commit_secret: CommitSecret = path_secret
             .derive_path_secret(backend, key_package.ciphersuite())?

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     ciphersuite::{hash_ref::KeyPackageRef, HpkePrivateKey, HpkePublicKey},
     error::LibraryError,
-    key_packages::{KeyPackage, KeyPackageBundle, KeyPackageError},
+    key_packages::{KeyPackage, KeyPackageBundle},
 };
 
 /// This struct implements the MLS leaf node and contains a [`KeyPackage`] and
@@ -32,7 +32,7 @@ impl LeafNode {
     pub(crate) fn new(
         key_package: KeyPackage,
         backend: &impl OpenMlsCrypto,
-    ) -> Result<Self, KeyPackageError> {
+    ) -> Result<Self, LibraryError> {
         let key_package_ref = Some(key_package.hash_ref(backend)?);
         Ok(Self {
             key_package_ref,
@@ -58,7 +58,7 @@ impl LeafNode {
     pub(crate) fn new_from_bundle(
         key_package_bundle: KeyPackageBundle,
         backend: &impl OpenMlsCrypto,
-    ) -> Result<Self, KeyPackageError> {
+    ) -> Result<Self, LibraryError> {
         let key_package = key_package_bundle.key_package;
         let private_key_option = Some(key_package_bundle.private_key);
         let key_package_ref = Some(key_package.hash_ref(backend)?);

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -73,6 +73,7 @@ impl<'a> TreeSyncDiff<'a> {
     /// Returns a vector containing the decrypted [`ParentNode`] instances, as
     /// well as the [`CommitSecret`] resulting from their derivation. Returns an
     /// error if the `sender_leaf_index` is outside of the tree.
+    /// TODO #804
     pub(crate) fn decrypt_path(
         &self,
         backend: &impl OpenMlsCryptoProvider,
@@ -87,14 +88,17 @@ impl<'a> TreeSyncDiff<'a> {
             .update_path
             .get(path_position)
             // We know the update path has the right length through validation, therefore there must be an element at this position
+            // TODO #804
             .ok_or_else(|| LibraryError::custom("Expected to find ciphertext in update path"))?;
 
         let (decryption_key, resolution_position) = self
             .decryption_key(params.sender_leaf_index, params.exclusion_list)
+            // TODO #804
             .map_err(|_| LibraryError::custom("Expected sender to be in the tree"))?;
         let ciphertext = update_path_node
             .encrypted_path_secrets(resolution_position)
             // We know the update path has the right length through validation, therefore there must be a ciphertext at this position
+            // TODO #804
             .ok_or_else(|| LibraryError::custom("Expected to find ciphertext in update path"))?;
 
         let path_secret = PathSecret::decrypt(


### PR DESCRIPTION
This PR 

 - refactors the framing errors (gets rid of MlsPlaintextError in the process) 
 - gets rid of the old verification function in `CoreGroup` that was only used in tests
 - refactors `MlsGroup`-level errors
 - makes `StageCommitError` & `ExternalCommitValidationError` public (refactoring in TreeSync/TreeKem needed for that)
 - makes `UnverifiedMessageError` public, as return value from `MlsGroup::process_unverified_message()`
 - Refactors a further 20% of the total errors to use `thiserror`