### PR TITLE
disable kats 2

### DIFF
--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -324,14 +324,15 @@ pub fn run_test_vector(
 
 #[apply(backends)]
 fn read_test_vectors_transcript(backend: &impl OpenMlsCryptoProvider) {
-    let tests: Vec<TranscriptTestVector> = read("test_vectors/kat_transcripts.json");
+    let _tests: Vec<TranscriptTestVector> = read("test_vectors/kat_transcripts.json");
 
-    for test_vector in tests {
-        match run_test_vector(test_vector, backend) {
-            Ok(_) => {}
-            Err(e) => panic!("Error while checking transcript test vector.\n{:?}", e),
-        }
-    }
+    // FIXME: Disabled for now. Tracking re-enabling them in #1051
+    // for test_vector in tests {
+    //     match run_test_vector(test_vector, backend) {
+    //         Ok(_) => {}
+    //         Err(e) => panic!("Error while checking transcript test vector.\n{:?}", e),
+    //     }
+    // }
 
     // FIXME: change test vector spec. See https://github.com/mlswg/mls-implementations/pull/47
     // // mlspp test vectors

--- a/openmls/src/schedule/kat_key_schedule.rs
+++ b/openmls/src/schedule/kat_key_schedule.rs
@@ -273,13 +273,15 @@ fn write_test_vectors() {
 
 #[apply(backends)]
 fn read_test_vectors_key_schedule(backend: &impl OpenMlsCryptoProvider) {
-    let tests: Vec<KeyScheduleTestVector> = read("test_vectors/kat_key_schedule_openmls.json");
-    for test_vector in tests {
-        match run_test_vector(test_vector, backend) {
-            Ok(_) => {}
-            Err(e) => panic!("Error while checking key schedule test vector.\n{:?}", e),
-        }
-    }
+    let _tests: Vec<KeyScheduleTestVector> = read("test_vectors/kat_key_schedule_openmls.json");
+
+    // FIXME: Disabled for now. Tracking re-enabling them in #1051
+    // for test_vector in tests {
+    //     match run_test_vector(test_vector, backend) {
+    //         Ok(_) => {}
+    //         Err(e) => panic!("Error while checking key schedule test vector.\n{:?}", e),
+    //     }
+    // }
 
     // FIXME: Interop #495
     // // mlspp test vectors


### PR DESCRIPTION
Followup to #1052 to disable transcript and key schedule KATs to avoid churn as in #1074 and #1076.