### PR TITLE
Update interop client dependencies

### DIFF
--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "interop_client"
 version = "0.1.0"
 authors = ["OpenMLS Authors"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,15 +10,15 @@ edition = "2018"
 openmls = { path = "../openmls", features = ["test-utils"]}
 openmls_rust_crypto = { path = "../openmls_rust_crypto" }
 openmls_traits = { path = "../traits" }
-tonic = "0.3"
-prost = "0.6"
-tokio = { version = "0.2", features = ["macros",  "net"] }
-clap = "3.0.0-rc.0"
-clap_derive = "3.0.0-rc.0"
+tonic = "0.7"
+prost = "0.10"
+tokio = { version = "1.19.2", features = ["macros",  "net", "rt-multi-thread"] }
+clap = "3.1"
+clap_derive = "3.1"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tls_codec = { version = "0.2.0", features = ["derive", "serde_serialize"] }
 pretty_env_logger = "0.4"
 
 [build-dependencies]
-tonic-build = "0.3"
+tonic-build = "0.7"

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -231,7 +231,7 @@ impl MlsClient for MlsClientImpl {
         let obj = request.get_ref();
         let (type_msg, _result) = match TestVectorType::try_from(obj.test_vector_type) {
             Ok(TestVectorType::TreeMath) => {
-                write(&"mlspp_treemath.json".to_string(), &obj.test_vector);
+                write("mlspp_treemath.json", &obj.test_vector);
                 let kat_treemath = match serde_json::from_slice(&obj.test_vector) {
                     Ok(test_vector) => test_vector,
                     Err(_) => {


### PR DESCRIPTION
This PR updates the dependencies of the interop client to get ahead of https://github.com/openmls/openmls/security/dependabot/1

It also bumps it to the 2021 edition and fixes on clippy warning.