### PR TITLE
Changes towards draft-16 wire format

### DIFF
--- a/openmls/src/framing/ciphertext.rs
+++ b/openmls/src/framing/ciphertext.rs
@@ -253,7 +253,7 @@ impl MlsCiphertext {
             .map_err(|_| MessageDecryptionError::MalformedContent)
     }
 
-    /// This function decrypts an [`MlsCiphertext`] into an [`VerifiableMlsPlaintext`].
+    /// This function decrypts an [`MlsCiphertext`] into an [`VerifiableMlsAuthContent`].
     /// In order to get an [`MlsPlaintext`] the result must be verified.
     pub(crate) fn to_plaintext(
         &self,
@@ -263,7 +263,7 @@ impl MlsCiphertext {
         sender_index: SecretTreeLeafIndex,
         sender_ratchet_configuration: &SenderRatchetConfiguration,
         sender_data: MlsSenderData,
-    ) -> Result<VerifiableMlsPlaintext, MessageDecryptionError> {
+    ) -> Result<VerifiableMlsAuthContent, MessageDecryptionError> {
         let secret_type = SecretType::from(&self.content_type);
         // Extract generation and key material for encryption
         let (ratchet_key, ratchet_nonce) = message_secrets
@@ -292,7 +292,7 @@ impl MlsCiphertext {
             mls_ciphertext_content.content
         );
 
-        let verifiable = VerifiableMlsPlaintext::new(
+        let verifiable = VerifiableMlsAuthContent::new(
             MlsContentTbs::new(
                 self.wire_format,
                 self.group_id.clone(),

--- a/openmls/src/framing/ciphertext.rs
+++ b/openmls/src/framing/ciphertext.rs
@@ -293,7 +293,7 @@ impl MlsCiphertext {
         );
 
         let verifiable = VerifiableMlsPlaintext::new(
-            MlsPlaintextTbs::new(
+            MlsContentTbs::new(
                 self.wire_format,
                 self.group_id.clone(),
                 self.epoch,

--- a/openmls/src/framing/ciphertext.rs
+++ b/openmls/src/framing/ciphertext.rs
@@ -36,7 +36,7 @@ pub(crate) struct MlsCiphertext {
     group_id: GroupId,
     epoch: GroupEpoch,
     content_type: ContentType,
-    authenticated_data: TlsByteVecU32,
+    authenticated_data: VLBytes,
     encrypted_sender_data: TlsByteVecU8,
     ciphertext: TlsByteVecU32,
 }
@@ -53,7 +53,7 @@ impl MlsCiphertext {
         group_id: GroupId,
         epoch: GroupEpoch,
         content_type: ContentType,
-        authenticated_data: TlsByteVecU32,
+        authenticated_data: VLBytes,
         encrypted_sender_data: TlsByteVecU8,
         ciphertext: TlsByteVecU32,
     ) -> Self {

--- a/openmls/src/framing/codec.rs
+++ b/openmls/src/framing/codec.rs
@@ -3,7 +3,7 @@ use tls_codec::{Deserialize, Serialize, Size, TlsByteVecU32, TlsByteVecU8};
 use super::*;
 use std::io::{Read, Write};
 
-impl Deserialize for VerifiableMlsPlaintext {
+impl Deserialize for VerifiableMlsAuthContent {
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error> {
         let wire_format = WireFormat::tls_deserialize(bytes)?;
         let content: MlsContent = MlsContent::tls_deserialize(bytes)?;
@@ -18,7 +18,7 @@ impl Deserialize for VerifiableMlsPlaintext {
             ));
         }
 
-        let verifiable = VerifiableMlsPlaintext::new(
+        let verifiable = VerifiableMlsAuthContent::new(
             MlsContentTbs::new(
                 wire_format,
                 content.group_id,
@@ -36,7 +36,7 @@ impl Deserialize for VerifiableMlsPlaintext {
     }
 }
 
-impl Size for VerifiableMlsPlaintext {
+impl Size for VerifiableMlsAuthContent {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
         self.tbs.wire_format.tls_serialized_len()
@@ -47,7 +47,7 @@ impl Size for VerifiableMlsPlaintext {
     }
 }
 
-impl Serialize for VerifiableMlsPlaintext {
+impl Serialize for VerifiableMlsAuthContent {
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
         let mut written = self.tbs.wire_format.tls_serialize(writer)?;
         written += self.tbs.content.tls_serialize(writer)?;
@@ -149,7 +149,7 @@ impl Deserialize for MlsMessage {
                 let wire_format = WireFormat::tls_deserialize(&mut vec![*first_byte].as_slice())?;
                 let body = match wire_format {
                     WireFormat::MlsPlaintext => {
-                        let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut chain)?;
+                        let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut chain)?;
                         MlsMessageBody::Plaintext(plaintext)
                     }
                     WireFormat::MlsCiphertext => {
@@ -171,7 +171,7 @@ impl Size for MlsMessage {
     fn tls_serialized_len(&self) -> usize {
         match &self.body {
             MlsMessageBody::Plaintext(plaintext) => {
-                VerifiableMlsPlaintext::tls_serialized_len(plaintext)
+                VerifiableMlsAuthContent::tls_serialized_len(plaintext)
             }
             MlsMessageBody::Ciphertext(ciphertext) => MlsCiphertext::tls_serialized_len(ciphertext),
         }

--- a/openmls/src/framing/codec.rs
+++ b/openmls/src/framing/codec.rs
@@ -19,7 +19,7 @@ impl Deserialize for VerifiableMlsPlaintext {
         }
 
         let verifiable = VerifiableMlsPlaintext::new(
-            MlsPlaintextTbs::new(
+            MlsContentTbs::new(
                 wire_format,
                 content.group_id,
                 content.epoch,
@@ -94,7 +94,7 @@ pub(super) fn serialize_plaintext_tbs<'a, W: Write>(
     payload.tls_serialize(buffer).map(|l| l + written)
 }
 
-impl Size for MlsPlaintextTbs {
+impl Size for MlsContentTbs {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
         let context_len = if let Some(serialized_context) = &self.serialized_context {
@@ -112,7 +112,7 @@ impl Size for MlsPlaintextTbs {
     }
 }
 
-impl Serialize for MlsPlaintextTbs {
+impl Serialize for MlsContentTbs {
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
         serialize_plaintext_tbs(
             self.serialized_context.as_deref(),

--- a/openmls/src/framing/codec.rs
+++ b/openmls/src/framing/codec.rs
@@ -107,7 +107,7 @@ impl Deserialize for MlsCiphertext {
         let group_id = GroupId::tls_deserialize(bytes)?;
         let epoch = GroupEpoch::tls_deserialize(bytes)?;
         let content_type = ContentType::tls_deserialize(bytes)?;
-        let authenticated_data = TlsByteVecU32::tls_deserialize(bytes)?;
+        let authenticated_data = VLBytes::tls_deserialize(bytes)?;
         let encrypted_sender_data = TlsByteVecU8::tls_deserialize(bytes)?;
         let ciphertext = TlsByteVecU32::tls_deserialize(bytes)?;
 

--- a/openmls/src/framing/message.rs
+++ b/openmls/src/framing/message.rs
@@ -66,7 +66,7 @@ pub(crate) struct MlsMessage {
 pub(crate) enum MlsMessageBody {
     /// Plaintext message
     #[tls_codec(discriminant = 1)]
-    Plaintext(VerifiableMlsPlaintext),
+    Plaintext(VerifiableMlsAuthContent),
 
     /// Ciphertext message
     #[tls_codec(discriminant = 2)]
@@ -189,8 +189,8 @@ pub struct MlsMessageOut {
     pub(crate) mls_message: MlsMessage,
 }
 
-impl From<VerifiableMlsPlaintext> for MlsMessageOut {
-    fn from(plaintext: VerifiableMlsPlaintext) -> Self {
+impl From<VerifiableMlsAuthContent> for MlsMessageOut {
+    fn from(plaintext: VerifiableMlsAuthContent) -> Self {
         let body = MlsMessageBody::Plaintext(plaintext);
 
         Self {
@@ -202,7 +202,7 @@ impl From<VerifiableMlsPlaintext> for MlsMessageOut {
 impl From<MlsPlaintext> for MlsMessageOut {
     fn from(plaintext: MlsPlaintext) -> Self {
         let body =
-            MlsMessageBody::Plaintext(VerifiableMlsPlaintext::from_plaintext(plaintext, None));
+            MlsMessageBody::Plaintext(VerifiableMlsAuthContent::from_plaintext(plaintext, None));
 
         Self {
             mls_message: MlsMessage { body },
@@ -268,8 +268,8 @@ impl From<MlsMessageOut> for MlsMessageIn {
 }
 
 #[cfg(any(feature = "test-utils", test))]
-impl From<VerifiableMlsPlaintext> for MlsMessageIn {
-    fn from(plaintext: VerifiableMlsPlaintext) -> Self {
+impl From<VerifiableMlsAuthContent> for MlsMessageIn {
+    fn from(plaintext: VerifiableMlsAuthContent) -> Self {
         let body = MlsMessageBody::Plaintext(plaintext);
 
         Self {

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -478,15 +478,15 @@ fn encode_tbs<'a>(
 }
 
 #[derive(PartialEq, Debug, Clone)]
-pub(crate) struct VerifiableMlsPlaintext {
+pub(crate) struct VerifiableMlsAuthContent {
     pub(super) tbs: MlsContentTbs,
     pub(super) signature: Signature,
     pub(super) confirmation_tag: Option<ConfirmationTag>,
     pub(super) membership_tag: Option<MembershipTag>,
 }
 
-impl VerifiableMlsPlaintext {
-    /// Create a new [`VerifiableMlsPlaintext`] from a [`MlsContentTbs`] and
+impl VerifiableMlsAuthContent {
+    /// Create a new [`VerifiableMlsAuthContent`] from a [`MlsContentTbs`] and
     /// a [`Signature`].
     pub(crate) fn new(
         tbs: MlsContentTbs,
@@ -502,7 +502,7 @@ impl VerifiableMlsPlaintext {
         }
     }
 
-    /// Create a [`VerifiableMlsPlaintext`] from an [`MlsPlaintext`] and the
+    /// Create a [`VerifiableMlsAuthContent`] from an [`MlsPlaintext`] and the
     /// serialized context.
     pub(crate) fn from_plaintext(
         mls_plaintext: MlsPlaintext,
@@ -744,7 +744,7 @@ impl MlsContentTbs {
     }
 }
 
-impl Verifiable for VerifiableMlsPlaintext {
+impl Verifiable for VerifiableMlsAuthContent {
     fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
         self.tbs.tls_serialize_detached()
     }
@@ -763,8 +763,8 @@ mod private_mod {
     pub(crate) struct Seal;
 }
 
-impl VerifiedStruct<VerifiableMlsPlaintext> for MlsPlaintext {
-    fn from_verifiable(v: VerifiableMlsPlaintext, _seal: Self::SealingType) -> Self {
+impl VerifiedStruct<VerifiableMlsAuthContent> for MlsPlaintext {
+    fn from_verifiable(v: VerifiableMlsAuthContent, _seal: Self::SealingType) -> Self {
         Self {
             wire_format: v.tbs.wire_format,
             content: v.tbs.content,

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -56,7 +56,7 @@ pub(crate) struct MlsContent {
     pub(crate) group_id: GroupId,
     pub(crate) epoch: GroupEpoch,
     pub(crate) sender: Sender,
-    pub(crate) authenticated_data: TlsByteVecU32,
+    pub(crate) authenticated_data: VLBytes,
 
     pub(crate) body: MlsContentBody,
 }
@@ -704,7 +704,7 @@ impl MlsContentTbs {
         group_id: GroupId,
         epoch: impl Into<GroupEpoch>,
         sender: Sender,
-        authenticated_data: TlsByteVecU32,
+        authenticated_data: VLBytes,
         body: MlsContentBody,
     ) -> Self {
         let content = MlsContent {
@@ -796,7 +796,7 @@ pub(crate) struct MlsPlaintextCommitContent<'a> {
     pub(super) group_id: &'a GroupId,
     pub(super) epoch: GroupEpoch,
     pub(super) sender: &'a Sender,
-    pub(super) authenticated_data: &'a TlsByteVecU32,
+    pub(super) authenticated_data: &'a VLBytes,
     pub(super) content_type: ContentType,
     pub(super) commit: &'a Commit,
     pub(super) signature: &'a Signature,

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -64,7 +64,7 @@ fn codec_plaintext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     let enc = orig
         .tls_serialize_detached()
         .expect("An unexpected error occurred.");
-    let mut copy = VerifiableMlsPlaintext::tls_deserialize(&mut enc.as_slice())
+    let mut copy = VerifiableMlsAuthContent::tls_deserialize(&mut enc.as_slice())
         .expect("An unexpected error occurred.");
     copy.set_context(serialized_context);
     let copy = copy
@@ -335,7 +335,7 @@ fn membership_tag(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .expect("An unexpected error occurred.");
 
     let verifiable_mls_plaintext =
-        VerifiableMlsPlaintext::from_plaintext(mls_plaintext.clone(), serialized_context.clone());
+        VerifiableMlsAuthContent::from_plaintext(mls_plaintext.clone(), serialized_context.clone());
 
     println!(
         "Membership tag error: {:?}",
@@ -350,7 +350,7 @@ fn membership_tag(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // Change the content of the plaintext message
     mls_plaintext.set_content(MlsContentBody::Application(vec![7, 8, 9].into()));
     let verifiable_mls_plaintext =
-        VerifiableMlsPlaintext::from_plaintext(mls_plaintext.clone(), serialized_context);
+        VerifiableMlsAuthContent::from_plaintext(mls_plaintext.clone(), serialized_context);
 
     // Expect the signature & membership tag verification to fail
     assert!(verifiable_mls_plaintext
@@ -760,7 +760,7 @@ fn invalid_plaintext_signature(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
     //     .tls_serialize_detached()
     //     .expect("An unexpected error occurred.");
     // let mut input_commit =
-    //     VerifiableMlsPlaintext::tls_deserialize(&mut original_encoded_commit.as_slice())
+    //     VerifiableMlsAuthContent::tls_deserialize(&mut original_encoded_commit.as_slice())
     //         .expect("An unexpected error occurred.");
     // let original_input_commit = input_commit.clone();
 
@@ -814,7 +814,7 @@ fn invalid_plaintext_signature(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
     //     .commit
     //     .tls_serialize_detached()
     //     .expect("An unexpected error occurred.");
-    // let input_commit = VerifiableMlsPlaintext::tls_deserialize(&mut encoded_commit.as_slice())
+    // let input_commit = VerifiableMlsAuthContent::tls_deserialize(&mut encoded_commit.as_slice())
     //     .expect("An unexpected error occurred.");
     // let decoded_commit = group_bob.verify(input_commit, backend);
     // assert_eq!(
@@ -880,7 +880,7 @@ fn invalid_plaintext_signature(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
     //     .commit
     //     .tls_serialize_detached()
     //     .expect("An unexpected error occurred.");
-    // let input_commit = VerifiableMlsPlaintext::tls_deserialize(&mut encoded_commit.as_slice())
+    // let input_commit = VerifiableMlsAuthContent::tls_deserialize(&mut encoded_commit.as_slice())
     //     .expect("An unexpected error occurred.");
     // let decoded_commit = group_bob
     //     .verify(input_commit, backend)

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -48,7 +48,7 @@ fn codec_plaintext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     let serialized_context = group_context
         .tls_serialize_detached()
         .expect("An unexpected error occurred.");
-    let signature_input = MlsPlaintextTbs::new(
+    let signature_input = MlsContentTbs::new(
         WireFormat::MlsPlaintext,
         GroupId::random(backend),
         1,
@@ -97,7 +97,7 @@ fn codec_ciphertext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     let serialized_context = group_context
         .tls_serialize_detached()
         .expect("An unexpected error occurred.");
-    let signature_input = MlsPlaintextTbs::new(
+    let signature_input = MlsContentTbs::new(
         WireFormat::MlsCiphertext,
         GroupId::random(backend),
         1,
@@ -176,7 +176,7 @@ fn wire_format_checks(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProv
     let serialized_context = group_context
         .tls_serialize_detached()
         .expect("An unexpected error occurred.");
-    let signature_input = MlsPlaintextTbs::new(
+    let signature_input = MlsContentTbs::new(
         WireFormat::MlsCiphertext,
         GroupId::random(backend),
         1,

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -52,11 +52,11 @@ use super::*;
 ///  - ValSem007
 ///  - ValSem009
 pub(crate) struct DecryptedMessage {
-    plaintext: VerifiableMlsPlaintext,
+    plaintext: VerifiableMlsAuthContent,
 }
 
 impl DecryptedMessage {
-    /// Constructs a [DecryptedMessage] from a [VerifiableMlsPlaintext].
+    /// Constructs a [DecryptedMessage] from a [VerifiableMlsAuthContent].
     pub(crate) fn from_inbound_plaintext(
         inbound_message: MlsMessageIn,
     ) -> Result<Self, ValidationError> {
@@ -68,7 +68,7 @@ impl DecryptedMessage {
     }
 
     /// Constructs a [DecryptedMessage] from a [MlsCiphertext] by attempting to decrypt it
-    /// to a [VerifiableMlsPlaintext] first.
+    /// to a [VerifiableMlsAuthContent] first.
     pub(crate) fn from_inbound_ciphertext(
         inbound_message: MlsMessageIn,
         backend: &impl OpenMlsCryptoProvider,
@@ -106,7 +106,7 @@ impl DecryptedMessage {
     // - Confirmation tag must be present for Commit messages
     // - Membership tag must be present for member messages, if the original incoming message was not an MlsCiphertext
     // - Ensures application messages were originally MlsCiphertext messages
-    fn from_plaintext(plaintext: VerifiableMlsPlaintext) -> Result<Self, ValidationError> {
+    fn from_plaintext(plaintext: VerifiableMlsAuthContent) -> Result<Self, ValidationError> {
         // ValSem007
         if plaintext.sender().is_member()
             && plaintext.wire_format() != WireFormat::MlsCiphertext
@@ -205,7 +205,7 @@ impl DecryptedMessage {
     }
 
     /// Returns the plaintext.
-    pub(crate) fn plaintext(&self) -> &VerifiableMlsPlaintext {
+    pub(crate) fn plaintext(&self) -> &VerifiableMlsAuthContent {
         &self.plaintext
     }
 }
@@ -215,7 +215,7 @@ impl DecryptedMessage {
 /// and the optional `aad` if the original message was encrypted.
 #[derive(Debug, Clone)]
 pub struct UnverifiedMessage {
-    plaintext: VerifiableMlsPlaintext,
+    plaintext: VerifiableMlsAuthContent,
     credential: Option<Credential>,
     aad_option: Option<Vec<u8>>,
 }
@@ -254,12 +254,12 @@ impl UnverifiedMessage {
     }
 
     /// Decomposes an [UnverifiedMessage] into its parts.
-    pub(crate) fn into_parts(self) -> (VerifiableMlsPlaintext, Option<Credential>) {
+    pub(crate) fn into_parts(self) -> (VerifiableMlsAuthContent, Option<Credential>) {
         (self.plaintext, self.credential)
     }
 }
 
-/// Contains an VerifiableMlsPlaintext and a [Credential] if it is a message
+/// Contains an VerifiableMlsAuthContent and a [Credential] if it is a message
 /// from a `Member`, a `Preconfigured`, a `NewMemberProposal` or a `NewMemberCommit`. It sets the
 /// serialized group context and verifies the membership tag for member messages. It can be
 /// converted to a verified message by verifying the signature, either with the credential or an
@@ -326,7 +326,7 @@ impl UnverifiedContextMessage {
 
 /// Part of [UnverifiedContextMessage].
 pub(crate) struct UnverifiedGroupMessage {
-    plaintext: VerifiableMlsPlaintext,
+    plaintext: VerifiableMlsAuthContent,
     credential: Credential,
 }
 
@@ -358,7 +358,7 @@ impl UnverifiedGroupMessage {
 
 /// Part of [UnverifiedContextMessage].
 pub(crate) struct UnverifiedNewMemberMessage {
-    plaintext: VerifiableMlsPlaintext,
+    plaintext: VerifiableMlsAuthContent,
     credential: Credential,
 }
 
@@ -390,7 +390,7 @@ impl UnverifiedNewMemberMessage {
 // TODO #151/#106: We don't support external senders yet
 /// Part of [UnverifiedContextMessage].
 pub(crate) struct UnverifiedExternalMessage {
-    plaintext: VerifiableMlsPlaintext,
+    plaintext: VerifiableMlsAuthContent,
 }
 
 impl UnverifiedExternalMessage {

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -476,7 +476,7 @@ impl CoreGroup {
         mls_ciphertext: &MlsCiphertext,
         backend: &impl OpenMlsCryptoProvider,
         sender_ratchet_configuration: &SenderRatchetConfiguration,
-    ) -> Result<VerifiableMlsPlaintext, MessageDecryptionError> {
+    ) -> Result<VerifiableMlsAuthContent, MessageDecryptionError> {
         use crate::tree::index::SecretTreeLeafIndex;
 
         let ciphersuite = self.ciphersuite();

--- a/openmls/src/group/core_group/validation.rs
+++ b/openmls/src/group/core_group/validation.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::{
     proposals::ProposalQueue, ContentType, CoreGroup, KeyPackage, Member, MlsMessageIn,
-    ProposalValidationError, VerifiableMlsPlaintext, WireFormat,
+    ProposalValidationError, VerifiableMlsAuthContent, WireFormat,
 };
 
 impl CoreGroup {
@@ -56,7 +56,7 @@ impl CoreGroup {
     ///  - ValSem009
     pub(crate) fn validate_plaintext(
         &self,
-        plaintext: &VerifiableMlsPlaintext,
+        plaintext: &VerifiableMlsAuthContent,
     ) -> Result<(), ValidationError> {
         // ValSem004
         let sender = plaintext.sender();

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -615,7 +615,7 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // Fake the wire format so we can deserialize
     tv_mls_plaintext_application[0] = WireFormat::MlsPlaintext as u8;
     let my_mls_plaintext_application =
-        VerifiableMlsPlaintext::tls_deserialize(&mut tv_mls_plaintext_application.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut tv_mls_plaintext_application.as_slice())
             .expect("An unexpected error occurred.")
             .tls_serialize_detached()
             .expect("An unexpected error occurred.");
@@ -634,7 +634,7 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // Fake the wire format so we can deserialize
     tv_mls_plaintext_proposal[0] = WireFormat::MlsPlaintext as u8;
     let my_mls_plaintext_proposal =
-        VerifiableMlsPlaintext::tls_deserialize(&mut tv_mls_plaintext_proposal.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut tv_mls_plaintext_proposal.as_slice())
             .expect("An unexpected error occurred.")
             .tls_serialize_detached()
             .expect("An unexpected error occurred.");
@@ -653,7 +653,7 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
     // Fake the wire format so we can deserialize
     tv_mls_plaintext_commit[0] = WireFormat::MlsPlaintext as u8;
     let my_mls_plaintext_commit =
-        VerifiableMlsPlaintext::tls_deserialize(&mut tv_mls_plaintext_commit.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut tv_mls_plaintext_commit.as_slice())
             .expect("An unexpected error occurred.")
             .tls_serialize_detached()
             .expect("An unexpected error occurred.");

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -209,7 +209,7 @@ pub fn run_test_vector(
 
     // Check membership and confirmation tags.
     let commit_bytes = hex_to_bytes(&test_vector.commit);
-    let mut commit = VerifiableMlsPlaintext::tls_deserialize(&mut commit_bytes.as_slice())
+    let mut commit = VerifiableMlsAuthContent::tls_deserialize(&mut commit_bytes.as_slice())
         .expect("Error decoding commit");
     let context = GroupContext::new(
         ciphersuite,

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -156,7 +156,7 @@ fn test_valsem200(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .proposals
         .push(ProposalOrRef::Proposal(proposal));
 
-    plaintext.set_content(MlsContentBody::Commit(commit_content));
+    plaintext.set_content_body(MlsContentBody::Commit(commit_content));
 
     let alice_credential_bundle = backend
         .key_store()
@@ -260,7 +260,7 @@ fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     commit_content.proposals = vec![];
 
-    update.set_content(MlsContentBody::Commit(commit_content));
+    update.set_content_body(MlsContentBody::Commit(commit_content));
 
     let serialized_update = update
         .tls_serialize_detached()
@@ -446,7 +446,7 @@ fn erase_path(
     };
     commit_content.path = None;
 
-    plaintext.set_content(MlsContentBody::Commit(commit_content));
+    plaintext.set_content_body(MlsContentBody::Commit(commit_content));
 
     let alice_credential_bundle = backend
         .key_store()
@@ -527,7 +527,7 @@ fn test_valsem202(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         path.pop();
     };
 
-    plaintext.set_content(MlsContentBody::Commit(commit_content));
+    plaintext.set_content_body(MlsContentBody::Commit(commit_content));
 
     let alice_credential_bundle = backend
         .key_store()
@@ -637,7 +637,7 @@ fn test_valsem203(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         path.flip_eps_bytes();
     };
 
-    plaintext.set_content(MlsContentBody::Commit(commit_content));
+    plaintext.set_content_body(MlsContentBody::Commit(commit_content));
 
     let alice_credential_bundle = backend
         .key_store()
@@ -747,7 +747,7 @@ fn test_valsem204(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         path.flip_node_bytes();
     };
 
-    plaintext.set_content(MlsContentBody::Commit(commit_content));
+    plaintext.set_content_body(MlsContentBody::Commit(commit_content));
 
     let alice_credential_bundle = backend
         .key_store()

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -120,7 +120,7 @@ fn test_valsem200(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     // Let's get the proposal out of the message.
     let proposal_message =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_proposal_message.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_proposal_message.as_slice())
             .expect("Could not deserialize message.");
 
     let proposal = if let MlsContentBody::Proposal(proposal) = proposal_message.content() {
@@ -140,8 +140,9 @@ fn test_valsem200(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
     let original_plaintext = plaintext.clone();
@@ -197,8 +198,8 @@ fn test_valsem200(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .set_membership_tag(backend, &serialized_context, membership_key)
         .expect("error refreshing membership tag");
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     // Have Bob try to process the commit.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
@@ -246,7 +247,7 @@ fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("error serializing plaintext");
 
-    let mut update = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let mut update = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // The self-update currently contains an update proposal. This should change
@@ -282,7 +283,7 @@ fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -356,7 +357,7 @@ fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_remove_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_remove.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_remove.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -416,7 +417,7 @@ fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -434,7 +435,7 @@ fn erase_path(
     alice_group: &MlsGroup,
 ) -> MlsMessageIn {
     let mut plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut pt).expect("Could not deserialize message.");
+        VerifiableMlsAuthContent::tls_deserialize(&mut pt).expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
     let original_plaintext = plaintext.clone();
@@ -487,8 +488,8 @@ fn erase_path(
         .set_membership_tag(backend, &serialized_context, membership_key)
         .expect("error refreshing membership tag");
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     MlsMessageIn::from(verifiable_plaintext)
 }
@@ -512,8 +513,9 @@ fn test_valsem202(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
+            .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
     let original_plaintext = plaintext.clone();
@@ -568,8 +570,8 @@ fn test_valsem202(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .set_membership_tag(backend, &serialized_context, membership_key)
         .expect("error refreshing membership tag");
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
@@ -589,7 +591,7 @@ fn test_valsem202(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -620,8 +622,9 @@ fn test_valsem203(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
+            .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
     let original_plaintext = plaintext.clone();
@@ -678,8 +681,8 @@ fn test_valsem203(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .set_membership_tag(backend, &serialized_context, membership_key)
         .expect("error refreshing membership tag");
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
@@ -699,7 +702,7 @@ fn test_valsem203(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -730,8 +733,9 @@ fn test_valsem204(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
+            .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
     let original_plaintext = plaintext.clone();
@@ -788,8 +792,8 @@ fn test_valsem204(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .set_membership_tag(backend, &serialized_context, membership_key)
         .expect("error refreshing membership tag");
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
@@ -809,7 +813,7 @@ fn test_valsem204(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -840,8 +844,9 @@ fn test_valsem205(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
+            .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
     let original_plaintext = plaintext.clone();
@@ -879,8 +884,8 @@ fn test_valsem205(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .set_membership_tag(backend, &serialized_context, membership_key)
         .expect("error refreshing membership tag");
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(verified_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(verified_plaintext, None);
 
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 

--- a/openmls/src/group/tests/test_encoding.rs
+++ b/openmls/src/group/tests/test_encoding.rs
@@ -131,7 +131,7 @@ fn test_update_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
             .tls_serialize_detached()
             .expect("Could not encode proposal.");
         let mut update_decoded =
-            match VerifiableMlsPlaintext::tls_deserialize(&mut update_encoded.as_slice()) {
+            match VerifiableMlsAuthContent::tls_deserialize(&mut update_encoded.as_slice()) {
                 Ok(a) => a,
                 Err(err) => panic!("Error decoding MPLSPlaintext Update: {:?}", err),
             };
@@ -197,7 +197,7 @@ fn test_add_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
             .tls_serialize_detached()
             .expect("Could not encode proposal.");
         let mut verifiable_plaintext =
-            VerifiableMlsPlaintext::tls_deserialize(&mut add_encoded.as_slice())
+            VerifiableMlsAuthContent::tls_deserialize(&mut add_encoded.as_slice())
                 .expect("An unexpected error occurred.");
 
         verifiable_plaintext.set_context(
@@ -246,7 +246,7 @@ fn test_remove_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
             .tls_serialize_detached()
             .expect("Could not encode proposal.");
         let mut verifiable_plaintext =
-            VerifiableMlsPlaintext::tls_deserialize(&mut remove_encoded.as_slice())
+            VerifiableMlsAuthContent::tls_deserialize(&mut remove_encoded.as_slice())
                 .expect("An unexpected error occurred.");
 
         verifiable_plaintext.set_context(
@@ -357,7 +357,7 @@ fn test_commit_encoding(backend: &impl OpenMlsCryptoProvider) {
             .expect("An unexpected error occurred.");
 
         let mut verifiable_plaintext =
-            VerifiableMlsPlaintext::tls_deserialize(&mut commit_encoded.as_slice())
+            VerifiableMlsAuthContent::tls_deserialize(&mut commit_encoded.as_slice())
                 .expect("An unexpected error occurred.");
 
         verifiable_plaintext.set_context(

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -160,7 +160,7 @@ fn test_valsem240(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     content.proposals.remove(proposal_position);
 
-    plaintext.set_content(MlsContentBody::Commit(content));
+    plaintext.set_content_body(MlsContentBody::Commit(content));
 
     // We have to re-sign, since we changed the content.
     let mut signed_plaintext: MlsPlaintext = plaintext
@@ -232,7 +232,7 @@ fn test_valsem241(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     content.proposals.push(second_ext_init_prop);
 
-    plaintext.set_content(MlsContentBody::Commit(content));
+    plaintext.set_content_body(MlsContentBody::Commit(content));
 
     // We have to re-sign, since we changed the content.
     let mut signed_plaintext: MlsPlaintext = plaintext
@@ -313,7 +313,7 @@ fn test_valsem242(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     content.proposals.push(add_proposal);
 
-    plaintext.set_content(MlsContentBody::Commit(content));
+    plaintext.set_content_body(MlsContentBody::Commit(content));
 
     // We have to re-sign, since we changed the content.
     let mut signed_plaintext: MlsPlaintext = plaintext
@@ -449,7 +449,7 @@ fn test_valsem243(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     content.proposals.push(update_proposal);
 
-    plaintext.set_content(MlsContentBody::Commit(content));
+    plaintext.set_content_body(MlsContentBody::Commit(content));
 
     // We have to re-sign, since we changed the content.
     let mut signed_plaintext: MlsPlaintext = plaintext
@@ -582,7 +582,7 @@ fn test_valsem244(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     content.proposals.push(remove_proposal);
 
-    plaintext.set_content(MlsContentBody::Commit(content));
+    plaintext.set_content_body(MlsContentBody::Commit(content));
 
     // We have to re-sign, since we changed the content.
     let mut signed_plaintext: MlsPlaintext = plaintext
@@ -688,7 +688,7 @@ fn test_valsem245(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     content.proposals.push(proposal_reference);
 
-    plaintext.set_content(MlsContentBody::Commit(content));
+    plaintext.set_content_body(MlsContentBody::Commit(content));
 
     // We have to re-sign, since we changed the content.
     let mut signed_plaintext: MlsPlaintext = plaintext
@@ -755,7 +755,7 @@ fn test_valsem246(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // Remove the path from the commit
     content.path = None;
 
-    plaintext.set_content(MlsContentBody::Commit(content));
+    plaintext.set_content_body(MlsContentBody::Commit(content));
 
     // We have to re-sign, since we changed the content.
     let mut signed_plaintext: MlsPlaintext = plaintext
@@ -833,7 +833,7 @@ fn test_valsem247(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         path.set_leaf_key_package(bob_new_key_package)
     }
 
-    plaintext.set_content(MlsContentBody::Commit(content));
+    plaintext.set_content_body(MlsContentBody::Commit(content));
 
     // We have to re-sign, since we changed the content.
     let mut signed_plaintext: MlsPlaintext = plaintext

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -29,8 +29,8 @@ use super::utils::{generate_credential_bundle, generate_key_package_bundle};
 struct ECValidationTestSetup {
     alice_group: MlsGroup,
     bob_credential_bundle: CredentialBundle,
-    plaintext: VerifiableMlsPlaintext,
-    original_plaintext: VerifiableMlsPlaintext,
+    plaintext: VerifiableMlsAuthContent,
+    original_plaintext: VerifiableMlsAuthContent,
 }
 
 // Validation test setup
@@ -118,7 +118,7 @@ fn validation_test_setup(
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let message = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
+    let message = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
         .expect("Could not deserialize message.");
 
     let original_plaintext = message.clone();
@@ -177,8 +177,8 @@ fn test_valsem240(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .clone(),
     );
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
@@ -249,8 +249,8 @@ fn test_valsem241(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .clone(),
     );
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
@@ -330,8 +330,8 @@ fn test_valsem242(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .clone(),
     );
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
@@ -421,8 +421,9 @@ fn test_valsem243(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     assert!(matches!(plaintext.sender(), Sender::NewMemberCommit));
 
@@ -466,8 +467,8 @@ fn test_valsem243(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .clone(),
     );
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
@@ -553,8 +554,9 @@ fn test_valsem244(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     let original_plaintext = plaintext.clone();
 
@@ -599,8 +601,8 @@ fn test_valsem244(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .clone(),
     );
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
@@ -705,8 +707,8 @@ fn test_valsem245(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .clone(),
     );
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
@@ -772,8 +774,8 @@ fn test_valsem246(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .clone(),
     );
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
@@ -850,8 +852,8 @@ fn test_valsem247(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .clone(),
     );
 
-    let verifiable_plaintext: VerifiableMlsPlaintext =
-        VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None);
+    let verifiable_plaintext: VerifiableMlsAuthContent =
+        VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);

--- a/openmls/src/group/tests/test_framing.rs
+++ b/openmls/src/group/tests/test_framing.rs
@@ -137,7 +137,7 @@ fn bad_padding(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
         );
 
         let plaintext = {
-            let plaintext_tbs = MlsPlaintextTbs::new(
+            let plaintext_tbs = MlsContentTbs::new(
                 WireFormat::MlsCiphertext,
                 GroupId::random(backend),
                 1,

--- a/openmls/src/group/tests/test_framing_validation.rs
+++ b/openmls/src/group/tests/test_framing_validation.rs
@@ -366,7 +366,7 @@ fn test_valsem005(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     let original_message = plaintext.clone();
 
-    plaintext.set_content(MlsContentBody::Application(vec![1, 2, 3].into()));
+    plaintext.set_content_body(MlsContentBody::Application(vec![1, 2, 3].into()));
 
     let message_in = MlsMessageIn::from(plaintext);
 

--- a/openmls/src/group/tests/test_framing_validation.rs
+++ b/openmls/src/group/tests/test_framing_validation.rs
@@ -110,7 +110,7 @@ fn test_valsem001(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     serialized_message[0] = WireFormat::MlsCiphertext as u8;
 
-    let err = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
+    let err = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
         .expect_err("Could deserialize message despite wrong wire format.");
 
     assert_eq!(
@@ -119,7 +119,7 @@ fn test_valsem001(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     // Positive case
-    VerifiableMlsPlaintext::tls_deserialize(&mut original_message.as_slice())
+    VerifiableMlsAuthContent::tls_deserialize(&mut original_message.as_slice())
         .expect("Unexpected error.");
 
     // Test with MlsCiphertext
@@ -174,8 +174,9 @@ fn test_valsem002(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     let original_message = plaintext.clone();
 
@@ -259,8 +260,9 @@ fn test_valsem003(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     let original_message = plaintext.clone();
 
@@ -317,8 +319,9 @@ fn test_valsem004(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     let original_message = plaintext.clone();
 
@@ -361,8 +364,9 @@ fn test_valsem005(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     let original_message = plaintext.clone();
 
@@ -467,8 +471,9 @@ fn test_valsem007(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     let original_message = plaintext.clone();
 
@@ -532,8 +537,9 @@ fn test_valsem008(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     let original_message = plaintext.clone();
 
@@ -582,8 +588,9 @@ fn test_valsem009(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     let original_message = plaintext.clone();
 
@@ -647,8 +654,9 @@ fn test_valsem010(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.");
 
     let original_message = plaintext.clone();
 

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -13,7 +13,7 @@ use crate::{
     credentials::*,
     framing::{
         MlsContentBody, MlsMessageIn, MlsMessageOut, MlsPlaintext, ProcessedMessage, Sender,
-        VerifiableMlsPlaintext,
+        VerifiableMlsAuthContent,
     },
     group::{errors::*, *},
     key_packages::*,
@@ -176,10 +176,10 @@ fn validation_test_setup(
 fn insert_proposal_and_resign(
     backend: &impl OpenMlsCryptoProvider,
     proposal_or_ref: ProposalOrRef,
-    mut plaintext: VerifiableMlsPlaintext,
-    original_plaintext: &VerifiableMlsPlaintext,
+    mut plaintext: VerifiableMlsAuthContent,
+    original_plaintext: &VerifiableMlsAuthContent,
     committer_group: &MlsGroup,
-) -> VerifiableMlsPlaintext {
+) -> VerifiableMlsAuthContent {
     let mut commit_content = if let MlsContentBody::Commit(commit) = plaintext.content() {
         commit.clone()
     } else {
@@ -229,7 +229,7 @@ fn insert_proposal_and_resign(
         .set_membership_tag(backend, &serialized_context, membership_key)
         .expect("error refreshing membership tag");
 
-    VerifiableMlsPlaintext::from_plaintext(signed_plaintext, None)
+    VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None)
 }
 
 enum KeyUniqueness {
@@ -307,7 +307,7 @@ fn test_valsem100(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
@@ -323,7 +323,7 @@ fn test_valsem100(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         key_package: charlie_key_package,
     });
 
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Proposal(second_add_proposal),
         plaintext,
@@ -350,7 +350,7 @@ fn test_valsem100(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -457,7 +457,7 @@ fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
@@ -477,7 +477,7 @@ fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         key_package: dave_key_package_bundle.key_package().clone(),
     });
 
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Proposal(second_add_proposal),
         plaintext,
@@ -504,7 +504,7 @@ fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -617,7 +617,7 @@ fn test_valsem102(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
@@ -638,7 +638,7 @@ fn test_valsem102(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         key_package: dave_key_package_bundle.key_package().clone(),
     });
 
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Proposal(second_add_proposal),
         plaintext,
@@ -665,7 +665,7 @@ fn test_valsem102(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -739,7 +739,7 @@ fn test_valsem103(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
@@ -750,7 +750,7 @@ fn test_valsem103(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     });
 
     // Artificially add a proposal trying to add (another) Bob.
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Proposal(add_proposal),
         plaintext,
@@ -777,7 +777,7 @@ fn test_valsem103(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -892,7 +892,7 @@ fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
@@ -922,7 +922,7 @@ fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     });
 
     // Artificially add a proposal trying to add (another) Bob.
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Proposal(add_proposal),
         plaintext,
@@ -949,7 +949,7 @@ fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -1058,7 +1058,7 @@ fn test_valsem105(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
@@ -1090,7 +1090,7 @@ fn test_valsem105(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     // Artificially add a proposal trying to add someone with an existing HPKE
     // public key.
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Proposal(add_proposal),
         plaintext,
@@ -1117,7 +1117,7 @@ fn test_valsem105(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -1290,8 +1290,9 @@ fn test_valsem106(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .tls_serialize_detached()
             .expect("Could not serialize message.");
 
-        let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
-            .expect("Could not deserialize message.");
+        let plaintext =
+            VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
+                .expect("Could not deserialize message.");
 
         // Keep the original plaintext for positive test later.
         let original_plaintext = plaintext.clone();
@@ -1310,7 +1311,7 @@ fn test_valsem106(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
                 ),
             };
             // Artificially add the proposal.
-            let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+            let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
                 backend,
                 proposal_or_ref,
                 plaintext.clone(),
@@ -1361,7 +1362,7 @@ fn test_valsem106(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             assert_eq!(err, expected_error);
 
             let original_update_plaintext =
-                VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+                VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
                     .expect("Could not deserialize message.");
 
             // Positive case
@@ -1425,8 +1426,9 @@ fn test_valsem107(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .tls_serialize_detached()
             .expect("error serializing plaintext");
 
-        let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
-            .expect("Could not deserialize message.");
+        let plaintext =
+            VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
+                .expect("Could not deserialize message.");
 
         let commit_content = if let MlsContentBody::Commit(commit) = plaintext.content() {
             commit.clone()
@@ -1530,7 +1532,7 @@ fn test_valsem108(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
@@ -1541,7 +1543,7 @@ fn test_valsem108(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     // Artificially add a proposal trying to remove someone that is not in a
     // group.
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Proposal(remove_proposal),
         plaintext,
@@ -1568,7 +1570,7 @@ fn test_valsem108(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -1669,7 +1671,7 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
@@ -1680,7 +1682,7 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     });
 
     // Artificially add the proposal.
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Reference(
             ProposalRef::from_proposal(ciphersuite, backend, &update_proposal)
@@ -1710,7 +1712,7 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -1825,7 +1827,7 @@ fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
@@ -1836,7 +1838,7 @@ fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     });
 
     // Artificially add the proposal.
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Reference(
             ProposalRef::from_proposal(ciphersuite, backend, &update_proposal)
@@ -1866,7 +1868,7 @@ fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -1922,7 +1924,7 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("error serializing plaintext");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_message.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_message.as_slice())
         .expect("Could not deserialize message.");
 
     let commit_content = if let MlsContentBody::Commit(commit) = plaintext.content() {
@@ -1938,14 +1940,14 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
     let original_plaintext = plaintext.clone();
 
     // Let's insert the proposal into the commit.
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Proposal(update_proposal.clone()),
         plaintext,
@@ -1997,7 +1999,7 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
@@ -2005,7 +2007,7 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     // Let's insert the proposal into the commit.
     // Artificially add the proposal.
-    let verifiable_plaintext: VerifiableMlsPlaintext = insert_proposal_and_resign(
+    let verifiable_plaintext: VerifiableMlsAuthContent = insert_proposal_and_resign(
         backend,
         ProposalOrRef::Reference(
             ProposalRef::from_proposal(ciphersuite, backend, &update_proposal)
@@ -2035,7 +2037,7 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let original_update_plaintext =
-        VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
             .expect("Could not deserialize message.");
 
     // Positive case
@@ -2074,13 +2076,14 @@ fn test_valsem112(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .tls_serialize_detached()
         .expect("error serializing plaintext");
 
-    let plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
+    let plaintext = VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
         .expect("Could not deserialize message.");
 
     assert!(plaintext.sender().is_member());
 
-    let mut plaintext = VerifiableMlsPlaintext::tls_deserialize(&mut serialized_update.as_slice())
-        .expect("Could not deserialize message.");
+    let mut plaintext =
+        VerifiableMlsAuthContent::tls_deserialize(&mut serialized_update.as_slice())
+            .expect("Could not deserialize message.");
 
     // Keep the original plaintext for positive test later.
     let original_plaintext = plaintext.clone();

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -188,7 +188,7 @@ fn insert_proposal_and_resign(
 
     commit_content.proposals.push(proposal_or_ref);
 
-    plaintext.set_content(MlsContentBody::Commit(commit_content));
+    plaintext.set_content_body(MlsContentBody::Commit(commit_content));
 
     let committer_credential_bundle = backend
         .key_store()

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -581,7 +581,7 @@ pub fn run_test_vector(
                 );
 
             // Note that we can't actually get an MlsPlaintext because we don't
-            // have enough information. We encode the VerifiableMlsPlaintext
+            // have enough information. We encode the VerifiableMlsAuthContent
             // and compare it to the plaintext in the test vector instead.
 
             // Swap secret tree


### PR DESCRIPTION
This PR contains a few changes towards the updated wire format and framing structure in draft 16. It is meant as an intermediate PR towards #979.

* Rename `MlsPlaintextTbs` to `MlsContentTbs`
* Rename `VerifiableMlsPlaintext` to `VerifiableMlsAuthContent`
* Restructure `MlsContentTbs` s.t. it contains `MlsContent` rather than its individual parts