### PR TITLE
clean up MlsGroup config and harder rustdoc requirements

### DIFF
--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -125,14 +125,8 @@ pub fn write(file_name: &str, payload: &[u8]) {
 // A helper function translating the bool in the protobuf to OpenMLS' WireFormat
 pub fn wire_format_policy(encrypt: bool) -> WireFormatPolicy {
     match encrypt {
-        false => WireFormatPolicy::new(
-            OutgoingWireFormatPolicy::AlwaysPlaintext,
-            IncomingWireFormatPolicy::AlwaysPlaintext,
-        ),
-        true => WireFormatPolicy::new(
-            OutgoingWireFormatPolicy::AlwaysCiphertext,
-            IncomingWireFormatPolicy::AlwaysCiphertext,
-        ),
+        false => PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+        true => PURE_CIPHERTEXT_WIRE_FORMAT_POLICY,
     }
 }
 

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -12,7 +12,6 @@ readme = "../README.md"
 [dependencies]
 openmls_traits = { version = "0.1.0-pre.2" }
 uuid = { version = "0.8", features = ["v4"] }
-lazy_static = "1.4"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 log = { version = "0.4", features = ["std"] }
@@ -50,6 +49,7 @@ tempfile = "3"
 rstest = "^0.12"
 rstest_reuse = "^0.1"
 backtrace = "0.3"
+lazy_static = "1.4"
 
 # x64 targets get evercrypt compiled into dev-dependencies.
 [target.'cfg(target_arch = "x86_64")'.dev-dependencies.openmls]

--- a/openmls/src/ciphersuite/signature.rs
+++ b/openmls/src/ciphersuite/signature.rs
@@ -185,4 +185,9 @@ impl SignaturePrivateKey {
     pub fn signature_scheme(&self) -> SignatureScheme {
         self.signature_scheme
     }
+
+    /// Returns the raw private key bytes as slice.
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        &self.value
+    }
 }

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -233,9 +233,13 @@ impl CredentialBundle {
         &self.credential
     }
 
