### PR TITLE
Sync `GroupInfo{,TBS}` with draft-ietf-mls-protocol-16.

### DIFF
--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -312,18 +312,25 @@ impl CoreGroup {
             } else {
                 Vec::new()
             };
-            // Create GroupInfo object
-            let group_info = GroupInfoPayload::new(
-                provisional_group_context.group_id().clone(),
-                provisional_group_context.epoch(),
-                tree_hash,
-                confirmed_transcript_hash.clone(),
-                self.group_context_extensions(),
-                &other_extensions,
-                confirmation_tag.clone(),
-                diff.hash_ref()?,
-            );
-            let group_info = group_info.sign(backend, params.credential_bundle())?;
+            // Create to-be-signed group info.
+            let group_info_tbs = {
+                let group_context = GroupContext::new(
+                    provisional_group_context.group_id().clone(),
+                    provisional_group_context.epoch(),
+                    tree_hash,
+                    confirmed_transcript_hash.clone(),
+                    self.group_context_extensions(),
+                );
+
+                GroupInfoPayload::new(
+                    group_context,
+                    &other_extensions,
+                    confirmation_tag.clone(),
+                    diff.hash_ref()?,
+                )
+            };
+            // Sign to-be-signed group info.
+            let group_info = group_info_tbs.sign(backend, params.credential_bundle())?;
 
             // Encrypt GroupInfo object
             let (welcome_key, welcome_nonce) = welcome_secret

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -322,7 +322,7 @@ impl CoreGroup {
                     self.group_context_extensions(),
                 );
 
