### PR TITLE
Update most TLS syntax to variable length

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -41,8 +41,8 @@ jobs:
           crate: cargo-fuzz
           version: latest
       - name: Fuzz Welcome
-        run: cargo fuzz run welcome_decode -- -runs=100000
+        run: cargo fuzz run welcome_decode -- -runs=10000
       - name: Fuzz MLSMessageIn
-        run: cargo fuzz run mls_message_decode -- -runs=100000
+        run: cargo fuzz run mls_message_decode -- -runs=50000
       - name: Fuzz Proposal
         run: cargo fuzz run proposal_decode -- -runs=100000

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 log = { version = "0.4", features = ["std"] }
 typetag = "0.1"
-tls_codec = { version = "0.2.0", features = ["derive", "serde_serialize"] }
+tls_codec = { version = "0.2.0", features = ["derive", "serde_serialize", "mls"] }
 # Only required for tests.
 rand = { version = "0.8", optional = true }
 # The js feature is required for wasm.
@@ -62,4 +62,4 @@ harness = false
 
 # Patching unreleased crates
 [patch.crates-io]
-tls_codec = { git = "https://github.com/RustCrypto/formats.git", features = ["derive", "serde_serialize"] }
+tls_codec = { git = "https://github.com/RustCrypto/formats.git", features = ["derive", "serde_serialize", "mls"] }

--- a/openmls/fuzz/Cargo.toml
+++ b/openmls/fuzz/Cargo.toml
@@ -44,4 +44,4 @@ doc = false
 
 # Patching unreleased crates
 [patch.crates-io]
-tls_codec = { git = "https://github.com/RustCrypto/formats.git", features = ["derive", "serde_serialize"] }
+tls_codec = { git = "https://github.com/RustCrypto/formats.git", features = ["derive", "serde_serialize", "mls"] }

--- a/openmls/src/ciphersuite/codec.rs
+++ b/openmls/src/ciphersuite/codec.rs
@@ -3,7 +3,6 @@
 
 use crate::ciphersuite::*;
 use std::io::{Read, Write};
