### PR TITLE
[FixUp] join_by_external_commit does not need to request proposal store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Signature keys can be imported and exported with the crypto-subtle feature.
  - BasicCredentials can now be created from existing signature keys.
 
+### Changed
+ -  [#890:](https://github.com/openmls/openmls/pull/890) Join group by external commit API does not expect proposal store.
+
 ## 0.4.0 (2022-02-28)
 
 * initial release

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -137,7 +137,6 @@ impl MlsGroup {
         mls_group_config: &MlsGroupConfig,
         aad: &[u8],
         credential_bundle: &CredentialBundle,
-        proposal_store: ProposalStore,
     ) -> Result<(Self, MlsMessageOut), ExternalCommitError> {
         let resumption_secret_store =
             ResumptionSecretStore::new(mls_group_config.number_of_resumption_secrets);
@@ -146,6 +145,7 @@ impl MlsGroup {
         let framing_parameters =
             FramingParameters::new(aad, mls_group_config.wire_format_policy().outgoing());
 
+        let proposal_store = ProposalStore::new();
         let params = CreateCommitParams::builder()
             .framing_parameters(framing_parameters)
             .credential_bundle(credential_bundle)

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -104,7 +104,6 @@ fn validation_test_setup(
             .expect("Error deserializing PGS");
     let tree_option = alice_group.export_ratchet_tree();
 
-    let proposal_store = ProposalStore::new();
     let (_bob_group, message) = MlsGroup::join_by_external_commit(
         backend,
         Some(&tree_option),
@@ -112,7 +111,6 @@ fn validation_test_setup(
         alice_group.configuration(),
         &[],
         &bob_credential_bundle,
-        proposal_store,
     )
     .expect("Error initializing group externally.");
 
@@ -409,7 +407,6 @@ fn test_valsem243(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Error deserializing PGS");
     let tree_option = alice_group.export_ratchet_tree();
 
-    let proposal_store = ProposalStore::new();
     let (_bob_group, message) = MlsGroup::join_by_external_commit(
         backend,
         Some(&tree_option), // Note that this isn't actually used.
@@ -417,7 +414,6 @@ fn test_valsem243(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         alice_group.configuration(),
         &[],
         &bob_credential_bundle,
-        proposal_store,
     )
     .expect("Error initializing group externally.");
 
@@ -541,7 +537,6 @@ fn test_valsem244(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Error deserializing PGS");
     let tree_option = alice_group.export_ratchet_tree();
 
-    let proposal_store = ProposalStore::new();
     let (_bob_group, message) = MlsGroup::join_by_external_commit(
         backend,
         Some(&tree_option),
@@ -549,7 +544,6 @@ fn test_valsem244(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         alice_group.configuration(),
         &[],
         &bob_credential_bundle,
-        proposal_store,
     )
     .expect("Error initializing group externally.");
 


### PR DESCRIPTION
ProposalStore::new() method visibility is for crate only, so no one is the application can call this method which is required by join_by_external_commit method.
Also there are no public methods which allow temporary proposal to be stored proposals that are received from the DS in between two commit messages by the application before creating group.

https://github.com/openmls/openmls/blob/main/openmls/src/group/core_group/proposals.rs#L27