### PR TITLE
README update and Cargo.toml updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 OpenMLS Authors
+Copyright (c) 2020 OpenMLS Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Raphael Robert
+Copyright (c) 2022 OpenMLS Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -113,17 +113,17 @@ You can start by looking at the [open issues](https://github.com/openmls/openmls
 
 OpenMLS adheres to the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Coduct. Please read the [Code of Conduct](CODE_OF_CONDUCT.md) carefully.
 
-[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg?style=flat&logo=zulip
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg?style=for-the-badge&logo=zulip
 [chat-link]: https://openmls.zulipchat.com
-[list-image]: https://img.shields.io/badge/mailing-list-blue.svg?style=flat
+[list-image]: https://img.shields.io/badge/mailing-list-blue.svg?style=for-the-badge
 [list-link]: https://groups.google.com/u/0/g/openmls-dev
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg?style=flat&logo=rust
-[docs-main-badge]: https://img.shields.io/badge/docs-main-blue.svg?style=flat
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg?style=for-the-badge&logo=rust
+[docs-main-badge]: https://img.shields.io/badge/docs-main-blue.svg?style=for-the-badge
 [docs-release-link]: https://docs.rs/crate/openmls/latest
 [docs-main-link]: https://openmls.tech/openmls/doc/openmls/index.html
 [book-release-link]: https://openmls.tech/book
 [book-main-link]: https://openmls.tech/openmls/book
-[drone-image]: https://img.shields.io/drone/build/openmls/openmls/main?label=ARM64%20Build%20Status&logo=drone
-[codecov-image]: https://img.shields.io/codecov/c/github/openmls/openmls/main?logo=codecov
-[gh-tests-image]: https://img.shields.io/github/workflow/status/openmls/openmls/Tests/main?label=Tests&style=flat&logo=github
-[gh-deploy-docs-image]: https://img.shields.io/github/workflow/status/openmls/openmls/Deploy%20Docs/main?label=Deploy%20Docs&logo=github
+[drone-image]: https://img.shields.io/drone/build/openmls/openmls/main?label=ARM64%20Build%20Status&logo=drone&style=for-the-badge
+[codecov-image]: https://img.shields.io/codecov/c/github/openmls/openmls/main?logo=codecov&style=for-the-badge
+[gh-tests-image]: https://img.shields.io/github/workflow/status/openmls/openmls/Tests/main?label=Tests&style=for-the-badge&logo=github
+[gh-deploy-docs-image]: https://img.shields.io/github/workflow/status/openmls/openmls/Deploy%20Docs/main?label=Deploy%20Docs&logo=github&style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ You can start by looking at the [open issues](https://github.com/openmls/openmls
 
 OpenMLS adheres to the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Coduct. Please read the [Code of Conduct](CODE_OF_CONDUCT.md) carefully.
 
-[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg?style=flat&logo=appveyor
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg?style=flat&logo=zulip
 [chat-link]: https://openmls.zulipchat.com
-[list-image]: https://img.shields.io/badge/mailing-list-blue.svg?style=flat&logo=appveyor
+[list-image]: https://img.shields.io/badge/mailing-list-blue.svg?style=flat
 [list-link]: https://groups.google.com/u/0/g/openmls-dev
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg?style=flat&logo=appveyor
-[docs-main-badge]: https://img.shields.io/badge/docs-main-blue.svg?style=flat&logo=appveyor
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg?style=flat&logo=rust
+[docs-main-badge]: https://img.shields.io/badge/docs-main-blue.svg?style=flat
 [docs-main-link]: https://openmls.tech/openmls/doc/openmls/index.html
 [book-link]: https://openmls.tech/openmls/book
-[drone-image]: https://img.shields.io/drone/build/openmls/openmls/main?label=ARM64%20Build%20Status
+[drone-image]: https://img.shields.io/drone/build/openmls/openmls/main?label=ARM64%20Build%20Status&logo=drone
 [codecov-image]: https://img.shields.io/codecov/c/github/openmls/openmls/main?logo=codecov

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # OpenMLS [![OpenMLS Chat][chat-image]][chat-link]
 
 [![Tests & Checks](https://github.com/openmls/openmls/actions/workflows/tests.yml/badge.svg)](https://github.com/openmls/openmls/actions/workflows/tests.yml)
-[![ARM64 Build Status](https://cloud.drone.io/api/badges/openmls/openmls/status.svg?ref=refs/heads/main)](https://cloud.drone.io/openmls/openmls)
+[![ARM64 Build Status][drone-image]](https://cloud.drone.io/openmls/openmls)
 [![Deploy Docs](https://github.com/openmls/openmls/workflows/Deploy%20Docs/badge.svg)][docs-main-link]
-[![codecov](https://codecov.io/gh/openmls/openmls/branch/main/graph/badge.svg?token=5SDRDRTZI0)](https://codecov.io/gh/openmls/openmls)
+[![codecov][codecov-image]](https://codecov.io/gh/openmls/openmls)
 [![OpenMLS List][list-image]][list-link]
 [![Docs][docs-main-badge]][docs-main-link]
 ![Rust Version][rustc-image]
 
 A WIP Rust implementation of [Messaging Layer Security](https://github.com/mlswg/mls-protocol/blob/master/draft-ietf-mls-protocol.md) based on draft 12+.
+
+### Documentation
+
+A user manual detailing how basic MLS operations can be performed using OpenMLS
+can be found [here][book-link]. More detailed documentation on OpenMLS' public
+API can be found [here][docs-main-link].
 
 ### Supported ciphersuites
 
@@ -44,11 +50,11 @@ OpenMLS only supports 32 and 64 bit platforms.
 
 #### Cryptography
 
-OpenMLS does not implement its own cryptographic primitives.
-Instead, it relies on existing implementations of the cryptographic primitives used.
-There are two different cryptography backends implemented right now.
-But consumers can bring their own implementation.
-See [traits](./traits/Readme.md) for more details.
+OpenMLS does not implement its own cryptographic primitives.  Instead, it relies
+on existing implementations of the cryptographic primitives used by MLS.  There
+are two different cryptography backends implemented right now.  But consumers
+can bring their own implementation.  See [traits](./traits/Readme.md) for more
+details.
 
 ## Development
 
@@ -103,10 +109,13 @@ You can start by looking at the [open issues](https://github.com/openmls/openmls
 
 OpenMLS adheres to the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Coduct. Please read the [Code of Conduct](CODE_OF_CONDUCT.md) carefully.
 
-[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg?style=flat&logo=appveyor
 [chat-link]: https://openmls.zulipchat.com
-[list-image]: https://img.shields.io/badge/mailing-list-blue.svg
+[list-image]: https://img.shields.io/badge/mailing-list-blue.svg?style=flat&logo=appveyor
 [list-link]: https://groups.google.com/u/0/g/openmls-dev
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
-[docs-main-badge]: https://img.shields.io/badge/docs-main-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg?style=flat&logo=appveyor
+[docs-main-badge]: https://img.shields.io/badge/docs-main-blue.svg?style=flat&logo=appveyor
 [docs-main-link]: https://openmls.tech/openmls/doc/openmls/index.html
+[book-link]: https://openmls.tech/openmls/book
+[drone-image]: https://img.shields.io/drone/build/openmls/openmls/main?label=ARM64%20Build%20Status
+[codecov-image]: https://img.shields.io/codecov/c/github/openmls/openmls/main?logo=codecov

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ This repository is a cargo workspace with the OpenMLS library as the main compon
 In order to use OpenMLS an implementation of the [traits](./traits/Readme.md) is required.
 This repository provides two default implementations
 
-- [Rust Crypto](./openmls_rust_crypto/Readme.md)
-- [Evercrypt](./evercrypt_backend/Readme.md)
+- [Rust Crypto](./openmls_rust_crypto/README.md)
+- [Evercrypt](./openmls/evercrypt_backend/README.md)
 
 It further holds the following crates that are used for testing.
 
@@ -92,7 +92,7 @@ Note that this is a PoC for testing and must not be used for anything else.
 
 ## License
 
-OpenMLS is licensed under the MIT license. The license can be found [here](https://github.com/openmls/openmls/LICENSE).
+OpenMLS is licensed under the MIT license. The license can be found [here](./LICENSE).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OpenMLS [![OpenMLS Chat][chat-image]][chat-link]
 
-[![Tests & Checks](https://github.com/openmls/openmls/actions/workflows/tests.yml/badge.svg)](https://github.com/openmls/openmls/actions/workflows/tests.yml)
+[![Tests & Checks][gh-tests-image]](https://github.com/openmls/openmls/actions/workflows/tests.yml)
 [![ARM64 Build Status][drone-image]](https://cloud.drone.io/openmls/openmls)
-[![Deploy Docs](https://github.com/openmls/openmls/workflows/Deploy%20Docs/badge.svg)][docs-main-link]
+[![Deploy Docs][gh-deploy-docs-image]][docs-main-link]
 [![codecov][codecov-image]](https://codecov.io/gh/openmls/openmls)
 [![OpenMLS List][list-image]][list-link]
 [![Docs][docs-main-badge]][docs-main-link]
@@ -12,9 +12,13 @@ A WIP Rust implementation of [Messaging Layer Security](https://github.com/mlswg
 
 ### Documentation
 
+We publish documentation both for the latest release of OpenMLS, as well as for
+the current state of `main`.
+
 A user manual detailing how basic MLS operations can be performed using OpenMLS
-can be found [here][book-link]. More detailed documentation on OpenMLS' public
-API can be found [here][docs-main-link].
+can be found [here (latest release)][book-release-link] or [here (`main`)][book-main-link].
+More detailed documentation on OpenMLS' public API
+can be found [here (latest release)][docs-release-link] or [here (`main`)][docs-main-link].
 
 ### Supported ciphersuites
 
@@ -115,7 +119,11 @@ OpenMLS adheres to the [Contributor Covenant](https://www.contributor-covenant.o
 [list-link]: https://groups.google.com/u/0/g/openmls-dev
 [rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg?style=flat&logo=rust
 [docs-main-badge]: https://img.shields.io/badge/docs-main-blue.svg?style=flat
+[docs-release-link]: https://docs.rs/crate/openmls/latest
 [docs-main-link]: https://openmls.tech/openmls/doc/openmls/index.html
-[book-link]: https://openmls.tech/openmls/book
+[book-release-link]: https://openmls.tech/book
+[book-main-link]: https://openmls.tech/openmls/book
 [drone-image]: https://img.shields.io/drone/build/openmls/openmls/main?label=ARM64%20Build%20Status&logo=drone
 [codecov-image]: https://img.shields.io/codecov/c/github/openmls/openmls/main?logo=codecov
+[gh-tests-image]: https://img.shields.io/github/workflow/status/openmls/openmls/Tests/main?label=Tests&style=flat&logo=github
+[gh-deploy-docs-image]: https://img.shields.io/github/workflow/status/openmls/openmls/Deploy%20Docs/main?label=Deploy%20Docs&logo=github

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Tests & Checks][gh-tests-image]](https://github.com/openmls/openmls/actions/workflows/tests.yml)
 [![ARM64 Build Status][drone-image]](https://cloud.drone.io/openmls/openmls)
-[![Deploy Docs][gh-deploy-docs-image]][docs-main-link]
 [![codecov][codecov-image]](https://codecov.io/gh/openmls/openmls)
 [![OpenMLS List][list-image]][list-link]
-[![Docs][docs-main-badge]][docs-main-link]
+[![Docs][docs-release-badge]][docs-release-link]
+[![Book][book-release-badge]][book-release-link]
 ![Rust Version][rustc-image]
 
 A WIP Rust implementation of [Messaging Layer Security](https://github.com/mlswg/mls-protocol/blob/master/draft-ietf-mls-protocol.md) based on draft 12+.
@@ -118,9 +118,10 @@ OpenMLS adheres to the [Contributor Covenant](https://www.contributor-covenant.o
 [list-image]: https://img.shields.io/badge/mailing-list-blue.svg?style=for-the-badge
 [list-link]: https://groups.google.com/u/0/g/openmls-dev
 [rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg?style=for-the-badge&logo=rust
-[docs-main-badge]: https://img.shields.io/badge/docs-main-blue.svg?style=for-the-badge
+[docs-release-badge]: https://img.shields.io/badge/docs-release-blue.svg?style=for-the-badge
 [docs-release-link]: https://docs.rs/crate/openmls/latest
 [docs-main-link]: https://openmls.tech/openmls/doc/openmls/index.html
+[book-release-badge]: https://img.shields.io/badge/book-release-blue.svg?style=for-the-badge
 [book-release-link]: https://openmls.tech/book
 [book-main-link]: https://openmls.tech/openmls/book
 [drone-image]: https://img.shields.io/drone/build/openmls/openmls/main?label=ARM64%20Build%20Status&logo=drone&style=for-the-badge

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cli"
 version = "0.1.0"
-authors = ["Franziskus Kiefer <franziskuskiefer@gmail.com>"]
+authors = ["OpenMLS Authors"]
 edition = "2018"
 
 [dependencies]
@@ -14,7 +14,7 @@ termion = "1.5"
 tls_codec = "0.2.0"
 
 openmls = {features = ["test-utils"], version = "0.4.0-pre.2" }
-openmls_traits = "0.1.0-pre.2" 
+openmls_traits = "0.1.0-pre.2"
 openmls_rust_crypto = "0.1.0-pre.2"
 
 ds-lib = { path = "../delivery-service/ds-lib/" }

--- a/delivery-service/ds-lib/Cargo.toml
+++ b/delivery-service/ds-lib/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "ds-lib"
 version = "0.1.0"
-authors = ["Franziskus Kiefer <franziskuskiefer@gmail.com>"]
+authors = ["OpenMLS Authors"]
 edition = "2018"
 description = "Types to interact with the OpenMLS DS."
 
 [dependencies]
 tls_codec = "0.2.0"
 openmls = {features = ["test-utils"], version = "0.4.0-pre.2" }
-openmls_traits = "0.1.0-pre.2" 
+openmls_traits = "0.1.0-pre.2"
 openmls_rust_crypto = "0.1.0-pre.2"
 
 [patch.crates-io]

--- a/delivery-service/ds/Cargo.toml
+++ b/delivery-service/ds/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mls-ds"
 version = "0.1.0"
-authors = ["Franziskus Kiefer <franziskuskiefer@gmail.com>"]
+authors = ["OpenMLS Authors"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -21,7 +21,7 @@ base64 = "0.13"
 tls_codec = "0.2.0"
 
 openmls = {features = ["test-utils"], version = "0.4.0-pre.2" }
-openmls_traits = "0.1.0-pre.2" 
+openmls_traits = "0.1.0-pre.2"
 openmls_rust_crypto = "0.1.0-pre.2"
 
 ds-lib = { path = "../ds-lib/" }

--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "interop_client"
 version = "0.1.0"
-authors = ["Konrad Kohbrok <konrad.kohbrok@datashrine.de>"]
+authors = ["OpenMLS Authors"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 openmls = {features = ["test-utils"], version = "0.4.0-pre.2" }
-openmls_traits = "0.1.0-pre.2" 
+openmls_traits = "0.1.0-pre.2"
 openmls_rust_crypto = "0.1.0-pre.2"
 tonic = "0.3"
 prost = "0.6"


### PR DESCRIPTION
This PR updates the readme, fixes a few links and changes the authors in a few Cargo.toml files to `OpenMLS Authors`.

Fixes #796.