### PR TITLE
remove unnecessary lifetimes

### DIFF
--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -15,7 +15,6 @@ uuid = { version = "1.0", features = ["v4"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 log = { version = "0.4", features = ["std"] }
-typetag = "0.1"
 tls_codec = { version = "0.2.0", features = ["derive", "serde_serialize", "mls"] }
 # Only required for tests.
 rand = { version = "0.8", optional = true }

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -699,10 +699,10 @@ impl CoreGroup {
     }
 
     /// Get the message secrets. Either from the secrets store or from the group.
-    pub(crate) fn message_secrets_mut<'secret, 'group: 'secret>(
-        &'group mut self,
+    pub(crate) fn message_secrets_mut(
+        &mut self,
         epoch: GroupEpoch,
-    ) -> Result<&'secret mut MessageSecrets, SecretTreeError> {
+    ) -> Result<&mut MessageSecrets, SecretTreeError> {
         if epoch < self.context().epoch() {
             self.message_secrets_store
                 .secrets_for_epoch_mut(epoch)
@@ -713,10 +713,10 @@ impl CoreGroup {
     }
 
     /// Get the message secrets. Either from the secrets store or from the group.
-    pub(crate) fn message_secrets_for_epoch<'secret, 'group: 'secret>(
-        &'group self,
+    pub(crate) fn message_secrets_for_epoch(
+        &self,
         epoch: GroupEpoch,
-    ) -> Result<&'secret MessageSecrets, SecretTreeError> {
+    ) -> Result<&MessageSecrets, SecretTreeError> {
         if epoch < self.context().epoch() {
             self.message_secrets_store
                 .secrets_for_epoch(epoch)
@@ -731,10 +731,10 @@ impl CoreGroup {
     ///
     /// Note that the leaves vector is empty for message secrets of the current
     /// epoch. The caller can use treesync in this case.
-    pub(crate) fn message_secrets_and_leaves_mut<'secret, 'group: 'secret>(
-        &'group mut self,
+    pub(crate) fn message_secrets_and_leaves_mut(
+        &mut self,
         epoch: GroupEpoch,
-    ) -> Result<(&'secret mut MessageSecrets, &[Member]), MessageDecryptionError> {
+    ) -> Result<(&mut MessageSecrets, &[Member]), MessageDecryptionError> {
         if epoch < self.context().epoch() {
             self.message_secrets_store
                 .secrets_and_leaves_for_epoch_mut(epoch)


### PR DESCRIPTION
The lifetimes can be infered by now and the typetag crate isn't used anymore.