### PR TITLE
handle conflicting commits

### DIFF
--- a/book/src/forward_secrecy.md
+++ b/book/src/forward_secrecy.md
@@ -24,6 +24,10 @@ committer is stored in the diff. It exists alongside the key material of the
 ratchet tree before the commit until the client merges the diff, upon which the
 key material in the original ratchet tree is dropped.
 
+Because the client cannot know if the commit it creates will conflict with another commit created by another client
+for the same epoch, it MUST wait for the acknowledgement from the Delivery Service before merging the diff and dropping
+the previous ratchet tree.
+
 ### Commit Processing
 
 Upon receiving a commit from another group member, the client processes the

--- a/book/src/user_manual/join_from_welcome.md
+++ b/book/src/user_manual/join_from_welcome.md
@@ -6,3 +6,6 @@ If the group configuration does not use the ratchet tree extension, the ratchet 
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code.rs:bob_joins_with_welcome}}
 ```
+
+Pay attention not to forward a Welcome message to a client before its associated commit has been accepted by the 
+Delivery Service. Otherwise, you would end up with an invalid MLS group instance.


### PR DESCRIPTION
No sources modification have been required for this one as 2 commits with the same epoch were already failing when the message was parsed. Anyway, added a test to make sure it happened.  

Then, documented in the book that both commits and welcome messages should be dealt with caution and nothing should be merged locally before the Delivery Service approves the message.

Fixes #939