### PR TITLE
Remove re-exports from lib.rs

### DIFF
--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     key_packages::{KeyPackage, KeyPackageBundle},
     messages::{proposals::*, Welcome},
     schedule::ResumptionSecret,
+    treesync::Node,
 };
 use ser::*;
 use std::io::{Error, Read, Write};
@@ -35,8 +36,6 @@ use std::io::{Error, Read, Write};
 pub(crate) use resumption::ResumptionSecretStore;
 
 // Public exports
-pub use crate::treesync::node::Node;
-pub use crate::treesync::node::{leaf_node::LeafNode, parent_node::ParentNode};
 pub use {config::*, errors::*, membership::RemoveOperation};
 
 /// Pending Commit state. Differentiates between Commits issued by group members

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -55,7 +55,6 @@
 //!     // Create the key package bundle
 //!     let key_package_bundle =
 //!         KeyPackageBundle::new(ciphersuites, &credential_bundle, backend, vec![])?;
-//!     // let key_package = key_package_bundle.key_package().clone();
 //!
 //!     // Store it in the key store
 //!     let key_package_id = key_package_bundle.key_package()
@@ -167,19 +166,14 @@ pub mod framing;
 pub mod group;
 pub mod key_packages;
 pub mod messages;
+pub mod schedule;
+pub mod treesync;
 pub mod versions;
 
 // Private
 mod binary_tree;
 mod key_store;
-mod schedule;
 mod tree;
-mod treesync;
 
 /// Single place, re-exporting the most used public functions.
 pub mod prelude;
-
-// Re-export types from Key Schedule
-pub use crate::schedule::{errors::PskError, AuthenticationSecret, ResumptionSecret};
-// Re-export types from TreeSync
-pub use crate::treesync::errors::{ApplyUpdatePathError, PublicTreeError};

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -1,6 +1,6 @@
 //! This module implements the ratchet tree component of MLS.
 //!
-//! Ite exposes the [`Node`] enum that can contain either a [`LeafNode`] or a [`ParentNode`],
+//! It exposes the [`Node`] enum that can contain either a [`LeafNode`] or a [`ParentNode`],
 //! as well as the following error types: [`ApplyUpdatePathError`], and [`PublicTreeError`].
 
 // # Internal documentation

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -1,29 +1,23 @@
 //! This module implements the ratchet tree component of MLS.
 //!
-//! # About
-//!
-//! This module provides the [`TreeSync`] struct, which contains the state
-//! shared between a group of MLS clients in the shape of a tree, where each
-//! non-blank leaf corresponds to one group member. The functions provided by
-//! its implementation allow the creation of a [`TreeSyncDiff`] instance, which
-//! in turn can be mutably operated on and merged back into the original
-//! [`TreeSync`] instance.
-//!
-//! The submodules of this module define the nodes of the tree (`nodes`),
-//! helper functions and structs for the algorithms used to sync the tree across
-//! the group ([`hashes`]) and the diff functionality ([`diff`]).
-//!
-//! Finally, this module contains the [`treekem`] module, which allows the
-//! encryption and decryption of updates to the tree.
-//!
-//! # Don't Panic!
-//!
-//! Functions in this module should never panic. However, if there is a bug in
-//! the implementation, a function will return an unrecoverable
-//! [`LibraryError`](TreeSyncError::LibraryError). This means that some
-//! functions that are not expected to fail and throw an error, will still
-//! return a [`Result`] since they may throw a
-//! [`LibraryError`](TreeSyncError::LibraryError).
+//! Ite exposes the [`Node`] enum that can contain either a [`LeafNode`] or a [`ParentNode`],
+//! as well as the following error types: [`ApplyUpdatePathError`], and [`PublicTreeError`].
+
+// # Internal documentation
+//
+// This module provides the [`TreeSync`] struct, which contains the state
+// shared between a group of MLS clients in the shape of a tree, where each
+// non-blank leaf corresponds to one group member. The functions provided by
+// its implementation allow the creation of a [`TreeSyncDiff`] instance, which
+// in turn can be mutably operated on and merged back into the original
+// [`TreeSync`] instance.
+//
+// The submodules of this module define the nodes of the tree (`nodes`),
+// helper functions and structs for the algorithms used to sync the tree across
+// the group ([`hashes`]) and the diff functionality ([`diff`]).
+//
+// Finally, this module contains the [`treekem`] module, which allows the
+// encryption and decryption of updates to the tree.
 
 use std::collections::BTreeMap;
 
@@ -43,7 +37,6 @@ use crate::{
 
 use self::{
     diff::{StagedTreeSyncDiff, TreeSyncDiff},
-    node::{leaf_node::LeafNode, Node},
     treesync_node::{TreeSyncNode, TreeSyncNodeError},
 };
 
@@ -57,8 +50,9 @@ pub(crate) mod node;
 pub(crate) mod treekem;
 pub(crate) mod treesync_node;
 
-// Crate re-exports
-pub(crate) use errors::*;
+// Public re-exports
+pub use errors::*;
+pub use node::{leaf_node::LeafNode, parent_node::ParentNode, Node};
 
 // Tests
 #[cfg(any(feature = "test-utils", test))]


### PR DESCRIPTION
This PR removes the re-exports from `lib.rs`, as discussed previously. It doesn't address #852 fully yet.