### PR TITLE
Removed unrequired mutable borrows

### DIFF
--- a/openmls/src/framing/ciphertext.rs
+++ b/openmls/src/framing/ciphertext.rs
@@ -156,7 +156,7 @@ impl MlsCiphertext {
     /// Decrypt the sender data from this [`MlsCiphertext`].
     pub(crate) fn sender_data(
         &self,
-        message_secrets: &mut MessageSecrets,
+        message_secrets: &MessageSecrets,
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: Ciphersuite,
     ) -> Result<MlsSenderData, MessageDecryptionError> {

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -645,7 +645,7 @@ fn confirmation_tag_presence(ciphersuite: Ciphersuite, backend: &impl OpenMlsCry
 
     // We have to create Bob's group so he can process the commit with the
     // broken confirmation tag, because Alice can't process her own commit.
-    let mut group_bob = CoreGroup::new_from_welcome(
+    let group_bob = CoreGroup::new_from_welcome(
         create_commit_result
             .welcome_option
             .expect("commit didn't return a welcome as expected"),

--- a/openmls/src/group/core_group/apply_proposals.rs
+++ b/openmls/src/group/core_group/apply_proposals.rs
@@ -9,7 +9,7 @@ use crate::{
     group::errors::ApplyProposalsError,
     key_packages::KeyPackageBundle,
     messages::proposals::{AddProposal, Proposal, ProposalType},
-    schedule::{psk::*, InitSecret},
+    schedule::InitSecret,
     treesync::{diff::TreeSyncDiff, node::leaf_node::LeafNode},
 };
 

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -2,9 +2,7 @@ use openmls_traits::OpenMlsCryptoProvider;
 
 use crate::{
     ciphersuite::signable::Signable,
-    framing::*,
-    group::{core_group::*, errors::CreateCommitError, *},
-    messages::*,
+    group::{core_group::*, errors::CreateCommitError},
     treesync::{
         diff::TreeSyncDiff,
         node::parent_node::PlainUpdatePathNode,

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -32,6 +32,7 @@ mod test_external_init;
 mod test_past_secrets;
 #[cfg(test)]
 mod test_proposals;
+
 #[cfg(test)]
 use super::errors::CreateGroupContextExtProposalError;
 
@@ -624,6 +625,20 @@ impl CoreGroup {
                 .ok_or(SecretTreeError::TooDistantInThePast)
         } else {
             Ok(self.message_secrets_store.message_secrets_mut())
+        }
+    }
+
+    /// Get the message secrets. Either from the secrets store or from the group.
+    pub(crate) fn message_secrets_for_epoch<'secret, 'group: 'secret>(
+        &'group self,
+        epoch: GroupEpoch,
+    ) -> Result<&'secret MessageSecrets, SecretTreeError> {
+        if epoch < self.context().epoch() {
+            self.message_secrets_store
+                .secrets_for_epoch(epoch)
+                .ok_or(SecretTreeError::TooDistantInThePast)
+        } else {
+            Ok(self.message_secrets_store.message_secrets())
         }
     }
 

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -5,10 +5,8 @@ use tls_codec::Deserialize;
 use crate::{
     ciphersuite::{hash_ref::HashReference, signable::Verifiable},
     extensions::ExtensionType,
-    group::{core_group::*, errors::WelcomeError, *},
-    key_packages::*,
-    messages::*,
-    schedule::{errors::PskError, *},
+    group::{core_group::*, errors::WelcomeError},
+    schedule::errors::PskError,
     treesync::{errors::TreeSyncFromNodesError, node::Node},
 };
 

--- a/openmls/src/group/core_group/past_secrets.rs
+++ b/openmls/src/group/core_group/past_secrets.rs
@@ -93,6 +93,21 @@ impl MessageSecretsStore {
         None
     }
 
+    /// Get a reference to a secret tree for a given epoch `group_epoch`.
+    /// If no message secrets are found for that epoch, `None` is returned.
+    pub(crate) fn secrets_for_epoch(
+        &self,
+        group_epoch: impl Into<GroupEpoch>,
+    ) -> Option<&MessageSecrets> {
+        let epoch = group_epoch.into().as_u64();
+        for epoch_tree in self.past_epoch_trees.iter() {
+            if epoch_tree.epoch == epoch {
+                return Some(&epoch_tree.message_secrets);
+            }
+        }
+        None
+    }
+
     /// Get a mutable reference to a secret tree for a given epoch `group_epoch`.
     /// Return a vector with the key package references and leaf indices of the
     /// epoch.

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -105,7 +105,7 @@ impl CoreGroup {
     ///  - ValSem245
     ///  - ValSem247 (as part of ValSem010)
     pub(crate) fn process_unverified_message(
-        &mut self,
+        &self,
         unverified_message: UnverifiedMessage,
         signature_key: Option<&SignaturePublicKey>,
         proposal_store: &ProposalStore,
@@ -115,7 +115,7 @@ impl CoreGroup {
         // Add the context to the message and verify the membership tag if necessary.
         // If the message is older than the current epoch, we need to fetch the correct secret tree first.
         let message_secrets = self
-            .message_secrets_mut(unverified_message.epoch())
+            .message_secrets_for_epoch(unverified_message.epoch())
             .map_err(|e| match e {
                 SecretTreeError::TooDistantInThePast => UnverifiedMessageError::NoPastEpochData,
                 _ => LibraryError::custom("Unexpected return value").into(),

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -52,7 +52,7 @@ impl CoreGroup {
     /// Returns an error if the given commit was sent by the owner of this
     /// group.
     pub(crate) fn stage_commit(
-        &mut self,
+        &self,
         mls_plaintext: &MlsPlaintext,
         proposal_store: &ProposalStore,
         own_key_packages: &[KeyPackageBundle],

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -627,7 +627,7 @@ fn test_own_commit_processing(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
     .expect("An unexpected error occurred.");
 
     // === Alice creates a group ===
-    let mut alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
+    let alice_group = CoreGroup::builder(GroupId::random(backend), alice_key_package_bundle)
         .build(backend)
         .expect("Error creating group.");
 

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -55,7 +55,7 @@ impl MlsGroup {
     /// Returns an [`UnverifiedMessageError`] when the validation checks fail
     /// with the exact reason of the failure.
     pub fn process_unverified_message(
-        &mut self,
+        &self,
         unverified_message: UnverifiedMessage,
         signature_key: Option<&SignaturePublicKey>,
         backend: &impl OpenMlsCryptoProvider,


### PR DESCRIPTION
Some mutable borrows were required in some methods, especially `process_unverified_message` whereas it was not required.
Removing them makes the methods intent clearer, helps working with borrow checker rules and could also have runtime advantages.