### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.4.1 (2022-06-07)
 
 ### Added
- - [#873:] Signature sub-module of the ciphersuite module is now public.
- - [#873:] Signature keys can be imported and exported with the crypto-subtle feature.
- - [#873:] BasicCredentials can now be created from existing signature keys.
+ - [#873:](https://github.com/openmls/openmls/pull/873) Signature sub-module of the ciphersuite module is now public.
+ - [#873:](https://github.com/openmls/openmls/pull/873) Signature keys can be imported and exported with the crypto-subtle feature.
+ - [#873:](https://github.com/openmls/openmls/pull/873) BasicCredentials can now be created from existing signature keys.
 
 ### Changed
  -  [#890:](https://github.com/openmls/openmls/pull/890) Join group by External Commit API does not expect proposal store.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.4.1 (2022-06-07)
+
 ### Added
- - Signature sub-module of the ciphersuite module is now public.
- - Signature keys can be imported and exported with the crypto-subtle feature.
- - BasicCredentials can now be created from existing signature keys.
+ - [#873:] Signature sub-module of the ciphersuite module is now public.
+ - [#873:] Signature keys can be imported and exported with the crypto-subtle feature.
+ - [#873:] BasicCredentials can now be created from existing signature keys.
 
 ### Changed
- -  [#890:](https://github.com/openmls/openmls/pull/890) Join group by external commit API does not expect proposal store.
+ -  [#890:](https://github.com/openmls/openmls/pull/890) Join group by External Commit API does not expect proposal store.
 
 ## 0.4.0 (2022-02-28)
 

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "openmls"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["OpenMLS Authors"]
 edition = "2021"
-description = "This is a WIP Rust implementation of the Messaging Layer Security (MLS) protocol based on draft 9+."
+description = "This is a WIP Rust implementation of the Messaging Layer Security (MLS) protocol based on draft 12+."
 license = "MIT"
 documentation = "https://openmls.github.io/openmls/"
 repository = "https://github.com/openmls/openmls/"


### PR DESCRIPTION
This PR prepares release v0.4.1 which fixes the API as mentioned in the CHANGELOG.