### PR TITLE
Disable concurrency groups for clippy/coverage

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -4,10 +4,6 @@ on:
   - push
   - pull_request_target
 
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 defaults:
   run:
     working-directory: openmls

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,10 +4,6 @@ on:
   - push
   - pull_request_target
 
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 defaults:
   run:
     working-directory: openmls


### PR DESCRIPTION
I suspect that github.ref is from main for pull_request_target jobs such that these jobs get cancelled all the time.