### PR TITLE
Add a marker byte to tree hash input structs

### DIFF
--- a/openmls/src/binary_tree/array_representation/diff.rs
+++ b/openmls/src/binary_tree/array_representation/diff.rs
@@ -87,13 +87,6 @@ impl NodeId {
         diff.out_of_bounds(node_index)?;
         Ok(NodeId { node_index })
     }
-
-    /// FIXME: This is only needed to workaround the current presence of a
-    /// NodeIndex in the ParentNodeTreeHashInput struct in the spec and should
-    /// go away when #507 in the MLS spec is integrated.
-    pub(crate) fn node_index(&self) -> LeafIndex {
-        self.node_index
-    }
 }
 
 /// The [`AbDiff`] represents a set of differences (i.e. a "Diff") for an

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -786,7 +786,7 @@ impl<'a> TreeSyncDiff<'a> {
             let tree_hash =
                 // Giving 0 as a node index here for now. See comment in the
                 // function for context.
-                leaf.compute_tree_hash(backend, ciphersuite, Some(leaf_index), 0,vec![], vec![])?;
+                leaf.compute_tree_hash(backend, ciphersuite, Some(leaf_index), vec![], vec![])?;
             return Ok(tree_hash);
         }
         // Return early if there's already a cached tree hash.
@@ -814,15 +814,8 @@ impl<'a> TreeSyncDiff<'a> {
             .diff
             .node_mut(node_id)
             .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
-        let node_index = node_id.node_index();
-        let tree_hash = node.compute_tree_hash(
-            backend,
-            ciphersuite,
-            None,
-            node_index,
-            left_hash,
-            right_hash,
-        )?;
+        let tree_hash =
+            node.compute_tree_hash(backend, ciphersuite, None, left_hash, right_hash)?;
 
         Ok(tree_hash)
     }

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -784,8 +784,6 @@ impl<'a> TreeSyncDiff<'a> {
                 .node_mut(node_id)
                 .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
             let tree_hash =
-                // Giving 0 as a node index here for now. See comment in the
-                // function for context.
                 leaf.compute_tree_hash(backend, ciphersuite, Some(leaf_index), vec![], vec![])?;
             return Ok(tree_hash);
         }

