### PR TITLE
Remove signature key indirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#903](https://github.com/openmls/openmls/pull/903): Rename MlsGroup's resumptionn_secret to resumption_secret 
 - [#1058](https://github.com/openmls/openmls/pull/1058): Rename resumption_secret to resumption_psk
 - [#900:](https://github.com/openmls/openmls/pull/900) Expose SerializedMlsGroup until issue [#245](https://github.com/openmls/openmls/issues/245) is done
+- [#1117](https://github.com/openmls/openmls/pull/1117): Remove signature key indirection
 
 ## 0.4.1 (2022-06-07)
 

--- a/book/src/user_manual/processing.md
+++ b/book/src/user_manual/processing.md
@@ -12,19 +12,11 @@ Incoming messages can be deserialized from byte slices into an `MlsMessageIn`:
 
 If the message is malformed, the function will fail with an error.
 
-## Parsing messages
-
-In the next step, the incoming message needs to be parsed. If the message was encrypted, it will be decrypted automatically:
-
-```rust,no_run,noplayground
-{{#include ../../../openmls/tests/book_code.rs:parse_message}}
-```
-
-Parsing can fail if, e.g., decrypting the message fails. The exact reason for failure is returned in the error value.
-
 ## Processing messages
 
-In the next step, the unverified message needs to be processed. This step performs all remaining validity checks and verifies the message's signature. Optionally, a signature key can be provided to verify the message's signature. This can be used when processing external messages. By default, the sender's credential is used to verify the signature.
+In the next step, the message needs to be processed. If the message was
+encrypted, it will be decrypted automatically. This step performs all syntactic
+and semantic validation checks and verifies the message's signature:
 
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code.rs:process_message}}
@@ -32,7 +24,10 @@ In the next step, the unverified message needs to be processed. This step perfor
 
 ## Interpreting the processed message
 
-In the last step, the message is ready for inspection. There are 3 different kinds of messages:
+In the last step, the message is ready for inspection. The `ProcessedMessage`
+obtained in the previous step exposes header fields such as group ID, epoch,
+sender, and authenticated data. It also exposes the message's content. There are
+3 different content types:
 
 ### Application messages
 

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -370,13 +370,12 @@ async fn test_group() {
     assert!(messages.is_empty());
 
     // Decrypt the message on Client1
-    let unverified_message = group
-        .parse_message(mls_message, crypto)
-        .expect("Could not parse message.");
     let processed_message = group
-        .process_unverified_message(unverified_message, None, crypto)
+        .process_message(crypto, mls_message)
         .expect("Could not process unverified message.");
-    if let ProcessedMessage::ApplicationMessage(application_message) = processed_message {
+    if let ProcessedMessageContent::ApplicationMessage(application_message) =
+        processed_message.into_content()
+    {
         assert_eq!(client2_message, &application_message.into_bytes()[..]);
     } else {
         panic!("Expected application message");

--- a/openmls/src/framing/mod.rs
+++ b/openmls/src/framing/mod.rs
@@ -4,7 +4,6 @@
 //!
 //!  - [`MlsMessageIn`]/[`MlsMessageOut`]: Unified message type for incoming & outgoing MLS messages
 //!  - [`ApplicationMessage`]: Application message received through a [`ProcessedMessage`]
-//!  - [`UnverifiedMessage`]: Partially checked and potentially decrypted message (if it was originally encrypted)
 
 use crate::ciphersuite::*;
 use crate::credentials::*;

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -374,24 +374,6 @@ pub(crate) struct UnverifiedExternalMessage {
     _plaintext: VerifiableMlsAuthContent,
 }
 
-impl UnverifiedExternalMessage {
-    /// Verifies the signature on an [UnverifiedExternalMessage] and returns a [VerifiedExternalMessage] if the
-    /// verification is successful.
-    /// This function implements the following checks:
-    ///  - ValSem010
-    pub(crate) fn _into_verified(
-        self,
-        backend: &impl OpenMlsCryptoProvider,
-        signature_key: &OpenMlsSignaturePublicKey,
-    ) -> Result<VerifiedExternalMessage, ValidationError> {
-        // ValSem010
-        self._plaintext
-            .verify_with_key(backend, signature_key)
-            .map(|plaintext| VerifiedExternalMessage { plaintext })
-            .map_err(|_| ValidationError::InvalidSignature)
-    }
-}
-
 /// Member message, where all semantic checks on the framing have been successfully performed.
 pub(crate) struct VerifiedMemberMessage {
     plaintext: MlsPlaintext,

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -33,6 +33,7 @@
 //! V
 //! ProcessedMessage (Application, Proposal, ExternalProposal, Commit, External Commit)
 //! ```
+// TODO #106/#151: Update the above diagram
 
 use crate::{group::errors::ValidationError, tree::index::SecretTreeLeafIndex, treesync::TreeSync};
 use core_group::{proposals::QueuedProposal, staged_commit::StagedCommit};
@@ -214,10 +215,9 @@ impl DecryptedMessage {
 /// Use this to inspect the [`Credential`] of the message sender
 /// and the optional `aad` if the original message was encrypted.
 #[derive(Debug, Clone)]
-pub struct UnverifiedMessage {
+pub(crate) struct UnverifiedMessage {
     plaintext: VerifiableMlsAuthContent,
     credential: Option<Credential>,
-    aad_option: Option<Vec<u8>>,
 }
 
 impl UnverifiedMessage {
@@ -229,28 +229,12 @@ impl UnverifiedMessage {
         UnverifiedMessage {
             plaintext: decrypted_message.plaintext,
             credential,
-            aad_option: None,
         }
     }
 
     /// Returns the epoch.
-    pub fn epoch(&self) -> GroupEpoch {
+    pub(crate) fn epoch(&self) -> GroupEpoch {
         self.plaintext.epoch()
-    }
-
-    /// Returns the AAD.
-    pub fn aad(&self) -> &Option<Vec<u8>> {
-        &self.aad_option
-    }
-
-    /// Returns the sender.
-    pub fn sender(&self) -> &Sender {
-        self.plaintext.sender()
-    }
-
-    /// Return the credential if there is one.
-    pub fn credential(&self) -> Option<&Credential> {
-        self.credential.as_ref()
     }
 
     /// Decomposes an [UnverifiedMessage] into its parts.
@@ -338,21 +322,19 @@ impl UnverifiedGroupMessage {
     pub(crate) fn into_verified(
         self,
         backend: &impl OpenMlsCryptoProvider,
-        signature_key: Option<&OpenMlsSignaturePublicKey>,
     ) -> Result<VerifiedMemberMessage, ValidationError> {
-        // If a signature key is provided it will be used,
-        // otherwise we take the key from the credential
-        let verified_member_message = if let Some(signature_public_key) = signature_key {
-            // ValSem010
-            self.plaintext
-                .verify_with_key(backend, signature_public_key)
-        } else {
-            // ValSem010
-            self.plaintext.verify(backend, &self.credential)
-        }
-        .map(|plaintext| VerifiedMemberMessage { plaintext })
-        .map_err(|_| ValidationError::InvalidSignature)?;
+        // ValSem010
+        let verified_member_message = self
+            .plaintext
+            .verify(backend, &self.credential)
+            .map(|plaintext| VerifiedMemberMessage { plaintext })
+            .map_err(|_| ValidationError::InvalidSignature)?;
         Ok(verified_member_message)
+    }
+
+    /// Returns the credential.
+    pub(crate) fn credential(&self) -> &Credential {
+        &self.credential
     }
 }
 
@@ -370,27 +352,26 @@ impl UnverifiedNewMemberMessage {
     pub(crate) fn into_verified(
         self,
         backend: &impl OpenMlsCryptoProvider,
-        signature_key: Option<&OpenMlsSignaturePublicKey>,
     ) -> Result<VerifiedExternalMessage, ValidationError> {
-        // If a signature key is provided it will be used, otherwise we take it from the credential
-        let verified_external_message = if let Some(signature_public_key) = signature_key {
-            // ValSem010
-            self.plaintext
-                .verify_with_key(backend, signature_public_key)
-        } else {
-            // ValSem010
-            self.plaintext.verify(backend, &self.credential)
-        }
-        .map(|plaintext| VerifiedExternalMessage { plaintext })
-        .map_err(|_| ValidationError::InvalidSignature)?;
+        // ValSem010
+        let verified_external_message = self
+            .plaintext
+            .verify(backend, &self.credential)
+            .map(|plaintext| VerifiedExternalMessage { plaintext })
+            .map_err(|_| ValidationError::InvalidSignature)?;
         Ok(verified_external_message)
+    }
+
+    /// Returns the credential.
+    pub(crate) fn credential(&self) -> &Credential {
+        &self.credential
     }
 }
 
 // TODO #151/#106: We don't support external senders yet
 /// Part of [UnverifiedContextMessage].
 pub(crate) struct UnverifiedExternalMessage {
-    plaintext: VerifiableMlsAuthContent,
+    _plaintext: VerifiableMlsAuthContent,
 }
 
 impl UnverifiedExternalMessage {
@@ -398,13 +379,13 @@ impl UnverifiedExternalMessage {
     /// verification is successful.
     /// This function implements the following checks:
     ///  - ValSem010
-    pub(crate) fn into_verified(
+    pub(crate) fn _into_verified(
         self,
         backend: &impl OpenMlsCryptoProvider,
         signature_key: &OpenMlsSignaturePublicKey,
     ) -> Result<VerifiedExternalMessage, ValidationError> {
         // ValSem010
-        self.plaintext
+        self._plaintext
             .verify_with_key(backend, signature_key)
             .map(|plaintext| VerifiedExternalMessage { plaintext })
             .map_err(|_| ValidationError::InvalidSignature)
@@ -417,11 +398,6 @@ pub(crate) struct VerifiedMemberMessage {
 }
 
 impl VerifiedMemberMessage {
-    /// Returns a reference to the inner [MlsPlaintext].
-    pub(crate) fn plaintext(&self) -> &MlsPlaintext {
-        &self.plaintext
-    }
-
     /// Consumes the message and returns the inner [MlsPlaintext].
     pub(crate) fn take_plaintext(self) -> MlsPlaintext {
         self.plaintext
@@ -447,11 +423,78 @@ impl VerifiedExternalMessage {
 }
 
 /// A message that has passed all syntax and semantics checks.
+#[derive(Debug)]
+pub struct ProcessedMessage {
+    group_id: GroupId,
+    epoch: GroupEpoch,
+    sender: Sender,
+    authenticated_data: Vec<u8>,
+    content: ProcessedMessageContent,
+    credential: Option<Credential>,
+}
+
+impl ProcessedMessage {
+    /// Create a new `ProcessedMessage`.
+    pub(crate) fn new(
+        group_id: GroupId,
+        epoch: GroupEpoch,
+        sender: Sender,
+        authenticated_data: Vec<u8>,
+        content: ProcessedMessageContent,
+        credential: Option<Credential>,
+    ) -> Self {
+        Self {
+            group_id,
+            epoch,
+            sender,
+            authenticated_data,
+            content,
+            credential,
+        }
+    }
+
+    /// Returns the group ID of the message.
+    pub fn group_id(&self) -> &GroupId {
+        &self.group_id
+    }
+
+    /// Returns the epoch of the message.
+    pub fn epoch(&self) -> GroupEpoch {
+        self.epoch
+    }
+
+    /// Returns the sender of the message.
+    pub fn sender(&self) -> &Sender {
+        &self.sender
+    }
+
+    /// Returns the authenticated data of the message.
+    pub fn authenticated_data(&self) -> &[u8] {
+        &self.authenticated_data
+    }
+
+    /// Returns the content of the message.
+    pub fn content(&self) -> &ProcessedMessageContent {
+        &self.content
+    }
+
+    /// Returns the content of the message and consumes the message.
+    pub fn into_content(self) -> ProcessedMessageContent {
+        self.content
+    }
+
+    /// Returns the credential of the message if present.
+    pub fn credential(&self) -> Option<&Credential> {
+        self.credential.as_ref()
+    }
+}
+
+/// Content of a processed message.
 ///
-/// See the variants' documentation for more information.
+/// See the content variants' documentation for more information.
 /// [`StagedCommit`] and [`QueuedProposal`] can be inspected for authorization purposes.
 #[derive(Debug)]
-pub enum ProcessedMessage {
+pub enum ProcessedMessageContent {
     /// An application message.
     ///
     /// The [`ApplicationMessage`] contains a vector of bytes that can be used right-away.

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -1,6 +1,6 @@
 use core_group::{proposals::QueuedProposal, staged_commit::StagedCommit};
 
-use crate::group::{errors::ValidationError, mls_group::errors::UnverifiedMessageError};
+use crate::group::{errors::ValidationError, mls_group::errors::ProcessMessageError};
 
 use super::{proposals::ProposalStore, *};
 
@@ -106,17 +106,16 @@ impl CoreGroup {
     pub(crate) fn process_unverified_message(
         &self,
         unverified_message: UnverifiedMessage,
-        signature_key: Option<&OpenMlsSignaturePublicKey>,
         proposal_store: &ProposalStore,
         own_kpbs: &[KeyPackageBundle],
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<ProcessedMessage, UnverifiedMessageError> {
+    ) -> Result<ProcessedMessage, ProcessMessageError> {
         // Add the context to the message and verify the membership tag if necessary.
         // If the message is older than the current epoch, we need to fetch the correct secret tree first.
         let message_secrets = self
             .message_secrets_for_epoch(unverified_message.epoch())
             .map_err(|e| match e {
-                SecretTreeError::TooDistantInThePast => UnverifiedMessageError::NoPastEpochData,
+                SecretTreeError::TooDistantInThePast => ProcessMessageError::NoPastEpochData,
                 _ => LibraryError::custom("Unexpected return value").into(),
             })?;
 
@@ -127,29 +126,46 @@ impl CoreGroup {
             message_secrets,
             backend,
         )
-        .map_err(|_| UnverifiedMessageError::InvalidMembershipTag)?;
+        .map_err(|_| ProcessMessageError::InvalidMembershipTag)?;
+
+        let group_id = self.group_id().clone();
+        let epoch = self.group_context.epoch();
 
         match context_plaintext {
             UnverifiedContextMessage::Group(unverified_message) => {
+                let credential = unverified_message.credential().clone();
                 // Checks the following semantic validation:
                 //  - ValSem010
                 //  - ValSem246 (as part of ValSem010)
-                let verified_member_message = unverified_message
-                    .into_verified(backend, signature_key)
-                    .map_err(|_| UnverifiedMessageError::InvalidSignature)?;
+                let plaintext = unverified_message
+                    .into_verified(backend)
+                    .map_err(|_| ProcessMessageError::InvalidSignature)?
+                    .take_plaintext();
 
-                Ok(match verified_member_message.plaintext().content() {
-                    MlsContentBody::Application(application_message) => {
-                        ProcessedMessage::ApplicationMessage(ApplicationMessage::new(
+                Ok(match plaintext.content() {
+                    MlsContentBody::Application(application_message) => ProcessedMessage::new(
+                        group_id,
+                        epoch,
+                        plaintext.sender().clone(),
+                        plaintext.authenticated_data().to_owned(),
+                        ProcessedMessageContent::ApplicationMessage(ApplicationMessage::new(
                             application_message.as_slice().to_vec(),
-                        ))
-                    }
-                    MlsContentBody::Proposal(_proposal) => ProcessedMessage::ProposalMessage(
-                        Box::new(QueuedProposal::from_mls_plaintext(
-                            self.ciphersuite(),
-                            backend,
-                            verified_member_message.take_plaintext(),
-                        )?),
+                        )),
+                        Some(credential),
+                    ),
+                    MlsContentBody::Proposal(_proposal) => ProcessedMessage::new(
+                        group_id,
+                        epoch,
+                        plaintext.sender().clone(),
+                        plaintext.authenticated_data().to_owned(),
+                        ProcessedMessageContent::ProposalMessage(Box::new(
+                            QueuedProposal::from_mls_plaintext(
+                                self.ciphersuite(),
+                                backend,
+                                plaintext,
+                            )?,
+                        )),
+                        Some(credential),
                     ),
                     MlsContentBody::Commit(_commit) => {
                         //  - ValSem100
@@ -178,62 +194,129 @@ impl CoreGroup {
                         //  - ValSem242
                         //  - ValSem243
                         //  - ValSem244
-                        let staged_commit = self.stage_commit(
-                            verified_member_message.plaintext(),
-                            proposal_store,
-                            own_kpbs,
-                            backend,
-                        )?;
-                        ProcessedMessage::StagedCommitMessage(Box::new(staged_commit))
+                        let staged_commit =
+                            self.stage_commit(&plaintext, proposal_store, own_kpbs, backend)?;
+                        ProcessedMessage::new(
+                            group_id,
+                            epoch,
+                            plaintext.sender().clone(),
+                            plaintext.authenticated_data().to_owned(),
+                            ProcessedMessageContent::StagedCommitMessage(Box::new(staged_commit)),
+                            Some(credential),
+                        )
                     }
                 })
             }
-            UnverifiedContextMessage::External(external_message) => {
-                // Signature verification
-                if let Some(signature_public_key) = signature_key {
-                    let _verified_external_message = external_message
-                        .into_verified(backend, signature_public_key)
-                        .map_err(|_| UnverifiedMessageError::InvalidSignature)?;
-                } else {
-                    return Err(UnverifiedMessageError::MissingSignatureKey);
-                }
-
+            UnverifiedContextMessage::External(_external_message) => {
                 // We don't support messages from external senders yet
                 // TODO #151/#106
                 todo!()
             }
-            UnverifiedContextMessage::NewMember(external_message) => {
+            UnverifiedContextMessage::NewMember(unverified_new_member_message) => {
+                let credential = unverified_new_member_message.credential().clone();
                 // Signature verification
-                let verified_external_message = external_message
-                    .into_verified(backend, signature_key)
-                    .map_err(|_| UnverifiedMessageError::InvalidSignature)?;
-                Ok(match verified_external_message.plaintext().content() {
-                    MlsContentBody::Proposal(_proposal) => {
-                        ProcessedMessage::ExternalJoinProposalMessage(Box::new(
+                let verified_new_member_message = unverified_new_member_message
+                    .into_verified(backend)
+                    .map_err(|_| ProcessMessageError::InvalidSignature)?;
+                Ok(match verified_new_member_message.plaintext().content() {
+                    MlsContentBody::Proposal(_proposal) => ProcessedMessage::new(
+                        group_id,
+                        epoch,
+                        verified_new_member_message.plaintext().sender().clone(),
+                        verified_new_member_message
+                            .plaintext()
+                            .authenticated_data()
+                            .to_owned(),
+                        ProcessedMessageContent::ExternalJoinProposalMessage(Box::new(
                             QueuedProposal::from_mls_plaintext(
                                 self.ciphersuite(),
                                 backend,
-                                verified_external_message.take_plaintext(),
+                                verified_new_member_message.take_plaintext(),
                             )?,
-                        ))
-                    }
+                        )),
+                        Some(credential),
+                    ),
                     MlsContentBody::Commit(_commit) => {
                         let staged_commit = self.stage_commit(
-                            verified_external_message.plaintext(),
+                            verified_new_member_message.plaintext(),
                             proposal_store,
                             own_kpbs,
                             backend,
                         )?;
-                        ProcessedMessage::StagedCommitMessage(Box::new(staged_commit))
+                        ProcessedMessage::new(
+                            group_id,
+                            epoch,
+                            verified_new_member_message.plaintext().sender().clone(),
+                            verified_new_member_message
+                                .plaintext()
+                                .authenticated_data()
+                                .to_owned(),
+                            ProcessedMessageContent::StagedCommitMessage(Box::new(staged_commit)),
+                            Some(credential),
+                        )
                     }
                     _ => {
-                        return Err(UnverifiedMessageError::LibraryError(LibraryError::custom(
+                        return Err(ProcessMessageError::LibraryError(LibraryError::custom(
                             "Implementation error",
                         )))
                     }
                 })
             }
         }
+    }
+
+    /// This function is used to parse messages from the DS. It checks for
+    /// syntactic errors and does semantic validation as well. If the input is a
+    /// [MlsCiphertext] message, it will be decrypted. It returns a
+    /// [ProcessedMessage] enum. Checks the following semantic validation:
+    ///  - ValSem002
+    ///  - ValSem003
+    ///  - ValSem004
+    ///  - ValSem005
+    ///  - ValSem006
+    ///  - ValSem007
+    ///  - ValSem008
+    ///  - ValSem009
+    ///  - ValSem010
+    ///  - ValSem100
+    ///  - ValSem101
+    ///  - ValSem102
+    ///  - ValSem103
+    ///  - ValSem104
+    ///  - ValSem105
+    ///  - ValSem106
+    ///  - ValSem107
+    ///  - ValSem108
+    ///  - ValSem109
+    ///  - ValSem110
+    ///  - ValSem111
+    ///  - ValSem112
+    ///  - ValSem200
+    ///  - ValSem201
+    ///  - ValSem202: Path must be the right length
+    ///  - ValSem203: Path secrets must decrypt correctly
+    ///  - ValSem204: Public keys from Path must be verified and match the
+    ///               private keys from the direct path
+    ///  - ValSem205
+    ///  - ValSem240
+    ///  - ValSem241
+    ///  - ValSem242
+    ///  - ValSem243
+    ///  - ValSem244
+    ///  - ValSem245
+    ///  - ValSem246 (as part of ValSem010)
+    pub(crate) fn process_message(
+        &mut self,
+        backend: &impl OpenMlsCryptoProvider,
+        message: MlsMessageIn,
+        sender_ratchet_configuration: &SenderRatchetConfiguration,
+        proposal_store: &ProposalStore,
+        own_kpbs: &[KeyPackageBundle],
+    ) -> Result<ProcessedMessage, ProcessMessageError> {
+        let unverified_message = self
+            .parse_message(backend, message, sender_ratchet_configuration)
+            .map_err(ProcessMessageError::from)?;
+        self.process_unverified_message(unverified_message, proposal_store, own_kpbs, backend)
     }
 
     /// Merge a [StagedCommit] into the group after inspection

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -62,9 +62,9 @@ pub enum MlsGroupStateError {
     NoPendingCommit,
 }
 
-/// Parse message error
+/// Process message error
 #[derive(Error, Debug, PartialEq, Clone)]
-pub enum ParseMessageError {
+pub enum ProcessMessageError {
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
@@ -77,14 +77,6 @@ pub enum ParseMessageError {
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
     GroupStateError(#[from] MlsGroupStateError),
-}
-
-/// Unverified message error
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum UnverifiedMessageError {
-    /// See [`LibraryError`] for more details.
-    #[error(transparent)]
-    LibraryError(#[from] LibraryError),
     /// The message is from an epoch too far in the past.
     #[error("The message is from an epoch too far in the past.")]
     NoPastEpochData,

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -127,21 +127,20 @@ pub enum MlsGroupState {
     Inactive,
 }
 
-/// A `MlsGroup` represents an MLS group with
-/// a high-level API. The API exposes
+/// A `MlsGroup` represents an MLS group with a high-level API. The API exposes
 /// high level functions to manage a group by adding/removing members, get the
 /// current member list, etc.
 ///
 /// The API is modeled such that it can serve as a direct interface to the
 /// Delivery Service. Functions that modify the public state of the group will
-/// return a `Vec<MLSMessageOut>` that can be sent to the Delivery
-/// Service directly. Conversely, incoming messages from the Delivery Service
-/// can be fed into [parse_message()](`MlsGroup::parse_message()`).
+/// return a `Vec<MLSMessageOut>` that can be sent to the Delivery Service
+/// directly. Conversely, incoming messages from the Delivery Service can be fed
+/// into [process_message()](`MlsGroup::process_message()`).
 ///
-/// An `MlsGroup` has an internal queue of pending proposals that builds up
-/// as new messages are processed. When creating proposals, those messages are
-/// not automatically appended to this queue, instead they have to be processed
-/// again through [parse_message()](`MlsGroup::parse_message()`). This
+/// An `MlsGroup` has an internal queue of pending proposals that builds up as
+/// new messages are processed. When creating proposals, those messages are not
+/// automatically appended to this queue, instead they have to be processed
+/// again through [process_message()](`MlsGroup::process_message()`). This
 /// allows the Delivery Service to reject them (e.g. if they reference the wrong
 /// epoch).
 ///

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -4,6 +4,7 @@
 
 mod group_context;
 
+#[cfg(any(feature = "test-utils", test))]
 use crate::ciphersuite::*;
 use crate::extensions::*;
 use crate::utils::*;

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -179,27 +179,20 @@ fn test_valsem240(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
 
-    let unverified_message = alice_group
-        .parse_message(message_in, backend)
-        .expect("Could not parse message.");
-
     let err = alice_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite missing external init proposal.");
+        .process_message(backend, message_in)
+        .expect_err("Could process message despite missing external init proposal.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ExternalCommitValidation(
+        ProcessMessageError::InvalidCommit(StageCommitError::ExternalCommitValidation(
             ExternalCommitValidationError::NoExternalInitProposals
         ))
     );
 
     // Positive case
-    let unverified_message = alice_group
-        .parse_message(MlsMessageIn::from(original_plaintext), backend)
-        .expect("Could not parse message.");
     alice_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -251,29 +244,20 @@ fn test_valsem241(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
 
-    let unverified_message = alice_group
-        .parse_message(message_in, backend)
-        .expect("Could not parse message.");
-
     let err = alice_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err(
-            "Could process unverified message despite second ext. init proposal in commit.",
-        );
+        .process_message(backend, message_in)
+        .expect_err("Could process message despite second ext. init proposal in commit.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ExternalCommitValidation(
+        ProcessMessageError::InvalidCommit(StageCommitError::ExternalCommitValidation(
             ExternalCommitValidationError::MultipleExternalInitProposals
         ))
     );
 
     // Positive case
-    let unverified_message = alice_group
-        .parse_message(MlsMessageIn::from(original_plaintext), backend)
-        .expect("Could not parse message.");
     alice_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -403,25 +387,18 @@ fn test_valsem242(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
         let verifiable_plaintext = VerifiableMlsAuthContent::from_plaintext(signed_plaintext, None);
 
-        let unverified_msg = alice_group
-            .parse_message(verifiable_plaintext.into(), backend)
-            .unwrap();
-
-        let processed_msg = alice_group.process_unverified_message(unverified_msg, None, backend);
+        let processed_msg = alice_group.process_message(backend, verifiable_plaintext.into());
 
         assert_eq!(
             processed_msg.unwrap_err(),
-            UnverifiedMessageError::InvalidCommit(StageCommitError::ExternalCommitValidation(
+            ProcessMessageError::InvalidCommit(StageCommitError::ExternalCommitValidation(
                 ExternalCommitValidationError::InvalidInlineProposals
             ))
         );
 
         // Positive case
-        let unverified_message = alice_group
-            .parse_message(original_plaintext.into(), backend)
-            .unwrap();
         alice_group
-            .process_unverified_message(unverified_message, None, backend)
+            .process_message(backend, original_plaintext.into())
             .unwrap();
     }
 }
@@ -536,17 +513,13 @@ fn test_valsem243(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
 
-    let unverified_message = alice_group
-        .parse_message(message_in, backend)
-        .expect("Could not parse message.");
-
-    let err = alice_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite the remove proposal targeting the wrong group member.");
+    let err = alice_group.process_message(backend, message_in).expect_err(
+        "Could process message despite the remove proposal targeting the wrong group member.",
+    );
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ExternalCommitValidation(
+        ProcessMessageError::InvalidCommit(StageCommitError::ExternalCommitValidation(
             ExternalCommitValidationError::InvalidRemoveProposal
         ))
     );
@@ -575,11 +548,8 @@ fn test_valsem243(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     assert!(alice_external_commit.is_ok());
 
     // Positive case
-    let unverified_message = alice_group
-        .parse_message(MlsMessageIn::from(original_plaintext), backend)
-        .expect("Could not parse message.");
     alice_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -642,27 +612,20 @@ fn test_valsem244(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
 
-    let unverified_message = alice_group
-        .parse_message(message_in, backend)
-        .expect("Could not parse message.");
-
     let err = alice_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite the external commit including an external init proposal by reference.");
+        .process_message(backend, message_in)
+        .expect_err("Could process message despite the external commit including an external init proposal by reference.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ExternalCommitValidation(
+        ProcessMessageError::InvalidCommit(StageCommitError::ExternalCommitValidation(
             ExternalCommitValidationError::MultipleExternalInitProposals
         ))
     );
 
     // Positive case
-    let unverified_message = alice_group
-        .parse_message(MlsMessageIn::from(original_plaintext), backend)
-        .expect("Could not parse message.");
     alice_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -710,20 +673,17 @@ fn test_valsem245(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let message_in = MlsMessageIn::from(verifiable_plaintext);
 
     let err = alice_group
-        .parse_message(message_in, backend)
-        .expect_err("Could process unverified message despite missing path.");
+        .process_message(backend, message_in)
+        .expect_err("Could process message despite missing path.");
 
     assert_eq!(
         err,
-        ParseMessageError::ValidationError(ValidationError::NoPath)
+        ProcessMessageError::ValidationError(ValidationError::NoPath)
     );
 
     // Positive case
-    let unverified_message = alice_group
-        .parse_message(MlsMessageIn::from(original_plaintext), backend)
-        .expect("Could not parse message.");
     alice_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -787,17 +747,13 @@ fn test_valsem246(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // Have alice process the commit resulting from external init.
     let message_in = MlsMessageIn::from(verifiable_plaintext);
 
-    let unverified_message = alice_group
-        .parse_message(message_in, backend)
-        .expect("Could not parse message.");
-
     let err = alice_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite wrong signature.");
+        .process_message(backend, message_in)
+        .expect_err("Could process message despite wrong signature.");
 
     // This shows that signature verification fails if the signature is not done
     // using the credential in the path.
-    assert_eq!(err, UnverifiedMessageError::InvalidSignature);
+    assert_eq!(err, ProcessMessageError::InvalidSignature);
 
     // This shows that the credential in the original path key package is actually bob's credential.
     let content = if let MlsContentBody::Commit(commit) = original_plaintext.content() {
@@ -824,11 +780,8 @@ fn test_valsem246(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // This shows it again, since ValSem010 ensures that the signature is
     // correct (which it only is, if alice is using the credential in the path
     // key package).
-    let unverified_message = alice_group
-        .parse_message(MlsMessageIn::from(original_plaintext), backend)
-        .expect("Could not parse message.");
     alice_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -867,5 +820,5 @@ fn test_pure_ciphertest(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
     assert_eq!(message.wire_format(), WireFormat::MlsPlaintext);
 
     // Would fail if handshake message processing did not distinguish external messages
-    assert!(alice_group.parse_message(message.into(), backend).is_ok());
+    assert!(alice_group.process_message(backend, message.into()).is_ok());
 }

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -12,7 +12,7 @@ use crate::{
     ciphersuite::{hash_ref::ProposalRef, signable::Signable},
     credentials::*,
     framing::{
-        MlsContentBody, MlsMessageIn, MlsMessageOut, MlsPlaintext, ProcessedMessage, Sender,
+        MlsContentBody, MlsMessageIn, MlsMessageOut, MlsPlaintext, ProcessedMessageContent, Sender,
         VerifiableMlsAuthContent,
     },
     group::{errors::*, *},
@@ -334,17 +334,13 @@ fn test_valsem100(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::DuplicateIdentityAddProposal
         ))
     );
@@ -354,11 +350,8 @@ fn test_valsem100(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Could not deserialize message.");
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_update_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -488,17 +481,13 @@ fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::DuplicateSignatureKeyAddProposal
         ))
     );
@@ -508,11 +497,8 @@ fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Could not deserialize message.");
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_update_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -649,17 +635,13 @@ fn test_valsem102(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::DuplicatePublicKeyAddProposal
         ))
     );
@@ -669,11 +651,8 @@ fn test_valsem102(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Could not deserialize message.");
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_update_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -761,17 +740,13 @@ fn test_valsem103(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::ExistingIdentityAddProposal
         ))
     );
@@ -781,11 +756,8 @@ fn test_valsem103(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Could not deserialize message.");
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_update_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -933,17 +905,13 @@ fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::ExistingSignatureKeyAddProposal
         ))
     );
@@ -953,11 +921,8 @@ fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Could not deserialize message.");
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_update_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -1101,17 +1066,13 @@ fn test_valsem105(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::ExistingPublicKeyAddProposal
         ))
     );
@@ -1121,11 +1082,8 @@ fn test_valsem105(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Could not deserialize message.");
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_update_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -1336,27 +1294,21 @@ fn test_valsem106(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             }
 
             // Have bob process the resulting plaintext
-            let unverified_message = bob_group
-                .parse_message(update_message_in, backend)
-                .expect("Could not parse message.");
-
             let err = bob_group
-                .process_unverified_message(unverified_message, None, backend)
-                .expect_err("Could process unverified message despite injected add proposal.");
+                .process_message(backend, update_message_in)
+                .expect_err("Could process message despite injected add proposal.");
 
             let expected_error = match key_package_version {
                 // We get an error even if the key package is valid. This is
                 // because Bob would expect the encrypted path in the commit to
                 // be longer due to the included Add proposal. Since we added
                 // the Add artificially, we thus have a path length mismatch.
-                KeyPackageTestVersion::ValidTestCase => UnverifiedMessageError::InvalidCommit(
+                KeyPackageTestVersion::ValidTestCase => ProcessMessageError::InvalidCommit(
                     StageCommitError::UpdatePathError(ApplyUpdatePathError::PathLengthMismatch),
                 ),
-                _ => UnverifiedMessageError::InvalidCommit(
-                    StageCommitError::ProposalValidationError(
-                        ProposalValidationError::InsufficientCapabilities,
-                    ),
-                ),
+                _ => ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+                    ProposalValidationError::InsufficientCapabilities,
+                )),
             };
 
             assert_eq!(err, expected_error);
@@ -1366,11 +1318,8 @@ fn test_valsem106(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
                     .expect("Could not deserialize message.");
 
             // Positive case
-            let unverified_message = bob_group
-                .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-                .expect("Could not parse message.");
             bob_group
-                .process_unverified_message(unverified_message, None, backend)
+                .process_message(backend, MlsMessageIn::from(original_update_plaintext))
                 .expect("Unexpected error.");
         }
 
@@ -1554,17 +1503,13 @@ fn test_valsem108(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::UnknownMemberRemoval
         ))
     );
@@ -1574,11 +1519,8 @@ fn test_valsem108(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Could not deserialize message.");
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_update_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -1630,13 +1572,10 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .expect("error while creating remove proposal");
 
     // Have Alice process this proposal.
-    let unverified_message = alice_group
-        .parse_message(update_proposal.into(), backend)
-        .expect("error parsing message");
-
-    if let ProcessedMessage::ProposalMessage(proposal) = alice_group
-        .process_unverified_message(unverified_message, None, backend)
+    if let ProcessedMessageContent::ProposalMessage(proposal) = alice_group
+        .process_message(backend, update_proposal.into())
         .expect("error processing proposal")
+        .into_content()
     {
         alice_group.store_pending_proposal(*proposal)
     } else {
@@ -1696,17 +1635,13 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::UpdateProposalIdentityMismatch
         ))
     );
@@ -1716,11 +1651,8 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Could not deserialize message.");
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_update_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -1786,13 +1718,10 @@ fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .expect("error while creating remove proposal");
 
     // Have Alice process this proposal.
-    let unverified_message = alice_group
-        .parse_message(update_proposal.into(), backend)
-        .expect("error parsing message");
-
-    if let ProcessedMessage::ProposalMessage(proposal) = alice_group
-        .process_unverified_message(unverified_message, None, backend)
+    if let ProcessedMessageContent::ProposalMessage(proposal) = alice_group
+        .process_message(backend, update_proposal.into())
         .expect("error processing proposal")
+        .into_content()
     {
         alice_group.store_pending_proposal(*proposal)
     } else {
@@ -1852,17 +1781,13 @@ fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::ExistingPublicKeyUpdateProposal
         ))
     );
@@ -1872,11 +1797,8 @@ fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Could not deserialize message.");
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_update_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -1958,17 +1880,13 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::CommitterIncludedOwnUpdate
         ))
     );
@@ -2021,17 +1939,13 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let update_message_in = MlsMessageIn::from(verifiable_plaintext);
 
     // Have bob process the resulting plaintext
-    let unverified_message = bob_group
-        .parse_message(update_message_in, backend)
-        .expect("Could not parse message.");
-
     let err = bob_group
-        .process_unverified_message(unverified_message, None, backend)
-        .expect_err("Could process unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could process message despite modified public key in path.");
 
     assert_eq!(
         err,
-        UnverifiedMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
             ProposalValidationError::CommitterIncludedOwnUpdate
         ))
     );
@@ -2041,11 +1955,8 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .expect("Could not deserialize message.");
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_update_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_update_plaintext))
         .expect("Unexpected error.");
 }
 
@@ -2095,12 +2006,12 @@ fn test_valsem112(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     // Have bob process the resulting plaintext
     let err = bob_group
-        .parse_message(update_message_in, backend)
-        .expect_err("Could parse unverified message despite modified public key in path.");
+        .process_message(backend, update_message_in)
+        .expect_err("Could parse message despite modified public key in path.");
 
     assert_eq!(
         err,
-        ParseMessageError::ValidationError(ValidationError::NotACommit)
+        ProcessMessageError::ValidationError(ValidationError::NotACommit)
     );
 
     // We can't test with sender type External, since that currently panics
@@ -2108,10 +2019,7 @@ fn test_valsem112(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // TODO This test should thus be extended when fixing #106.
 
     // Positive case
-    let unverified_message = bob_group
-        .parse_message(MlsMessageIn::from(original_plaintext), backend)
-        .expect("Could not parse message.");
     bob_group
-        .process_unverified_message(unverified_message, None, backend)
+        .process_message(backend, MlsMessageIn::from(original_plaintext))
         .expect("Unexpected error.");
 }

--- a/openmls/src/group/tests/test_remove_operation.rs
+++ b/openmls/src/group/tests/test_remove_operation.rs
@@ -113,15 +113,12 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
 
                 // Alice & Charlie store the pending proposal
                 for group in [&mut alice_group, &mut charlie_group] {
-                    let unverified_message = group
-                        .parse_message(message.clone().into(), backend)
-                        .expect("Could not parse message.");
                     let processed_message = group
-                        .process_unverified_message(unverified_message, None, backend)
-                        .expect("Could not process unverified message.");
+                        .process_message(backend, message.clone().into())
+                        .expect("Could not process message.");
 
-                    match processed_message {
-                        ProcessedMessage::ProposalMessage(proposal) => {
+                    match processed_message.into_content() {
+                        ProcessedMessageContent::ProposalMessage(proposal) => {
                             group.store_pending_proposal(*proposal);
                         }
                         _ => unreachable!(),
@@ -172,15 +169,12 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
 
         // === Remove operation from Bob's perspective ===
 
-        let unverified_message = bob_group
-            .parse_message(message.clone().into(), backend)
-            .expect("Could not parse message.");
         let bob_processed_message = bob_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, message.clone().into())
+            .expect("Could not process message.");
 
-        match bob_processed_message {
-            ProcessedMessage::StagedCommitMessage(bob_staged_commit) => {
+        match bob_processed_message.into_content() {
+            ProcessedMessageContent::StagedCommitMessage(bob_staged_commit) => {
                 let remove_proposal = bob_staged_commit
                     .remove_proposals()
                     .next()
@@ -226,15 +220,12 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
 
         // === Remove operation from Charlie's perspective ===
 
-        let unverified_message = charlie_group
-            .parse_message(message.into(), backend)
-            .expect("Could not parse message.");
         let charlie_processed_message = charlie_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, message.into())
+            .expect("Could not process message.");
 
-        match charlie_processed_message {
-            ProcessedMessage::StagedCommitMessage(charlie_staged_commit) => {
+        match charlie_processed_message.into_content() {
+            ProcessedMessageContent::StagedCommitMessage(charlie_staged_commit) => {
                 let remove_proposal = charlie_staged_commit
                     .remove_proposals()
                     .next()

--- a/openmls/src/group/tests/test_wire_format_policy.rs
+++ b/openmls/src/group/tests/test_wire_format_policy.rs
@@ -101,7 +101,7 @@ fn test_wire_policy_positive(ciphersuite: Ciphersuite, backend: &impl OpenMlsCry
         let mut alice_group = create_group(ciphersuite, backend, *wire_format_policy);
         let message = receive_message(ciphersuite, backend, &mut alice_group);
         alice_group
-            .parse_message(message.into(), backend)
+            .process_message(backend, message.into())
             .expect("An unexpected error occurred.");
     }
 }
@@ -124,8 +124,8 @@ fn test_wire_policy_negative(ciphersuite: Ciphersuite, backend: &impl OpenMlsCry
         let mut alice_group = create_group(ciphersuite, backend, wire_format_policy);
         let message = receive_message(ciphersuite, backend, &mut alice_group);
         let err = alice_group
-            .parse_message(message.into(), backend)
+            .process_message(backend, message.into())
             .expect_err("An unexpected error occurred.");
-        assert_eq!(err, ParseMessageError::IncompatibleWireFormat);
+        assert_eq!(err, ProcessMessageError::IncompatibleWireFormat);
     }
 }

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -161,19 +161,17 @@ impl Client {
                 group_state.clear_pending_commit();
             }
             // Process the message.
-            let unverified_message = group_state.parse_message(message.clone(), &self.crypto)?;
-            let processed_message =
-                group_state.process_unverified_message(unverified_message, None, &self.crypto)?;
+            let processed_message = group_state.process_message(&self.crypto, message.clone())?;
 
-            match processed_message {
-                ProcessedMessage::ApplicationMessage(_) => {}
-                ProcessedMessage::ProposalMessage(staged_proposal) => {
+            match processed_message.into_content() {
+                ProcessedMessageContent::ApplicationMessage(_) => {}
+                ProcessedMessageContent::ProposalMessage(staged_proposal) => {
                     group_state.store_pending_proposal(*staged_proposal);
                 }
-                ProcessedMessage::ExternalJoinProposalMessage(staged_proposal) => {
+                ProcessedMessageContent::ExternalJoinProposalMessage(staged_proposal) => {
                     group_state.store_pending_proposal(*staged_proposal);
                 }
-                ProcessedMessage::StagedCommitMessage(staged_commit) => {
+                ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
                     group_state.merge_staged_commit(*staged_commit)?;
                 }
             }

--- a/openmls/src/test_utils/test_framework/errors.rs
+++ b/openmls/src/test_utils/test_framework/errors.rs
@@ -53,9 +53,9 @@ pub enum ClientError {
     FailedToJoinGroup(#[from] WelcomeError),
     #[error(transparent)]
     TlsCodecError(#[from] tls_codec::Error),
-    /// See [`UnverifiedMessageError`] for more details.
+    /// See [`ProcessMessageError`] for more details.
     #[error(transparent)]
-    UnverifiedMessageError(#[from] UnverifiedMessageError),
+    ProcessMessageError(#[from] ProcessMessageError),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
     MlsGroupStateError(#[from] MlsGroupStateError),
@@ -83,9 +83,6 @@ pub enum ClientError {
     /// See [`ProposeSelfUpdateError`] for more details.
     #[error(transparent)]
     ProposeSelfUpdateError(#[from] ProposeSelfUpdateError),
-    /// See [`ParseMessageError`] for more details.
-    #[error(transparent)]
-    ParseMessageError(#[from] ParseMessageError),
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -215,8 +215,6 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             .expect("Expected a credential.")
             .clone();
 
-        //let sender = processed_message
-
         // Check that we received the correct message
         if let ProcessedMessageContent::ApplicationMessage(application_message) =
             processed_message.into_content()

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -207,19 +207,20 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             .create_message(backend, message_alice)
             .expect("Error creating application message");
 
-        let unverified_message = bob_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
-        let sender = unverified_message
+        let processed_message = bob_group
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
+        let sender = processed_message
             .credential()
             .expect("Expected a credential.")
             .clone();
-        let processed_message = bob_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+
+        //let sender = processed_message
 
         // Check that we received the correct message
-        if let ProcessedMessage::ApplicationMessage(application_message) = processed_message {
+        if let ProcessedMessageContent::ApplicationMessage(application_message) =
+            processed_message.into_content()
+        {
             // Check the message
             assert_eq!(application_message.into_bytes(), message_alice);
             // Check that Alice sent the message
@@ -239,15 +240,14 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             Err(e) => panic!("Error performing self-update: {:?}", e),
         };
 
-        let unverified_message = alice_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let alice_processed_message = alice_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
 
         // Check that we received the correct message
-        if let ProcessedMessage::StagedCommitMessage(staged_commit) = alice_processed_message {
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            alice_processed_message.into_content()
+        {
             let update_kp = staged_commit
                 .commit_update_key_package()
                 .expect("Expected a KeyPackage.")
@@ -297,15 +297,14 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             Err(e) => panic!("Error performing self-update: {:?}", e),
         };
 
-        let unverified_message = bob_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let bob_processed_message = bob_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
 
         // Check that we received the correct proposals
-        if let ProcessedMessage::ProposalMessage(staged_proposal) = bob_processed_message {
+        if let ProcessedMessageContent::ProposalMessage(staged_proposal) =
+            bob_processed_message.into_content()
+        {
             if let Proposal::Update(ref update_proposal) = staged_proposal.proposal() {
                 // Check that Alice updated
                 assert_eq!(
@@ -335,15 +334,14 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
                 Err(e) => panic!("Error performing self-update: {:?}", e),
             };
 
-        let unverified_message = bob_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let bob_processed_message = bob_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
 
         // Check that we received the correct message
-        if let ProcessedMessage::StagedCommitMessage(staged_commit) = bob_processed_message {
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            bob_processed_message.into_content()
+        {
             let update_kp = staged_commit
                 .commit_update_key_package()
                 .expect("Expected a KeyPackage.")
@@ -394,18 +392,17 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             Err(e) => panic!("Could not add member to group: {:?}", e),
         };
 
-        let unverified_message = alice_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let alice_processed_message = alice_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
         bob_group
             .merge_pending_commit()
             .expect("error merging pending commit");
 
         // Merge Commit
-        if let ProcessedMessage::StagedCommitMessage(staged_commit) = alice_processed_message {
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            alice_processed_message.into_content()
+        {
             alice_group
                 .merge_staged_commit(*staged_commit)
                 .expect("Could not merge StagedCommit");
@@ -445,18 +442,12 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             .create_message(backend, message_charlie)
             .expect("Error creating application message");
 
-        let unverified_message = alice_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let _alice_processed_message = alice_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
-        let unverified_message = bob_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
         let _bob_processed_message = bob_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
 
         // === Charlie updates and commits ===
         let (queued_message, welcome_option) = match charlie_group.self_update(backend, None) {
@@ -464,24 +455,20 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             Err(e) => panic!("Error performing self-update: {:?}", e),
         };
 
-        let unverified_message = alice_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let alice_processed_message = alice_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
-        let unverified_message = bob_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
         let bob_processed_message = bob_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
         charlie_group
             .merge_pending_commit()
             .expect("error merging pending commit");
 
         // Merge Commit
-        if let ProcessedMessage::StagedCommitMessage(staged_commit) = alice_processed_message {
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            alice_processed_message.into_content()
+        {
             alice_group
                 .merge_staged_commit(*staged_commit)
                 .expect("Could not merge StagedCommit");
@@ -490,7 +477,9 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
         }
 
         // Merge Commit
-        if let ProcessedMessage::StagedCommitMessage(staged_commit) = bob_processed_message {
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            bob_processed_message.into_content()
+        {
             bob_group
                 .merge_staged_commit(*staged_commit)
                 .expect("Could not merge StagedCommit");
@@ -530,24 +519,20 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
         // Check that Bob's group is still active
         assert!(bob_group.is_active());
 
-        let unverified_message = alice_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let alice_processed_message = alice_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
-        let unverified_message = bob_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
         let bob_processed_message = bob_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
         charlie_group
             .merge_pending_commit()
             .expect("error merging pending commit");
 
         // Check that we receive the correct proposal for Alice
-        if let ProcessedMessage::StagedCommitMessage(staged_commit) = alice_processed_message {
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            alice_processed_message.into_content()
+        {
             let remove = staged_commit
                 .remove_proposals()
                 .next()
@@ -568,7 +553,9 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
         }
 
         // Check that we receive the correct proposal for Alice
-        if let ProcessedMessage::StagedCommitMessage(staged_commit) = bob_processed_message {
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            bob_processed_message.into_content()
+        {
             let remove = staged_commit
                 .remove_proposals()
                 .next()
@@ -633,15 +620,14 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             .propose_remove_member(backend, charlie_group.own_leaf_index())
             .expect("Could not create proposal to remove Charlie");
 
-        let unverified_message = charlie_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let charlie_processed_message = charlie_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
 
         // Check that we received the correct proposals
-        if let ProcessedMessage::ProposalMessage(staged_proposal) = charlie_processed_message {
+        if let ProcessedMessageContent::ProposalMessage(staged_proposal) =
+            charlie_processed_message.into_content()
+        {
             if let Proposal::Remove(ref remove_proposal) = staged_proposal.proposal() {
                 // Check that Charlie was removed
                 assert_eq!(remove_proposal.removed(), members[1].index);
@@ -665,15 +651,14 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             .propose_add_member(backend, &bob_key_package)
             .expect("Could not create proposal to add Bob");
 
-        let unverified_message = charlie_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let charlie_processed_message = charlie_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
 
         // Check that we received the correct proposals
-        if let ProcessedMessage::ProposalMessage(staged_proposal) = charlie_processed_message {
+        if let ProcessedMessageContent::ProposalMessage(staged_proposal) =
+            charlie_processed_message.into_content()
+        {
             if let Proposal::Add(add_proposal) = staged_proposal.proposal() {
                 // Check that Bob was added
                 assert_eq!(add_proposal.key_package().credential(), &bob_credential);
@@ -697,12 +682,9 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             .commit_to_pending_proposals(backend)
             .expect("Could not flush proposals");
 
-        let unverified_message = charlie_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let charlie_processed_message = charlie_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
 
         // Merge Commit
         alice_group
@@ -710,7 +692,9 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             .expect("error merging pending commit");
 
         // Merge Commit
-        if let ProcessedMessage::StagedCommitMessage(staged_commit) = charlie_processed_message {
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            charlie_processed_message.into_content()
+        {
             charlie_group
                 .merge_staged_commit(*staged_commit)
                 .expect("Could not merge StagedCommit");
@@ -780,19 +764,19 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
         let queued_message = alice_group
             .create_message(backend, message_alice)
             .expect("Error creating application message");
-        let unverified_message = bob_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
-        let sender = unverified_message
+
+        let bob_processed_message = bob_group
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
+        let sender = bob_processed_message
             .credential()
             .expect("Expected a credential.")
             .clone();
-        let bob_processed_message = bob_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
 
         // Check that we received the correct message
-        if let ProcessedMessage::ApplicationMessage(application_message) = bob_processed_message {
+        if let ProcessedMessageContent::ApplicationMessage(application_message) =
+            bob_processed_message.into_content()
+        {
             // Check the message
             assert_eq!(application_message.into_bytes(), message_alice);
             // Check that Alice sent the message
@@ -810,15 +794,14 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             .leave_group(backend)
             .expect("Could not leave group");
 
-        let unverified_message = alice_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let alice_processed_message = alice_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
 
         // Store proposal
-        if let ProcessedMessage::ProposalMessage(staged_proposal) = alice_processed_message {
+        if let ProcessedMessageContent::ProposalMessage(staged_proposal) =
+            alice_processed_message.into_content()
+        {
             // Store proposal
             alice_group.store_pending_proposal(*staged_proposal);
         } else {
@@ -861,15 +844,14 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             .merge_pending_commit()
             .expect("Could not merge Commit.");
 
-        let unverified_message = bob_group
-            .parse_message(queued_message.clone().into(), backend)
-            .expect("Could not parse message.");
         let bob_processed_message = bob_group
-            .process_unverified_message(unverified_message, None, backend)
-            .expect("Could not process unverified message.");
+            .process_message(backend, queued_message.clone().into())
+            .expect("Could not process message.");
 
         // Check that we received the correct proposals
-        if let ProcessedMessage::StagedCommitMessage(staged_commit) = bob_processed_message {
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            bob_processed_message.into_content()
+        {
             let remove = staged_commit
                 .remove_proposals()
                 .next()


### PR DESCRIPTION
This PR fixes #1088.

It introduces the following changes:
 - Message processing becomes easier because we can now drop the parsing step. `MlsMessageIn` can now be processed directly.
 - `ProcessedMessage` now also consistently exposes header values (epoch, sender, aad, etc.). The content is exposed through `.content()` or `.into_content()` and is equivalent to the old enum that has now been renamed to `ProcessedMessageContent`.
 - The API change revealed that most ValSem positive tests were not entirely correct (as well as a few other tests), this has now been fixed.

The first commit contains the relevant code changes, the other commits only contain the adjustments to the new API and the test fixes.