### PR TITLE
Fix framing rustdocs

### DIFF
--- a/openmls/src/framing/errors.rs
+++ b/openmls/src/framing/errors.rs
@@ -1,7 +1,6 @@
 //! # Framing errors.
 //!
-//! `MlsPlaintextError` and `MlsCiphertextError` are thrown on errors
-//! handling `MlsPlaintext` and `MlsCiphertext`.
+//! This module contains errors related to message framing operations.
 
 use crate::error::LibraryError;
 use thiserror::Error;

--- a/openmls/src/framing/message.rs
+++ b/openmls/src/framing/message.rs
@@ -1,10 +1,10 @@
 //! MLS Message types
 //!
 //! This module defines two opaque message types that are used by the [`MlsGroup`] API.
-//! [`MlsMessageIn`] is used for messages between the DS and the client. It can be instantiated
+//! [`MlsMessageIn`] is used for messages between the Delivery Service and the client. It can be instantiated
 //! from a byte slice.
 //! [`MlsMessageOut`] is returned by various functions of the [`MlsGroup`] API. It is to be used between
-//! the client and the DS. It can be serialized to a byte vector.
+//! the client and the Delivery Service. It can be serialized to a byte vector.
 //!
 //! Both messages have the same API. The framing part of the message can be inspected through it. In particular,
 //! it is important to look at [`MlsMessageIn::group_id()`] to determine in which [`MlsGroup`] it should be processed.
@@ -30,7 +30,7 @@ pub(crate) enum MlsMessage {
 }
 
 impl MlsMessage {
-    /// Get the wire format
+    /// Returns the wire format.
     fn wire_format(&self) -> WireFormat {
         match self {
             MlsMessage::Ciphertext(_) => WireFormat::MlsCiphertext,
@@ -38,7 +38,7 @@ impl MlsMessage {
         }
     }
 
-    /// Get the group ID
+    /// Returns the group ID.
     fn group_id(&self) -> &GroupId {
         match self {
             MlsMessage::Ciphertext(m) => m.group_id(),
@@ -46,7 +46,7 @@ impl MlsMessage {
         }
     }
 
-    /// Get the epoch
+    /// Returns the epoch.
     fn epoch(&self) -> GroupEpoch {
         match self {
             MlsMessage::Ciphertext(m) => m.epoch(),
@@ -54,7 +54,7 @@ impl MlsMessage {
         }
     }
 
-    /// Get the content type
+    /// Returns the content type.
     fn content_type(&self) -> ContentType {
         match self {
             MlsMessage::Ciphertext(m) => m.content_type(),
@@ -87,22 +87,22 @@ pub struct MlsMessageIn {
 }
 
 impl MlsMessageIn {
-    /// Get the wire format
+    /// Returns the wire format.
     pub fn wire_format(&self) -> WireFormat {
         self.mls_message.wire_format()
     }
 
-    /// Get the group ID
+    /// Returns the group ID.
     pub fn group_id(&self) -> &GroupId {
         self.mls_message.group_id()
     }
 
-    /// Get the epoch
+    /// Returns the epoch.
     pub fn epoch(&self) -> GroupEpoch {
         self.mls_message.epoch()
     }
 
-    /// Get the content type
+    /// Returns the content type.
     pub fn content_type(&self) -> ContentType {
         self.mls_message.content_type()
     }
@@ -158,22 +158,22 @@ impl From<MlsCiphertext> for MlsMessageOut {
 }
 
 impl MlsMessageOut {
-    /// Get the wire format
+    /// Returns the wire format.
     pub fn wire_format(&self) -> WireFormat {
         self.mls_message.wire_format()
     }
 
-    /// Get the group ID
+    /// Returns the group ID.
     pub fn group_id(&self) -> &GroupId {
         self.mls_message.group_id()
     }
 
-    /// Get the epoch
+    /// Returns the epoch.
     pub fn epoch(&self) -> GroupEpoch {
         self.mls_message.epoch()
     }
 
-    /// Get the content type
+    /// Returns the content type.
     pub fn content_type(&self) -> ContentType {
         self.mls_message.content_type()
     }

--- a/openmls/src/framing/mod.rs
+++ b/openmls/src/framing/mod.rs
@@ -1,6 +1,10 @@
 //! # Message framing
 //!
-//! This module implements framing for MLS messages.
+//! This module contains framing-related operations for MLS messages, including validation operations.
+//!
+//!  - [`MlsMessageIn`]/[`MlsMessageOut`]: Unified message type for incoming & outgoing MLS messages
+//!  - [`ApplicationMessage`]: Application message received through a [`ProcessedMessage`]
+//!  - [`UnverifiedMessage`]: Partially checked and potentially decrypted message (if it was originally encrypted)
 
 use crate::ciphersuite::*;
 use crate::credentials::*;

--- a/openmls/src/framing/sender.rs
+++ b/openmls/src/framing/sender.rs
@@ -1,33 +1,4 @@
-//! # The sender of a message
-//!
-//! Section  9. Message Framing
-//!
-//! ```text
-//! enum {
-//!     reserved(0),
-//!     application(1),
-//!     proposal(2),
-//!     commit(3),
-//!     (255)
-//! } ContentType;
-//!
-//! enum {
-//!     reserved(0),
-//!     member(1),
-//!     preconfigured(2),
-//!     new_member(3),
-//!     (255)
-//! } SenderType;
-//!
-//! struct {
-//!     SenderType sender_type;
-//!     switch (sender_type) {
-//!         case member:        KeyPackageRef member;
-//!         case preconfigured: opaque external_key_id<0..255>;
-//!         case new_member:    struct{};
-//!     }
-//! } Sender;
-//! ```
+//! # The sender of a message.
 
 use super::*;
 use crate::ciphersuite::hash_ref::KeyPackageRef;

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -408,9 +408,9 @@ impl VerifiedExternalMessage {
     }
 }
 
-/// Message that has passed all syntax and semantics checks.
+/// A message that has passed all syntax and semantics checks.
 ///
-/// See the vriants' documentation for mor information.
+/// See the variants' documentation for more information.
 /// [`StagedCommit`] and [`QueuedProposal`] can be inspected for authorization purposes.
 #[derive(Debug)]
 pub enum ProcessedMessage {
@@ -427,7 +427,7 @@ pub enum ProcessedMessage {
     /// A Commit message.
     ///
     /// The [`StagedCommit`] can be inspected for authorization purposes by the application.
-    /// If the type of the commit and the proposals it covers aredeemed to be allowed,
+    /// If the type of the commit and the proposals it covers are deemed to be allowed,
     /// the commit should be merged into the group's state using [`MlsGroup::merge_staged_commit()`].
     StagedCommitMessage(Box<StagedCommit>),
 }

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -413,7 +413,7 @@ impl VerifiedExternalMessage {
 pub enum ProcessedMessage {
     /// An application message.
     ///
-    /// The [`ApplllicationMessage`] contains a vector of bytes that can be used right-away.
+    /// The [`ApplicationMessage`] contains a vector of bytes that can be used right-away.
     ApplicationMessage(ApplicationMessage),
     /// A standalone proposal.
     ///

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -1,4 +1,5 @@
 //! MLS messages and message framing.
+// TODO: #774
 
 use crate::{
     ciphersuite::hash_ref::KeyPackageRef,


### PR DESCRIPTION
Fixes #769.

Note that I could turn some types into `pub(crate)` and I'm therefore only touching the public docs.