### PR TITLE
[Fixup] Expose SerializedMlsGroup until issue #245 is done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+-  [#900:](https://github.com/openmls/openmls/pull/900) Expose SerializedMlsGroup until issue [#245](https://github.com/openmls/openmls/issues/245) is done
+
 ## 0.4.1 (2022-06-07)
 
 ### Added

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -25,7 +25,6 @@ mod application;
 mod creation;
 mod exporting;
 mod resumption;
-mod ser;
 mod updates;
 
 use config::*;
@@ -38,6 +37,7 @@ pub(crate) mod config;
 pub(crate) mod errors;
 pub(crate) mod membership;
 pub(crate) mod processing;
+pub(crate) mod ser;
 
 // Tests
 #[cfg(test)]

--- a/openmls/src/group/mls_group/ser.rs
+++ b/openmls/src/group/mls_group/ser.rs
@@ -6,8 +6,12 @@ use serde::{
 };
 
 /// Helper struct that contains the serializable values of an `MlsGroup.
+#[deprecated(
+    since = "0.4.1",
+    note = "It is temporarily exposed, it will be private again after #245"
+)]
 #[derive(Serialize, Deserialize)]
-pub(crate) struct SerializedMlsGroup {
+pub struct SerializedMlsGroup {
     mls_group_config: MlsGroupConfig,
     group: CoreGroup,
     proposal_store: ProposalStore,
@@ -18,7 +22,8 @@ pub(crate) struct SerializedMlsGroup {
 }
 
 impl SerializedMlsGroup {
-    pub(crate) fn into_mls_group(self) -> MlsGroup {
+    /// Helper method that converts the SerializedMlsGroup to MlsGroup.
+    pub fn into_mls_group(self) -> MlsGroup {
         MlsGroup {
             mls_group_config: self.mls_group_config,
             group: self.group,

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -2,7 +2,7 @@
 //! Include this to get access to all the public functions of OpenMLS.
 
 // MlsGroup
-pub use crate::group::{errors::*, *};
+pub use crate::group::{errors::*, ser::*, *};
 
 // Ciphersuite
 pub use crate::ciphersuite::{hash_ref::KeyPackageRef, signable::*, signature::*, *};


### PR DESCRIPTION
Expose SerializedMlsGroup because currently MlsGroup expose [load and save](https://github.com/openmls/openmls/blob/main/openmls/src/group/mls_group/mod.rs#L296-L308) methods but that uses serde_json which is not at all optimized. For 2 people group it spits around 60kb of bytes. 
For time being, until #245 is not done, SerializedMlsGroup can be used with [bincode](https://github.com/bincode-org/bincode) to serialize and it outputs ~4075 bytes for 2 people group.