### PR TITLE
Group API tweaks

### DIFF
--- a/openmls/src/framing/mod.rs
+++ b/openmls/src/framing/mod.rs
@@ -11,24 +11,25 @@ use crate::credentials::*;
 use crate::group::*;
 use crate::messages::{proposals::*, *};
 use crate::schedule::{message_secrets::*, *};
-pub(crate) use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use tls_codec::*;
 
 pub(crate) mod ciphertext;
 pub(crate) mod codec;
-pub(crate) mod errors;
 pub(crate) mod message;
 pub(crate) mod plaintext;
 pub(crate) mod sender;
 pub(crate) mod validation;
 pub(crate) use ciphertext::*;
+pub(crate) use errors::*;
 pub(crate) use plaintext::*;
 
 // Crate
 pub(crate) use sender::*;
 
 // Public
-pub use errors::*;
+pub mod errors;
+
 pub use message::*;
 pub use sender::*;
 pub use validation::*;

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -303,7 +303,7 @@ impl UnverifiedContextMessage {
                     plaintext,
                     // If the message type is `Sender` or `NewMember`, the
                     // message always contains a credential.
-                    credential: credential_option.ok_or({
+                    credential: credential_option.ok_or_else(|| {
                         ValidationError::from(LibraryError::custom("Expected credential"))
                     })?,
                 }))

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -14,6 +14,8 @@ use thiserror::Error;
 
 // === Public errors ===
 