-use tls_codec::{TlsSliceU8, TlsVecU8};
 
 impl tls_codec::Serialize for SignaturePublicKey {
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
@@ -19,19 +18,19 @@ impl tls_codec::Size for SignaturePublicKey {
 
 impl tls_codec::Size for Secret {
     fn tls_serialized_len(&self) -> usize {
-        TlsSliceU8(&self.value).tls_serialized_len()
+        self.value.tls_serialized_len()
     }
 }
 
 impl tls_codec::Serialize for Secret {
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, ::tls_codec::Error> {
-        TlsSliceU8(&self.value).tls_serialize(writer)
+        self.value.tls_serialize(writer)
     }
 }
 
 impl tls_codec::Deserialize for Secret {
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, ::tls_codec::Error> {
-        let value = TlsVecU8::tls_deserialize(bytes)?.into();
+        let value = Vec::tls_deserialize(bytes)?.into();
         Ok(Secret {
             value,
             mls_version: ProtocolVersion::default(),

--- a/openmls/src/ciphersuite/codec.rs
+++ b/openmls/src/ciphersuite/codec.rs
@@ -30,7 +30,7 @@ impl tls_codec::Serialize for Secret {
 
 impl tls_codec::Deserialize for Secret {
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, ::tls_codec::Error> {
-        let value = Vec::tls_deserialize(bytes)?.into();
+        let value = Vec::tls_deserialize(bytes)?;
         Ok(Secret {
             value,
             mls_version: ProtocolVersion::default(),

--- a/openmls/src/ciphersuite/kdf_label.rs
+++ b/openmls/src/ciphersuite/kdf_label.rs
@@ -1,3 +1,5 @@
+use tls_codec::Serialize;
+
 use super::*;
 
 /// `KdfLabel` is later serialized and used in the `label` field of
@@ -14,8 +16,8 @@ use super::*;
 #[derive(TlsSerialize, TlsSize)]
 pub(in crate::ciphersuite) struct KdfLabel {
     length: u16,
-    label: TlsByteVecU8,
-    context: TlsByteVecU32,
+    label: VLBytes,
+    context: VLBytes,
 }
 
 impl KdfLabel {

--- a/openmls/src/ciphersuite/mac.rs
+++ b/openmls/src/ciphersuite/mac.rs
@@ -7,7 +7,7 @@ use super::*;
 /// } MAC;
 #[derive(Debug, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize)]
 pub(crate) struct Mac {
-    pub(crate) mac_value: TlsByteVecU8,
+    pub(crate) mac_value: VLBytes,
 }
 
 impl PartialEq for Mac {

--- a/openmls/src/ciphersuite/mac.rs
+++ b/openmls/src/ciphersuite/mac.rs
@@ -1,10 +1,8 @@
 use super::*;
 
-/// 9.2 Message framing
+/// 7.1 Content Authentication
 ///
-/// struct {
-///     opaque mac_value<0..255>;
-/// } MAC;
+/// opaque MAC<V>;
 #[derive(Debug, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize)]
 pub(crate) struct Mac {
     pub(crate) mac_value: VLBytes,

--- a/openmls/src/ciphersuite/mod.rs
+++ b/openmls/src/ciphersuite/mod.rs
@@ -14,7 +14,7 @@ use openmls_traits::{
 use signable::SignedStruct;
 
 use std::hash::Hash;
-use tls_codec::{Serialize as TlsSerializeTrait, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8};
+use tls_codec::{Serialize as TlsSerializeTrait, TlsByteVecU32, TlsByteVecU8};
 
 mod aead;
 mod codec;

--- a/openmls/src/ciphersuite/mod.rs
+++ b/openmls/src/ciphersuite/mod.rs
@@ -14,7 +14,6 @@ use openmls_traits::{
 use signable::SignedStruct;
 
 use std::hash::Hash;
-use tls_codec::{Serialize as TlsSerializeTrait, TlsByteVecU32, TlsByteVecU8};
 
 mod aead;
 mod codec;

--- a/openmls/src/ciphersuite/signature.rs
+++ b/openmls/src/ciphersuite/signature.rs
@@ -9,7 +9,7 @@ use super::*;
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
 pub struct Signature {
-    value: TlsByteVecU16,
+    value: VLBytes,
 }
 
 /// Labeled signature content.

--- a/openmls/src/ciphersuite/signature.rs
+++ b/openmls/src/ciphersuite/signature.rs
@@ -2,6 +2,8 @@
 //!
 //! This module contains structs for creating signature keys, issuing signatures and verifying them.
 
+use tls_codec::Serialize;
+
 use super::*;
 
 /// Signature.

--- a/openmls/src/extensions/capabilities_extension.rs
+++ b/openmls/src/extensions/capabilities_extension.rs
@@ -57,10 +57,10 @@ fn default_ciphersuites() -> Vec<Ciphersuite> {
 impl Default for CapabilitiesExtension {
     fn default() -> Self {
         CapabilitiesExtension {
-            versions: default_versions().into(),
-            ciphersuites: default_ciphersuites().into(),
-            extensions: default_extensions().into(),
-            proposals: default_proposals().into(),
+            versions: default_versions(),
+            ciphersuites: default_ciphersuites(),
+            extensions: default_extensions(),
+            proposals: default_proposals(),
         }
     }
 }
@@ -78,19 +78,19 @@ impl CapabilitiesExtension {
         Self {
             versions: match versions {
                 Some(v) => v.into(),
-                None => default_versions().into(),
+                None => default_versions(),
             },
             ciphersuites: match ciphersuites {
                 Some(c) => c.into(),
-                None => default_ciphersuites().into(),
+                None => default_ciphersuites(),
             },
             extensions: match extensions {
                 Some(e) => e.into(),
-                None => default_extensions().into(),
+                None => default_extensions(),
             },
             proposals: match proposals {
                 Some(p) => p.into(),
-                None => default_proposals().into(),
+                None => default_proposals(),
             },
         }
     }

--- a/openmls/src/extensions/ratchet_tree_extension.rs
+++ b/openmls/src/extensions/ratchet_tree_extension.rs
@@ -1,4 +1,4 @@
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 
 use super::{Deserialize, Serialize};
 use crate::treesync::node::Node;
@@ -11,13 +11,13 @@ use crate::treesync::node::Node;
     PartialEq, Clone, Debug, Default, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
 )]
 pub struct RatchetTreeExtension {
-    tree: TlsVecU32<Option<Node>>,
+    tree: Vec<Option<Node>>,
 }
 
 impl RatchetTreeExtension {
     /// Build a new extension from a vector of [`Node`]s.
     pub fn new(tree: Vec<Option<Node>>) -> Self {
-        RatchetTreeExtension { tree: tree.into() }
+        RatchetTreeExtension { tree }
     }
 
     /// Get a slice of the nodes in tis tree.

--- a/openmls/src/extensions/required_capabilities.rs
+++ b/openmls/src/extensions/required_capabilities.rs
@@ -1,4 +1,4 @@
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, TlsVecU8};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 
 use crate::messages::proposals::ProposalType;
 
@@ -31,8 +31,8 @@ use super::{Deserialize, ExtensionError, ExtensionType, Serialize};
     TlsSize,
 )]
 pub struct RequiredCapabilitiesExtension {
-    extensions: TlsVecU8<ExtensionType>,
-    proposals: TlsVecU8<ProposalType>,
+    extensions: Vec<ExtensionType>,
+    proposals: Vec<ProposalType>,
 }
 
 impl RequiredCapabilitiesExtension {

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -199,7 +199,7 @@ impl CoreGroup {
 
         // Create commit message
         let commit = Commit {
-            proposals: proposal_reference_list.into(),
+            proposals: proposal_reference_list,
             path: path_processing_result.encrypted_path,
         };
 

--- a/openmls/src/group/group_context.rs
+++ b/openmls/src/group/group_context.rs
@@ -16,9 +16,9 @@ pub struct GroupContext {
     ciphersuite: Ciphersuite,
     group_id: GroupId,
     epoch: GroupEpoch,
-    tree_hash: TlsByteVecU8,
-    confirmed_transcript_hash: TlsByteVecU8,
-    extensions: TlsVecU32<Extension>,
+    tree_hash: VLBytes,
+    confirmed_transcript_hash: VLBytes,
+    extensions: Vec<Extension>,
 }
 
 #[cfg(any(feature = "test-utils", test))]

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -46,7 +46,7 @@ pub use proposals::*;
     Hash, Eq, Debug, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
 )]
 pub struct GroupId {
-    value: TlsByteVecU8,
+    value: VLBytes,
 }
 
 impl GroupId {

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -186,8 +186,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
         ciphersuite: ciphersuite_name,
         extensions: vec![Extension::RatchetTree(RatchetTreeExtension::new(
             ratchet_tree.clone(),
-        ))]
-        .into(),
+        ))],
     };
     // We don't support external init proposals yet.
     let external_init_proposal = tls_codec::TlsByteVecU16::new(Vec::new());

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -93,7 +93,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> TranscriptTestVector {
         framing_parameters,
         sender,
         Commit {
-            proposals: vec![].into(),
+            proposals: vec![],
             path: None,
         },
         &credential_bundle,

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -263,7 +263,7 @@ fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         panic!("Unexpected content type.");
     };
 
-    commit_content.proposals = vec![].into();
+    commit_content.proposals = vec![];
 
     update.set_content(MlsContentBody::Commit(commit_content));
 

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -260,7 +260,7 @@ impl GroupInfo {
     /// Set the extensions.
     #[cfg(test)]
     pub(crate) fn set_extensions(&mut self, extensions: Vec<Extension>) {
-        self.payload.extensions = extensions.into();
+        self.payload.extensions = extensions;
     }
 
     /// Returns the confirmation tag.

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -49,8 +49,8 @@ use crate::schedule::psk::{ExternalPsk, PreSharedKeyId, Psk};
 pub struct Welcome {
     version: ProtocolVersion,
     cipher_suite: Ciphersuite,
-    secrets: TlsVecU32<EncryptedGroupSecrets>,
-    encrypted_group_info: TlsByteVecU32,
+    secrets: Vec<EncryptedGroupSecrets>,
+    encrypted_group_info: VLBytes,
 }
 
 impl Welcome {
@@ -65,7 +65,7 @@ impl Welcome {
         Self {
             version,
             cipher_suite,
-            secrets: secrets.into(),
+            secrets,
             encrypted_group_info: encrypted_group_info.into(),
         }
     }
@@ -150,7 +150,7 @@ impl EncryptedGroupSecrets {
     Debug, PartialEq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
 pub(crate) struct Commit {
-    pub(crate) proposals: TlsVecU32<ProposalOrRef>,
+    pub(crate) proposals: Vec<ProposalOrRef>,
     pub(crate) path: Option<UpdatePath>,
 }
 
@@ -189,7 +189,7 @@ pub struct ConfirmationTag(pub(crate) Mac);
 #[derive(TlsDeserialize, TlsSerialize, TlsSize)]
 pub(crate) struct GroupInfoTBS {
     group_context: GroupContext,
-    extensions: TlsVecU32<Extension>,
+    extensions: Vec<Extension>,
     confirmation_tag: ConfirmationTag,
     signer: KeyPackageRef,
 }

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -19,7 +19,7 @@ use openmls_traits::{types::Ciphersuite, OpenMlsCryptoProvider};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use tls_codec::{
-    Serialize as TlsSerializeTrait, TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32,
+    Serialize as TlsSerializeTrait, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32, VLBytes,
 };
 
 // Public types
@@ -228,7 +228,7 @@ pub struct ReInitProposal {
     pub(crate) group_id: GroupId,
     pub(crate) version: ProtocolVersion,
     pub(crate) ciphersuite: Ciphersuite,
-    pub(crate) extensions: TlsVecU32<Extension>,
+    pub(crate) extensions: Vec<Extension>,
 }
 
 /// ExternalInit Proposal.
@@ -238,7 +238,7 @@ pub struct ReInitProposal {
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
 pub struct ExternalInitProposal {
-    kem_output: TlsByteVecU16,
+    kem_output: VLBytes,
 }
 
 impl ExternalInitProposal {
@@ -274,13 +274,13 @@ pub struct AppAckProposal {
 /// in the GroupContext for the group.
 ///
 /// ```text
-/// struct { Extension extensions<0..2^32-1>; } GroupContextExtensions;
+/// struct { Extension extensions<V>; } GroupContextExtensions;
 /// ```
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
 pub struct GroupContextExtensionProposal {
-    extensions: TlsVecU32<Extension>,
+    extensions: Vec<Extension>,
 }
 
 impl GroupContextExtensionProposal {

--- a/openmls/src/messages/tests/test_codec.rs
+++ b/openmls/src/messages/tests/test_codec.rs
@@ -68,7 +68,7 @@ fn test_reinit_proposal_codec(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
         group_id: GroupId::random(backend),
         version: ProtocolVersion::default(),
         ciphersuite,
-        extensions: vec![].into(),
+        extensions: vec![],
     };
     let encoded = orig
         .tls_serialize_detached()

--- a/openmls/src/treesync/hashes.rs
+++ b/openmls/src/treesync/hashes.rs
@@ -1,7 +1,7 @@
 //! This module contains helper structs and functions related to parent hashing
 //! and tree hashing.
 use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite, OpenMlsCryptoProvider};
-use tls_codec::{Serialize, TlsSerialize, TlsSize, TlsSliceU32, TlsSliceU8};
+use tls_codec::{Serialize, TlsSerialize, TlsSize, TlsSliceU32, TlsSliceU8, VLByteSlice};
 
 use crate::{binary_tree::LeafIndex, ciphersuite::HpkePublicKey, error::LibraryError};
 
@@ -93,8 +93,8 @@ impl<'a> LeafNodeHashInput<'a> {
 pub(super) struct ParentNodeHashInput<'a> {
     node_index: LeafIndex,
     parent_node: Option<&'a ParentNode>,
-    left_hash: TlsSliceU8<'a, u8>,
-    right_hash: TlsSliceU8<'a, u8>,
+    left_hash: VLByteSlice<'a>,
+    right_hash: VLByteSlice<'a>,
 }
 
 impl<'a> ParentNodeHashInput<'a> {
@@ -102,8 +102,8 @@ impl<'a> ParentNodeHashInput<'a> {
     pub(super) fn new(
         node_index: LeafIndex,
         parent_node: Option<&'a ParentNode>,
-        left_hash: TlsSliceU8<'a, u8>,
-        right_hash: TlsSliceU8<'a, u8>,
+        left_hash: VLByteSlice<'a>,
+        right_hash: VLByteSlice<'a>,
     ) -> Self {
         Self {
             node_index,

--- a/openmls/src/treesync/node/codec.rs
+++ b/openmls/src/treesync/node/codec.rs
@@ -1,4 +1,4 @@
-use tls_codec::{TlsByteVecU8, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
 
 use crate::{ciphersuite::HpkePublicKey, key_packages::KeyPackage};
 
@@ -111,8 +111,8 @@ impl tls_codec::Deserialize for ParentNode {
         Self: Sized,
     {
         let public_key = HpkePublicKey::tls_deserialize(bytes)?;
-        let parent_hash = TlsByteVecU8::tls_deserialize(bytes)?;
-        let unmerged_leaves = TlsVecU32::tls_deserialize(bytes)?;
+        let parent_hash = VLBytes::tls_deserialize(bytes)?;
+        let unmerged_leaves = Vec::tls_deserialize(bytes)?;
         Ok(Self::new(public_key, parent_hash, unmerged_leaves))
     }
 }

--- a/openmls/src/treesync/node/parent_node.rs
+++ b/openmls/src/treesync/node/parent_node.rs
@@ -7,7 +7,7 @@ use openmls_traits::{
 };
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsByteVecU8, TlsVecU32};
+use tls_codec::VLBytes;
 
 use crate::{
     binary_tree::LeafIndex,
@@ -24,8 +24,8 @@ use crate::{
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ParentNode {
     pub(super) public_key: HpkePublicKey,
-    pub(super) parent_hash: TlsByteVecU8,
-    pub(super) unmerged_leaves: TlsVecU32<LeafIndex>,
+    pub(super) parent_hash: VLBytes,
+    pub(super) unmerged_leaves: Vec<LeafIndex>,
     private_key_option: Option<HpkePrivateKey>,
 }
 
@@ -94,8 +94,8 @@ impl ParentNode {
     /// Create a new [`ParentNode`].
     pub(super) fn new(
         public_key: HpkePublicKey,
-        parent_hash: TlsByteVecU8,
-        unmerged_leaves: TlsVecU32<u32>,
+        parent_hash: VLBytes,
+        unmerged_leaves: Vec<u32>,
     ) -> Self {
         Self {
             public_key,

--- a/openmls/src/treesync/node/parent_node.rs
+++ b/openmls/src/treesync/node/parent_node.rs
@@ -42,7 +42,7 @@ impl From<HpkePublicKey> for ParentNode {
         Self {
             public_key,
             parent_hash: vec![].into(),
-            unmerged_leaves: vec![].into(),
+            unmerged_leaves: vec![],
             private_key_option: None,
         }
     }
@@ -74,7 +74,7 @@ impl PlainUpdatePathNode {
 
         UpdatePathNode {
             public_key: self.public_key.clone(),
-            encrypted_path_secrets: encrypted_path_secrets.into(),
+            encrypted_path_secrets,
         }
     }
 
@@ -204,8 +204,8 @@ impl ParentNode {
     pub(in crate::treesync) fn clone_without_private_key(&self) -> Self {
         Self {
             public_key: self.public_key().clone(),
-            parent_hash: self.parent_hash().to_vec().into(),
-            unmerged_leaves: self.unmerged_leaves().to_vec().into(),
+            parent_hash: self.parent_hash.clone(),
+            unmerged_leaves: self.unmerged_leaves.clone(),
             private_key_option: None,
         }
     }

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -48,7 +48,7 @@ impl<'a> TreeSyncDiff<'a> {
         path: &[PlainUpdatePathNode],
         group_context: &[u8],
         exclusion_list: &HashSet<&LeafIndex>,
-        key_package: KeyPackage,
+        leaf_key_package: KeyPackage,
     ) -> Result<UpdatePath, LibraryError> {
         let copath_resolutions = self.copath_resolutions(self.own_leaf_index(), exclusion_list)?;
 
@@ -56,15 +56,15 @@ impl<'a> TreeSyncDiff<'a> {
         debug_assert_eq!(copath_resolutions.len(), path.len());
 
         // Encrypt the secrets
-        let update_path_nodes = path
+        let nodes = path
             .par_iter()
             .zip(copath_resolutions.par_iter())
             .map(|(node, resolution)| node.encrypt(backend, ciphersuite, resolution, group_context))
             .collect::<Vec<UpdatePathNode>>();
 
         Ok(UpdatePath {
-            leaf_key_package: key_package,
-            nodes: update_path_nodes.into(),
+            leaf_key_package,
+            nodes,
         })
     }
 
@@ -343,7 +343,7 @@ impl UpdatePath {
     /// Consume the [`UpdatePath`] and return its individual parts: A
     /// [`KeyPackage`] and a vector of [`UpdatePathNode`] instances.
     pub(crate) fn into_parts(self) -> (KeyPackage, Vec<UpdatePathNode>) {
-        (self.leaf_key_package, self.nodes.into())
+        (self.leaf_key_package, self.nodes)
     }
 
     #[cfg(test)]

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -6,7 +6,7 @@
 //! updates for a [`TreeSyncDiff`] instance.
 use rayon::prelude::*;
 use std::collections::HashSet;
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, TlsVecU32};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 
 use openmls_traits::{
     crypto::OpenMlsCrypto,
@@ -178,7 +178,7 @@ pub(crate) struct DecryptPathParams<'a> {
 /// ```text
 /// struct {
 ///     HPKEPublicKey public_key;
-///     HPKECiphertext encrypted_path_secret<0..2^32-1>;
+///     HPKECiphertext encrypted_path_secret<V>;
 /// } UpdatePathNode;
 /// ```
 #[derive(
@@ -186,7 +186,7 @@ pub(crate) struct DecryptPathParams<'a> {
 )]
 pub struct UpdatePathNode {
     pub(super) public_key: HpkePublicKey,
-    pub(super) encrypted_path_secrets: TlsVecU32<HpkeCiphertext>,
+    pub(super) encrypted_path_secrets: Vec<HpkeCiphertext>,
 }
 
 impl UpdatePathNode {
@@ -323,7 +323,7 @@ impl PlaintextSecret {
 /// ```text
 /// struct {
 ///     KeyPackage leaf_key_package;
-///     UpdatePathNode nodes<0..2^32-1>;
+///     UpdatePathNode nodes<V>;
 /// } UpdatePath;
 /// ```
 #[derive(
@@ -331,7 +331,7 @@ impl PlaintextSecret {
 )]
 pub struct UpdatePath {
     leaf_key_package: KeyPackage,
-    nodes: TlsVecU32<UpdatePathNode>,
+    nodes: Vec<UpdatePathNode>,
 }
 
 impl UpdatePath {

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -214,7 +214,7 @@ impl UpdatePathNode {
             new_eps.ciphertext.push(last_bits);
             new_eps_vec.push(new_eps);
         }
-        self.encrypted_path_secrets = new_eps_vec.into();
+        self.encrypted_path_secrets = new_eps_vec;
     }
 
     /// Flip the last byte of the public key in this node.
@@ -355,7 +355,7 @@ impl UpdatePath {
             new_node.flip_last_byte();
             new_nodes.push(new_node);
         }
-        self.nodes = new_nodes.into();
+        self.nodes = new_nodes;
     }
 
     #[cfg(test)]

--- a/openmls/src/treesync/treesync_node.rs
+++ b/openmls/src/treesync/treesync_node.rs
@@ -3,7 +3,7 @@
 use openmls_traits::{types::Ciphersuite, OpenMlsCryptoProvider};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tls_codec::TlsSliceU8;
+use tls_codec::VLByteSlice;
 
 use crate::{
     binary_tree::{LeafIndex, MlsBinaryTreeDiffError},
@@ -135,8 +135,8 @@ impl TreeSyncNode {
             let hash_input = ParentNodeHashInput::new(
                 node_index,
                 parent_node_option,
-                TlsSliceU8(&left_hash),
-                TlsSliceU8(&right_hash),
+                VLByteSlice(&left_hash),
+                VLByteSlice(&right_hash),
             );
             hash_input.hash(ciphersuite, backend)?
         };

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/traits.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tls_codec = { version = "0.2.0", features = ["derive", "serde_serialize"] }
+tls_codec = { version = "0.2.0", features = ["derive", "serde_serialize", "mls"] }
 
 # Patching unreleased crates
 [patch.crates-io]
-tls_codec = { git = "https://github.com/RustCrypto/formats.git", features = ["derive", "serde_serialize"] }
+tls_codec = { git = "https://github.com/RustCrypto/formats.git", features = ["derive", "serde_serialize", "mls"] }

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
-use tls_codec::{TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 #[repr(u16)]

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
-use tls_codec::{TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 #[repr(u16)]
@@ -214,16 +214,16 @@ pub enum HpkeAeadType {
 ///
 /// ```text
 /// struct {
-///     opaque kem_output<0..2^16-1>;
-///     opaque ciphertext<0..2^16-1>;
+///     opaque kem_output<V>;
+///     opaque ciphertext<V>;
 /// } HPKECiphertext;
 /// ```
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
 )]
 pub struct HpkeCiphertext {
-    pub kem_output: TlsByteVecU16,
-    pub ciphertext: TlsByteVecU16,
+    pub kem_output: VLBytes,
+    pub ciphertext: VLBytes,
 }
 
 /// Helper holding a (private, public) key pair as byte vectors.


### PR DESCRIPTION
Progress towards #877.

It updates all TLS syntax to use variable length encoding except for some places where code will change as part of larger spec changes. Hence this is not closing #877 yet but the remaining work will most likely happen in other issues. I'll keep #877 upon until that's happened.
