### PR TITLE
Rename `ParentNodeTreeHashInput` to `ParentNodeHashInput`.

### DIFF
--- a/openmls/src/treesync/hashes.rs
+++ b/openmls/src/treesync/hashes.rs
@@ -80,6 +80,15 @@ impl<'a> LeafNodeHashInput<'a> {
 }
 
 /// Helper struct that can be serialized in the course of tree hash computation.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-16
+/// struct {
+///     optional<ParentNode> parent_node;
+///     opaque left_hash<V>;
+///     opaque right_hash<V>;
+/// } ParentNodeHashInput;
+/// ```
 #[derive(TlsSerialize, TlsSize)]
 pub(super) struct ParentNodeHashInput<'a> {
     node_index: LeafIndex,

--- a/openmls/src/treesync/hashes.rs
+++ b/openmls/src/treesync/hashes.rs
@@ -81,14 +81,14 @@ impl<'a> LeafNodeHashInput<'a> {
 
 /// Helper struct that can be serialized in the course of tree hash computation.
 #[derive(TlsSerialize, TlsSize)]
-pub(super) struct ParentNodeTreeHashInput<'a> {
+pub(super) struct ParentNodeHashInput<'a> {
     node_index: LeafIndex,
     parent_node: Option<&'a ParentNode>,
     left_hash: TlsSliceU8<'a, u8>,
     right_hash: TlsSliceU8<'a, u8>,
 }
 
-impl<'a> ParentNodeTreeHashInput<'a> {
+impl<'a> ParentNodeHashInput<'a> {
     /// Create a new [`ParentNodeTreeHashInput`] instance.
     pub(super) fn new(
         node_index: LeafIndex,

--- a/openmls/src/treesync/treesync_node.rs
+++ b/openmls/src/treesync/treesync_node.rs
@@ -8,7 +8,7 @@ use tls_codec::TlsSliceU8;
 use crate::{
     binary_tree::{LeafIndex, MlsBinaryTreeDiffError},
     error::LibraryError,
-    treesync::hashes::{LeafNodeHashInput, ParentNodeTreeHashInput},
+    treesync::hashes::{LeafNodeHashInput, ParentNodeHashInput},
 };
 
 use super::{errors::NodeError, node::leaf_node::LeafNode, Node};
@@ -132,7 +132,7 @@ impl TreeSyncNode {
             // FIXME: After PR #507 of the spec is merged, this not include a
             // NodeIndex. To be able to verify against test vectors, we include
             // it here for now.
-            let hash_input = ParentNodeTreeHashInput::new(
+            let hash_input = ParentNodeHashInput::new(
                 node_index,
                 parent_node_option,
                 TlsSliceU8(&left_hash),


### PR DESCRIPTION
This closes #997.