### PR TITLE
feat: use an allowlist for validating external commit proposals

### DIFF
--- a/book/src/message_validation.md
+++ b/book/src/message_validation.md
@@ -83,13 +83,12 @@ The following is a list of the individual semantic validation steps performed by
 
 ### External Commit message validation
 
-| ValidationStep | Description                                                                            | Implemented | Tested | Test File                                                    |
-| -------------- | -------------------------------------------------------------------------------------- | ----------- | ------ | ------------------------------------------------------------ |
-| `ValSem240`    | External Commit must cover at least one inline ExternalInit proposal                   | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem241`    | External Commit must cover at most one inline ExternalInit proposal                    | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem242`    | External Commit must not cover any inline Add proposals                                | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem243`    | External Commit must not cover any inline Update proposals                             | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem244`    | Identity of inline Remove proposal target and external committer must be the same      | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem245`    | External Commit must not cover any ExternalInit proposals by reference                 | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem246`    | External Commit must contain a path                                                    | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem247`    | External Commit signature must be verified using the credential in the path KeyPackage | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| ValidationStep | Description                                                                                       | Implemented | Tested | Test File                                                    |
+|----------------|---------------------------------------------------------------------------------------------------|-------------|--------|--------------------------------------------------------------|
+| `ValSem240`    | External Commit must cover at least one inline ExternalInit proposal                              | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem241`    | External Commit must cover at most one inline ExternalInit proposal                               | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem242`    | External Commit must only cover inline proposal in allowlist (ExternalInit, Remove, PreSharedKey) | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem243`    | Identity of inline Remove proposal target and external committer must be the same                 | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem244`    | External Commit must not cover any ExternalInit proposals by reference                            | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem245`    | External Commit must contain a path                                                               | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem246`    | External Commit signature must be verified using the credential in the path KeyPackage            | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -134,9 +134,9 @@ impl DecryptedMessage {
     /// Gets the correct credential from the message depending on the sender type.
     /// Checks the following semantic validation:
     ///  - ValSem112
-    ///  - ValSem246
-    ///  - Prepares ValSem247 by setting the right credential. The remainder
-    ///    of ValSem247 is validated as part of ValSem010.
+    ///  - ValSem245
+    ///  - Prepares ValSem246 by setting the right credential. The remainder
+    ///    of ValSem246 is validated as part of ValSem010.
     pub(crate) fn credential(
         &self,
         treesync: &TreeSync,

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -19,7 +19,7 @@ impl CoreGroup {
     ///  - ValSem007
     ///  - ValSem009
     ///  - ValSem112
-    ///  - ValSem246
+    ///  - ValSem245
     pub(crate) fn parse_message(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
@@ -56,9 +56,9 @@ impl CoreGroup {
         // Extract the credential if the sender is a member or a new member.
         // Checks the following semantic validation:
         //  - ValSem112
-        //  - ValSem246
-        //  - Prepares ValSem247 by setting the right credential. The remainder
-        //    of ValSem247 is validated as part of ValSem010.
+        //  - ValSem245
+        //  - Prepares ValSem246 by setting the right credential. The remainder
+        //    of ValSem246 is validated as part of ValSem010.
         // External senders are not supported yet #106/#151.
         let credential = decrypted_message.credential(
             self.treesync(),
@@ -102,8 +102,7 @@ impl CoreGroup {
     ///  - ValSem242
     ///  - ValSem243
     ///  - ValSem244
-    ///  - ValSem245
-    ///  - ValSem247 (as part of ValSem010)
+    ///  - ValSem246 (as part of ValSem010)
     pub(crate) fn process_unverified_message(
         &self,
         unverified_message: UnverifiedMessage,
@@ -134,7 +133,7 @@ impl CoreGroup {
             UnverifiedContextMessage::Group(unverified_message) => {
                 // Checks the following semantic validation:
                 //  - ValSem010
-                //  - ValSem247 (as part of ValSem010)
+                //  - ValSem246 (as part of ValSem010)
                 let verified_member_message = unverified_message
                     .into_verified(backend, signature_key)
                     .map_err(|_| UnverifiedMessageError::InvalidSignature)?;
@@ -179,7 +178,6 @@ impl CoreGroup {
                         //  - ValSem242
                         //  - ValSem243
                         //  - ValSem244
-                        //  - ValSem245
                         let staged_commit = self.stage_commit(
                             verified_member_message.plaintext(),
                             proposal_store,

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -48,7 +48,6 @@ impl CoreGroup {
     ///  - ValSem242
     ///  - ValSem243
     ///  - ValSem244
-    ///  - ValSem245
     /// Returns an error if the given commit was sent by the owner of this
     /// group.
     pub(crate) fn stage_commit(
@@ -142,11 +141,10 @@ impl CoreGroup {
             Sender::NewMemberCommit => {
                 // ValSem240: External Commit, inline Proposals: There MUST be at least one ExternalInit proposal.
                 // ValSem241: External Commit, inline Proposals: There MUST be at most one ExternalInit proposal.
-                // ValSem242: External Commit, inline Proposals: There MUST NOT be any Add proposals.
-                // ValSem243: External Commit, inline Proposals: There MUST NOT be any Update proposals.
-                // ValSem244: External Commit, inline Remove Proposal: The identity and the endpoint_id of the removed
+                // ValSem242: External Commit must only cover inline proposal in allowlist (ExternalInit, Remove, PreSharedKey)
+                // ValSem243: External Commit, inline Remove Proposal: The identity and the endpoint_id of the removed
                 //            leaf are identical to the ones in the path KeyPackage.
-                // ValSem245: External Commit, referenced Proposals: There MUST NOT be any ExternalInit proposals.
+                // ValSem244: External Commit, referenced Proposals: There MUST NOT be any ExternalInit proposals.
                 self.validate_external_commit(&proposal_queue, commit_update_key_package.as_ref())?;
                 // Since there are no update proposals in an External Commit we have no public keys to return
                 HashSet::new()


### PR DESCRIPTION
This PR validates proposals included in an external commit by using an allowlist rather than a denylist as before. Proposals allowed in an external commit are : `ExternalInit`, `Remove` & `PreSharedKey`.
Note that I merged (and rephrased) ValSem242 & ValSem243 and also shifted the others ValSem[244..247]

Note: **There are no tests to verify PSK proposals are supported (and their cardinality) since it is not supported by external commits.** And I couldn't find any issue tracking this. Is this in draft-16 scope ? If not we should probably create an issue to track that down.

Fixes #878