### PR TITLE
tls codec main

### DIFF
--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -59,3 +59,7 @@ features = ["test-utils", "evercrypt"]
 [[bench]]
 name = "benchmark"
 harness = false
+
+# Patching unreleased crates
+[patch.crates-io]
+tls_codec = { git = "https://github.com/RustCrypto/formats.git", features = ["derive", "serde_serialize"] }

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -269,7 +269,7 @@ impl OpenMlsCrypto for RustCrypto {
                 }
                 let mut sig = [0u8; ed25519_dalek::SIGNATURE_LENGTH];
                 sig.clone_from_slice(signature);
-                k.verify_strict(data, &ed25519_dalek::Signature::new(sig))
+                k.verify_strict(data, &ed25519_dalek::Signature::from(sig))
                     .map_err(|_| CryptoError::InvalidSignature)
             }
             _ => Err(CryptoError::UnsupportedSignatureScheme),


### PR DESCRIPTION
Until #877 is fixed and a new version of the `tls_codec` crate is released OpenMLS should build against `tls_codec` main.