+pub use super::mls_group::errors::*;
+
 /// Welcome error
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum WelcomeError {

--- a/openmls/src/group/group_context.rs
+++ b/openmls/src/group/group_context.rs
@@ -78,8 +78,7 @@ impl GroupContext {
         self.extensions
             .iter()
             .find(|e| e.extension_type() == ExtensionType::RequiredCapabilities)
-            .map(|e| e.as_required_capabilities_extension().ok())
-            .flatten()
+            .and_then(|e| e.as_required_capabilities_extension().ok())
     }
 
     /// Return the confirmed transcript hash

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -3,6 +3,8 @@
 //! This module defines the public errors that can be returned from all calls
 //! to methods of [`MlsGroup`](super::MlsGroup).
 
+// These errors are exposed through `crate::group::group::errors`.
+
 use crate::{
     error::LibraryError,
     group::errors::{CreateCommitError, StageCommitError, ValidationError},

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -3,7 +3,7 @@
 //! This module defines the public errors that can be returned from all calls
 //! to methods of [`MlsGroup`](super::MlsGroup).
 
-// These errors are exposed through `crate::group::group::errors`.
+// These errors are exposed through `crate::group::errors`.
 
 use crate::{
     error::LibraryError,

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -33,11 +33,11 @@ use errors::*;
 use resumption::*;
 use ser::*;
 
-// Public
-pub mod config;
-pub mod errors;
-pub mod membership;
-pub mod processing;
+// Crate
+pub(crate) mod config;
+pub(crate) mod errors;
+pub(crate) mod membership;
+pub(crate) mod processing;
 
 // Tests
 #[cfg(test)]

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -5,8 +5,10 @@ use tls_codec::Serialize;
 use crate::{
     ciphersuite::hash_ref::KeyPackageRef,
     credentials::{errors::CredentialError, *},
-    group::{errors::ValidationError, mls_group::*},
+    framing::*,
+    group::{errors::*, *},
     key_packages::{errors::*, *},
+    messages::proposals::*,
     test_utils::test_framework::{
         errors::ClientError, ActionType::Commit, CodecUse, MlsGroupTestSetup,
     },

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -15,14 +15,19 @@ use tls_codec::*;
 // Crate
 pub(crate) mod core_group;
 pub(crate) use core_group::*;
+pub(crate) mod mls_group;
 #[cfg(not(any(feature = "test-utils", test)))]
 pub(crate) use group_context::*;
 
 // Public
 pub mod errors;
-pub mod mls_group;
+
 pub use core_group::proposals::*;
 pub use core_group::staged_commit::StagedCommit;
+pub use mls_group::config::*;
+pub use mls_group::membership::*;
+pub use mls_group::processing::*;
+pub use mls_group::*;
 
 // Tests
 #[cfg(any(feature = "test-utils", test))]

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -14,10 +14,7 @@ use crate::{
     ciphersuite::signable::{Signable, Verifiable},
     credentials::*,
     framing::*,
-    group::{
-        errors::StageCommitError,
-        mls_group::{config::*, errors::*, *},
-    },
+    group::errors::*,
     messages::proposals::ProposalOrRef,
     treesync::errors::ApplyUpdatePathError,
 };

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -13,11 +13,7 @@ use crate::{
     ciphersuite::signable::{Signable, Verifiable},
     credentials::{errors::*, *},
     framing::*,
-    group::{
-        errors::{ExternalCommitValidationError, StageCommitError, ValidationError},
-        mls_group::{config::*, errors::*, *},
-        *,
-    },
+    group::{errors::*, *},
     messages::{
         proposals::{
             AddProposal, ExternalInitProposal, Proposal, ProposalOrRef, ProposalType,

--- a/openmls/src/group/tests/test_framing_validation.rs
+++ b/openmls/src/group/tests/test_framing_validation.rs
@@ -9,14 +9,10 @@ use rstest::*;
 use rstest_reuse::{self, *};
 
 use crate::{
-    ciphersuite::{hash_ref::KeyPackageRef, *},
+    ciphersuite::hash_ref::KeyPackageRef,
     credentials::*,
     framing::*,
-    group::{
-        errors::*,
-        mls_group::{config::*, errors::*, *},
-        GroupId,
-    },
+    group::{errors::*, *},
     key_packages::*,
 };
 

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -10,11 +10,7 @@ use rstest_reuse::{self, *};
 use crate::{
     credentials::{CredentialBundle, CredentialType},
     framing::{MessageDecryptionError, ProcessedMessage},
-    group::{
-        errors::*,
-        mls_group::{config::*, errors::*, *},
-        GroupId,
-    },
+    group::{errors::*, *},
     key_packages::KeyPackageBundle,
 };
 

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -15,11 +15,7 @@ use crate::{
         MlsMessageIn, MlsMessageOut, MlsPlaintext, MlsPlaintextContentType, ProcessedMessage,
         Sender, VerifiableMlsPlaintext,
     },
-    group::{
-        errors::*,
-        mls_group::{config::*, errors::*, *},
-        *,
-    },
+    group::{errors::*, *},
     key_packages::*,
     messages::{
         proposals::{AddProposal, Proposal, ProposalOrRef, RemoveProposal, UpdateProposal},

--- a/openmls/src/group/tests/test_remove_operation.rs
+++ b/openmls/src/group/tests/test_remove_operation.rs
@@ -1,16 +1,7 @@
 //! This module tests the classification of remove operations with RemoveOperation
 
 use super::utils::{generate_credential_bundle, generate_key_package_bundle};
-use crate::{
-    credentials::*,
-    framing::*,
-    group::{
-        mls_group::{config::*, membership::*, *},
-        *,
-    },
-    test_utils::*,
-    *,
-};
+use crate::{credentials::*, framing::*, group::*, test_utils::*, *};
 use openmls_rust_crypto::OpenMlsRustCrypto;
 
 // Tests the differen variants of the RemoveOperation enum.

--- a/openmls/src/group/tests/test_wire_format_policy.rs
+++ b/openmls/src/group/tests/test_wire_format_policy.rs
@@ -9,10 +9,7 @@ use rstest_reuse::{self, *};
 use crate::{
     credentials::*,
     framing::*,
-    group::{
-        mls_group::{config::*, errors::*, *},
-        *,
-    },
+    group::{errors::*, *},
 };
 
 use super::utils::{generate_credential_bundle, generate_key_package_bundle};

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -2,11 +2,7 @@
 //! Include this to get access to all the public functions of OpenMLS.
 
 // MlsGroup
-pub use crate::group::{
-    errors::*,
-    mls_group::{config::*, errors::*, membership::*, *},
-    *,
-};
+pub use crate::group::{errors::*, *};
 
 // Ciphersuite
 pub use crate::ciphersuite::{hash_ref::KeyPackageRef, signable::*, *};

--- a/openmls/src/prelude_test.rs
+++ b/openmls/src/prelude_test.rs
@@ -3,8 +3,6 @@
 
 pub use crate::ciphersuite::{signable::Verifiable, *};
 pub use crate::framing::{plaintext::*, *};
-pub use crate::schedule::*;
-pub use crate::treesync::*;
 
 // KATs
 pub use crate::binary_tree::array_representation::kat_treemath;

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -8,18 +8,8 @@ use openmls_traits::{key_store::OpenMlsKeyStore, types::Ciphersuite, OpenMlsCryp
 use tls_codec::Serialize;
 
 use crate::{
-    credentials::*,
-    extensions::*,
-    framing::MlsMessageIn,
-    framing::*,
-    group::{
-        mls_group::{config::*, *},
-        *,
-    },
-    key_packages::*,
-    messages::*,
-    prelude_test::hash_ref::KeyPackageRef,
-    treesync::node::Node,
+    ciphersuite::hash_ref::KeyPackageRef, credentials::*, extensions::*, framing::MlsMessageIn,
+    framing::*, group::*, key_packages::*, messages::*, treesync::node::Node,
 };
 
 use super::{errors::ClientError, ActionType};

--- a/openmls/src/test_utils/test_framework/errors.rs
+++ b/openmls/src/test_utils/test_framework/errors.rs
@@ -1,9 +1,6 @@
 use thiserror::Error;
 
-use crate::{
-    error::LibraryError,
-    group::{errors::WelcomeError, mls_group::errors::*},
-};
+use crate::{error::LibraryError, group::errors::*};
 
 /// Setup error
 #[derive(Error, Debug, PartialEq, Clone)]

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     ciphersuite::{hash_ref::KeyPackageRef, *},
     credentials::*,
     framing::*,
-    group::{mls_group::config::*, *},
+    group::*,
     key_packages::*,
     messages::*,
     treesync::node::Node,

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -440,8 +440,7 @@ impl TreeSync {
                 Ok(leaf) => leaf
                     .node()
                     .as_ref()
-                    .map(|node| node.as_leaf_node().ok())
-                    .flatten(),
+                    .and_then(|node| node.as_leaf_node().ok()),
                 Err(_) => None,
             },
             Err(_) => None,


### PR DESCRIPTION
This PR tweaks the group API so that it can be used with just `use openmls::group::{errors::*, *};`.

It also exposes the errors of the `framing` module separately and makes a few other minor tweaks.