### PR TITLE
docs: Use C-style comments in TLS presentation syntax.

### DIFF
--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -237,7 +237,7 @@ impl Signable for GroupInfoTBS {
 ///     Extension extensions<V>;
 ///     MAC confirmation_tag;
 ///     uint32 signer;
-///     // SignWithLabel(., "GroupInfoTBS", GroupInfoTBS)
+///     /* SignWithLabel(., "GroupInfoTBS", GroupInfoTBS) */
 ///     opaque signature<V>;
 /// } GroupInfo;
 /// ```


### PR DESCRIPTION
Closes #975.