### PR TITLE
chore: Silence temporary warnings.

### DIFF
--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -324,6 +324,9 @@ pub fn run_test_vector(
 
 #[apply(backends)]
 fn read_test_vectors_transcript(backend: &impl OpenMlsCryptoProvider) {
+    // FIXME: Silence warning. Remove this during #1051.
+    let _ = backend;
+
     let _tests: Vec<TranscriptTestVector> = read("test_vectors/kat_transcripts.json");
 
     // FIXME: Disabled for now. Tracking re-enabling them in #1051

--- a/openmls/src/schedule/kat_key_schedule.rs
+++ b/openmls/src/schedule/kat_key_schedule.rs
@@ -273,6 +273,9 @@ fn write_test_vectors() {
 
 #[apply(backends)]
 fn read_test_vectors_key_schedule(backend: &impl OpenMlsCryptoProvider) {
+    // FIXME: Silence warning. Remove this during #1051.
+    let _ = backend;
+
     let _tests: Vec<KeyScheduleTestVector> = read("test_vectors/kat_key_schedule_openmls.json");
 
     // FIXME: Disabled for now. Tracking re-enabling them in #1051


### PR DESCRIPTION
This is a followup to #1077. I propose to aim for zero warnings. Otherwise they tend to accumulate :-)