### PR TITLE
fix: group's creator could not join the group with an external commit

### DIFF
--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -136,7 +136,7 @@ impl CoreGroup {
                     CreateCommitError::OwnKeyNotFound
                 }
             })?;
-        if apply_proposals_values.self_removed {
+        if apply_proposals_values.self_removed && params.commit_type() != CommitType::External {
             return Err(CreateCommitError::CannotRemoveSelf);
         }
 


### PR DESCRIPTION
Part of #767 

Any client within a group should be able to create an external commit to rejoin a group. This should create a commit with a `Remove` proposal to remove its previous self.

It was working for all clients except the group's creator (index 0). The problem happened [here](https://github.com/openmls/openmls/blob/main/openmls/src/group/core_group/apply_proposals.rs#L129-L134) because `self.key_package_ref()` will always return the creator's ref, causing `self_removed` to always be true when the external commit was created by the group's creator.

To fix this we simply adapt `CoreGroup#create_commit` not to fail when an external commit does `self_removed`