### PR TITLE
Remove Send + Sync requirement on OpenMlsKeyStore

### DIFF
--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -588,7 +588,7 @@ impl WelcomeSecret {
             self.secret.ciphersuite()
         );
         let aead_secret = self.secret.hkdf_expand(
-            backend,
+            backend.crypto(),
             b"key",
             self.secret.ciphersuite().aead_key_length(),
         )?;
@@ -601,7 +601,7 @@ impl WelcomeSecret {
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<AeadNonce, CryptoError> {
         let nonce_secret = self.secret.hkdf_expand(
-            backend,
+            backend.crypto(),
             b"nonce",
             self.secret.ciphersuite().aead_nonce_length(),
         )?;
@@ -630,7 +630,7 @@ impl EpochSecret {
         serialized_group_context: &[u8],
     ) -> Result<Self, CryptoError> {
         let secret = intermediate_secret.secret.kdf_expand_label(
-            backend,
+            backend.crypto(),
             "epoch",
             serialized_group_context,
             ciphersuite.hash_length(),
@@ -737,7 +737,7 @@ impl ExporterSecret {
         Ok(self
             .secret
             .derive_secret(backend, label)?
-            .kdf_expand_label(backend, label, context_hash, key_length)?
+            .kdf_expand_label(backend.crypto(), label, context_hash, key_length)?
             .as_slice()
             .to_vec())
     }
@@ -940,7 +940,7 @@ impl SenderDataSecret {
             ciphertext_sample
         );
         let secret = self.secret.kdf_expand_label(
-            backend,
+            backend.crypto(),
             "key",
             ciphertext_sample,
             self.secret.ciphersuite().aead_key_length(),
@@ -961,7 +961,7 @@ impl SenderDataSecret {
             ciphertext_sample
         );
         let nonce_secret = self.secret.kdf_expand_label(
-            backend,
+            backend.crypto(),
             "nonce",
             ciphertext_sample,
             ciphersuite.aead_nonce_length(),

--- a/openmls/src/schedule/psk.rs
+++ b/openmls/src/schedule/psk.rs
@@ -327,7 +327,7 @@ impl PskSecret {
 
             let psk_input = psk_extracted
                 .kdf_expand_label(
-                    backend,
+                    backend.crypto(),
                     "derived psk",
                     &psk_label,
                     ciphersuite.hash_length(),

--- a/openmls/src/tree/secret_tree.rs
+++ b/openmls/src/tree/secret_tree.rs
@@ -79,7 +79,7 @@ pub(crate) fn derive_tree_secret(
         length
     );
     log_crypto!(trace, "Input secret {:x?}", secret.as_slice());
-    Ok(secret.kdf_expand_label(backend, label, &generation.to_be_bytes(), length)?)
+    Ok(secret.kdf_expand_label(backend.crypto(), label, &generation.to_be_bytes(), length)?)
 }
 
 #[derive(Debug, TlsSerialize, TlsSize)]
@@ -213,8 +213,12 @@ impl SecretTree {
             None => return Err(SecretTreeError::LibraryError),
         };
 
-        let handshake_ratchet_secret =
-            node_secret.kdf_expand_label(backend, "handshake", b"", ciphersuite.hash_length())?;
+        let handshake_ratchet_secret = node_secret.kdf_expand_label(
+            backend.crypto(),
+            "handshake",
+            b"",
+            ciphersuite.hash_length(),
+        )?;
         let application_ratchet_secret = derive_tree_secret(
             node_secret,
             "application",
@@ -360,8 +364,10 @@ impl SecretTree {
             left(index_in_tree).expect("derive_down: Error while computing left child.");
         let right_index = right(index_in_tree, self.size)
             .expect("derive_down: Error while computing right child.");
-        let left_secret = node_secret.kdf_expand_label(backend, "tree", b"left", hash_len)?;
-        let right_secret = node_secret.kdf_expand_label(backend, "tree", b"right", hash_len)?;
+        let left_secret =
+            node_secret.kdf_expand_label(backend.crypto(), "tree", b"left", hash_len)?;
+        let right_secret =
+            node_secret.kdf_expand_label(backend.crypto(), "tree", b"right", hash_len)?;
         log_crypto!(
             trace,
             "Left node ({}) secret: {:x?}",

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -410,7 +410,7 @@ impl<'a> TreeSyncDiff<'a> {
                 // then we should have the secret for this node.
                 if !pn.unmerged_leaves().contains(&self.own_leaf_index) {
                     let (public_key, private_key) =
-                        path_secret.derive_key_pair(backend, ciphersuite)?;
+                        path_secret.derive_key_pair(backend.crypto(), ciphersuite)?;
                     // The derived public key should match the one in the node.
                     // If not, the tree is corrupt.
                     if pn.public_key() != &public_key {

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -56,10 +56,11 @@ impl<'a> TreeSyncDiff<'a> {
         debug_assert_eq!(copath_resolutions.len(), path.len());
 
         // Encrypt the secrets
+        let crypto = backend.crypto();
         let update_path_nodes = path
             .par_iter()
             .zip(copath_resolutions.par_iter())
-            .map(|(node, resolution)| node.encrypt(backend, ciphersuite, resolution, group_context))
+            .map(|(node, resolution)| node.encrypt(crypto, ciphersuite, resolution, group_context))
             .collect::<Vec<UpdatePathNode>>();
 
         Ok(UpdatePath {

--- a/traits/src/crypto.rs
+++ b/traits/src/crypto.rs
@@ -7,7 +7,7 @@ use crate::types::{
     HpkeKeyPair, KemOutput, SignatureScheme,
 };
 
-pub trait OpenMlsCrypto {
+pub trait OpenMlsCrypto: Send + Sync {
     /// Check whether the [`Ciphersuite`] is supported by the backend or not.
     ///
     /// Returns a [`CryptoError::UnsupportedCiphersuite`] if the ciphersuite is not supported.

--- a/traits/src/key_store.rs
+++ b/traits/src/key_store.rs
@@ -13,7 +13,7 @@ pub trait ToKeyStoreValue {
 }
 
 /// The Key Store trait
-pub trait OpenMlsKeyStore: Send + Sync {
+pub trait OpenMlsKeyStore {
     /// The error type returned by the [`OpenMlsKeyStore`].
     type Error: Debug + Clone + PartialEq + Into<String>;
 

--- a/traits/src/traits.rs
+++ b/traits/src/traits.rs
@@ -12,7 +12,7 @@ pub mod types;
 ///
 /// An implementation of this trait must be passed in to the public OpenMLS API
 /// to perform randomness generation, cryptographic operations, and key storage.
-pub trait OpenMlsCryptoProvider: Send + Sync {
+pub trait OpenMlsCryptoProvider {
     type CryptoProvider: crypto::OpenMlsCrypto;
     type RandProvider: random::OpenMlsRand;
     type KeyStoreProvider: key_store::OpenMlsKeyStore;


### PR DESCRIPTION
Send + Sync requirement is needed for rayon to work. It turns out that
OpenMlsKeyStore is never accessed in parallel so such bound is not
necessary.

Use case: rusqlite's Connection is not thread-safe so it is not possible
to save credential and key package bundles in SQLite out of the box.

Possible alternatives:

1. Unsafely implement Send + Sync on Connection.
    This is what Wire app uses ([Reference](https://github.com/wireapp/core-crypto/blob/develop/keystore/src/connection/platform/generic/mod.rs#L29))
2. Add a cargo feature to disable parallelization.

What do you think?