--- a/openmls/src/treesync/hashes.rs
+++ b/openmls/src/treesync/hashes.rs
@@ -50,6 +50,7 @@ impl<'a> ParentHashInput<'a> {
 /// Helper struct that can be serialized in the course of tree hash computation.
 ///
 /// ```c
+/// // draft-ietf-mls-protocol-16
 /// enum {
 ///     reserved(0),
 ///     leaf(1),

--- a/openmls/src/treesync/hashes.rs
+++ b/openmls/src/treesync/hashes.rs
@@ -48,26 +48,74 @@ impl<'a> ParentHashInput<'a> {
 }
 
 /// Helper struct that can be serialized in the course of tree hash computation.
+///
+/// ```c
+/// enum {
+///     reserved(0),
+///     leaf(1),
+///     parent(2),
+///     (255)
+/// } NodeType;
+/// ```
 #[derive(TlsSerialize, TlsSize)]
-pub struct LeafNodeHashInput<'a> {
-    pub(super) leaf_index: &'a LeafIndex,
-    pub(super) key_package: Option<&'a KeyPackage>,
+#[repr(u8)]
+enum NodeType<'a> {
+    #[tls_codec(discriminant = 1)]
+    Leaf(LeafNodeHashInput<'a>),
+    #[tls_codec(discriminant = 2)]
+    Parent(ParentNodeHashInput<'a>),
 }
 
-impl<'a> LeafNodeHashInput<'a> {
-    /// Create a new [`LeafNodeHashInput`] instance.
-    pub(super) fn new(leaf_index: &'a LeafIndex, key_package: Option<&'a KeyPackage>) -> Self {
+/// Helper struct that can be serialized in the course of tree hash computation.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-16
+/// struct {
+///   NodeType node_type;
+/// select (TreeHashInput.node_type) {
+///     case leaf:   LeafNodeHashInput leaf_node;
+///     case parent: ParentNodeHashInput parent_node;
+///   }
+/// } TreeHashInput;
+/// ```
+#[derive(TlsSerialize, TlsSize)]
+pub(super) struct TreeHashInput<'a> {
+    node_type: NodeType<'a>,
+}
+
+impl<'a> TreeHashInput<'a> {
+    /// Create a new [`TreeHashInput`] instance from a leaf node.
+    pub(super) fn new_leaf(leaf_index: &'a LeafIndex, key_package: Option<&'a KeyPackage>) -> Self {
         Self {
-            leaf_index,
-            key_package,
+            node_type: NodeType::Leaf(LeafNodeHashInput {
+                leaf_index,
+                key_package,
+            }),
         }
     }
 
-    /// Serialize and hash this instance of [`LeafNodeHashInput`].
+    /// Create a new [`TreeHashInput`] instance from a parent node.
+    pub(super) fn new_parent(
+        node_index: LeafIndex,
+        parent_node: Option<&'a ParentNode>,
+        left_hash: VLByteSlice<'a>,
+        right_hash: VLByteSlice<'a>,
+    ) -> Self {
+        Self {
+            node_type: NodeType::Parent(ParentNodeHashInput {
+                node_index,
+                parent_node,
+                left_hash,
+                right_hash,
+            }),
+        }
+    }
+
+    /// Serialize and hash this instance of [`TreeHashInput`].
     pub(super) fn hash(
         &self,
-        ciphersuite: Ciphersuite,
         backend: &impl OpenMlsCryptoProvider,
+        ciphersuite: Ciphersuite,
     ) -> Result<Vec<u8>, LibraryError> {
         let payload = self
             .tls_serialize_detached()
@@ -84,47 +132,30 @@ impl<'a> LeafNodeHashInput<'a> {
 /// ```c
 /// // draft-ietf-mls-protocol-16
 /// struct {
+///     uint32 leaf_index;
+///     optional<LeafNode> leaf_node;
+/// } LeafNodeHashInput;
+/// ```
+#[derive(TlsSerialize, TlsSize)]
+struct LeafNodeHashInput<'a> {
+    leaf_index: &'a LeafIndex,
+    key_package: Option<&'a KeyPackage>,
+}
+
+/// Helper struct that can be serialized in the course of tree hash computation.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-16
+/// struct {
 ///     optional<ParentNode> parent_node;
 ///     opaque left_hash<V>;
 ///     opaque right_hash<V>;
 /// } ParentNodeHashInput;
 /// ```
 #[derive(TlsSerialize, TlsSize)]
-pub(super) struct ParentNodeHashInput<'a> {
+struct ParentNodeHashInput<'a> {
     node_index: LeafIndex,
     parent_node: Option<&'a ParentNode>,
     left_hash: VLByteSlice<'a>,
     right_hash: VLByteSlice<'a>,
-}
-
-impl<'a> ParentNodeHashInput<'a> {
-    /// Create a new [`ParentNodeTreeHashInput`] instance.
-    pub(super) fn new(
-        node_index: LeafIndex,
-        parent_node: Option<&'a ParentNode>,
-        left_hash: VLByteSlice<'a>,
-        right_hash: VLByteSlice<'a>,
-    ) -> Self {
-        Self {
-            node_index,
-            parent_node,
-            left_hash,
-            right_hash,
-        }
-    }
-
-    /// Serialize and hash this instance of [`ParentNodeTreeHashInput`].
-    pub(super) fn hash(
-        &self,
-        ciphersuite: Ciphersuite,
-        backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<Vec<u8>, LibraryError> {
-        let payload = self
-            .tls_serialize_detached()
-            .map_err(LibraryError::missing_bound_check)?;
-        backend
-            .crypto()
-            .hash(ciphersuite.hash_algorithm(), &payload)
-            .map_err(LibraryError::unexpected_crypto_error)
-    }
 }

--- a/openmls/src/treesync/hashes.rs
+++ b/openmls/src/treesync/hashes.rs
@@ -97,14 +97,12 @@ impl<'a> TreeHashInput<'a> {
 
     /// Create a new [`TreeHashInput`] instance from a parent node.
     pub(super) fn new_parent(
-        node_index: LeafIndex,
         parent_node: Option<&'a ParentNode>,
         left_hash: VLByteSlice<'a>,
         right_hash: VLByteSlice<'a>,
     ) -> Self {
         Self {
             node_type: NodeType::Parent(ParentNodeHashInput {
-                node_index,
                 parent_node,
                 left_hash,
                 right_hash,
@@ -140,6 +138,7 @@ impl<'a> TreeHashInput<'a> {
 #[derive(TlsSerialize, TlsSize)]
 struct LeafNodeHashInput<'a> {
     leaf_index: &'a LeafIndex,
+    // TODO #819: Replace this with a LeafNode
     key_package: Option<&'a KeyPackage>,
 }
 
@@ -155,7 +154,6 @@ struct LeafNodeHashInput<'a> {
 /// ```
 #[derive(TlsSerialize, TlsSize)]
 struct ParentNodeHashInput<'a> {
-    node_index: LeafIndex,
     parent_node: Option<&'a ParentNode>,
     left_hash: VLByteSlice<'a>,
     right_hash: VLByteSlice<'a>,

--- a/openmls/src/treesync/treesync_node.rs
+++ b/openmls/src/treesync/treesync_node.rs
@@ -95,8 +95,6 @@ impl TreeSyncNode {
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: Ciphersuite,
         leaf_index_option: Option<LeafIndex>,
-        // This is temporary. See below.
-        node_index: LeafIndex,
         left_hash: Vec<u8>,
         right_hash: Vec<u8>,
     ) -> Result<Vec<u8>, LibraryError> {
@@ -132,7 +130,6 @@ impl TreeSyncNode {
             // NodeIndex. To be able to verify against test vectors, we include
             // it here for now.
             let hash_input = TreeHashInput::new_parent(
-                node_index,
                 parent_node_option,
                 VLByteSlice(&left_hash),
                 VLByteSlice(&right_hash),

--- a/openmls/src/treesync/treesync_node.rs
+++ b/openmls/src/treesync/treesync_node.rs
@@ -8,10 +8,9 @@ use tls_codec::VLByteSlice;
 use crate::{
     binary_tree::{LeafIndex, MlsBinaryTreeDiffError},
     error::LibraryError,
-    treesync::hashes::{LeafNodeHashInput, ParentNodeHashInput},
 };
 
-use super::{errors::NodeError, node::leaf_node::LeafNode, Node};
+use super::{errors::NodeError, hashes::TreeHashInput, node::leaf_node::LeafNode, Node};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
@@ -119,8 +118,8 @@ impl TreeSyncNode {
             // FIXME: After PR #507 of the spec is merged, this should really be the
             // leaf index. For now, we translate to node index here.
             let leaf_index = leaf_index * 2;
-            let hash_input = LeafNodeHashInput::new(&leaf_index, key_package_option);
-            hash_input.hash(ciphersuite, backend)?
+            let hash_input = TreeHashInput::new_leaf(&leaf_index, key_package_option);
+            hash_input.hash(backend, ciphersuite)?
         } else {
             let parent_node_option = match self.node.as_ref() {
                 Some(node) => Some(
@@ -132,13 +131,13 @@ impl TreeSyncNode {
             // FIXME: After PR #507 of the spec is merged, this not include a
             // NodeIndex. To be able to verify against test vectors, we include
             // it here for now.
-            let hash_input = ParentNodeHashInput::new(
+            let hash_input = TreeHashInput::new_parent(
                 node_index,
                 parent_node_option,
                 VLByteSlice(&left_hash),
                 VLByteSlice(&right_hash),
             );
-            hash_input.hash(ciphersuite, backend)?
+            hash_input.hash(backend, ciphersuite)?
         };
         self.tree_hash = Some(hash.clone());
         Ok(hash)

--- a/openmls/src/treesync/treesync_node.rs
+++ b/openmls/src/treesync/treesync_node.rs
@@ -113,9 +113,6 @@ impl TreeSyncNode {
                 None => None,
             }
             .map(|leaf_node| leaf_node.key_package());
-            // FIXME: After PR #507 of the spec is merged, this should really be the
-            // leaf index. For now, we translate to node index here.
-            let leaf_index = leaf_index * 2;
             let hash_input = TreeHashInput::new_leaf(&leaf_index, key_package_option);
             hash_input.hash(backend, ciphersuite)?
         } else {
@@ -126,9 +123,6 @@ impl TreeSyncNode {
                 ),
                 None => None,
             };
-            // FIXME: After PR #507 of the spec is merged, this not include a
-            // NodeIndex. To be able to verify against test vectors, we include
-            // it here for now.
             let hash_input = TreeHashInput::new_parent(
                 parent_node_option,
                 VLByteSlice(&left_hash),


### PR DESCRIPTION
Fixes #927.

Note that there are no tests because this PR only changes the input to a hash, this will be tested during interop.