-                GroupInfoPayload::new(
+                GroupInfoTBS::new(
                     group_context,
                     &other_extensions,
                     confirmation_tag.clone(),

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -114,13 +114,14 @@ impl CoreGroup {
         // this group. Note that this is not strictly necessary. But there's
         // currently no other mechanism to enable the extension.
         let (nodes, enable_ratchet_tree_extension) =
-            match try_nodes_from_extensions(group_info.other_extensions(), backend.crypto())
-                .map_err(|e| match e {
+            match try_nodes_from_extensions(group_info.extensions(), backend.crypto()).map_err(
+                |e| match e {
                     ExtensionError::DuplicateRatchetTreeExtension => {
                         WelcomeError::DuplicateRatchetTreeExtension
                     }
                     _ => LibraryError::custom("Unexpected extension error").into(),
-                })? {
+                },
+            )? {
                 Some(nodes) => (nodes, true),
                 None => match nodes_option {
                     Some(n) => (n, false),

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -86,7 +86,7 @@ impl CoreGroup {
             .map_err(|_| WelcomeError::MalformedWelcomeMessage)?;
 
         // Make sure that we can support the required capabilities in the group info.
-        let group_context_extensions = group_info.group_context_extensions();
+        let group_context_extensions = group_info.group_context().extensions();
         let required_capabilities = group_context_extensions
             .iter()
             .find(|&extension| extension.extension_type() == ExtensionType::RequiredCapabilities);
@@ -156,10 +156,13 @@ impl CoreGroup {
 
         // Compute state
         let group_context = GroupContext::new(
-            group_info.group_id().clone(),
-            group_info.epoch(),
+            group_info.group_context().group_id().clone(),
+            group_info.group_context().epoch(),
             tree.tree_hash().to_vec(),
-            group_info.confirmed_transcript_hash().to_vec(),
+            group_info
+                .group_context()
+                .confirmed_transcript_hash()
+                .to_vec(),
             group_context_extensions,
         );
 

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -102,7 +102,7 @@ fn test_failed_groupinfo_decryption(
             &Vec::new(),
         );
 
-        GroupInfoPayload::new(
+        GroupInfoTBS::new(
             group_context,
             &extensions,
             confirmation_tag,

--- a/openmls/src/group/core_group/test_duplicate_extension.rs
+++ b/openmls/src/group/core_group/test_duplicate_extension.rs
@@ -143,7 +143,7 @@ fn duplicate_ratchet_tree_extension(
         .expect("Could not decode GroupInfo");
 
     // Duplicate extensions
-    let extensions = group_info.other_extensions();
+    let extensions = group_info.extensions();
     let duplicate_extensions = vec![extensions[0].clone(), extensions[0].clone()];
     group_info.set_other_extensions(duplicate_extensions);
 

--- a/openmls/src/group/core_group/test_duplicate_extension.rs
+++ b/openmls/src/group/core_group/test_duplicate_extension.rs
@@ -145,7 +145,7 @@ fn duplicate_ratchet_tree_extension(
     // Duplicate extensions
     let extensions = group_info.extensions();
     let duplicate_extensions = vec![extensions[0].clone(), extensions[0].clone()];
-    group_info.set_other_extensions(duplicate_extensions);
+    group_info.set_extensions(duplicate_extensions);
 
     // Put everything back together
     let group_info = group_info

--- a/openmls/src/group/group_context.rs
+++ b/openmls/src/group/group_context.rs
@@ -58,17 +58,22 @@ impl GroupContext {
         )
     }
 
-    /// Return the group ID
+    /// Return the group ID.
     pub(crate) fn group_id(&self) -> &GroupId {
         &self.group_id
     }
 
-    /// Return the epoch
+    /// Return the epoch.
     pub(crate) fn epoch(&self) -> GroupEpoch {
         self.epoch
     }
 
-    /// Return the extensions of the context
+    /// Return the confirmed transcript hash.
+    pub(crate) fn confirmed_transcript_hash(&self) -> &[u8] {
+        self.confirmed_transcript_hash.as_slice()
+    }
+
+    /// Return the extensions.
     pub(crate) fn extensions(&self) -> &[Extension] {
         self.extensions.as_slice()
     }
@@ -79,10 +84,5 @@ impl GroupContext {
             .iter()
             .find(|e| e.extension_type() == ExtensionType::RequiredCapabilities)
             .and_then(|e| e.as_required_capabilities_extension().ok())
-    }
-
-    /// Return the confirmed transcript hash
-    pub(crate) fn confirmed_transcript_hash(&self) -> &[u8] {
-        self.confirmed_transcript_hash.as_slice()
     }
 }

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -98,7 +98,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
             )],
         );
 
-        GroupInfoPayload::new(
+        GroupInfoTBS::new(
             group_context,
             &[Extension::RatchetTree(RatchetTreeExtension::new(
                 ratchet_tree.clone(),

--- a/openmls/src/messages/codec.rs
+++ b/openmls/src/messages/codec.rs
@@ -30,7 +30,7 @@ impl tls_codec::Serialize for GroupInfo {
 
 impl tls_codec::Deserialize for GroupInfo {
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error> {
-        let payload = GroupInfoPayload::tls_deserialize(bytes)?;
+        let payload = GroupInfoTBS::tls_deserialize(bytes)?;
         let signature = Signature::tls_deserialize(bytes)?;
         Ok(GroupInfo { payload, signature })
     }

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -166,14 +166,14 @@ impl Commit {
 pub struct ConfirmationTag(pub(crate) Mac);
 
 #[derive(TlsDeserialize, TlsSerialize, TlsSize)]
-pub(crate) struct GroupInfoPayload {
+pub(crate) struct GroupInfoTBS {
     group_context: GroupContext,
     extensions: TlsVecU32<Extension>,
     confirmation_tag: ConfirmationTag,
     signer: KeyPackageRef,
 }
 
-impl GroupInfoPayload {
+impl GroupInfoTBS {
     /// Create a new group info payload struct.
     pub(crate) fn new(
         group_context: GroupContext,
@@ -190,7 +190,7 @@ impl GroupInfoPayload {
     }
 }
 
-impl Signable for GroupInfoPayload {
+impl Signable for GroupInfoTBS {
     type SignedOutput = GroupInfo;
 
     fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
@@ -218,7 +218,7 @@ impl Signable for GroupInfoPayload {
 /// } GroupInfo;
 /// ```
 pub(crate) struct GroupInfo {
-    payload: GroupInfoPayload,
+    payload: GroupInfoTBS,
     signature: Signature,
 }
 
@@ -270,8 +270,8 @@ impl Verifiable for GroupInfo {
     }
 }
 
-impl SignedStruct<GroupInfoPayload> for GroupInfo {
-    fn from_payload(payload: GroupInfoPayload, signature: Signature) -> Self {
+impl SignedStruct<GroupInfoTBS> for GroupInfo {
+    fn from_payload(payload: GroupInfoTBS, signature: Signature) -> Self {
         Self { payload, signature }
     }
 }

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -172,7 +172,7 @@ pub(crate) struct GroupInfoPayload {
     tree_hash: TlsByteVecU8,
     confirmed_transcript_hash: TlsByteVecU8,
     group_context_extensions: TlsVecU32<Extension>,
-    other_extensions: TlsVecU32<Extension>,
+    extensions: TlsVecU32<Extension>,
     confirmation_tag: ConfirmationTag,
     signer: KeyPackageRef,
 }
@@ -186,7 +186,7 @@ impl GroupInfoPayload {
         tree_hash: Vec<u8>,
         confirmed_transcript_hash: Vec<u8>,
         group_context_extensions: &[Extension],
-        other_extensions: &[Extension],
+        extensions: &[Extension],
         confirmation_tag: ConfirmationTag,
         signer: &KeyPackageRef,
     ) -> Self {
@@ -196,7 +196,7 @@ impl GroupInfoPayload {
             tree_hash: tree_hash.into(),
             confirmed_transcript_hash: confirmed_transcript_hash.into(),
             group_context_extensions: group_context_extensions.into(),
-            other_extensions: other_extensions.into(),
+            extensions: extensions.into(),
             confirmation_tag,
             signer: *signer,
         }
@@ -262,8 +262,8 @@ impl GroupInfo {
     }
 
     /// Returns other application extensions.
-    pub(crate) fn other_extensions(&self) -> &[Extension] {
-        self.payload.other_extensions.as_slice()
+    pub(crate) fn extensions(&self) -> &[Extension] {
+        self.payload.extensions.as_slice()
     }
 
     /// Returns the [`GroupContext`] extensions.
@@ -274,7 +274,7 @@ impl GroupInfo {
     /// Set the group info's other extensions.
     #[cfg(test)]
     pub(crate) fn set_other_extensions(&mut self, extensions: Vec<Extension>) {
-        self.payload.other_extensions = extensions.into();
+        self.payload.extensions = extensions.into();
     }
 
     /// Re-sign the group info.

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -167,35 +167,22 @@ pub struct ConfirmationTag(pub(crate) Mac);
 
 #[derive(TlsDeserialize, TlsSerialize, TlsSize)]
 pub(crate) struct GroupInfoPayload {
-    group_id: GroupId,
-    epoch: GroupEpoch,
-    tree_hash: TlsByteVecU8,
-    confirmed_transcript_hash: TlsByteVecU8,
-    group_context_extensions: TlsVecU32<Extension>,
+    group_context: GroupContext,
     extensions: TlsVecU32<Extension>,
     confirmation_tag: ConfirmationTag,
     signer: KeyPackageRef,
 }
 
 impl GroupInfoPayload {
-    #[allow(clippy::too_many_arguments)] // TODO: #569 refactor GroupInfoPayload
     /// Create a new group info payload struct.
     pub(crate) fn new(
-        group_id: GroupId,
-        epoch: impl Into<GroupEpoch>,
-        tree_hash: Vec<u8>,
-        confirmed_transcript_hash: Vec<u8>,
-        group_context_extensions: &[Extension],
+        group_context: GroupContext,
         extensions: &[Extension],
         confirmation_tag: ConfirmationTag,
         signer: &KeyPackageRef,
     ) -> Self {
         Self {
-            group_id,
-            epoch: epoch.into(),
-            tree_hash: tree_hash.into(),
-            confirmed_transcript_hash: confirmed_transcript_hash.into(),
-            group_context_extensions: group_context_extensions.into(),
+            group_context: group_context.into(),
             extensions: extensions.into(),
             confirmation_tag,
             signer: *signer,
@@ -236,45 +223,30 @@ pub(crate) struct GroupInfo {
 }
 
 impl GroupInfo {
-    /// Returns the signer.
-    pub(crate) fn signer(&self) -> &KeyPackageRef {
-        &self.payload.signer
+    /// Returns the group context.
+    pub(crate) fn group_context(&self) -> &GroupContext {
+        &self.payload.group_context
     }
 
-    /// Returns the group ID.
-    pub(crate) fn group_id(&self) -> &GroupId {
-        &self.payload.group_id
-    }
-
-    /// Returns the epoch.
-    pub(crate) fn epoch(&self) -> GroupEpoch {
-        self.payload.epoch
-    }
-
-    /// Returns the confirmed transcript hash.
-    pub(crate) fn confirmed_transcript_hash(&self) -> &[u8] {
-        self.payload.confirmed_transcript_hash.as_slice()
-    }
-
-    /// Returns the confirmed tag.
-    pub(crate) fn confirmation_tag(&self) -> &ConfirmationTag {
-        &self.payload.confirmation_tag
-    }
-
-    /// Returns other application extensions.
+    /// Returns the extensions.
     pub(crate) fn extensions(&self) -> &[Extension] {
         self.payload.extensions.as_slice()
     }
 
-    /// Returns the [`GroupContext`] extensions.
-    pub(crate) fn group_context_extensions(&self) -> &[Extension] {
-        self.payload.group_context_extensions.as_slice()
+    /// Set the extensions.
+    #[cfg(test)]
+    pub(crate) fn set_extensions(&mut self, extensions: Vec<Extension>) {
+        self.payload.extensions = extensions.into();
     }
 
-    /// Set the group info's other extensions.
-    #[cfg(test)]
-    pub(crate) fn set_other_extensions(&mut self, extensions: Vec<Extension>) {
-        self.payload.extensions = extensions.into();
+    /// Returns the confirmation tag.
+    pub(crate) fn confirmation_tag(&self) -> &ConfirmationTag {
+        &self.payload.confirmation_tag
+    }
+
+    /// Returns the signer.
+    pub(crate) fn signer(&self) -> &KeyPackageRef {
+        &self.payload.signer
     }
 
     /// Re-sign the group info.

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -165,6 +165,18 @@ impl Commit {
 )]
 pub struct ConfirmationTag(pub(crate) Mac);
 
+/// GroupInfo (To Be Signed)
+///
+/// ```c
+/// // draft-ietf-mls-protocol-16
+///
+/// struct {
+///     GroupContext group_context;
+///     Extension extensions<V>;
+///     MAC confirmation_tag;
+///     uint32 signer;
+/// } GroupInfoTBS;
+/// ```
 #[derive(TlsDeserialize, TlsSerialize, TlsSize)]
 pub(crate) struct GroupInfoTBS {
     group_context: GroupContext,
@@ -174,7 +186,7 @@ pub(crate) struct GroupInfoTBS {
 }
 
 impl GroupInfoTBS {
-    /// Create a new group info payload struct.
+    /// Create a new to-be-signed group info.
     pub(crate) fn new(
         group_context: GroupContext,
         extensions: &[Extension],
@@ -200,21 +212,18 @@ impl Signable for GroupInfoTBS {
 
 /// GroupInfo
 ///
-/// The struct is split into the payload and the signature.
-/// `GroupInfoPayload` holds the actual values, stored in `payload` here.
+/// Note: The struct is split into a `GroupInfoTBS` payload and a signature.
 ///
-/// > 11.2.2. Welcoming New Members
+/// ```c
+/// // draft-ietf-mls-protocol-16
 ///
-/// ```text
 /// struct {
-///   opaque group_id<0..255>;
-///   uint64 epoch;
-///   opaque tree_hash<0..255>;
-///   opaque confirmed_transcript_hash<0..255>;
-///   Extension extensions<0..2^32-1>;
-///   MAC confirmation_tag;
-///   KeyPackageRef signer;
-///   opaque signature<0..2^16-1>;
+///     GroupContext group_context;
+///     Extension extensions<V>;
+///     MAC confirmation_tag;
+///     uint32 signer;
+///     // SignWithLabel(., "GroupInfoTBS", GroupInfoTBS)
+///     opaque signature<V>;
 /// } GroupInfo;
 /// ```
 pub(crate) struct GroupInfo {

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -12,6 +12,7 @@ use crate::{
 use rstest::*;
 use rstest_reuse::{self, *};
 
+use crate::group::GroupContext;
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::{
     crypto::OpenMlsCrypto, random::OpenMlsRand, types::Ciphersuite, OpenMlsCryptoProvider,
@@ -29,23 +30,29 @@ fn test_welcome_message_with_version(
     version: ProtocolVersion,
 ) {
     // We use this dummy group info in all test cases.
-    let group_info = GroupInfoPayload::new(
-        GroupId::random(backend),
-        123,
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
-        vec![1, 1, 1],
-        &Vec::new(),
-        &Vec::new(),
-        ConfirmationTag(Mac {
-            mac_value: vec![1, 2, 3, 4, 5].into(),
-        }),
-        &KeyPackageRef::from_slice(
-            &backend
-                .rand()
-                .random_vec(16)
-                .expect("An unexpected error occurred."),
-        ),
-    );
+    let group_info_tbs = {
+        let group_context = GroupContext::new(
+            GroupId::random(backend),
+            123,
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            vec![1, 1, 1],
+            &Vec::new(),
+        );
+
+        GroupInfoPayload::new(
+            group_context,
+            &Vec::new(),
+            ConfirmationTag(Mac {
+                mac_value: vec![1, 2, 3, 4, 5].into(),
+            }),
+            &KeyPackageRef::from_slice(
+                &backend
+                    .rand()
+                    .random_vec(16)
+                    .expect("An unexpected error occurred."),
+            ),
+        )
+    };
 
     // We need a credential bundle to sign the group info.
     let credential_bundle = CredentialBundle::new(
@@ -55,7 +62,7 @@ fn test_welcome_message_with_version(
         backend,
     )
     .expect("An unexpected error occurred.");
-    let group_info = group_info
+    let group_info = group_info_tbs
         .sign(backend, &credential_bundle)
         .expect("Error signing GroupInfo");
 

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -5,7 +5,7 @@ use crate::{
     ciphersuite::{signable::Signable, AeadKey, AeadNonce, Mac, Secret},
     credentials::{CredentialBundle, CredentialType},
     group::GroupId,
-    messages::{ConfirmationTag, EncryptedGroupSecrets, GroupInfoPayload, Welcome},
+    messages::{ConfirmationTag, EncryptedGroupSecrets, GroupInfoTBS, Welcome},
     versions::ProtocolVersion,
 };
 
@@ -39,7 +39,7 @@ fn test_welcome_message_with_version(
             &Vec::new(),
         );
 
-        GroupInfoPayload::new(
+        GroupInfoTBS::new(
             group_context,
             &Vec::new(),
             ConfirmationTag(Mac {


### PR DESCRIPTION
This PR is work towards #979 and closes #569.

It does the following (from commit messages):

* refactor: Rename `GroupInfoPayload::other_extensions` to `GroupInfoPayload::extensions`.
* refactor: Introduce `GroupInfoPayload::group_context` field.  
    * Use `group_context` instead of `GroupInfoPayload::{group_id, epoch, ...}`.
    * This fixes #569.
* refactor: Rename `GroupInfoPayload` to `GroupInfoTBS`.
* docs: Add documentation to `GroupInfo{,TBS}`.

The commits are "clean" and can be review one-by-one.