### PR TITLE
Use thiserror in support crates

### DIFF
--- a/evercrypt_backend/CHANGELOG.md
+++ b/evercrypt_backend/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- [#909](https://github.com/openmls/openmls/pull/909): Use thiserror crate for errors
+
+## 0.1.0 (2022-02-28)
+- initial release
+
+*Please disregard any previous versions.*

--- a/evercrypt_backend/Cargo.toml
+++ b/evercrypt_backend/Cargo.toml
@@ -19,3 +19,4 @@ hpke = { version = "0.1.0", package = "hpke-rs", features = ["hazmat", "serializ
 log = { version = "0.4", features = ["std"] }
 hpke-rs-crypto = { version = "0.1.1" }
 hpke-rs-evercrypt = { version = "0.1.2" }
+thiserror = "1.0"

--- a/evercrypt_backend/src/provider.rs
+++ b/evercrypt_backend/src/provider.rs
@@ -824,21 +824,29 @@ fn test_der_encoding() {
 }
 
 impl OpenMlsRand for EvercryptProvider {
-    type Error = &'static str;
+    type Error = RandError;
 
     fn random_array<const N: usize>(&self) -> Result<[u8; N], Self::Error> {
-        let mut rng = self.rng.write().map_err(|_| "Rng lock is poisoned.")?;
+        let mut rng = self.rng.write().map_err(|_| Self::Error::LockPoisoned)?;
         let mut out = [0u8; N];
         rng.try_fill_bytes(&mut out)
-            .map_err(|_| "Unable to collect enough randomness.")?;
+            .map_err(|_| Self::Error::NotEnoughRandomness)?;
         Ok(out)
     }
 
     fn random_vec(&self, len: usize) -> Result<Vec<u8>, Self::Error> {
-        let mut rng = self.rng.write().map_err(|_| "Rng lock is poisoned.")?;
+        let mut rng = self.rng.write().map_err(|_| Self::Error::LockPoisoned)?;
         let mut out = vec![0u8; len];
         rng.try_fill_bytes(&mut out)
-            .map_err(|_| "Unable to collect enough randomness.")?;
+            .map_err(|_| Self::Error::NotEnoughRandomness)?;
         Ok(out)
     }
+}
+
+#[derive(thiserror::Error, Debug, Copy, Clone, PartialEq)]
+pub enum RandError {
+    #[error("Rng lock is poisoned.")]
+    LockPoisoned,
+    #[error("Unable to collect enough randomness.")]
+    NotEnoughRandomness,
 }

--- a/memory_keystore/CHANGELOG.md
+++ b/memory_keystore/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- [#909](https://github.com/openmls/openmls/pull/909): Use thiserror crate for errors
+
+## 0.1.0 (2022-02-28)
+- initial release
+
+*Please disregard any previous versions.*

--- a/memory_keystore/Cargo.toml
+++ b/memory_keystore/Cargo.toml
@@ -11,3 +11,4 @@ readme = "README.md"
 
 [dependencies]
 openmls_traits = { version = "0.1.0", path = "../traits" }
+thiserror = "1.0"

--- a/memory_keystore/src/lib.rs
+++ b/memory_keystore/src/lib.rs
@@ -54,21 +54,12 @@ impl OpenMlsKeyStore for MemoryKeyStore {
 }
 
 /// Errors thrown by the key store.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(thiserror::Error, Debug, Copy, Clone, PartialEq)]
 pub enum Error {
+    #[error("The key store does not allow storing serialized values.")]
     UnsupportedValueTypeBytes,
+    #[error("Updating is not supported by this key store.")]
     UnsupportedMethod,
+    #[error("Error serializing value.")]
     SerializationError,
-}
-
-impl From<Error> for String {
-    fn from(val: Error) -> Self {
-        match val {
-            Error::UnsupportedValueTypeBytes => {
-                "The key store does not allow storing serialized values.".to_string()
-            }
-            Error::UnsupportedMethod => "Updating is not supported by this key store.".to_string(),
-            Error::SerializationError => "Error serializing value.".to_string(),
-        }
-    }
 }

--- a/openmls/src/key_store.rs
+++ b/openmls/src/key_store.rs
@@ -1,7 +1,8 @@
 //! Serialization for key store objects.
 
 use crate::{
-    credentials::CredentialBundle, key_packages::KeyPackageBundle, schedule::psk::PskBundle,
+    credentials::CredentialBundle, key_packages::KeyPackageBundle, prelude::LibraryError,
+    schedule::psk::PskBundle,
 };
 
 use openmls_traits::key_store::{FromKeyStoreValue, ToKeyStoreValue};
@@ -9,45 +10,47 @@ use openmls_traits::key_store::{FromKeyStoreValue, ToKeyStoreValue};
 // === OpenMLS Key Store Types
 
 impl FromKeyStoreValue for KeyPackageBundle {
-    type Error = &'static str;
+    type Error = LibraryError;
     fn from_key_store_value(ksv: &[u8]) -> Result<Self, Self::Error> {
-        serde_json::from_slice(ksv).map_err(|_| "Invalid key package bundle.")
+        serde_json::from_slice(ksv).map_err(|_| LibraryError::custom("Invalid key package bundle."))
     }
 }
 
 impl FromKeyStoreValue for CredentialBundle {
-    type Error = &'static str;
+    type Error = LibraryError;
     fn from_key_store_value(ksv: &[u8]) -> Result<Self, Self::Error> {
-        serde_json::from_slice(ksv).map_err(|_| "Invalid credential bundle.")
+        serde_json::from_slice(ksv).map_err(|_| LibraryError::custom("Invalid credential bundle."))
     }
 }
 
 impl ToKeyStoreValue for KeyPackageBundle {
-    type Error = &'static str;
+    type Error = LibraryError;
     fn to_key_store_value(&self) -> Result<Vec<u8>, Self::Error> {
-        serde_json::to_vec(self).map_err(|_| "Error serializing key package bundle.")
+        serde_json::to_vec(self)
+            .map_err(|_| LibraryError::custom("Error serializing key package bundle."))
     }
 }
 
 impl ToKeyStoreValue for CredentialBundle {
-    type Error = &'static str;
+    type Error = LibraryError;
     fn to_key_store_value(&self) -> Result<Vec<u8>, Self::Error> {
-        serde_json::to_vec(self).map_err(|_| "Error serializing key package bundle.")
+        serde_json::to_vec(self)
+            .map_err(|_| LibraryError::custom("Error serializing key package bundle."))
     }
 }
 
 // PSKs
 
 impl FromKeyStoreValue for PskBundle {
-    type Error = &'static str;
+    type Error = LibraryError;
     fn from_key_store_value(ksv: &[u8]) -> Result<Self, Self::Error> {
-        serde_json::from_slice(ksv).map_err(|_| "Invalid PSK bundle.")
+        serde_json::from_slice(ksv).map_err(|_| LibraryError::custom("Invalid PSK bundle."))
     }
 }
 
 impl ToKeyStoreValue for PskBundle {
-    type Error = &'static str;
+    type Error = LibraryError;
     fn to_key_store_value(&self) -> Result<Vec<u8>, Self::Error> {
-        serde_json::to_vec(self).map_err(|_| "Error serializing PSK bundle.")
+        serde_json::to_vec(self).map_err(|_| LibraryError::custom("Error serializing PSK bundle."))
     }
 }

--- a/openmls_rust_crypto/CHANGELOG.md
+++ b/openmls_rust_crypto/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- [#909](https://github.com/openmls/openmls/pull/909): Use thiserror crate for errors
+
+## 0.1.0 (2022-02-28)
+- initial release
+
+*Please disregard any previous versions.*

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -26,6 +26,7 @@ rand_chacha = { version = "0.3" }
 hpke = { version = "0.1.0", package = "hpke-rs", default-features = false, features = ["hazmat", "serialization"] }
 hpke-rs-crypto = { version = "0.1.1" }
 hpke-rs-rust-crypto = { version = "0.1.1" }
+thiserror = "1.0"
 
 [patch.crates-io]
 openmls_traits = { path = "../traits" }

--- a/traits/CHANGELOG.md
+++ b/traits/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- [#909](https://github.com/openmls/openmls/pull/909): Use thiserror crate for errors
+
+## 0.1.0 (2022-02-28)
+- initial release
+
+*Please disregard any previous versions.*

--- a/traits/src/key_store.rs
+++ b/traits/src/key_store.rs
@@ -3,19 +3,19 @@
 use std::fmt::Debug;
 
 pub trait FromKeyStoreValue: Sized {
-    type Error: Debug + Clone + PartialEq + Into<String>;
+    type Error: std::error::Error + Debug;
     fn from_key_store_value(ksv: &[u8]) -> Result<Self, Self::Error>;
 }
 
 pub trait ToKeyStoreValue {
-    type Error: Debug + Clone + PartialEq + Into<String>;
+    type Error: std::error::Error + Debug;
     fn to_key_store_value(&self) -> Result<Vec<u8>, Self::Error>;
 }
 
 /// The Key Store trait
 pub trait OpenMlsKeyStore: Send + Sync {
     /// The error type returned by the [`OpenMlsKeyStore`].
-    type Error: Debug + Clone + PartialEq + Into<String>;
+    type Error: std::error::Error + Debug;
 
     /// Store a value `v` that implements the [`ToKeyStoreValue`] trait for
     /// serialization for ID `k`.

--- a/traits/src/random.rs
+++ b/traits/src/random.rs
@@ -6,7 +6,7 @@
 use std::fmt::Debug;
 
 pub trait OpenMlsRand {
-    type Error: Debug + Clone + PartialEq + Into<String>;
+    type Error: std::error::Error + Debug + Clone + PartialEq;
 
     /// Fill an array with random bytes.
     fn random_array<const N: usize>(&self) -> Result<[u8; N], Self::Error>;


### PR DESCRIPTION
I've noticed that majority of errors have been migrated to thiserror. This PR transitions public errors from support crates to derive `std::error::Error` as well.