### PR TITLE
chore: #[allow(clippy::large_enum_variant)] on `Node` and `ProposalOrRef`.

### DIFF
--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -354,6 +354,7 @@ pub(crate) enum ProposalOrRefType {
 )]
 #[repr(u8)]
 #[allow(missing_docs)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum ProposalOrRef {
     #[tls_codec(discriminant = 1)]
     Proposal(Proposal),

--- a/openmls/src/treesync/node.rs
+++ b/openmls/src/treesync/node.rs
@@ -16,6 +16,7 @@ pub(crate) mod parent_node;
 /// Container enum for leaf and parent nodes.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
+#[allow(clippy::large_enum_variant)]
 pub enum Node {
     LeafNode(OpenMlsLeafNode),
     ParentNode(ParentNode),


### PR DESCRIPTION
This PR silences two (remaining) Clippy warnings about the large size difference in `Node`s and `ProposalOrRef`s enum variants.

Should we `Box` the large variant? Or would it be sufficient for now to file an issue that reminds us to re-evaluate later?