### PR TITLE
Enable android targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
           - aarch64-unknown-linux-gnu
           # Android
           - aarch64-linux-android
+          - armv7-linux-androideabi
+          - x86_64-linux-android
+          - i686-linux-android
           # iOS
           - aarch64-apple-ios
           # WASM


### PR DESCRIPTION
With the new added targets, openmls will always be ready for Android platform.

Source: https://crates.io/crates/cargo-ndk
https://github.com/bbqsrc/cargo-ndk/blob/main/README.md#L15-L19
```
rustup target add \
    aarch64-linux-android \
    armv7-linux-androideabi \
    x86_64-linux-android \
    i686-linux-android
```