-    /// Separates the bundle into the [`Credential`] and the [`SignaturePrivateKey`].
-    pub fn into_parts(self) -> (Credential, SignaturePrivateKey) {
-        (self.credential, self.signature_private_key)
+    /// Separates the bundle into the [`Credential`] and the signature private
+    /// key as raw byte vector.
+    pub fn into_parts(self) -> (Credential, Vec<u8>) {
+        (
+            self.credential,
+            self.signature_private_key.as_slice().to_vec(),
+        )
     }
 
     /// Sign a `msg` using the private key of the credential bundle.

--- a/openmls/src/error.rs
+++ b/openmls/src/error.rs
@@ -5,6 +5,8 @@
 use std::fmt::Display;
 
 use backtrace::Backtrace;
+// Re-export errors.
+pub use crate::treesync::errors::{ApplyUpdatePathError, PublicTreeError};
 use openmls_traits::types::CryptoError;
 use thiserror::Error;
 use tls_codec::Error as TlsCodecError;

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -213,6 +213,7 @@ pub struct WireFormatPolicy {
 impl WireFormatPolicy {
     /// Creates a new wire format policy from an [`OutgoingWireFormatPolicy`]
     /// and an [`IncomingWireFormatPolicy`].
+    #[cfg(any(feature = "test-utils", test))]
     pub(crate) fn new(
         outgoing: OutgoingWireFormatPolicy,
         incoming: IncomingWireFormatPolicy,

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -1,8 +1,34 @@
 //! Configuration module for [`MlsGroup`] configurations.
+//!
+//! ## Building an MlsGroupConfig
+//! The [`MlsGroupConfigBuilder`] makes it easy to build configurations for the
+//! [`MlsGroup`].
+//!
+//! ```
+//! use openmls::prelude::*;
+//!
+//! let group_config = MlsGroupConfig::builder()
+//!     .use_ratchet_tree_extension(true)
+//!     .build();
+//! ```
+//!
+//! See [`MlsGroupConfigBuilder`](MlsGroupConfigBuilder#implementations) for
+//! all options that can be configured.
+//!
+//! ### Wire format policies
+//! Only some combination of possible wire formats are valid within OpenMLS.
+//! The [`WIRE_FORMAT_POLICIES`] lists all valid options that can be set.
+//!
+//! ```
+//! use openmls::prelude::*;
+//!
+//! let group_config = MlsGroupConfig::builder()
+//!     .wire_format_policy(MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY)
+//!     .build();
+//! ```
 
 use super::*;
 use crate::tree::sender_ratchet::SenderRatchetConfiguration;
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
 /// Specifies the configuration parameters for a [`MlsGroup`]. Refer to
@@ -105,7 +131,7 @@ impl MlsGroupConfigBuilder {
     /// **WARNING**
     ///
     /// This feature enables the storage of message secrets from past epochs.
-    /// It is a tradeoff between functionality and forward secrecy and should only be enabled
+    /// It is a trade-off between functionality and forward secrecy and should only be enabled
     /// if the Delivery Service cannot guarantee that application messages will be sent in
     /// the same epoch in which they were generated. The number for `max_epochs` should be
     /// as low as possible.
@@ -185,8 +211,12 @@ pub struct WireFormatPolicy {
 }
 
 impl WireFormatPolicy {
-    /// Creates a new wire format policy from an [`OutgoingWireFormatPolicy`] and an [`IncomingWireFormatPolicy`].
-    pub fn new(outgoing: OutgoingWireFormatPolicy, incoming: IncomingWireFormatPolicy) -> Self {
+    /// Creates a new wire format policy from an [`OutgoingWireFormatPolicy`]
+    /// and an [`IncomingWireFormatPolicy`].
+    pub(crate) fn new(
+        outgoing: OutgoingWireFormatPolicy,
+        incoming: IncomingWireFormatPolicy,
+    ) -> Self {
         Self { outgoing, incoming }
     }
 
@@ -199,21 +229,11 @@ impl WireFormatPolicy {
     pub fn incoming(&self) -> IncomingWireFormatPolicy {
         self.incoming
     }
-
-    /// Set the wire format policy's outgoing wire format policy.
-    pub fn set_outgoing(&mut self, outgoing: OutgoingWireFormatPolicy) {
-        self.outgoing = outgoing;
-    }
-
-    /// Set the wire format policy's incoming wire format policy.
-    pub fn set_incoming(&mut self, incoming: IncomingWireFormatPolicy) {
-        self.incoming = incoming;
-    }
 }
 
 impl Default for WireFormatPolicy {
     fn default() -> Self {
-        *PURE_CIPHERTEXT_WIRE_FORMAT_POLICY
+        PURE_CIPHERTEXT_WIRE_FORMAT_POLICY
     }
 }
 
@@ -226,44 +246,40 @@ impl From<OutgoingWireFormatPolicy> for WireFormat {
     }
 }
 
-lazy_static! {
-    /// All valid wire format policy combinations
-    pub static ref ALL_VALID_WIRE_FORMAT_POLICIES: Vec<WireFormatPolicy> = vec![
-        *PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
-        *PURE_CIPHERTEXT_WIRE_FORMAT_POLICY,
-        *MIXED_PLAINTEXT_WIRE_FORMAT_POLICY,
-        *MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY,
-    ];
-}
+/// All valid wire format policy combinations.
+/// - [`PURE_PLAINTEXT_WIRE_FORMAT_POLICY`]
+/// - [`PURE_CIPHERTEXT_WIRE_FORMAT_POLICY`]
+/// - [`MIXED_PLAINTEXT_WIRE_FORMAT_POLICY`]
+/// - [`MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY`]
+pub const WIRE_FORMAT_POLICIES: [WireFormatPolicy; 4] = [
+    PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+    PURE_CIPHERTEXT_WIRE_FORMAT_POLICY,
+    MIXED_PLAINTEXT_WIRE_FORMAT_POLICY,
+    MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY,
+];
 
-lazy_static! {
-    /// Pure plaintext wire format policy.
-    pub static ref PURE_PLAINTEXT_WIRE_FORMAT_POLICY: WireFormatPolicy = WireFormatPolicy::new(
-        OutgoingWireFormatPolicy::AlwaysPlaintext,
-        IncomingWireFormatPolicy::AlwaysPlaintext,
-    );
-}
+/// Incoming and outgoing wire formats are always plaintext.
+pub const PURE_PLAINTEXT_WIRE_FORMAT_POLICY: WireFormatPolicy = WireFormatPolicy {
+    outgoing: OutgoingWireFormatPolicy::AlwaysPlaintext,
+    incoming: IncomingWireFormatPolicy::AlwaysPlaintext,
+};
 
-lazy_static! {
-    /// Pure ciphertext wire format policy.
-    pub static ref PURE_CIPHERTEXT_WIRE_FORMAT_POLICY: WireFormatPolicy = WireFormatPolicy::new(
-        OutgoingWireFormatPolicy::AlwaysCiphertext,
-        IncomingWireFormatPolicy::AlwaysCiphertext,
-    );
-}
+/// Incoming and outgoing wire formats are always ciphertext.
+pub const PURE_CIPHERTEXT_WIRE_FORMAT_POLICY: WireFormatPolicy = WireFormatPolicy {
+    outgoing: OutgoingWireFormatPolicy::AlwaysCiphertext,
+    incoming: IncomingWireFormatPolicy::AlwaysCiphertext,
+};
 
-lazy_static! {
-    /// Mixed plaintext wire format policy combination.
-    pub static ref MIXED_PLAINTEXT_WIRE_FORMAT_POLICY: WireFormatPolicy = WireFormatPolicy::new(
-        OutgoingWireFormatPolicy::AlwaysPlaintext,
-        IncomingWireFormatPolicy::Mixed,
-    );
-}
+/// Incoming wire formats can be mixed while outgoing wire formats are always
+/// plaintext.
+pub const MIXED_PLAINTEXT_WIRE_FORMAT_POLICY: WireFormatPolicy = WireFormatPolicy {
+    outgoing: OutgoingWireFormatPolicy::AlwaysPlaintext,
+    incoming: IncomingWireFormatPolicy::Mixed,
+};
 
-lazy_static! {
-    /// Mixed ciphertext wire format policy combination.
-    pub static ref MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY: WireFormatPolicy = WireFormatPolicy::new(
-        OutgoingWireFormatPolicy::AlwaysCiphertext,
-        IncomingWireFormatPolicy::Mixed,
-    );
-}
+/// Incoming wire formats can be mixed while outgoing wire formats are always
+/// ciphertext.
+pub const MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY: WireFormatPolicy = WireFormatPolicy {
+    outgoing: OutgoingWireFormatPolicy::AlwaysCiphertext,
+    incoming: IncomingWireFormatPolicy::Mixed,
+};

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -1,7 +1,7 @@
 //! # MlsGroup errors
 //!
 //! This module defines the public errors that can be returned from all calls
-//! to methods of [`MlsGroup`].
+//! to methods of [`MlsGroup`](super::MlsGroup).
 
 use crate::error::LibraryError;
 use thiserror::Error;

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -107,7 +107,7 @@ fn test_valsem200(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let CommitValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let alice_hash_ref = *alice_group
         .key_package_ref()
@@ -232,7 +232,7 @@ fn test_valsem200(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 // ValSem201: Path must be present, if Commit contains Removes or Updates
 #[apply(ciphersuites_and_backends)]
 fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let wire_format_policy = *PURE_PLAINTEXT_WIRE_FORMAT_POLICY;
+    let wire_format_policy = PURE_PLAINTEXT_WIRE_FORMAT_POLICY;
     // Test with MlsPlaintext
     let CommitValidationTestSetup {
         mut alice_group,
@@ -509,7 +509,7 @@ fn test_valsem202(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let CommitValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Have Alice generate a self-updating commit, remove a node from the path,
     // re-sign and have Bob process it.
@@ -617,7 +617,7 @@ fn test_valsem203(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let CommitValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Have Alice generate a self-updating commit, scramble some ciphertexts and
     // have Bob process the resulting commit.
@@ -727,7 +727,7 @@ fn test_valsem204(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let CommitValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Have Alice generate a self-updating commit, flip the last byte of one of
     // the public keys in the path and have Bob process the commit.
@@ -837,7 +837,7 @@ fn test_valsem205(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let CommitValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Have Alice generate a self-updating commit, flip the last bit of the
     // confirmation tag and have Bob process the commit.

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -140,7 +140,7 @@ fn test_valsem240(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         bob_credential_bundle,
         mut plaintext,
         original_plaintext,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let mut content = if let MlsPlaintextContentType::Commit(commit) = plaintext.content() {
         commit.clone()
@@ -218,7 +218,7 @@ fn test_valsem241(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         bob_credential_bundle,
         mut plaintext,
         original_plaintext,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let mut content = if let MlsPlaintextContentType::Commit(commit) = plaintext.content() {
         commit.clone()
@@ -292,7 +292,7 @@ fn test_valsem242(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         bob_credential_bundle,
         mut plaintext,
         original_plaintext,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let mut content = if let MlsPlaintextContentType::Commit(commit) = plaintext.content() {
         commit.clone()
@@ -373,7 +373,7 @@ fn test_valsem243(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         bob_credential_bundle,
         plaintext: _,
         original_plaintext: _,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Alice has to add Bob first, so that in the external commit, we can have
     // an update proposal that comes from a leaf that's actually inside of the
@@ -507,7 +507,7 @@ fn test_valsem244(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         bob_credential_bundle,
         plaintext: _,
         original_plaintext: _,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Alice has to add Bob first, so that Bob actually creates a remove
     // proposal to remove his former self.
@@ -646,7 +646,7 @@ fn test_valsem245(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         bob_credential_bundle,
         mut plaintext,
         original_plaintext,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let mut content = if let MlsPlaintextContentType::Commit(commit) = plaintext.content() {
         commit.clone()
@@ -733,7 +733,7 @@ fn test_valsem246(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         bob_credential_bundle,
         mut plaintext,
         original_plaintext,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let mut content = if let MlsPlaintextContentType::Commit(commit) = plaintext.content() {
         commit.clone()
@@ -794,7 +794,7 @@ fn test_valsem247(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         bob_credential_bundle,
         mut plaintext,
         original_plaintext,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let mut content = if let MlsPlaintextContentType::Commit(commit) = plaintext.content() {
         commit.clone()

--- a/openmls/src/group/tests/test_framing_validation.rs
+++ b/openmls/src/group/tests/test_framing_validation.rs
@@ -94,7 +94,7 @@ fn test_valsem001(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let (message, _welcome) = alice_group
         .add_members(backend, &[bob_key_package])
@@ -127,7 +127,7 @@ fn test_valsem001(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_CIPHERTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_CIPHERTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let (message, _welcome) = alice_group
         .add_members(backend, &[bob_key_package])
@@ -162,7 +162,7 @@ fn test_valsem002(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let (message, _welcome) = alice_group
         .add_members(backend, &[bob_key_package])
@@ -205,7 +205,7 @@ fn test_valsem003(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Alice can't process her own commits, so we'll have to add Bob.
     let (_message, welcome) = alice_group
@@ -217,7 +217,7 @@ fn test_valsem003(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .expect("error merging pending commit");
 
     let mls_group_config = MlsGroupConfig::builder()
-        .wire_format_policy(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .build();
 
     let mut bob_group = MlsGroup::new_from_welcome(
@@ -305,7 +305,7 @@ fn test_valsem004(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let (message, _welcome) = alice_group
         .add_members(backend, &[bob_key_package])
@@ -354,7 +354,7 @@ fn test_valsem005(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let (message, _welcome) = alice_group
         .add_members(backend, &[bob_key_package])
@@ -398,7 +398,7 @@ fn test_valsem006(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_CIPHERTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_CIPHERTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let (_message, welcome) = alice_group
         .add_members(backend, &[bob_key_package])
@@ -428,7 +428,7 @@ fn test_valsem006(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ratchet_tree = alice_group.export_ratchet_tree();
 
     let mls_group_config = MlsGroupConfig::builder()
-        .wire_format_policy(*PURE_CIPHERTEXT_WIRE_FORMAT_POLICY)
+        .wire_format_policy(PURE_CIPHERTEXT_WIRE_FORMAT_POLICY)
         .build();
 
     let mut bob_group =
@@ -461,7 +461,7 @@ fn test_valsem007(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let (message, _welcome) = alice_group
         .add_members(backend, &[bob_key_package])
@@ -504,7 +504,7 @@ fn test_valsem008(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Alice can't process her own commits, so we'll have to add Bob.
     let (_message, welcome) = alice_group
@@ -516,7 +516,7 @@ fn test_valsem008(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .expect("error merging pending commit");
 
     let mls_group_config = MlsGroupConfig::builder()
-        .wire_format_policy(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .build();
 
     let mut bob_group = MlsGroup::new_from_welcome(
@@ -576,7 +576,7 @@ fn test_valsem009(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     let (message, _welcome) = alice_group
         .add_members(backend, &[bob_key_package])
@@ -619,7 +619,7 @@ fn test_valsem010(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_credential: _,
         _alice_key_package: _,
         bob_key_package,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Alice can't process her own commits, so we'll have to add Bob.
     let (_message, welcome) = alice_group
@@ -631,7 +631,7 @@ fn test_valsem010(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .expect("error merging pending commit");
 
     let mls_group_config = MlsGroupConfig::builder()
-        .wire_format_policy(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .build();
 
     let mut bob_group = MlsGroup::new_from_welcome(

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -281,7 +281,7 @@ fn test_valsem100(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We now have alice create a commit with an add proposal. Then we
     // artificially add another add proposal with the same identity.
@@ -430,7 +430,7 @@ fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We now have alice create a commit with an add proposal. Then we
     // artificially add another add proposal with a different identity,
@@ -590,7 +590,7 @@ fn test_valsem102(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We now have alice create a commit with an add proposal. Then we
     // artificially add another add proposal with a different identity,
@@ -713,7 +713,7 @@ fn test_valsem103(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We now have alice create a commit. Then we artificially add an Add
     // proposal with an existing identity (Bob).
@@ -869,7 +869,7 @@ fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We now have alice create a commit. Then we artificially add an Add
     // proposal with a different identity, but with the same signature public
@@ -1035,7 +1035,7 @@ fn test_valsem105(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We now have alice create a commit. Then we artificially add an Add
     // proposal with an existing HPKE public key.
@@ -1141,7 +1141,7 @@ fn test_valsem106(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Required capabilities validation includes two types of checks on the
     // capabilities of the `KeyPackage` in the Add proposal: One against the
@@ -1385,7 +1385,7 @@ fn test_valsem107(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We first try to make Alice create a commit with two remove proposals for
     // Bob.
@@ -1478,7 +1478,7 @@ fn test_valsem108(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We first try to make Alice create a commit with a proposal targeting a
     // non-existing group member.
@@ -1593,7 +1593,7 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We can't test this by having Alice propose an update herself, so we have
     // to have Bob propose the update. This is due to the commit logic filtering
@@ -1735,7 +1735,7 @@ fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We can't test this by having Alice propose an update herself, so we have
     // to have Bob propose the update. This is due to the commit logic filtering
@@ -1891,7 +1891,7 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // We can't test this by having Alice propose an update herself. This is due
     // to the commit logic filtering out own proposals and just including a path
@@ -2064,7 +2064,7 @@ fn test_valsem112(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let ProposalValidationTestSetup {
         mut alice_group,
         mut bob_group,
-    } = validation_test_setup(*PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
+    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // This can really only be tested by the receiver, as there is no way to
     // make a client create a proposal with a different sender type than

--- a/openmls/src/group/tests/test_wire_format_policy.rs
+++ b/openmls/src/group/tests/test_wire_format_policy.rs
@@ -93,7 +93,7 @@ fn receive_message(
 // Test positive cases with all valid (pure & mixed) policies
 #[apply(ciphersuites_and_backends)]
 fn test_wire_policy_positive(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    for wire_format_policy in ALL_VALID_WIRE_FORMAT_POLICIES.iter() {
+    for wire_format_policy in WIRE_FORMAT_POLICIES.iter() {
         let mut alice_group = create_group(ciphersuite, backend, *wire_format_policy);
         let message = receive_message(ciphersuite, backend, &mut alice_group);
         alice_group
@@ -105,7 +105,7 @@ fn test_wire_policy_positive(ciphersuite: Ciphersuite, backend: &impl OpenMlsCry
 // Test negative cases with only icompatible policies
 #[apply(ciphersuites_and_backends)]
 fn test_wire_policy_negative(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    // All combinations that are not part of ALL_VALID_WIRE_FORMAT_POLICIES
+    // All combinations that are not part of WIRE_FORMAT_POLICIES
     let incompatible_policies = vec![
         WireFormatPolicy::new(
             OutgoingWireFormatPolicy::AlwaysPlaintext,

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -718,12 +718,15 @@ impl KeyPackageBundle {
         &self.key_package
     }
 
-    /// Separates the bundle into the [`KeyPackage`] and the ([`HpkePrivateKey`],
-    /// [`Secret`]).
-    pub fn into_parts(self) -> (KeyPackage, (Vec<u8>, Secret)) {
+    /// Separates the bundle into the [`KeyPackage`] and the HPKE private key and
+    /// leaf secret as raw byte vectors.
+    pub fn into_parts(self) -> (KeyPackage, (Vec<u8>, Vec<u8>)) {
         (
             self.key_package,
-            (self.private_key.as_slice().to_vec(), self.leaf_secret),
+            (
+                self.private_key.as_slice().to_vec(),
+                self.leaf_secret.as_slice().to_vec(),
+            ),
         )
     }
 

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -181,7 +181,9 @@
 //! [user Manual]: https://openmls.tech/book
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), forbid(unsafe_code))]
-#![cfg_attr(not(feature = "test-utils"), warn(missing_docs))]
+#![cfg_attr(not(feature = "test-utils"), deny(missing_docs))]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::private_intra_doc_links)]
 
 // === Testing ===
 
@@ -220,6 +222,9 @@ mod binary_tree;
 mod key_store;
 mod tree;
 mod treesync;
+
+// Re-export items from private modules.
+pub use treesync::errors::{PublicTreeError, ApplyUpdatePathError};
 
 /// Single place, re-exporting the most used public functions.
 pub mod prelude;

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -223,8 +223,5 @@ mod key_store;
 mod tree;
 mod treesync;
 
-// Re-export items from private modules.
-pub use treesync::errors::{ApplyUpdatePathError, PublicTreeError};
-
 /// Single place, re-exporting the most used public functions.
 pub mod prelude;

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -224,7 +224,7 @@ mod tree;
 mod treesync;
 
 // Re-export items from private modules.
-pub use treesync::errors::{PublicTreeError, ApplyUpdatePathError};
+pub use treesync::errors::{ApplyUpdatePathError, PublicTreeError};
 
 /// Single place, re-exporting the most used public functions.
 pub mod prelude;

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -35,7 +35,10 @@ pub use crate::key_store::*;
 pub use crate::tree::SenderRatchetConfiguration;
 
 // TreeSync
-pub use crate::treesync::node::Node;
+pub use crate::treesync::{
+    errors::{ApplyUpdatePathError, PublicTreeError},
+    node::Node,
+};
 
 // PSKs
 // TODO #751

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -76,7 +76,7 @@ fn generate_key_package_bundle(
 ///  - Test saving the group state
 #[apply(ciphersuites_and_backends)]
 fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    for wire_format_policy in ALL_VALID_WIRE_FORMAT_POLICIES.iter() {
+    for wire_format_policy in WIRE_FORMAT_POLICIES.iter() {
         let group_id = GroupId::from_slice(b"Test Group");
 
         // Generate credential bundles
@@ -969,7 +969,7 @@ fn mls_group_ratchet_tree_extension(
     ciphersuite: Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) {
-    for wire_format_policy in ALL_VALID_WIRE_FORMAT_POLICIES.iter() {
+    for wire_format_policy in WIRE_FORMAT_POLICIES.iter() {
         let group_id = GroupId::from_slice(b"Test Group");
 
         // === Positive case: using the ratchet tree extension ===


### PR DESCRIPTION
This PR
- makes documentation of public items mandatory
- prohibits using private items in public documentation
- adds documentation for the MlsGroup config