### PR TITLE
Replace key package references with leaf indices

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -190,6 +190,7 @@ fn main() {
 }
 
 #[test]
+#[ignore]
 fn basic_test() {
     // Reset the server before doing anything for testing.
     backend::Backend::default().reset_server();

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -73,11 +73,23 @@ impl User {
         let mut recipients = Vec::new();
 
         let mls_group = group.mls_group.borrow();
-        for member in mls_group.members() {
-            if self.identity.borrow().credential.credential().identity()
-                != member.credential().identity()
+        for Member {
+            index: _,
+            encryption_key: _,
+            signature_key,
+            ..
+        } in mls_group.members().unwrap().iter()
+        {
+            if self
+                .identity
+                .borrow()
+                .credential
+                .credential()
+                .signature_key()
+                .as_slice()
+                != signature_key.as_slice()
             {
-                let contact = match self.contacts.get(member.credential().identity()) {
+                let contact = match self.contacts.get(signature_key) {
                     Some(c) => c.id.clone(),
                     None => panic!("There's a member in the group we don't know."),
                 };

--- a/interop_client/proto/mls_client.proto
+++ b/interop_client/proto/mls_client.proto
@@ -211,7 +211,7 @@ message UpdateProposalRequest {
 // rpc RemoveProposal
 message RemoveProposalRequest {
   uint32 state_id = 1;
-  bytes removed = 2;
+  uint32 removed = 2;
 }
 
 // rpc PSKProposal

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -738,10 +738,7 @@ impl MlsClient for MlsClientImpl {
 
         let proposal = interop_group
             .group
-            .propose_remove_member(
-                &self.crypto_provider,
-                &KeyPackageRef::from_slice(&remove_proposal_request.removed),
-            )
+            .propose_remove_member(&self.crypto_provider, remove_proposal_request.removed)
             .map_err(into_status)?
             .to_bytes()
             .unwrap();

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -21,7 +21,6 @@
 //! - [`RatchetTreeExtension`] (GroupInfo extension)
 //! - [`RequiredCapabilitiesExtension`] (GroupContext extension)
 
-use openmls_traits::crypto::OpenMlsCrypto;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt::Debug};
 use tls_codec::*;
@@ -294,23 +293,13 @@ impl Ord for Extension {
 /// error if there is either no [`RatchetTreeExtension`] or more than one.
 pub(crate) fn try_nodes_from_extensions(
     other_extensions: &[Extension],
-    crypto_backend: &impl OpenMlsCrypto,
 ) -> Result<Option<Vec<Option<Node>>>, ExtensionError> {
     let mut ratchet_tree_extensions = other_extensions
         .iter()
         .filter(|e| e.extension_type() == ExtensionType::RatchetTree);
 
     let nodes = match ratchet_tree_extensions.next() {
-        Some(e) => {
-            let mut nodes: Vec<Option<Node>> = e.as_ratchet_tree_extension()?.as_slice().into();
-            // Compute the key package references.
-            for node in nodes.iter_mut().flatten() {
-                if let Node::LeafNode(leaf) = node {
-                    leaf.set_key_package_ref(crypto_backend)?;
-                }
-            }
-            Some(nodes)
-        }
+        Some(e) => Some(e.as_ratchet_tree_extension()?.as_slice().into()),
         None => None,
     };
 

--- a/openmls/src/framing/ciphertext.rs
+++ b/openmls/src/framing/ciphertext.rs
@@ -138,9 +138,13 @@ impl MlsCiphertext {
         let mls_sender_data_aad_bytes = mls_sender_data_aad
             .tls_serialize_detached()
             .map_err(LibraryError::missing_bound_check)?;
+        let leaf_index = mls_plaintext
+            .sender()
+            .as_member()
+            .ok_or(MessageEncryptionError::SenderError(SenderError::NotAMember))?;
         let sender_data = MlsSenderData::from_sender(
-            // XXX: This will fail for messages with a non-member sender.
-            mls_plaintext.sender().as_member()?,
+            // XXX: #106 This will fail for messages with a non-member sender.
+            leaf_index,
             generation,
             reuse_guard,
         );

--- a/openmls/src/framing/ciphertext.rs
+++ b/openmls/src/framing/ciphertext.rs
@@ -6,7 +6,6 @@ use tls_codec::{
 };
 
 use crate::{
-    ciphersuite::hash_ref::{HashReference, KeyPackageRef},
     error::LibraryError,
     tree::{
         index::SecretTreeLeafIndex, secret_tree::SecretType,
@@ -84,11 +83,6 @@ impl MlsCiphertext {
         if mls_plaintext.wire_format() != WireFormat::MlsCiphertext {
             return Err(MessageEncryptionError::WrongWireFormat);
         }
-        // Check that the plaintext has the right sender type
-        let hash_ref = match mls_plaintext.sender() {
-            Sender::Member(hash_ref) => hash_ref,
-            _ => return Err(MessageEncryptionError::SenderError(SenderError::NotAMember)),
-        };
         // Serialize the content AAD
         let mls_ciphertext_content_aad = MlsCiphertextContentAad {
             group_id: header.group_id.clone(),
@@ -144,7 +138,12 @@ impl MlsCiphertext {
         let mls_sender_data_aad_bytes = mls_sender_data_aad
             .tls_serialize_detached()
             .map_err(LibraryError::missing_bound_check)?;
-        let sender_data = MlsSenderData::from_sender(hash_ref, generation, reuse_guard);
+        let sender_data = MlsSenderData::from_sender(
+            // XXX: This will fail for messages with a non-member sender.
+            mls_plaintext.sender().as_member()?,
+            generation,
+            reuse_guard,
+        );
         // Encrypt the sender data
         let encrypted_sender_data = sender_data_key
             .aead_seal(
@@ -385,20 +384,16 @@ impl MlsCiphertext {
 #[derive(Clone, TlsDeserialize, TlsSerialize, TlsSize)]
 #[cfg_attr(test, derive(Debug))]
 pub(crate) struct MlsSenderData {
-    pub(crate) sender: KeyPackageRef,
+    pub(crate) leaf_index: u32,
     pub(crate) generation: u32,
     pub(crate) reuse_guard: ReuseGuard,
 }
 
 impl MlsSenderData {
     /// Build new [`MlsSenderData`] for a [`Sender`].
-    pub(crate) fn from_sender(
-        hash_ref: &HashReference,
-        generation: u32,
-        reuse_guard: ReuseGuard,
-    ) -> Self {
+    pub(crate) fn from_sender(leaf_index: u32, generation: u32, reuse_guard: ReuseGuard) -> Self {
         MlsSenderData {
-            sender: hash_ref.clone(),
+            leaf_index,
             generation,
             reuse_guard,
         }

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -4,10 +4,7 @@
 //! Proposals, Commits and application messages.
 
 use crate::{
-    ciphersuite::{
-        hash_ref::KeyPackageRef,
-        signable::{Signable, SignedStruct, Verifiable, VerifiedStruct},
-    },
+    ciphersuite::signable::{Signable, SignedStruct, Verifiable, VerifiedStruct},
     error::LibraryError,
     group::errors::ValidationError,
 };
@@ -185,14 +182,14 @@ impl MlsPlaintext {
     #[inline]
     fn new_with_membership_tag(
         framing_parameters: FramingParameters,
-        sender_reference: &KeyPackageRef,
+        sender_leaf_index: u32,
         body: MlsContentBody,
         credential_bundle: &CredentialBundle,
         context: &GroupContext,
         membership_key: &MembershipKey,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<Self, LibraryError> {
-        let sender = Sender::build_member(sender_reference);
+        let sender = Sender::build_member(sender_leaf_index);
         let mut mls_plaintext = Self::new(
             framing_parameters,
             sender,
@@ -215,7 +212,7 @@ impl MlsPlaintext {
     /// The sender type is always `SenderType::Member`.
     pub(crate) fn member_proposal(
         framing_parameters: FramingParameters,
-        sender_reference: &KeyPackageRef,
+        sender_leaf_index: u32,
         proposal: Proposal,
         credential_bundle: &CredentialBundle,
         context: &GroupContext,
@@ -224,7 +221,7 @@ impl MlsPlaintext {
     ) -> Result<Self, LibraryError> {
         Self::new_with_membership_tag(
             framing_parameters,
-            sender_reference,
+            sender_leaf_index,
             MlsContentBody::Proposal(proposal),
             credential_bundle,
             context,
@@ -282,7 +279,7 @@ impl MlsPlaintext {
     /// This constructor builds an `MlsPlaintext` containing an application
     /// message. The sender type is always `SenderType::Member`.
     pub(crate) fn new_application(
-        sender_reference: &KeyPackageRef,
+        sender_leaf_index: u32,
         authenticated_data: &[u8],
         application_message: &[u8],
         credential_bundle: &CredentialBundle,
@@ -294,7 +291,7 @@ impl MlsPlaintext {
             FramingParameters::new(authenticated_data, WireFormat::MlsCiphertext);
         Self::new_with_membership_tag(
             framing_parameters,
-            sender_reference,
+            sender_leaf_index,
             MlsContentBody::Application(application_message.into()),
             credential_bundle,
             context,

--- a/openmls/src/framing/sender.rs
+++ b/openmls/src/framing/sender.rs
@@ -1,7 +1,6 @@
 //! # The sender of a message.
 
 use super::*;
-use crate::prelude::LibraryError;
 use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 
 /// All possible sender types according to the MLS protocol spec.
@@ -65,12 +64,12 @@ impl Sender {
         matches!(self, Sender::Member(_))
     }
 
-    /// Returns the leaf index of the [`Sender`] or a [`LibraryError`] if this
+    /// Returns the leaf index of the [`Sender`] or [`None`] if this
     /// is not a [`Sender::Member`].
-    pub(crate) fn as_member(&self) -> Result<u32, LibraryError> {
+    pub(crate) fn as_member(&self) -> Option<u32> {
         match self {
-            Sender::Member(leaf_index) => Ok(*leaf_index),
-            _ => Err(LibraryError::custom("The sender is not a member")),
+            Sender::Member(leaf_index) => Some(*leaf_index),
+            _ => None,
         }
     }
 }

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -7,10 +7,7 @@ use openmls_rust_crypto::OpenMlsRustCrypto;
 use tls_codec::{Deserialize, Serialize};
 
 use crate::{
-    ciphersuite::{
-        hash_ref::KeyPackageRef,
-        signable::{Signable, Verifiable},
-    },
+    ciphersuite::signable::{Signable, Verifiable},
     framing::*,
     group::{
         core_group::{
@@ -38,12 +35,7 @@ fn codec_plaintext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         backend,
     )
     .expect("An unexpected error occurred.");
-    let sender = Sender::build_member(&KeyPackageRef::from_slice(
-        &backend
-            .rand()
-            .random_vec(16)
-            .expect("An unexpected error occurred."),
-    ));
+    let sender = Sender::build_member(987543210);
     let group_context = GroupContext::new(
         ciphersuite,
         GroupId::random(backend),
@@ -92,12 +84,7 @@ fn codec_ciphertext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         backend,
     )
     .expect("An unexpected error occurred.");
-    let sender = Sender::build_member(&KeyPackageRef::from_slice(
-        &backend
-            .rand()
-            .random_vec(16)
-            .expect("An unexpected error occurred."),
-    ));
+    let sender = Sender::build_member(987543210);
     let group_context = GroupContext::new(
         ciphersuite,
         GroupId::from_slice(&[5, 5, 5]),
@@ -176,12 +163,7 @@ fn wire_format_checks(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProv
         backend,
     )
     .expect("An unexpected error occurred.");
-    let sender = Sender::build_member(&KeyPackageRef::from_slice(
-        &backend
-            .rand()
-            .random_vec(16)
-            .expect("An unexpected error occurred."),
-    ));
+    let sender = Sender::build_member(987543210);
     let group_context = GroupContext::new(
         ciphersuite,
         GroupId::from_slice(&[5, 5, 5]),
@@ -339,12 +321,7 @@ fn membership_tag(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Not enough randomness."),
     );
     let mut mls_plaintext = MlsPlaintext::new_application(
-        &KeyPackageRef::from_slice(
-            &backend
-                .rand()
-                .random_vec(16)
-                .expect("An unexpected error occurred."),
-        ),
+        987543210,
         &[1, 2, 3],
         &[4, 5, 6],
         &credential_bundle,
@@ -415,9 +392,6 @@ fn unknown_sender(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         KeyPackageBundle::new(&[ciphersuite], &bob_credential_bundle, backend, Vec::new())
             .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
-    let bob_kpr = bob_key_package
-        .hash_ref(backend.crypto())
-        .expect("Error computing hash reference.");
 
     let charlie_key_package_bundle = KeyPackageBundle::new(
         &[ciphersuite],
@@ -513,12 +487,7 @@ fn unknown_sender(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     // Alice removes Bob
     let bob_remove_proposal = group_alice
-        .create_remove_proposal(
-            framing_parameters,
-            &alice_credential_bundle,
-            &bob_kpr,
-            backend,
-        )
+        .create_remove_proposal(framing_parameters, &alice_credential_bundle, 1, backend)
         .expect("Could not create proposal.");
 
     proposal_store.empty();
@@ -554,12 +523,7 @@ fn unknown_sender(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // Alice sends a message with a sender that is outside of the group
     // Expected result: SenderError::UnknownSender
     let bogus_sender_message = MlsPlaintext::new_application(
-        &KeyPackageRef::from_slice(
-            &backend
-                .rand()
-                .random_vec(16)
-                .expect("An unexpected error occurred."),
-        ),
+        987543210,
         &[],
         &[1, 2, 3],
         &alice_credential_bundle,

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -87,6 +87,7 @@ pub struct Member {
 }
 
 impl Member {
+    /// Create new member.
     pub fn new(
         index: u32,
         encryption_key: Vec<u8>,
@@ -616,7 +617,7 @@ impl CoreGroup {
         self.treesync()
             .own_leaf_node()
             .ok()
-            .and_then(|node| Some(node.key_package().credential().identity()))
+            .map(|node| node.key_package().credential().identity())
     }
 
     /// Get a reference to the group epoch secrets from the group

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -116,14 +116,12 @@ impl CoreGroup {
         // this group. Note that this is not strictly necessary. But there's
         // currently no other mechanism to enable the extension.
         let (nodes, enable_ratchet_tree_extension) =
-            match try_nodes_from_extensions(group_info.extensions(), backend.crypto()).map_err(
-                |e| match e {
-                    ExtensionError::DuplicateRatchetTreeExtension => {
-                        WelcomeError::DuplicateRatchetTreeExtension
-                    }
-                    _ => LibraryError::custom("Unexpected extension error").into(),
-                },
-            )? {
+            match try_nodes_from_extensions(group_info.extensions()).map_err(|e| match e {
+                ExtensionError::DuplicateRatchetTreeExtension => {
+                    WelcomeError::DuplicateRatchetTreeExtension
+                }
+                _ => LibraryError::custom("Unexpected extension error").into(),
+            })? {
                 Some(nodes) => (nodes, true),
                 None => match nodes_option {
                     Some(n) => (n, false),
@@ -147,7 +145,8 @@ impl CoreGroup {
         })?;
 
         let signer_key_package = tree
-            .leaf_from_id(group_info.signer())
+            .leaf(group_info.signer())
+            .map_err(|_| WelcomeError::UnknownSender)?
             .ok_or(WelcomeError::UnknownSender)?
             .key_package();
 

--- a/openmls/src/group/core_group/past_secrets.rs
+++ b/openmls/src/group/core_group/past_secrets.rs
@@ -134,6 +134,16 @@ impl MessageSecretsStore {
         &[]
     }
 
+    /// Check if the provided epoch contains a leaf index.
+    pub(crate) fn epoch_has_leaf(&self, group_epoch: GroupEpoch, leaf_index: u32) -> bool {
+        self.past_epoch_trees.iter().any(|t| {
+            t.epoch == group_epoch.0
+                && t.leaves
+                    .iter()
+                    .any(|Member { index, .. }| *index == leaf_index)
+        })
+    }
+
     /// Get a mutable reference to the message secrets of the current epoch.
     pub(crate) fn message_secrets_mut(&mut self) -> &mut MessageSecrets {
         &mut self.message_secrets

--- a/openmls/src/group/core_group/past_secrets.rs
+++ b/openmls/src/group/core_group/past_secrets.rs
@@ -109,7 +109,8 @@ impl MessageSecretsStore {
     }
 
     /// Get a mutable reference to a secret tree for a given epoch `group_epoch`.
-    /// Return a vector with the leaf indices of the epoch.
+    /// Return a mutable reference to the [`MessageSecrets`] and a slice to the
+    /// [`Member`]s of the epoch.
     pub(crate) fn secrets_and_leaves_for_epoch_mut(
         &mut self,
         group_epoch: impl Into<GroupEpoch>,
@@ -123,7 +124,7 @@ impl MessageSecretsStore {
         None
     }
 
-    /// Return a slice with the leaf indices of the epoch.
+    /// Return a slice with the [`Member`]s of the `group_epoch`.
     pub(crate) fn leaves_for_epoch(&self, group_epoch: impl Into<GroupEpoch>) -> &[Member] {
         let epoch = group_epoch.into().as_u64();
         for epoch_tree in self.past_epoch_trees.iter() {

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -375,7 +375,7 @@ impl ProposalQueue {
                     // Only members can send update proposals
                     // ValSem112
                     let leaf_index = match queued_proposal.sender.clone() {
-                        Sender::Member(hash_ref) => hash_ref.clone(),
+                        Sender::Member(hash_ref) => hash_ref,
                         _ => return Err(ProposalQueueError::SenderError(SenderError::NotAMember)),
                     };
                     if leaf_index != own_index {

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -1,8 +1,5 @@
 use crate::{
-    ciphersuite::{
-        hash_ref::{KeyPackageRef, ProposalRef},
-        *,
-    },
+    ciphersuite::hash_ref::ProposalRef,
     error::LibraryError,
     framing::*,
     group::errors::*,
@@ -161,8 +158,8 @@ impl ProposalQueue {
                 ProposalOrRef::Proposal(proposal) => {
                     // ValSem200
                     if let Proposal::Remove(ref remove_proposal) = proposal {
-                        if let Sender::Member(hash_ref) = sender {
-                            if remove_proposal.removed() == hash_ref {
+                        if let Sender::Member(leaf_index) = sender {
+                            if remove_proposal.removed() == *leaf_index {
                                 return Err(FromCommittedProposalsError::SelfRemoval);
                             }
                         }
@@ -181,8 +178,8 @@ impl ProposalQueue {
                             // ValSem200
                             if let Proposal::Remove(ref remove_proposal) = queued_proposal.proposal
                             {
-                                if let Sender::Member(hash_ref) = sender {
-                                    if remove_proposal.removed() == hash_ref {
+                                if let Sender::Member(leaf_index) = sender {
+                                    if remove_proposal.removed() == *leaf_index {
                                         return Err(FromCommittedProposalsError::SelfRemoval);
                                     }
                                 }
@@ -333,14 +330,14 @@ impl ProposalQueue {
         sender: Sender,
         proposal_store: &'a ProposalStore,
         inline_proposals: &'a [Proposal],
-        own_kpr: impl Into<Option<&'a hash_ref::KeyPackageRef>>,
+        own_index: u32,
     ) -> Result<(Self, bool), ProposalQueueError> {
         #[derive(Clone, Default)]
         struct Member {
             updates: Vec<QueuedProposal>,
             removes: Vec<QueuedProposal>,
         }
-        let mut members = HashMap::<KeyPackageRef, Member>::new();
+        let mut members = HashMap::<u32, Member>::new();
         let mut adds: HashSet<ProposalRef> = HashSet::new();
         let mut valid_proposals: HashSet<ProposalRef> = HashSet::new();
         let mut proposal_pool: HashMap<ProposalRef, QueuedProposal> = HashMap::new();
@@ -368,7 +365,6 @@ impl ProposalQueue {
         );
 
         // Parse proposals and build adds and member list
-        let own_kpr = own_kpr.into();
         for queued_proposal in queued_proposal_list {
             match queued_proposal.proposal {
                 Proposal::Add(_) => {
@@ -376,18 +372,15 @@ impl ProposalQueue {
                     proposal_pool.insert(queued_proposal.proposal_reference(), queued_proposal);
                 }
                 Proposal::Update(_) => {
-                    let own_kpr = own_kpr.ok_or_else(|| {
-                        LibraryError::custom("own_kpr has to be Some for Member Commits")
-                    })?;
                     // Only members can send update proposals
                     // ValSem112
-                    let hash_ref = match queued_proposal.sender.clone() {
+                    let leaf_index = match queued_proposal.sender.clone() {
                         Sender::Member(hash_ref) => hash_ref.clone(),
                         _ => return Err(ProposalQueueError::SenderError(SenderError::NotAMember)),
                     };
-                    if &hash_ref != own_kpr {
+                    if leaf_index != own_index {
                         members
-                            .entry(hash_ref.clone())
+                            .entry(leaf_index)
                             .or_insert_with(Member::default)
                             .updates
                             .push(queued_proposal.clone());
@@ -400,7 +393,7 @@ impl ProposalQueue {
                 Proposal::Remove(ref remove_proposal) => {
                     let removed = remove_proposal.removed();
                     members
-                        .entry(removed.clone())
+                        .entry(removed)
                         .or_insert_with(Member::default)
                         .updates
                         .push(queued_proposal.clone());

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -211,9 +211,8 @@ impl CoreGroup {
             // there are no blanks and the new member extended the tree to
             // fit in.
             if apply_proposals_values.external_init_secret_option.is_some() {
-                let sender_leaf_index = diff
-                    .add_leaf(key_package.clone())
-                    .map_err(|e| match e {
+                let sender_leaf_index =
+                    diff.add_leaf(key_package.clone()).map_err(|e| match e {
                         TreeSyncAddLeaf::LibraryError(e) => e.into(),
                         TreeSyncAddLeaf::TreeFull => StageCommitError::TooManyNewMembers,
                     })?;

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -75,11 +75,7 @@ impl CoreGroup {
         let sender = mls_plaintext.sender();
 
         if let Sender::Member(member) = sender {
-            if member
-                == self
-                    .key_package_ref()
-                    .ok_or_else(|| LibraryError::custom("Expected own key package reference"))?
-            {
+            if *member == self.own_leaf_index() {
                 return Err(StageCommitError::OwnCommit);
             }
         }
@@ -128,12 +124,12 @@ impl CoreGroup {
         self.validate_remove_proposals(&proposal_queue)?;
 
         let public_key_set = match sender {
-            Sender::Member(hash_ref) => {
+            Sender::Member(leaf_index) => {
                 // ValSem109
                 // ValSem110
                 // ValSem111
                 // ValSem112
-                self.validate_update_proposals(&proposal_queue, hash_ref)?
+                self.validate_update_proposals(&proposal_queue, *leaf_index)?
             }
             Sender::External(_) => {
                 // A commit cannot be issued by a pre-configured sender.
@@ -166,13 +162,12 @@ impl CoreGroup {
 
         // Now we can actually look at the public keys as they might have changed.
         let sender_index = match sender {
-            Sender::Member(hash_ref) => {
+            Sender::Member(leaf_index) => {
                 // Own commits have to be merged directly instead of staging them.
-                // We can't check for this explicitly. But if it's an own commit
-                // we won't be able to get the sender index because the kpr is our
-                // own new one that's only in the staged commit.
-                self.sender_index(hash_ref)
-                    .map_err(|_| StageCommitError::InconsistentSenderIndex)?
+                if leaf_index == &self.own_leaf_index() {
+                    return Err(StageCommitError::InconsistentSenderIndex);
+                }
+                *leaf_index
             }
             Sender::NewMemberCommit => diff.free_leaf_index()?,
             _ => {
@@ -217,7 +212,7 @@ impl CoreGroup {
             // fit in.
             if apply_proposals_values.external_init_secret_option.is_some() {
                 let sender_leaf_index = diff
-                    .add_leaf(key_package.clone(), backend.crypto())
+                    .add_leaf(key_package.clone())
                     .map_err(|e| match e {
                         TreeSyncAddLeaf::LibraryError(e) => e.into(),
                         TreeSyncAddLeaf::TreeFull => StageCommitError::TooManyNewMembers,

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -829,7 +829,7 @@ fn test_proposal_application_after_self_was_removed(
         assert_eq!(charlie_member.index, bob_member.index);
         assert_eq!(charlie_member.identity, bob_member.identity);
         assert_eq!(charlie_member.signature_key, bob_member.signature_key);
-        assert_eq!(alice_member.encryption_key, alice_member.encryption_key);
+        assert_eq!(charlie_member.encryption_key, alice_member.encryption_key);
     }
 
     assert_eq!(bob_members[0].identity, b"Alice");

--- a/openmls/src/group/core_group/validation.rs
+++ b/openmls/src/group/core_group/validation.rs
@@ -255,7 +255,7 @@ impl CoreGroup {
         for remove_proposal in remove_proposals {
             let removed = remove_proposal.remove_proposal().removed();
             // ValSem107
-            if !removes_set.insert(removed.clone()) {
+            if !removes_set.insert(removed) {
                 return Err(ProposalValidationError::DuplicateMemberRemoval);
             }
 
@@ -287,8 +287,9 @@ impl CoreGroup {
                 self.treesync()
                     .leaf(index)
                     .and_then(|leaf| {
-                        leaf.and_then(|leaf| Some(leaf.public_key()))
-                            .ok_or(LibraryError::custom("This must have been a leaf node").into())
+                        leaf.map(|leaf| leaf.public_key()).ok_or_else(|| {
+                            LibraryError::custom("This must have been a leaf node").into()
+                        })
                     })
                     .unwrap() // This is a library error really
                     .as_slice()

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -454,6 +454,9 @@ pub(crate) enum CreateGroupContextExtProposalError {
     /// See [`KeyPackageExtensionSupportError`] for more details.
     #[error(transparent)]
     KeyPackageExtensionSupport(#[from] KeyPackageExtensionSupportError),
+    /// See [`TreeSyncError`] for more details.
+    #[error(transparent)]
+    TreeSyncError(#[from] TreeSyncError),
     /// See [`ExtensionError`] for more details.
     #[error(transparent)]
     Extension(#[from] ExtensionError),

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -162,6 +162,9 @@ pub enum ProposeRemoveMemberError {
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
     GroupStateError(#[from] MlsGroupStateError),
+    /// The member that should be removed can not be found.
+    #[error("The member that should be removed can not be found.")]
+    UnknownMember,
 }
 
 /// Remove members error
@@ -182,6 +185,9 @@ pub enum RemoveMembersError {
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
     GroupStateError(#[from] MlsGroupStateError),
+    /// The member that should be removed can not be found.
+    #[error("The member that should be removed can not be found.")]
+    UnknownMember,
 }
 
 /// Leave group error

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -57,6 +57,9 @@ pub enum MlsGroupStateError {
     /// Can't execute operation because a pending commit exists.
     #[error("Can't execute operation because a pending commit exists.")]
     PendingCommit,
+    /// Can't execute operation because there is no pending commit.
+    #[error("Can't execute operation because there is no pending commit")]
+    NoPendingCommit,
 }
 
 /// Parse message error

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -359,7 +359,7 @@ impl RemoveOperation {
 
             // Another member left
             if removed == *leaf_index {
-                return Ok(Self::TheyLeft(removed.clone()));
+                return Ok(Self::TheyLeft(removed));
             }
         }
 

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -89,9 +89,6 @@ impl MlsGroup {
     /// Removes members from the group.
     ///
     /// Members are removed by providing the member's leaf index.
-    /// The identity is an opaque byte string that is not interpreted by OpenMLS.
-    /// This can be the `identity` in a `BasicCredential` or some other form
-    /// of identity.
     ///
     /// If successful, it returns a tuple of [`MlsMessageOut`] and an optional [`Welcome`].
     /// The [Welcome] is [Some] when the queue of pending proposals contained add proposals

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -2,13 +2,8 @@
 //!
 //! This module contains membership-related operations and exposes [`RemoveOperation`].
 
-#[cfg(any(feature = "test-utils", test))]
-use std::collections::BTreeMap;
-
 use core_group::create_commit_params::CreateCommitParams;
 use tls_codec::Serialize;
-
-use crate::{ciphersuite::hash_ref::HashReference, ciphersuite::hash_ref::KeyPackageRef};
 
 use super::{
     errors::{AddMembersError, LeaveGroupError, RemoveMembersError},
@@ -93,7 +88,10 @@ impl MlsGroup {
 
     /// Removes members from the group.
     ///
-    /// Members are removed by providing the index of their leaf in the tree.
+    /// Members are removed by providing the member's "identity".
+    /// The identity is an opaque byte string that is not interpreted by OpenMLS.
+    /// This can be the `identity` in a [`BasicCredential`] or some other form
+    /// of identity.
     ///
     /// If successful, it returns a tuple of [`MlsMessageOut`] and an optional [`Welcome`].
     /// The [Welcome] is [Some] when the queue of pending proposals contained add proposals
@@ -102,7 +100,7 @@ impl MlsGroup {
     pub fn remove_members(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
-        members: &[KeyPackageRef],
+        members: &[u32],
     ) -> Result<(MlsMessageOut, Option<Welcome>), RemoveMembersError> {
         self.is_operational()?;
 
@@ -112,15 +110,13 @@ impl MlsGroup {
             ));
         }
 
+        // Get the leaf indices for the identities in the `members` slice.
         // Create inline remove proposals
-        let inline_proposals = members
-            .iter()
-            .map(|member| {
-                Proposal::Remove(RemoveProposal {
-                    removed: member.clone(),
-                })
-            })
-            .collect::<Vec<Proposal>>();
+        // XXX: Could be done more efficiently.
+        let mut inline_proposals = Vec::new();
+        for member in members.iter() {
+            inline_proposals.push(Proposal::Remove(RemoveProposal { removed: *member }))
+        }
 
         let credential = self.credential()?;
         let credential_bundle: CredentialBundle = backend
@@ -211,12 +207,13 @@ impl MlsGroup {
     }
 
     /// Creates proposals to remove members from the group.
+    /// The `member` has to be the member's "identity".
     ///
     /// Returns an error if there is a pending commit.
     pub fn propose_remove_member(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
-        member: &KeyPackageRef,
+        member: u32,
     ) -> Result<MlsMessageOut, ProposeRemoveMemberError> {
         self.is_operational()?;
 
@@ -278,10 +275,7 @@ impl MlsGroup {
             )
             .ok_or(LeaveGroupError::NoMatchingCredentialBundle)?;
 
-        let removed = self
-            .group
-            .key_package_ref()
-            .ok_or_else(|| LibraryError::custom("No key package reference for own key package."))?;
+        let removed = self.group.own_leaf_index();
         let remove_proposal = self.group.create_remove_proposal(
             self.framing_parameters(),
             &credential_bundle,
@@ -298,41 +292,24 @@ impl MlsGroup {
         Ok(self.plaintext_to_mls_message(remove_proposal, backend)?)
     }
 
-    /// Returns a list of [`KeyPackage`]s of the current group members.
-    pub fn members(&self) -> Vec<&KeyPackage> {
-        match self.group.treesync().full_leaves() {
-            Ok(leaves) => leaves.iter().map(|(_, &kp)| kp).collect(),
-            // This should not happen, but this way we avoid returning a library error
-            Err(e) => {
-                log::debug!("treesync::full_leaves() returned an error: {:?}", e);
-                Vec::new()
-            }
-        }
+    /// Returns a list of [`Members`] in the group.
+    pub fn members(&self) -> Result<Vec<Member>, LibraryError> {
+        self.group.treesync().full_leave_members()
     }
 
     /// Returns the [`KeyPackage`] of a member corresponding to the given
-    /// [`KeyPackageRef`]. Returns `None` if no matching [`KeyPackage`] can be
-    /// found in this group.
-    pub fn member(&self, key_package_ref: &KeyPackageRef) -> Option<&KeyPackage> {
+    /// leaf index. Returns `None` if the member can not be found in this group.
+    pub fn member(&self, leaf_index: u32) -> Option<&KeyPackage> {
         self.group
             .treesync()
             // Besides from returning an error if the member can't be found,
             // this will only return an error in case OpenMLS is compiled with a
             // sub-32 bit architecture. As a result, it should be safe to just
             // return `None` instead of propagating an error.
-            .leaf_from_id(key_package_ref)
-            .map(|leaf| leaf.key_package())
-    }
-
-    /// Returns the current list of members, indexed with the leaf index.
-    /// This should go away in future when all tests are rewritten to use key
-    /// package references instead of leaf indices.
-    #[cfg(any(feature = "test-utils", test))]
-    pub fn indexed_members(&self) -> Result<BTreeMap<u32, &KeyPackage>, LibraryError> {
-        self.group
-            .treesync()
-            .full_leaves()
-            .map_err(|_| LibraryError::custom("Unexpected error in TreeSync"))
+            .leaf(leaf_index)
+            .map(|leaf| leaf.map(|l| l.key_package()))
+            .ok()
+            .flatten()
     }
 }
 
@@ -346,14 +323,14 @@ pub enum RemoveOperation {
     WeLeft,
     /// Someone else (indicated by the [`Sender`]) removed us from the group.
     WeWereRemovedBy(Sender),
-    /// Another member (indicated by the [`HashReference`]) requested to leave
+    /// Another member (indicated by the leaf index) requested to leave
     /// the group by issuing a remove proposal in the previous epoch and the
     /// proposal has now been committed.
-    TheyLeft(HashReference),
-    /// Another member (indicated by the [`HashReference`]) was removed by the [`Sender`].
-    TheyWereRemovedBy((HashReference, Sender)),
-    /// We removed another member (indicated by the [`HashReference`]).
-    WeRemovedThem(HashReference),
+    TheyLeft(u32),
+    /// Another member (indicated by the leaf index) was removed by the [`Sender`].
+    TheyWereRemovedBy((u32, Sender)),
+    /// We removed another member (indicated by the leaf index).
+    WeRemovedThem(u32),
 }
 
 impl RemoveOperation {
@@ -363,28 +340,25 @@ impl RemoveOperation {
         queued_remove_proposal: QueuedRemoveProposal,
         group: &MlsGroup,
     ) -> Result<Self, LibraryError> {
-        let own_hash_ref = match group.key_package_ref() {
-            Some(key_package_ref) => key_package_ref,
-            None => return Err(LibraryError::custom("Own KeyPackage was empty.")),
-        };
+        let own_index = group.own_leaf_index();
         let sender = queued_remove_proposal.sender();
         let removed = queued_remove_proposal.remove_proposal().removed();
 
         // We start with the cases where the sender is a group member
-        if let Sender::Member(hash_ref) = sender {
+        if let Sender::Member(leaf_index) = sender {
             // We authored the remove proposal
-            if hash_ref == own_hash_ref {
-                if removed == own_hash_ref {
+            if *leaf_index == own_index {
+                if removed == own_index {
                     // We left
                     return Ok(Self::WeLeft);
                 } else {
                     // We removed another member
-                    return Ok(Self::WeRemovedThem(removed.clone()));
+                    return Ok(Self::WeRemovedThem(removed));
                 }
             }
 
             // Another member left
-            if removed == hash_ref {
+            if removed == *leaf_index {
                 return Ok(Self::TheyLeft(removed.clone()));
             }
         }
@@ -392,12 +366,12 @@ impl RemoveOperation {
         // The sender is not necessarily a group member. This covers all sender
         // types (members, pre-configured senders and new members).
 
-        if removed == own_hash_ref {
+        if removed == own_index {
             // We were removed
             Ok(Self::WeWereRemovedBy(sender.clone()))
         } else {
             // Another member was removed
-            Ok(Self::TheyWereRemovedBy((removed.clone(), sender.clone())))
+            Ok(Self::TheyWereRemovedBy((removed, sender.clone())))
         }
     }
 }

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -90,7 +90,7 @@ impl MlsGroup {
     ///
     /// Members are removed by providing the member's "identity".
     /// The identity is an opaque byte string that is not interpreted by OpenMLS.
-    /// This can be the `identity` in a [`BasicCredential`] or some other form
+    /// This can be the `identity` in a `BasicCredential` or some other form
     /// of identity.
     ///
     /// If successful, it returns a tuple of [`MlsMessageOut`] and an optional [`Welcome`].
@@ -292,7 +292,7 @@ impl MlsGroup {
         Ok(self.plaintext_to_mls_message(remove_proposal, backend)?)
     }
 
-    /// Returns a list of [`Members`] in the group.
+    /// Returns a list of [`Member`]s in the group.
     pub fn members(&self) -> Result<Vec<Member>, LibraryError> {
         self.group.treesync().full_leave_members()
     }

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -7,7 +7,7 @@ use super::{
     staged_commit::StagedCommit,
 };
 use crate::{
-    ciphersuite::{hash_ref::KeyPackageRef, signable::Signable},
+    ciphersuite::signable::Signable,
     credentials::{Credential, CredentialBundle},
     error::LibraryError,
     framing::*,
@@ -236,9 +236,14 @@ impl MlsGroup {
             .credential())
     }
 
-    /// Returns the [`KeyPackageRef`] of the client owning this group.
-    pub fn key_package_ref(&self) -> Option<&KeyPackageRef> {
-        self.group.key_package_ref()
+    /// Get the identity of the client's [`Credential`] owning this group.
+    pub fn own_identity(&self) -> Option<&[u8]> {
+        self.group.own_identity()
+    }
+
+    /// Returns the leaf index of the client in the tree owning this group.
+    pub fn own_leaf_index(&self) -> u32 {
+        self.group.treesync().own_leaf_index()
     }
 
     /// Returns the group ID.

--- a/openmls/src/group/tests/external_proposal.rs
+++ b/openmls/src/group/tests/external_proposal.rs
@@ -116,8 +116,8 @@ fn external_add_proposal_should_succeed(
             mut bob_group,
         } = validation_test_setup(policy, ciphersuite, backend);
 
-        assert_eq!(alice_group.members().len(), 2);
-        assert_eq!(bob_group.members().len(), 2);
+        assert_eq!(alice_group.members().unwrap().len(), 2);
+        assert_eq!(bob_group.members().unwrap().len(), 2);
 
         // A new client, Charlie, will now ask joining with an external Add proposal
         let charlie_cb = get_credential_bundle(
@@ -192,7 +192,7 @@ fn external_add_proposal_should_succeed(
         // and Alice will commit it
         let (commit, welcome) = alice_group.commit_to_pending_proposals(backend).unwrap();
         alice_group.merge_pending_commit().unwrap();
-        assert_eq!(alice_group.members().len(), 3);
+        assert_eq!(alice_group.members().unwrap().len(), 3);
 
         // Bob will also process the commit
         let parsed = bob_group.parse_message(commit.into(), backend).unwrap();
@@ -205,7 +205,7 @@ fn external_add_proposal_should_succeed(
             }
             _ => unreachable!(),
         }
-        assert_eq!(bob_group.members().len(), 3);
+        assert_eq!(bob_group.members().unwrap().len(), 3);
 
         // Finally, Charlie can join with the Welcome
         let cfg = MlsGroupConfig::builder().wire_format_policy(policy).build();
@@ -216,7 +216,7 @@ fn external_add_proposal_should_succeed(
             Some(alice_group.export_ratchet_tree()),
         )
         .unwrap();
-        assert_eq!(charlie_group.members().len(), 3);
+        assert_eq!(charlie_group.members().unwrap().len(), 3);
     }
 }
 
@@ -302,16 +302,7 @@ fn new_member_proposal_sender_should_be_reserved_for_join_proposals(
     alice_group.clear_pending_proposals();
 
     // Remove proposal cannot have a 'new_member_proposal' sender
-    let bob_kp = alice_group
-        .members()
-        .into_iter()
-        .find(|kp| kp.credential().identity() == b"Bob")
-        .unwrap();
-    let bob_kpr = bob_kp.hash_ref(backend.crypto()).unwrap();
-
-    let remove_proposal = alice_group
-        .propose_remove_member(backend, &bob_kpr)
-        .unwrap();
+    let remove_proposal = alice_group.propose_remove_member(backend, 1).unwrap();
     if let MlsMessageBody::Plaintext(mut plaintext) = remove_proposal.mls_message.body {
         plaintext.set_sender(Sender::NewMemberProposal);
         assert!(matches!(

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -5,20 +5,10 @@
 //! for more description on the test vectors.
 
 use crate::{
-    ciphersuite::signable::Signable,
-    credentials::*,
-    framing::*,
-    group::*,
-    key_packages::*,
-    messages::proposals::*,
-    messages::public_group_state::*,
-    messages::*,
-    prelude_test::{hash_ref::KeyPackageRef, signable::Verifiable},
-    schedule::psk::*,
-    test_utils::*,
-    tree::sender_ratchet::*,
-    treesync::node::Node,
-    versions::ProtocolVersion,
+    ciphersuite::signable::Signable, credentials::*, framing::*, group::*, key_packages::*,
+    messages::proposals::*, messages::public_group_state::*, messages::*,
+    prelude_test::signable::Verifiable, schedule::psk::*, test_utils::*, tree::sender_ratchet::*,
+    treesync::node::Node, versions::ProtocolVersion,
 };
 
 use openmls_rust_crypto::OpenMlsRustCrypto;
@@ -111,12 +101,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
                     .expect("An unexpected error occurred.")
                     .into(),
             }),
-            &KeyPackageRef::from_slice(
-                &crypto
-                    .rand()
-                    .random_vec(16)
-                    .expect("Error getting randomnes"),
-            ),
+            group.own_leaf_index(),
         )
     };
     let group_info = group_info_tbs
@@ -159,12 +144,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     // Create proposal to remove a user
     // TODO #525: This is not a valid RemoveProposal since random_u32() is not a valid KeyPackageRef.
     let remove_proposal = RemoveProposal {
-        removed: KeyPackageRef::from_slice(
-            &crypto
-                .rand()
-                .random_vec(16)
-                .expect("Error getting randomnes"),
-        ),
+        removed: 7, // XXX: use valid, random
     };
 
     let psk_id = PreSharedKeyId::new(

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -9,8 +9,8 @@ use std::convert::TryFrom;
 use crate::test_utils::{read, write};
 
 use crate::{
-    ciphersuite::hash_ref::KeyPackageRef, ciphersuite::signable::*, credentials::*, framing::*,
-    group::*, messages::*, schedule::*, test_utils::*, versions::ProtocolVersion,
+    ciphersuite::signable::*, credentials::*, framing::*, group::*, messages::*, schedule::*,
+    test_utils::*, versions::ProtocolVersion,
 };
 
 use openmls_rust_crypto::OpenMlsRustCrypto;
@@ -83,12 +83,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> TranscriptTestVector {
         .random_vec(48)
         .expect("An unexpected error occurred.");
     let framing_parameters = FramingParameters::new(&aad, WireFormat::MlsPlaintext);
-    let sender = Sender::build_member(&KeyPackageRef::from_slice(
-        &crypto
-            .rand()
-            .random_vec(16)
-            .expect("Error getting randomnes"),
-    ));
+    let sender = Sender::build_member(7); // XXX: use random, valid sender
     let mut commit = MlsPlaintext::commit(
         framing_parameters,
         sender,

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -109,16 +109,11 @@ fn test_valsem200(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         mut bob_group,
     } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
-    let alice_hash_ref = alice_group
-        .key_package_ref()
-        .cloned()
-        .expect("Couldn't find key package ref.");
-
     // Since Alice won't commit to her own removal directly, we have to create
     // proposal and commit independently and then insert the proposal into the
     // commit manually.
     let serialized_proposal_message = alice_group
-        .propose_remove_member(backend, &alice_hash_ref)
+        .propose_remove_member(backend, alice_group.own_leaf_index())
         .expect("error creating commit")
         .tls_serialize_detached()
         .expect("serialization error");
@@ -339,13 +334,7 @@ fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     // Create the remove.
     let serialized_remove = alice_group
-        .remove_members(
-            backend,
-            &[bob_group
-                .key_package_ref()
-                .cloned()
-                .expect("error retrieving kp ref")],
-        )
+        .remove_members(backend, &[bob_group.own_leaf_index()])
         .expect("Error creating remove")
         .tls_serialize_detached()
         .expect("Could not serialize message.");

--- a/openmls/src/group/tests/test_encoding.rs
+++ b/openmls/src/group/tests/test_encoding.rs
@@ -224,8 +224,6 @@ fn test_add_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
 /// This test tests encoding and decoding of remove proposals.
 #[apply(backends)]
 fn test_remove_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
-    use ciphersuite::hash_ref::KeyPackageRef;
-
     let test_setup = create_encoding_test_setup(backend);
     let test_clients = test_setup.clients.borrow();
     let alice = test_clients
@@ -242,17 +240,7 @@ fn test_remove_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
             .expect("An unexpected error occurred.");
 
         let remove = group_state
-            .create_remove_proposal(
-                framing_parameters,
-                credential_bundle,
-                &KeyPackageRef::from_slice(
-                    &backend
-                        .rand()
-                        .random_vec(16)
-                        .expect("An unexpected error occurred."),
-                ),
-                backend,
-            )
+            .create_remove_proposal(framing_parameters, credential_bundle, 777, backend)
             .expect("Could not create proposal.");
         let remove_encoded = remove
             .tls_serialize_detached()

--- a/openmls/src/group/tests/test_encoding.rs
+++ b/openmls/src/group/tests/test_encoding.rs
@@ -240,7 +240,7 @@ fn test_remove_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
             .expect("An unexpected error occurred.");
 
         let remove = group_state
-            .create_remove_proposal(framing_parameters, credential_bundle, 777, backend)
+            .create_remove_proposal(framing_parameters, credential_bundle, 1, backend)
             .expect("Could not create proposal.");
         let remove_encoded = remove
             .tls_serialize_detached()

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -577,10 +577,7 @@ fn test_valsem244(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     content.proposals.remove(proposal_position);
 
     let remove_proposal = ProposalOrRef::Proposal(Proposal::Remove(RemoveProposal {
-        removed: alice_group
-            .key_package_ref()
-            .cloned()
-            .expect("An unexpected error occurred."),
+        removed: alice_group.own_leaf_index(),
     }));
 
     content.proposals.push(remove_proposal);
@@ -680,12 +677,7 @@ fn test_valsem245(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         ciphersuite,
         backend,
         second_ext_init_prop,
-        &Sender::Member(
-            alice_group
-                .key_package_ref()
-                .cloned()
-                .expect("An unexpected error occurred."),
-        ),
+        &Sender::Member(alice_group.own_leaf_index()),
     )
     .expect("error creating queued proposal");
 

--- a/openmls/src/group/tests/test_framing.rs
+++ b/openmls/src/group/tests/test_framing.rs
@@ -10,7 +10,7 @@ use tls_codec::Serialize;
 
 use super::utils::*;
 use crate::{
-    ciphersuite::{hash_ref::KeyPackageRef, signable::Signable},
+    ciphersuite::signable::Signable,
     credentials::{CredentialBundle, CredentialType},
     framing::{MessageDecryptionError, WireFormat, *},
     group::*,
@@ -125,9 +125,7 @@ fn bad_padding(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
         )
         .unwrap();
 
-        let sender = Sender::build_member(&KeyPackageRef::from_slice(
-            &backend.rand().random_vec(16).unwrap(),
-        ));
+        let sender = Sender::build_member(654);
 
         let group_context = GroupContext::new(
             ciphersuite,
@@ -187,8 +185,8 @@ fn bad_padding(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
                 sender: SecretTreeLeafIndex(0),
             };
 
-            let hash_ref = match plaintext.sender() {
-                Sender::Member(hash_ref) => hash_ref,
+            let leaf_index = match plaintext.sender() {
+                Sender::Member(leaf_index) => *leaf_index,
                 _ => panic!("Unexpected match."),
             };
 
@@ -288,7 +286,7 @@ fn bad_padding(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
             );
             // Serialize the sender data AAD
             let mls_sender_data_aad_bytes = mls_sender_data_aad.tls_serialize_detached().unwrap();
-            let sender_data = MlsSenderData::from_sender(hash_ref, generation, reuse_guard);
+            let sender_data = MlsSenderData::from_sender(leaf_index, generation, reuse_guard);
             // Encrypt the sender data
             let encrypted_sender_data = sender_data_key
                 .aead_seal(

--- a/openmls/src/group/tests/test_framing_validation.rs
+++ b/openmls/src/group/tests/test_framing_validation.rs
@@ -2,14 +2,13 @@
 //! https://openmls.tech/book/message_validation.html#semantic-validation-of-message-framing
 
 use openmls_rust_crypto::OpenMlsRustCrypto;
-use openmls_traits::{random::OpenMlsRand, types::Ciphersuite, OpenMlsCryptoProvider};
+use openmls_traits::{types::Ciphersuite, OpenMlsCryptoProvider};
 use tls_codec::{Deserialize, Serialize};
 
 use rstest::*;
 use rstest_reuse::{self, *};
 
 use crate::{
-    ciphersuite::hash_ref::KeyPackageRef,
     credentials::*,
     framing::*,
     group::{errors::*, *},
@@ -323,12 +322,7 @@ fn test_valsem004(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     let original_message = plaintext.clone();
 
-    let random_sender = Sender::build_member(&KeyPackageRef::from_slice(
-        &backend
-            .rand()
-            .random_vec(16)
-            .expect("An unexpected error occurred."),
-    ));
+    let random_sender = Sender::build_member(987);
     plaintext.set_sender(random_sender);
 
     let message_in = MlsMessageIn::from(plaintext);

--- a/openmls/src/group/tests/test_group.rs
+++ b/openmls/src/group/tests/test_group.rs
@@ -844,9 +844,7 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         .create_remove_proposal(
             framing_parameters,
             &charlie_credential_bundle,
-            group_bob
-                .key_package_ref()
-                .expect("An unexpected error occurred."),
+            group_bob.own_leaf_index(),
             backend,
         )
         .expect("Could not create proposal.");

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -9,7 +9,7 @@ use rstest_reuse::{self, *};
 use tls_codec::{Deserialize, Serialize};
 
 use crate::{
-    ciphersuite::{hash_ref::ProposalRef, signable::Signable, *},
+    ciphersuite::{hash_ref::ProposalRef, signable::Signable},
     credentials::*,
     framing::{
         MlsContentBody, MlsMessageIn, MlsMessageOut, MlsPlaintext, ProcessedMessage, Sender,
@@ -1328,11 +1328,7 @@ fn test_valsem106(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
                         ciphersuite,
                         backend,
                         add_proposal.clone(),
-                        &Sender::build_member(
-                            alice_group
-                                .key_package_ref()
-                                .expect("error getting key package ref"),
-                        ),
+                        &Sender::build_member(alice_group.own_leaf_index()),
                     )
                     .expect("error creating queued proposal"),
                 )
@@ -1401,16 +1397,14 @@ fn test_valsem107(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // use the `remove_members` endpoint with two times the same KeyPackageRef
     // as input. We first create both commits and then make sure they look as
     // expected.
-    let bob_kp_ref = bob_group
-        .key_package_ref()
-        .expect("error getting key package ref");
+    let bob_leaf_index = bob_group.own_leaf_index();
 
     // We first go the manual route
     let _remove_proposal1 = alice_group
-        .propose_remove_member(backend, bob_kp_ref)
+        .propose_remove_member(backend, bob_leaf_index)
         .expect("error while creating remove proposal");
     let _remove_proposal2 = alice_group
-        .propose_remove_member(backend, bob_kp_ref)
+        .propose_remove_member(backend, bob_leaf_index)
         .expect("error while creating remove proposal");
     // While this shouldn't fail, it should produce a valid commit, i.e. one
     // that contains only one remove proposal.
@@ -1422,7 +1416,7 @@ fn test_valsem107(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     alice_group.clear_pending_commit();
 
     let (combined_commit, _welcome) = alice_group
-        .remove_members(backend, &[bob_kp_ref.clone(), bob_kp_ref.clone()])
+        .remove_members(backend, &[bob_leaf_index, bob_leaf_index])
         .expect("error while trying to remove the same member twice");
 
     // Now let's verify that both commits only contain one proposal.
@@ -1447,7 +1441,7 @@ fn test_valsem107(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         // Depending on the commit, the proposal is either inline or it's a
         // reference.
         let expected_inline_proposal = Proposal::Remove(RemoveProposal {
-            removed: bob_kp_ref.clone(),
+            removed: bob_leaf_index,
         });
         let expected_reference_proposal =
             ProposalRef::from_proposal(ciphersuite, backend, &expected_inline_proposal)
@@ -1492,16 +1486,21 @@ fn test_valsem108(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // There are two ways in which we could use the MlsGroup API to commit to
     // remove proposals: Create the proposals and then commit them manually or
     // use the `remove_members` endpoint.
-    let fake_kp_ref = hash_ref::HashReference::from_slice(&[0u8; 16]);
+    let fake_leaf_index = 9238754;
 
     // We first go the manual route
     let _remove_proposal1 = alice_group
-        .propose_remove_member(backend, &fake_kp_ref)
+        .propose_remove_member(backend, fake_leaf_index)
         .expect("error while creating remove proposal");
     // This should fail, since there is no member with the given hash reference.
     let err = alice_group.commit_to_pending_proposals(backend).expect_err(
         "no error while trying to commit to remove proposal targeting non group member",
     );
+
+    // // Creating the proposal should fail already because the member is not known.
+    // let err = alice_group
+    //     .propose_remove_member(backend, fake_leaf_index)
+    //     .expect_err("Successfully created remove proposal for unknown member");
 
     assert_eq!(
         err,
@@ -1517,7 +1516,7 @@ fn test_valsem108(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     alice_group.clear_pending_proposals();
 
     let err = alice_group
-        .remove_members(backend, &[fake_kp_ref.clone()])
+        .remove_members(backend, &[fake_leaf_index])
         .expect_err("no error while trying to remove non-group-member");
 
     assert_eq!(
@@ -1543,10 +1542,8 @@ fn test_valsem108(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // Keep the original plaintext for positive test later.
     let original_plaintext = plaintext.clone();
 
-    // Use the fake kp_ref generated earlier to create a remove proposal.
-    let remove_proposal = Proposal::Remove(RemoveProposal {
-        removed: fake_kp_ref,
-    });
+    // Use a random leaf index that doesn't exist to create a remove proposal.
+    let remove_proposal = Proposal::Remove(RemoveProposal { removed: 987 });
 
     // Artificially add a proposal trying to remove someone that is not in a
     // group.
@@ -1987,11 +1984,7 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             ciphersuite,
             backend,
             update_proposal.clone(),
-            &Sender::build_member(
-                alice_group
-                    .key_package_ref()
-                    .expect("error getting key package ref"),
-            ),
+            &Sender::build_member(alice_group.own_leaf_index()),
         )
         .expect("error creating queued proposal"),
     );

--- a/openmls/src/group/tests/test_remove_operation.rs
+++ b/openmls/src/group/tests/test_remove_operation.rs
@@ -95,20 +95,14 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
 
         // === Remove operation ===
 
-        let alice_kpr = alice_group
-            .key_package_ref()
-            .cloned()
-            .expect("An unexpected error occurred.");
-        let bob_kpr = bob_group
-            .key_package_ref()
-            .cloned()
-            .expect("An unexpected error occurred.");
+        let alice_index = alice_group.own_leaf_index();
+        let bob_index = bob_group.own_leaf_index();
 
         // We differentiate between the two test cases here
         let (message, _welcome) = match test_case {
             // Alice removes Bob
             TestCase::Remove => alice_group
-                .remove_members(backend, &[bob_kpr.clone()])
+                .remove_members(backend, &[bob_index])
                 .expect("Could not remove members."),
             // Bob leaves
             TestCase::Leave => {
@@ -159,7 +153,7 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
                 match remove_operation {
                     RemoveOperation::WeRemovedThem(removed) => {
                         // Check that it was indeed Bob who was removed
-                        assert_eq!(removed, bob_kpr.clone());
+                        assert_eq!(removed, bob_index);
                     }
                     _ => unreachable!(),
                 }
@@ -169,7 +163,7 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
                 match remove_operation {
                     RemoveOperation::TheyLeft(removed) => {
                         // Check that it was indeed Bob who left
-                        assert_eq!(removed, bob_kpr.clone());
+                        assert_eq!(removed, bob_index);
                     }
                     _ => unreachable!(),
                 }
@@ -207,7 +201,7 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
                                 match sender {
                                     Sender::Member(member) => {
                                         // Check that it was Alice who removed Bob
-                                        assert_eq!(member, alice_kpr.clone());
+                                        assert_eq!(member, alice_index);
                                     }
                                     _ => unreachable!(),
                                 }
@@ -257,11 +251,11 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
                                 // Make sure Alice is indeed a member
                                 assert!(sender.is_member());
                                 // Check that it was indeed Bob who was removed
-                                assert_eq!(removed, bob_kpr.clone());
+                                assert_eq!(removed, bob_index);
                                 match sender {
                                     Sender::Member(member) => {
                                         // Check that it was Alice who removed Bob
-                                        assert_eq!(member, alice_kpr.clone());
+                                        assert_eq!(member, alice_index);
                                     }
                                     _ => unreachable!(),
                                 }
@@ -274,7 +268,7 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
                         match remove_operation {
                             RemoveOperation::TheyLeft(removed) => {
                                 // Check that it was indeed Bob who left
-                                assert_eq!(removed, bob_kpr.clone());
+                                assert_eq!(removed, bob_index);
                             }
                             _ => unreachable!(),
                         }

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -363,8 +363,8 @@ impl KeyPackage {
     }
 
     /// Compute the [`KeyPackageRef`] of this [`KeyPackage`].
-    /// The [`KeyPackageRef`] is used to identify a member in a group (leaf in
-    /// the tree) within MLS.
+    /// The [`KeyPackageRef`] is used to identify a new member that should get
+    /// added to a group.
     pub fn hash_ref(&self, backend: &impl OpenMlsCrypto) -> Result<KeyPackageRef, LibraryError> {
         make_key_package_ref(
             &self

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -192,7 +192,7 @@ pub(crate) struct GroupInfoTBS {
     group_context: GroupContext,
     extensions: Vec<Extension>,
     confirmation_tag: ConfirmationTag,
-    signer: KeyPackageRef,
+    signer: u32,
 }
 
 impl GroupInfoTBS {
@@ -201,13 +201,13 @@ impl GroupInfoTBS {
         group_context: GroupContext,
         extensions: &[Extension],
         confirmation_tag: ConfirmationTag,
-        signer: &KeyPackageRef,
+        signer: u32,
     ) -> Self {
         Self {
             group_context,
             extensions: extensions.into(),
             confirmation_tag,
-            signer: signer.clone(),
+            signer,
         }
     }
 }
@@ -270,8 +270,8 @@ impl GroupInfo {
     }
 
     /// Returns the signer.
-    pub(crate) fn signer(&self) -> &KeyPackageRef {
-        &self.payload.signer
+    pub(crate) fn signer(&self) -> u32 {
+        self.payload.signer
     }
 
     /// Re-sign the group info.

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -182,13 +182,13 @@ impl UpdateProposal {
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
 pub struct RemoveProposal {
-    pub(crate) removed: KeyPackageRef,
+    pub(crate) removed: u32,
 }
 
 impl RemoveProposal {
-    /// Returns the [`KeyPackageRef`] index in this proposal.
-    pub fn removed(&self) -> &KeyPackageRef {
-        &self.removed
+    /// Returns the leaf index of the removed leaf in this proposal.
+    pub fn removed(&self) -> u32 {
+        self.removed
     }
 }
 

--- a/openmls/src/messages/public_group_state.rs
+++ b/openmls/src/messages/public_group_state.rs
@@ -8,7 +8,6 @@ use tls_codec::{Serialize, TlsByteVecU8, TlsDeserialize, TlsSerialize, TlsSize, 
 
 use crate::{
     ciphersuite::{
-        hash_ref::KeyPackageRef,
         signable::{Signable, SignedStruct, Verifiable, VerifiedStruct},
         HpkePublicKey, Signature,
     },
@@ -50,7 +49,7 @@ pub struct PublicGroupState {
     pub(crate) group_context_extensions: TlsVecU32<Extension>,
     pub(crate) other_extensions: TlsVecU32<Extension>,
     pub(crate) external_pub: HpkePublicKey,
-    pub(crate) signer: KeyPackageRef,
+    pub(crate) signer: u32,
     pub(crate) signature: Signature,
 }
 
@@ -88,8 +87,8 @@ impl VerifiablePublicGroupState {
     }
 
     /// Returns a reference to the [`KeyPackageRef`] of the signer.
-    pub(crate) fn signer(&self) -> &KeyPackageRef {
-        &self.tbs.signer
+    pub(crate) fn signer(&self) -> u32 {
+        self.tbs.signer
     }
 
     /// Returns a reference to the non [`GroupContext`] extensions of the unverified
@@ -183,7 +182,7 @@ pub(crate) struct PublicGroupStateTbs {
     pub(crate) group_context_extensions: TlsVecU32<Extension>,
     pub(crate) other_extensions: TlsVecU32<Extension>,
     pub(crate) external_pub: HpkePublicKey,
-    pub(crate) signer: KeyPackageRef,
+    pub(crate) signer: u32,
 }
 
 impl PublicGroupStateTbs {
@@ -218,10 +217,7 @@ impl PublicGroupStateTbs {
             other_extensions,
             external_pub: external_pub.into(),
             ciphersuite,
-            signer: core_group
-                .key_package_ref()
-                .cloned()
-                .ok_or_else(|| LibraryError::custom("missing key package ref"))?,
+            signer: core_group.own_leaf_index(),
         })
     }
 }

--- a/openmls/src/messages/tests/test_pgs.rs
+++ b/openmls/src/messages/tests/test_pgs.rs
@@ -84,12 +84,7 @@ fn test_pgs(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
         .expect("Could not export the public group state");
 
     // Make sure Alice is the signer
-    assert_eq!(
-        &pgs.signer,
-        group_alice
-            .key_package_ref()
-            .expect("An unexpected error occurred.")
-    );
+    assert_eq!(pgs.signer, group_alice.own_leaf_index());
 
     let encoded = pgs.tls_serialize_detached().expect("Could not encode");
     let verifiable_pgs = VerifiablePublicGroupState::tls_deserialize(&mut encoded.as_slice())

--- a/openmls/src/messages/tests/test_proposals.rs
+++ b/openmls/src/messages/tests/test_proposals.rs
@@ -1,9 +1,8 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
-use openmls_traits::random::OpenMlsRand;
 use tls_codec::{Deserialize, Serialize};
 
 use crate::{
-    ciphersuite::hash_ref::{KeyPackageRef, ProposalRef},
+    ciphersuite::hash_ref::ProposalRef,
     messages::proposals::{Proposal, ProposalOrRef, RemoveProposal},
     test_utils::*,
 };
@@ -14,14 +13,7 @@ use crate::{
 fn proposals_codec(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     // Proposal
 
-    let remove_proposal = RemoveProposal {
-        removed: KeyPackageRef::from_slice(
-            &backend
-                .rand()
-                .random_vec(16)
-                .expect("An unexpected error occurred."),
-        ),
-    };
+    let remove_proposal = RemoveProposal { removed: 72549 };
     let proposal = Proposal::Remove(remove_proposal);
     let proposal_or_ref = ProposalOrRef::Proposal(proposal.clone());
     let encoded = proposal_or_ref

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -18,7 +18,6 @@ use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::{
     crypto::OpenMlsCrypto,
     key_store::OpenMlsKeyStore,
-    random::OpenMlsRand,
     types::{Ciphersuite, SignatureScheme},
     OpenMlsCryptoProvider,
 };
@@ -258,12 +257,7 @@ fn test_welcome_message_with_version(
             ConfirmationTag(Mac {
                 mac_value: vec![1, 2, 3, 4, 5].into(),
             }),
-            &KeyPackageRef::from_slice(
-                &backend
-                    .rand()
-                    .random_vec(16)
-                    .expect("An unexpected error occurred."),
-            ),
+            1,
         )
     };
 

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -2,7 +2,7 @@
 //! Include this to get access to all the public functions of OpenMLS.
 
 // MlsGroup
-pub use crate::group::{errors::*, ser::*, *};
+pub use crate::group::{core_group::Member, errors::*, ser::*, *};
 
 // Ciphersuite
 pub use crate::ciphersuite::{hash_ref::KeyPackageRef, signable::*, signature::*, *};

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -283,9 +283,8 @@ impl Client {
 
     /// Get the identity of this client in the given group.
     pub fn identity(&self, group_id: &GroupId) -> Option<Vec<u8>> {
-        // XXX: cleanup?
         let groups = self.groups.read().unwrap();
         let group = groups.get(group_id).unwrap();
-        group.own_identity().and_then(|s| Some(s.to_vec()))
+        group.own_identity().map(|s| s.to_vec())
     }
 }

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -185,17 +185,11 @@ impl Client {
     /// Get the credential and the index of each group member of the group with
     /// the given id. Returns an error if no group exists with the given group
     /// id.
-    pub fn get_members_of_group(
-        &self,
-        group_id: &GroupId,
-    ) -> Result<Vec<(usize, Credential)>, ClientError> {
+    pub fn get_members_of_group(&self, group_id: &GroupId) -> Result<Vec<Member>, ClientError> {
         let groups = self.groups.read().expect("An unexpected error occurred.");
         let group = groups.get(group_id).ok_or(ClientError::NoMatchingGroup)?;
-        let members = group.indexed_members().expect("error getting members");
-        Ok(members
-            .into_iter()
-            .map(|(index, kp)| (index as usize, kp.credential().clone()))
-            .collect())
+        let members = group.members().expect("error getting members");
+        Ok(members)
     }
 
     /// Have the client either propose or commit (depending on the
@@ -264,7 +258,7 @@ impl Client {
         &self,
         action_type: ActionType,
         group_id: &GroupId,
-        targets: &[KeyPackageRef],
+        targets: &[u32],
     ) -> Result<(Vec<MlsMessageOut>, Option<Welcome>), ClientError> {
         let mut groups = self.groups.write().expect("An unexpected error occurred.");
         let group = groups
@@ -278,7 +272,7 @@ impl Client {
             ActionType::Proposal => {
                 let mut messages = Vec::new();
                 for target in targets {
-                    let message = group.propose_remove_member(&self.crypto, target)?;
+                    let message = group.propose_remove_member(&self.crypto, *target)?;
                     messages.push(message);
                 }
                 (messages, None)
@@ -287,10 +281,11 @@ impl Client {
         Ok(action_results)
     }
 
-    /// Get the [`KeyPackageRef`] of this client in the given group.
-    pub fn key_package_ref(&self, group_id: &GroupId) -> Option<KeyPackageRef> {
-        let groups = self.groups.read().expect("An unexpected error occurred.");
-        let group = groups.get(group_id).expect("An unexpected error occurred.");
-        group.key_package_ref().cloned()
+    /// Get the identity of this client in the given group.
+    pub fn identity(&self, group_id: &GroupId) -> Option<Vec<u8>> {
+        // XXX: cleanup?
+        let groups = self.groups.read().unwrap();
+        let group = groups.get(group_id).unwrap();
+        group.own_identity().and_then(|s| Some(s.to_vec()))
     }
 }

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -38,7 +38,7 @@ use openmls_traits::{
     types::{Ciphersuite, SignatureScheme},
     OpenMlsCryptoProvider,
 };
-use rayon::prelude::*; 
+use rayon::prelude::*;
 use std::{collections::HashMap, sync::RwLock};
 use tls_codec::*;
 

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -17,7 +17,7 @@
 //! functions that are not expected to fail and throw an error, will still
 //! return a [`Result`] since they may throw a
 //! [`LibraryError`](TreeSyncDiffError::LibraryError).
-use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite, OpenMlsCryptoProvider};
+use openmls_traits::{ types::Ciphersuite, OpenMlsCryptoProvider};
 use serde::{Deserialize, Serialize};
 
 use std::{collections::HashSet, convert::TryFrom};
@@ -37,9 +37,7 @@ use crate::{
     binary_tree::{
         array_representation::diff::NodeId, LeafIndex, MlsBinaryTreeDiff, StagedMlsBinaryTreeDiff,
     },
-    ciphersuite::{
-        hash_ref::KeyPackageRef, signable::Signable, HpkePrivateKey, HpkePublicKey, Secret,
-    },
+    ciphersuite::{signable::Signable, HpkePrivateKey, HpkePublicKey, Secret},
     credentials::CredentialBundle,
     error::LibraryError,
     extensions::ExtensionType,
@@ -173,12 +171,8 @@ impl<'a> TreeSyncDiff<'a> {
     /// path.
     ///
     /// Returns the LeafIndex of the new leaf.
-    pub(crate) fn add_leaf(
-        &mut self,
-        leaf_node: KeyPackage,
-        backend: &impl OpenMlsCrypto,
-    ) -> Result<LeafIndex, TreeSyncAddLeaf> {
-        let node = Node::LeafNode(LeafNode::new(leaf_node, backend)?);
+    pub(crate) fn add_leaf(&mut self, leaf_node: KeyPackage) -> Result<LeafIndex, TreeSyncAddLeaf> {
+        let node = Node::LeafNode(LeafNode::new(leaf_node));
         // Find a free leaf and fill it with the new key package.
         let leaf_index = self.free_leaf_index()?;
         // If the free leaf index is within the tree, put the new leaf there,
@@ -288,10 +282,7 @@ impl<'a> TreeSyncDiff<'a> {
         let key_package_bundle = key_package_bundle_payload.sign(backend, credential_bundle)?;
 
         let key_package = key_package_bundle.key_package().clone();
-        let node = Node::LeafNode(LeafNode::new_from_bundle(
-            key_package_bundle,
-            backend.crypto(),
-        )?);
+        let node = Node::LeafNode(LeafNode::new_from_bundle(key_package_bundle));
 
         // Replace the leaf.
         self.diff
@@ -332,7 +323,7 @@ impl<'a> TreeSyncDiff<'a> {
         };
 
         // Replace the leaf.
-        let node = Node::LeafNode(LeafNode::new(key_package, backend.crypto())?);
+        let node = Node::LeafNode(LeafNode::new(key_package));
         self.diff
             .replace_leaf(sender_leaf_index, node.into())
             // We assume the sender leaf is in the tree
@@ -916,26 +907,26 @@ impl<'a> TreeSyncDiff<'a> {
         Ok(nodes)
     }
 
-    /// Returns the [`KeyPackageRef`] for the own leaf in the tree resulting from
-    /// merging this diff.
-    ///
-    /// Returns an error if the own leaf is not in the tree.
-    pub(crate) fn hash_ref(&self) -> Result<&KeyPackageRef, LibraryError> {
-        let node = self
-            .diff
-            .node(
-                self.diff
-                    .leaf(self.own_leaf_index)
-                    .map_err(|_| LibraryError::custom("Expected own leaf to be in the tree"))?,
-            )
-            .map_err(|_| LibraryError::custom("Expected own leaf to be in the tree"))?;
-        if let Some(Node::LeafNode(node)) = node.node() {
-            node.key_package_ref()
-                .ok_or_else(|| LibraryError::custom("missing key package ref"))
-        } else {
-            Err(LibraryError::custom("missing leaf node"))
-        }
-    }
+    // /// Returns the [`KeyPackageRef`] for the own leaf in the tree resulting from
+    // /// merging this diff.
+    // ///
+    // /// Returns an error if the own leaf is not in the tree.
+    // pub(crate) fn hash_ref(&self) -> Result<&KeyPackageRef, LibraryError> {
+    //     let node = self
+    //         .diff
+    //         .node(
+    //             self.diff
+    //                 .leaf(self.own_leaf_index)
+    //                 .map_err(|_| LibraryError::custom("Expected own leaf to be in the tree"))?,
+    //         )
+    //         .map_err(|_| LibraryError::custom("Expected own leaf to be in the tree"))?;
+    //     if let Some(Node::LeafNode(node)) = node.node() {
+    //         node.key_package_ref()
+    //             .ok_or_else(|| LibraryError::custom("missing key package ref"))
+    //     } else {
+    //         Err(LibraryError::custom("missing leaf node"))
+    //     }
+    // }
 
     /// Get the length of the direct path of the given [`LeafIndex`].
     pub(super) fn direct_path_len(&self, leaf_index: LeafIndex) -> Result<usize, OutOfBoundsError> {

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -17,7 +17,7 @@
 //! functions that are not expected to fail and throw an error, will still
 //! return a [`Result`] since they may throw a
 //! [`LibraryError`](TreeSyncDiffError::LibraryError).
-use openmls_traits::{ types::Ciphersuite, OpenMlsCryptoProvider};
+use openmls_traits::{types::Ciphersuite, OpenMlsCryptoProvider};
 use serde::{Deserialize, Serialize};
 
 use std::{collections::HashSet, convert::TryFrom};

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -907,27 +907,6 @@ impl<'a> TreeSyncDiff<'a> {
         Ok(nodes)
     }
 
-    // /// Returns the [`KeyPackageRef`] for the own leaf in the tree resulting from
-    // /// merging this diff.
-    // ///
-    // /// Returns an error if the own leaf is not in the tree.
-    // pub(crate) fn hash_ref(&self) -> Result<&KeyPackageRef, LibraryError> {
-    //     let node = self
-    //         .diff
-    //         .node(
-    //             self.diff
-    //                 .leaf(self.own_leaf_index)
-    //                 .map_err(|_| LibraryError::custom("Expected own leaf to be in the tree"))?,
-    //         )
-    //         .map_err(|_| LibraryError::custom("Expected own leaf to be in the tree"))?;
-    //     if let Some(Node::LeafNode(node)) = node.node() {
-    //         node.key_package_ref()
-    //             .ok_or_else(|| LibraryError::custom("missing key package ref"))
-    //     } else {
-    //         Err(LibraryError::custom("missing leaf node"))
-    //     }
-    // }
-
     /// Get the length of the direct path of the given [`LeafIndex`].
     pub(super) fn direct_path_len(&self, leaf_index: LeafIndex) -> Result<usize, OutOfBoundsError> {
         Ok(self.diff.direct_path(leaf_index)?.len())

--- a/openmls/src/treesync/errors.rs
+++ b/openmls/src/treesync/errors.rs
@@ -62,15 +62,18 @@ pub enum ApplyUpdatePathError {
 
 // === Crate errors ===
 
+// TODO: This will go away in #819 again.
+// `UnsupportedExtension` is only used in tests for now
+#[allow(dead_code)]
 /// TreeSync error
 #[derive(Error, Debug, PartialEq, Clone)]
 pub(crate) enum TreeSyncError {
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
-    /// Found two KeyPackages with the same public key.
-    #[error("Found two KeyPackages with the same public key.")]
-    KeyPackageRefNotInTree,
+    /// A requested leaf is not in the tree.
+    #[error("The leaf does not exist in the tree.")]
+    LeafNotInTree,
     /// See [`TreeSyncSetPathError`] for more details.
     #[error(transparent)]
     SetPathError(#[from] TreeSyncSetPathError),
@@ -95,6 +98,9 @@ pub(crate) enum TreeSyncError {
     /// See [`CryptoError`] for more details.
     #[error(transparent)]
     CryptoError(#[from] CryptoError),
+    /// An extension type is not supported by a leaf in the tree.
+    #[error("An extension type is not supported by a leaf in the tree.")]
+    UnsupportedExtension,
 }
 
 /// TreeSync set path error

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -1,10 +1,9 @@
 //! This module contains the [`LeafNode`] struct and its implementation.
-use openmls_traits::crypto::OpenMlsCrypto;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ciphersuite::{hash_ref::KeyPackageRef, HpkePrivateKey, HpkePublicKey},
-    error::LibraryError,
+    binary_tree::LeafIndex,
+    ciphersuite::{HpkePrivateKey, HpkePublicKey},
     key_packages::{KeyPackage, KeyPackageBundle},
 };
 
@@ -12,7 +11,10 @@ use crate::{
 /// potentially a corresponding `HpkePrivateKey`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LeafNode {
-    key_package_ref: Option<KeyPackageRef>,
+    // TODO[FK]: The entire leaf node will change as part of #819
+    /// The position of this leaf in the tree.
+    /// Note that this can be `None` when the leaf is not in the tree yet.
+    leaf_index: Option<LeafIndex>,
     key_package: KeyPackage,
     private_key_option: Option<HpkePrivateKey>,
 }
@@ -29,44 +31,23 @@ impl PartialEq for LeafNode {
 
 impl LeafNode {
     /// Build a new [`LeafNode`] from a [`KeyPackage`].
-    pub(crate) fn new(
-        key_package: KeyPackage,
-        backend: &impl OpenMlsCrypto,
-    ) -> Result<Self, LibraryError> {
-        let key_package_ref = Some(key_package.hash_ref(backend)?);
-        Ok(Self {
-            key_package_ref,
-            key_package,
-            private_key_option: None,
-        })
-    }
-
-    /// Build a new [`LeafNode`] from a [`KeyPackage`] and the corresponding
-    /// [`KeyPackageRef`].
-    pub(crate) fn new_with_ref(
-        key_package: KeyPackage,
-        key_package_ref: Option<KeyPackageRef>,
-    ) -> Self {
+    pub(crate) fn new(key_package: KeyPackage) -> Self {
         Self {
-            key_package_ref,
             key_package,
             private_key_option: None,
+            leaf_index: None,
         }
     }
 
     /// Build a new [`LeafNode`] from a [`KeyPackageBundle`].
-    pub(crate) fn new_from_bundle(
-        key_package_bundle: KeyPackageBundle,
-        backend: &impl OpenMlsCrypto,
-    ) -> Result<Self, LibraryError> {
+    pub(crate) fn new_from_bundle(key_package_bundle: KeyPackageBundle) -> Self {
         let key_package = key_package_bundle.key_package;
         let private_key_option = Some(key_package_bundle.private_key);
-        let key_package_ref = Some(key_package.hash_ref(backend)?);
-        Ok(Self {
-            key_package_ref,
+        Self {
             key_package,
             private_key_option,
-        })
+            leaf_index: None,
+        }
     }
 
     /// Return a reference to the `public_key` of the [`KeyPackage`] in this
@@ -98,30 +79,14 @@ impl LeafNode {
     pub fn key_package(&self) -> &KeyPackage {
         &self.key_package
     }
-
-    /// Return a [`KeyPackageRef`] of this node('s key package).
-    /// Note that this returns `None` if the key package reference has not been
-    /// set explicitly with [`Self::set_key_package_ref()`].
-    pub(crate) fn key_package_ref(&self) -> Option<&KeyPackageRef> {
-        self.key_package_ref.as_ref()
-    }
-
-    /// Set the [`KeyPackageRef`] for this leaf node.
-    pub(crate) fn set_key_package_ref(
-        &mut self,
-        backend: &impl OpenMlsCrypto,
-    ) -> Result<(), LibraryError> {
-        self.key_package_ref = Some(self.key_package.hash_ref(backend)?);
-        Ok(())
-    }
 }
 
 impl From<KeyPackage> for LeafNode {
     fn from(key_package: KeyPackage) -> Self {
         LeafNode {
-            key_package_ref: None,
             key_package,
             private_key_option: None,
+            leaf_index: None,
         }
     }
 }

--- a/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
+++ b/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
@@ -64,7 +64,7 @@ fn test_free_leaf_computation(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
         .free_leaf_index()
         .expect("error computing free leaf index");
     let added_leaf_index = diff
-        .add_leaf(kpb_2.key_package().clone(), backend.crypto())
+        .add_leaf(kpb_2.key_package().clone())
         .expect("error adding leaf");
     assert_eq!(free_leaf_index, 1u32);
     assert_eq!(free_leaf_index, added_leaf_index);

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -242,7 +242,7 @@ impl UpdatePathNode {
 pub(crate) struct PlaintextSecret {
     public_key: HpkePublicKey,
     group_secrets_bytes: Vec<u8>,
-    key_package_ref: KeyPackageRef,
+    new_member: KeyPackageRef,
 }
 
 impl PlaintextSecret {
@@ -292,7 +292,7 @@ impl PlaintextSecret {
             plaintext_secrets.push(PlaintextSecret {
                 public_key: key_package.hpke_init_key().clone(),
                 group_secrets_bytes,
-                key_package_ref: key_package.hash_ref(backend.crypto())?,
+                new_member: key_package.hash_ref(backend.crypto())?,
             });
         }
         Ok(plaintext_secrets)
@@ -314,7 +314,7 @@ impl PlaintextSecret {
             &[],
             &self.group_secrets_bytes,
         );
-        EncryptedGroupSecrets::new(self.key_package_ref, encrypted_group_secrets)
+        EncryptedGroupSecrets::new(self.new_member, encrypted_group_secrets)
     }
 }
 

--- a/openmls/src/treesync/treesync_node.rs
+++ b/openmls/src/treesync/treesync_node.rs
@@ -59,10 +59,9 @@ impl TreeSyncNode {
     pub(in crate::treesync) fn node_without_private_key(&self) -> Option<Node> {
         if let Some(node) = self.node() {
             match node {
-                Node::LeafNode(leaf_node) => Node::LeafNode(LeafNode::new_with_ref(
-                    leaf_node.key_package().clone(),
-                    leaf_node.key_package_ref().cloned(),
-                )),
+                Node::LeafNode(leaf_node) => {
+                    Node::LeafNode(LeafNode::new(leaf_node.key_package().clone()))
+                }
                 Node::ParentNode(parent_node) => {
                     Node::ParentNode(parent_node.clone_without_private_key())
                 }

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -1110,7 +1110,6 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     let bob_key_package =
         generate_key_package_bundle(&[ciphersuite], bob_credential_bundle.credential(), backend)
             .expect("An unexpected error occurred.");
-    let bob_kp_ref = bob_key_package.hash_ref(backend.crypto()).unwrap();
 
     // ANCHOR: external_join_proposal
     let proposal = JoinProposal::new(
@@ -1136,28 +1135,28 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
             let (_commit, welcome) = alice_group
                 .commit_to_pending_proposals(backend)
                 .expect("Could not commit");
-            assert_eq!(alice_group.members().len(), 1);
+            assert_eq!(alice_group.members().unwrap().len(), 1);
             alice_group
                 .merge_pending_commit()
                 .expect("Could not merge commit");
-            assert_eq!(alice_group.members().len(), 2);
+            assert_eq!(alice_group.members().unwrap().len(), 2);
 
             let bob_group =
                 MlsGroup::new_from_welcome(backend, &mls_group_config, welcome.unwrap(), None)
                     .expect("Bob could not join the group");
-            assert_eq!(bob_group.members().len(), 2);
+            assert_eq!(bob_group.members().unwrap().len(), 2);
         }
         _ => unreachable!(),
     }
     // ANCHOR_END: decrypt_external_join_proposal
     // now cleanup
     alice_group
-        .remove_members(backend, &[bob_kp_ref])
+        .remove_members(backend, &[1])
         .expect("Could not remove Bob");
     alice_group
         .merge_pending_commit()
         .expect("Could not nerge commit");
-    assert_eq!(alice_group.members().len(), 1);
+    assert_eq!(alice_group.members().unwrap().len(), 1);
 
     // === Save the group state ===
 

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -228,9 +228,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         // Check that Alice added Bob
         assert!(matches!(
             add.sender(),
-            Sender::Member(member) if member == alice_group
-            .key_package_ref()
-            .expect("An unexpected error occurred.")
+            Sender::Member(member) if *member == alice_group.own_leaf_index()
         ));
     } else {
         unreachable!("Expected a StagedCommit.");
@@ -241,12 +239,20 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         .expect("error merging pending commit");
 
     // Check that the group now has two members
-    assert_eq!(alice_group.members().len(), 2);
+    assert_eq!(
+        alice_group
+            .members()
+            .expect("Library error getting group member list")
+            .len(),
+        2
+    );
 
     // Check that Alice & Bob are the members of the group
-    let members = alice_group.members();
-    assert_eq!(members[0].credential().identity(), b"Alice");
-    assert_eq!(members[1].credential().identity(), b"Bob");
+    let members = alice_group
+        .members()
+        .expect("Library error getting group member list");
+    assert_eq!(members[0].identity, b"Alice");
+    assert_eq!(members[1].identity, b"Bob");
 
     // ANCHOR: bob_joins_with_welcome
     let mut bob_group = MlsGroup::new_from_welcome(
@@ -259,7 +265,14 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     // ANCHOR_END: bob_joins_with_welcome
 
     // Make sure that both groups have the same members
-    assert_eq!(alice_group.members(), bob_group.members());
+    assert_eq!(
+        alice_group
+            .members()
+            .expect("Library error getting group member list"),
+        bob_group
+            .members()
+            .expect("Library error getting group member list")
+    );
 
     // Make sure that both groups have the same epoch authenticator
     assert_eq!(
@@ -399,9 +412,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         // Check that Alice sent the proposal
         assert!(matches!(
             staged_proposal.sender(),
-            Sender::Member(member) if member == alice_group
-            .key_package_ref()
-            .expect("An unexpected error occurred.")
+            Sender::Member(member) if *member == alice_group.own_leaf_index()
         ));
         bob_group.store_pending_proposal(*staged_proposal);
     } else {
@@ -503,25 +514,13 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     );
 
     // Check that Alice, Bob & Charlie are the members of the group
-    let members = alice_group.members();
-    assert_eq!(members[0].credential().identity(), b"Alice");
-    assert_eq!(members[1].credential().identity(), b"Bob");
-    assert_eq!(members[2].credential().identity(), b"Charlie");
+    let members = alice_group
+        .members()
+        .expect("Library error getting group member list");
+    assert_eq!(members[0].identity, b"Alice");
+    assert_eq!(members[1].identity, b"Bob");
+    assert_eq!(members[2].identity, b"Charlie");
     assert_eq!(members.len(), 3);
-
-    // Check that the `member` and the `members` function are consistent
-    for member in members {
-        assert_eq!(
-            alice_group
-                .member(
-                    &member
-                        .hash_ref(backend.crypto())
-                        .expect("Error creating KeyPackage ref"),
-                )
-                .expect("Couldn't find member KeyPackage via the `member` function."),
-            member
-        )
-    }
 
     // === Charlie sends a message to the group ===
     let message_charlie = b"Hi, I'm Charlie!";
@@ -606,28 +605,32 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     );
 
     // ANCHOR: retrieve_members
-    let charlie_members = charlie_group.members();
+    let charlie_members = charlie_group
+        .members()
+        .expect("Library error getting group member list");
     // ANCHOR_END: retrieve_members
 
-    let bob_kp_ref = charlie_members
+    let bob_member = charlie_members
         .iter()
-        .find(|&kp| kp.credential().identity() == b"Bob")
-        .expect("Couldn't find Bob in the list of group members.")
-        .hash_ref(backend.crypto())
-        .expect("Error computing hash reference.");
+        .find(
+            |Member {
+                 index: _, identity, ..
+             }| identity == b"Bob",
+        )
+        .expect("Couldn't find Bob in the list of group members.");
 
     // Make sure that this is Bob's actual KP reference.
     assert_eq!(
-        &bob_kp_ref,
+        bob_member.identity,
         bob_group
-            .key_package_ref()
+            .own_identity()
             .expect("An unexpected error occurred.")
     );
 
     // === Charlie removes Bob ===
     // ANCHOR: charlie_removes_bob
     let (mls_message_out, welcome_option) = charlie_group
-        .remove_members(backend, &[bob_kp_ref])
+        .remove_members(backend, &[bob_member.index])
         .expect("Could not remove Bob from group.");
     // ANCHOR_END: charlie_removes_bob
 
@@ -640,14 +643,21 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
 
     // Check that alice can use the member list to check if the message is
     // actually from Charlie.
-    let alice_members = alice_group.members();
+    let alice_members = alice_group
+        .members()
+        .expect("Library error getting group member list");
     let sender_credential = unverified_message
         .credential()
         .expect("Couldn't retrieve credential from unverified message.");
 
-    assert!(alice_members
-        .iter()
-        .any(|kp| kp.credential() == sender_credential));
+    assert!(alice_members.iter().any(
+        |Member {
+             index: _,
+             identity: _,
+             encryption_key: _,
+             signature_key,
+         }| signature_key.as_slice() == sender_credential.signature_key().as_slice()
+    ));
 
     assert_eq!(sender_credential, &charlie_credential);
 
@@ -660,10 +670,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     let bob_processed_message = bob_group
         .process_unverified_message(unverified_message, None, backend)
         .expect("Could not process unverified message.");
-    let charlies_old_kpr = charlie_group
-        .key_package_ref()
-        .cloned()
-        .expect("An unexpected error occurred.");
+    let charlies_leaf_index = charlie_group.own_leaf_index();
     charlie_group
         .merge_pending_commit()
         .expect("error merging pending commit");
@@ -679,14 +686,12 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         // Check that Bob was removed
         assert_eq!(
             remove.remove_proposal().removed(),
-            bob_group
-                .key_package_ref()
-                .expect("An unexpected error occurred.")
+            bob_group.own_leaf_index()
         );
         // Check that Charlie removed Bob
         assert!(matches!(
             remove.sender(),
-            Sender::Member(member) if member == &charlies_old_kpr
+            Sender::Member(member) if *member == charlies_leaf_index
         ));
         // Merge staged commit
         alice_group
@@ -715,7 +720,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
             RemoveOperation::WeLeft => unreachable!(),
             // We expect this variant, since Bob was removed by Charlie
             RemoveOperation::WeWereRemovedBy(member) => {
-                assert!(matches!(member, Sender::Member(member) if member == charlies_old_kpr));
+                assert!(matches!(member, Sender::Member(member) if member == charlies_leaf_index));
             }
             RemoveOperation::TheyLeft(_) => unreachable!(),
             RemoveOperation::TheyWereRemovedBy(_) => unreachable!(),
@@ -736,10 +741,12 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
 
     // Check that Bob's group is no longer active
     assert!(!bob_group.is_active());
-    let members = bob_group.members();
+    let members = bob_group
+        .members()
+        .expect("Library error getting group member list");
     assert_eq!(members.len(), 2);
-    assert_eq!(members[0].credential().identity(), b"Alice");
-    assert_eq!(members[1].credential().identity(), b"Charlie");
+    assert_eq!(members[0].identity, b"Alice");
+    assert_eq!(members[1].identity, b"Charlie");
     // ANCHOR_END: getting_removed
 
     // Make sure that all groups have the same public tree
@@ -749,12 +756,20 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     );
 
     // Make sure the group only contains two members
-    assert_eq!(alice_group.members().len(), 2);
+    assert_eq!(
+        alice_group
+            .members()
+            .expect("Library error getting group member list")
+            .len(),
+        2
+    );
 
     // Check that Alice & Charlie are the members of the group
-    let members = alice_group.members();
-    assert_eq!(members[0].credential().identity(), b"Alice");
-    assert_eq!(members[1].credential().identity(), b"Charlie");
+    let members = alice_group
+        .members()
+        .expect("Library error getting group member list");
+    assert_eq!(members[0].identity, b"Alice");
+    assert_eq!(members[1].identity, b"Charlie");
 
     // Check that Bob can no longer send messages
     assert!(bob_group
@@ -770,12 +785,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     // Create RemoveProposal and process it
     // ANCHOR: propose_remove
     let mls_message_out = alice_group
-        .propose_remove_member(
-            backend,
-            charlie_group
-                .key_package_ref()
-                .expect("An unexpected error occurred."),
-        )
+        .propose_remove_member(backend, charlie_group.own_leaf_index())
         .expect("Could not create proposal to remove Charlie.");
     // ANCHOR_END: propose_remove
 
@@ -790,12 +800,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     if let ProcessedMessage::ProposalMessage(staged_proposal) = charlie_processed_message {
         if let Proposal::Remove(ref remove_proposal) = staged_proposal.proposal() {
             // Check that Charlie was removed
-            assert_eq!(
-                remove_proposal.removed(),
-                charlie_group
-                    .key_package_ref()
-                    .expect("An unexpected error occurred.")
-            );
+            assert_eq!(remove_proposal.removed(), charlie_group.own_leaf_index());
             // Store proposal
             charlie_group.store_pending_proposal(*staged_proposal.clone());
         } else {
@@ -805,9 +810,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         // Check that Alice removed Charlie
         assert!(matches!(
             staged_proposal.sender(),
-            Sender::Member(member) if member == alice_group
-            .key_package_ref()
-            .expect("An unexpected error occurred.")
+            Sender::Member(member) if *member == alice_group.own_leaf_index()
         ));
     } else {
         unreachable!("Expected a QueuedProposal.");
@@ -841,9 +844,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         // Check that Alice added Bob
         assert!(matches!(
             staged_proposal.sender(),
-            Sender::Member(member) if member == alice_group
-            .key_package_ref()
-            .expect("An unexpected error occurred.")
+            Sender::Member(member) if *member == alice_group.own_leaf_index()
         ));
         // Store proposal
         charlie_group.store_pending_proposal(*staged_proposal);
@@ -880,12 +881,20 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     }
 
     // Make sure the group contains two members
-    assert_eq!(alice_group.members().len(), 2);
+    assert_eq!(
+        alice_group
+            .members()
+            .expect("Library error getting group member list")
+            .len(),
+        2
+    );
 
     // Check that Alice & Bob are the members of the group
-    let members = alice_group.members();
-    assert_eq!(members[0].credential().identity(), b"Alice");
-    assert_eq!(members[1].credential().identity(), b"Bob");
+    let members = alice_group
+        .members()
+        .expect("Library error getting group member list");
+    assert_eq!(members[0].identity, b"Alice");
+    assert_eq!(members[1].identity, b"Bob");
 
     // Bob creates a new group
     let mut bob_group = MlsGroup::new_from_welcome(
@@ -897,20 +906,36 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     .expect("Error creating group from Welcome");
 
     // Make sure the group contains two members
-    assert_eq!(alice_group.members().len(), 2);
+    assert_eq!(
+        alice_group
+            .members()
+            .expect("Library error getting group member list")
+            .len(),
+        2
+    );
 
     // Check that Alice & Bob are the members of the group
-    let members = alice_group.members();
-    assert_eq!(members[0].credential().identity(), b"Alice");
-    assert_eq!(members[1].credential().identity(), b"Bob");
+    let members = alice_group
+        .members()
+        .expect("Library error getting group member list");
+    assert_eq!(members[0].identity, b"Alice");
+    assert_eq!(members[1].identity, b"Bob");
 
     // Make sure the group contains two members
-    assert_eq!(bob_group.members().len(), 2);
+    assert_eq!(
+        bob_group
+            .members()
+            .expect("Library error getting group member list")
+            .len(),
+        2
+    );
 
     // Check that Alice & Bob are the members of the group
-    let members = bob_group.members();
-    assert_eq!(members[0].credential().identity(), b"Alice");
-    assert_eq!(members[1].credential().identity(), b"Bob");
+    let members = bob_group
+        .members()
+        .expect("Library error getting group member list");
+    assert_eq!(members[0].identity, b"Alice");
+    assert_eq!(members[1].identity, b"Bob");
 
     // === Alice sends a message to the group ===
     let message_alice = b"Hi, I'm Alice!";
@@ -930,9 +955,9 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
 
     // As provided by looking up the sender manually via the `member()` function
     // ANCHOR: member_lookup
-    let sender_cred_from_group = if let Sender::Member(hash_ref) = unverified_message.sender() {
+    let sender_cred_from_group = if let Sender::Member(sender_index) = unverified_message.sender() {
         bob_group
-            .member(hash_ref)
+            .member(*sender_index)
             .expect("Could not find sender in group.")
             .credential()
             .clone()
@@ -1006,16 +1031,12 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         // Check that Bob was removed
         assert_eq!(
             remove.remove_proposal().removed(),
-            bob_group
-                .key_package_ref()
-                .expect("An unexpected error occurred.")
+            bob_group.own_leaf_index()
         );
         // Check that Bob removed himself
         assert!(matches!(
             remove.sender(),
-            Sender::Member(member) if member == bob_group
-            .key_package_ref()
-            .expect("An unexpected error occurred.")
+            Sender::Member(member) if *member == bob_group.own_leaf_index()
         ));
         // Merge staged Commit
     } else {
@@ -1042,16 +1063,12 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         // Check that Bob was removed
         assert_eq!(
             remove.remove_proposal().removed(),
-            bob_group
-                .key_package_ref()
-                .expect("An unexpected error occurred.")
+            bob_group.own_leaf_index()
         );
         // Check that Bob removed himself
         assert!(matches!(
             remove.sender(),
-            Sender::Member(member) if member == bob_group
-            .key_package_ref()
-            .expect("An unexpected error occurred.")
+            Sender::Member(member) if *member == bob_group.own_leaf_index()
         ));
         assert!(staged_commit.self_removed());
         // Merge staged Commit
@@ -1066,11 +1083,19 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     assert!(!bob_group.is_active());
 
     // Make sure the group contains one member
-    assert_eq!(alice_group.members().len(), 1);
+    assert_eq!(
+        alice_group
+            .members()
+            .expect("Library error getting group member list")
+            .len(),
+        1
+    );
 
     // Check that Alice is the only member of the group
-    let members = alice_group.members();
-    assert_eq!(members[0].credential().identity(), b"Alice");
+    let members = alice_group
+        .members()
+        .expect("Library error getting group member list");
+    assert_eq!(members[0].identity, b"Alice");
 
     // === Re-Add Bob with external Add proposal ===
 

--- a/openmls/tests/test_decryption_key_index.rs
+++ b/openmls/tests/test_decryption_key_index.rs
@@ -41,11 +41,8 @@ fn decryption_key_index_computation(ciphersuite: Ciphersuite) {
         .find(|(index, _)| index == &0)
         .expect("An unexpected error occurred.")
         .clone();
-    let kpr_2 = setup
-        .key_package_ref_by_index(2, group)
-        .expect("Couldn't get key package reference.");
     setup
-        .remove_clients(ActionType::Commit, group, remover_id, &[kpr_2])
+        .remove_clients(ActionType::Commit, group, remover_id, &[2])
         .expect("An unexpected error occurred.");
 
     // Then we have the member at index 7 remove the one at index 3. This
@@ -60,11 +57,8 @@ fn decryption_key_index_computation(ciphersuite: Ciphersuite) {
         .find(|(index, _)| index == &7)
         .expect("An unexpected error occurred.")
         .clone();
-    let kpr_3 = setup
-        .key_package_ref_by_index(3, group)
-        .expect("Couldn't get key package reference.");
     setup
-        .remove_clients(ActionType::Commit, group, remover_id, &[kpr_3])
+        .remove_clients(ActionType::Commit, group, remover_id, &[3])
         .expect("An unexpected error occurred.");
 
     // Since the decryption failure doesn't cause a panic, but only an error

--- a/openmls/tests/test_interop_scenarios.rs
+++ b/openmls/tests/test_interop_scenarios.rs
@@ -242,13 +242,10 @@ fn remove(ciphersuite: Ciphersuite) {
         .last()
         .expect("An unexpected error occurred.")
         .clone();
-    let bob_kpr = setup
-        .key_package_ref_by_index(bob_index, group)
-        .expect("Couldn't get key package reference.");
 
     // Have alice remove Bob.
     setup
-        .remove_clients(ActionType::Commit, group, &alice_id, &[bob_kpr])
+        .remove_clients(ActionType::Commit, group, &alice_id, &[bob_index as u32])
         .expect("Error removing Bob from the group.");
 
     // Check that group members agree on a group state.
@@ -306,11 +303,8 @@ fn large_group_lifecycle(ciphersuite: Ciphersuite) {
         while remover_id == target_id {
             target_id = group.random_group_member();
         }
-        let target_kpr = setup
-            .key_package_ref_by_id(&target_id, group)
-            .expect("Couldn't get key package reference.");
         setup
-            .remove_clients(ActionType::Commit, group, &remover_id, &[target_kpr])
+            .remove_clients(ActionType::Commit, group, &remover_id.1, &[target_id.0])
             .expect("Error while removing group member.");
         group_members = group.members.clone();
         setup.check_group_states(group);

--- a/openmls/tests/test_managed_api.rs
+++ b/openmls/tests/test_managed_api.rs
@@ -35,12 +35,14 @@ fn test_mls_group_api(ciphersuite: Ciphersuite) {
 
     // Remove a member
     let (_, remover_id) = group.members[2].clone();
-    let (_, target_id) = group.members[3].clone();
-    let target_kpr = setup
-        .key_package_ref_by_id(&target_id, group)
-        .expect("Couldn't get key package reference.");
+    let (target_index, _) = group.members[3].clone();
     setup
-        .remove_clients(ActionType::Commit, group, &remover_id, &[target_kpr])
+        .remove_clients(
+            ActionType::Commit,
+            group,
+            &remover_id,
+            &[target_index as u32],
+        )
         .expect("An unexpected error occurred.");
 
     // Check that all group members agree on the same group state.


### PR DESCRIPTION
This is the first PR to tackle #819.

It only replaces key package references with leaf indices for now in a minimally intrusive way. Unfortunately quite some code in here will be rewritten again as soon as the content moves from the key package to the leaf node. But this should still be easier to review than doing it all at once.

This PR also introduces a `Member` struct with some identifying content for members, namely leaf index, encryption key, and signature key. This will probably need refinement later but combines information that allows us to uniquely identify members in the tree.