### PR TITLE
Remove LifetimeExtension

### DIFF
--- a/openmls/src/extensions/codec.rs
+++ b/openmls/src/extensions/codec.rs
@@ -4,8 +4,7 @@ use tls_codec::{Deserialize, Serialize, Size, TlsByteVecU32, TlsSliceU32};
 
 use crate::extensions::{
     ApplicationIdExtension, Extension, ExtensionType, ExternalPubExtension,
-    ExternalSendersExtension, LifetimeExtension, RatchetTreeExtension,
-    RequiredCapabilitiesExtension,
+    ExternalSendersExtension, RatchetTreeExtension, RequiredCapabilitiesExtension,
 };
 
 impl Size for Extension {
@@ -19,7 +18,6 @@ impl Size for Extension {
                 Extension::RequiredCapabilities(e) => e.tls_serialized_len(),
                 Extension::ExternalPub(e) => e.tls_serialized_len(),
                 Extension::ExternalSenders(e) => e.tls_serialized_len(),
-                Extension::Lifetime(e) => e.tls_serialized_len(),
             }
     }
 }
@@ -39,7 +37,6 @@ impl Serialize for Extension {
             Extension::RequiredCapabilities(e) => e.tls_serialize(&mut extension_data),
             Extension::ExternalPub(e) => e.tls_serialize(&mut extension_data),
             Extension::ExternalSenders(e) => e.tls_serialize(&mut extension_data),
-            Extension::Lifetime(e) => e.tls_serialize(&mut extension_data),
         }?;
         debug_assert_eq!(extension_data_written, extension_data_len);
         debug_assert_eq!(extension_data_written, extension_data.len());
@@ -75,9 +72,6 @@ impl Deserialize for Extension {
             ExtensionType::ExternalSenders => Extension::ExternalSenders(
                 ExternalSendersExtension::tls_deserialize(&mut extension_data)?,
             ),
-            ExtensionType::Lifetime => {
-                Extension::Lifetime(LifetimeExtension::tls_deserialize(&mut extension_data)?)
-            }
         })
     }
 }

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -29,29 +29,6 @@ fn key_package_id() {
     assert_eq!(&data[..], &serialized_extension_struct);
 }
 
-#[test]
-fn lifetime() {
-    // A freshly created extensions must be valid.
-    let ext = LifetimeExtension::default();
-    assert!(ext.is_valid());
-
-    // An extension without lifetime is invalid (waiting for 1 second).
-    let ext = LifetimeExtension::new(0);
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    assert!(!ext.is_valid());
-
-    // Test (de)serializing invalid extension
-    let serialized = ext
-        .tls_serialize_detached()
-        .expect("error encoding life time extension");
-    let ext_deserialized = LifetimeExtension::tls_deserialize(&mut serialized.as_slice())
-        .expect_err("Didn't get an error deserializing invalid life time extension");
-    assert_eq!(
-        ext_deserialized,
-        tls_codec::Error::DecodingError("Invalid".to_string()),
-    );
-}
-
 // This tests the ratchet tree extension to deliver the public ratcheting tree
 // in-band
 #[apply(ciphersuites_and_backends)]

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -702,6 +702,7 @@ impl VerifiableMlsAuthContent {
     }
 
     /// Set the serialized context before verifying the signature.
+    #[cfg(any(feature = "test-utils", test))]
     pub(crate) fn set_context(&mut self, serialized_context: Vec<u8>) {
         self.auth_content.tbs.serialized_context = Some(serialized_context);
     }

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -48,7 +48,10 @@ use crate::{
     messages::{proposals::*, *},
     schedule::{message_secrets::*, psk::*, *},
     tree::{secret_tree::SecretTreeError, sender_ratchet::SenderRatchetConfiguration},
-    treesync::{node::leaf_node::Capabilities, *},
+    treesync::{
+        node::leaf_node::{Capabilities, Lifetime},
+        *,
+    },
     versions::ProtocolVersion,
 };
 
@@ -140,7 +143,7 @@ pub(crate) struct CoreGroupBuilder {
     version: Option<ProtocolVersion>,
     required_capabilities: Option<RequiredCapabilitiesExtension>,
     max_past_epochs: usize,
-    lifetime: Option<LifetimeExtension>,
+    lifetime: Option<Lifetime>,
 }
 
 impl CoreGroupBuilder {
@@ -182,8 +185,8 @@ impl CoreGroupBuilder {
         self.max_past_epochs = max_past_epochs;
         self
     }
-    /// Set the [`LifetimeExtension`] for the own leaf in the group.
-    pub fn with_lifetime(mut self, lifetime: LifetimeExtension) -> Self {
+    /// Set the [`Lifetime`] for the own leaf in the group.
+    pub fn with_lifetime(mut self, lifetime: Lifetime) -> Self {
         self.lifetime = Some(lifetime);
         self
     }

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -28,7 +28,9 @@
 //! ```
 
 use super::*;
-use crate::tree::sender_ratchet::SenderRatchetConfiguration;
+use crate::{
+    tree::sender_ratchet::SenderRatchetConfiguration, treesync::node::leaf_node::Lifetime,
+};
 use serde::{Deserialize, Serialize};
 
 /// Specifies the configuration parameters for a [`MlsGroup`]. Refer to
@@ -52,7 +54,7 @@ pub struct MlsGroupConfig {
     /// Sender ratchet configuration
     pub(crate) sender_ratchet_configuration: SenderRatchetConfiguration,
     /// Lifetime of the own leaf node
-    pub(crate) lifetime: LifetimeExtension,
+    pub(crate) lifetime: Lifetime,
 }
 
 impl MlsGroupConfig {
@@ -92,7 +94,7 @@ impl MlsGroupConfig {
     }
 
     /// Returns the [`MlsGroupConfig`] lifetime configuration.
-    pub fn lifetime(&self) -> &LifetimeExtension {
+    pub fn lifetime(&self) -> &Lifetime {
         &self.lifetime
     }
 
@@ -170,7 +172,7 @@ impl MlsGroupConfigBuilder {
     }
 
     /// Sets the `lifetime` property of the MlsGroupConfig.
-    pub fn lifetime(mut self, lifetime: LifetimeExtension) -> Self {
+    pub fn lifetime(mut self, lifetime: Lifetime) -> Self {
         self.config.lifetime = lifetime;
         self
     }

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -73,7 +73,7 @@ impl MlsGroup {
             .with_config(group_config)
             .with_required_capabilities(mls_group_config.required_capabilities.clone())
             .with_max_past_epoch_secrets(mls_group_config.max_past_epochs)
-            .with_lifetime(mls_group_config.lifetime().clone())
+            .with_lifetime(*mls_group_config.lifetime())
             .build(&credential_bundle, backend)
             .map_err(|e| match e {
                 CoreGroupBuildError::LibraryError(e) => e.into(),

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -16,7 +16,10 @@ use crate::{
     schedule::psk::*,
     test_utils::*,
     tree::sender_ratchet::*,
-    treesync::node::{leaf_node::LeafNodeSource, Node},
+    treesync::node::{
+        leaf_node::{LeafNodeSource, Lifetime},
+        Node,
+    },
     versions::ProtocolVersion,
 };
 
@@ -70,7 +73,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
             .expect("An unexpected error occurred.");
     // TODO(#1149, #1051)
     // let capabilities = CapabilitiesExtension::default();
-    let lifetime = LifetimeExtension::default();
+    let lifetime = Lifetime::default();
 
     // Let's create a group
     let mut group = CoreGroup::builder(GroupId::random(&crypto), key_package_bundle)
@@ -439,7 +442,7 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
 
     // Lifetime
     let tv_lifetime = hex_to_bytes(&tv.lifetime);
-    let my_lifetime = LifetimeExtension::tls_deserialize(&mut tv_lifetime.as_slice())
+    let my_lifetime = Lifetime::tls_deserialize(&mut tv_lifetime.as_slice())
         .expect("An unexpected error occurred.")
         .tls_serialize_detached()
         .expect("An unexpected error occurred.");

--- a/openmls/src/group/tests/test_encoding.rs
+++ b/openmls/src/group/tests/test_encoding.rs
@@ -100,14 +100,11 @@ fn test_update_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
             .get(&group_state.ciphersuite())
             .expect("An unexpected error occurred.");
 
-        let lifetime_extension = Extension::Lifetime(LifetimeExtension::new(60));
-        let mandatory_extensions: Vec<Extension> = vec![lifetime_extension];
-
         let key_package_bundle = KeyPackageBundle::new(
             &[group_state.ciphersuite()],
             credential_bundle,
             backend,
-            mandatory_extensions,
+            vec![],
         )
         .expect("An unexpected error occurred.");
 
@@ -159,14 +156,11 @@ fn test_add_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
             .get(&group_state.ciphersuite())
             .expect("An unexpected error occurred.");
 
-        let lifetime_extension = Extension::Lifetime(LifetimeExtension::new(60));
-        let mandatory_extensions: Vec<Extension> = vec![lifetime_extension];
-
         let key_package_bundle = KeyPackageBundle::new(
             &[group_state.ciphersuite()],
             credential_bundle,
             backend,
-            mandatory_extensions,
+            vec![],
         )
         .expect("An unexpected error occurred.");
 
@@ -259,14 +253,11 @@ fn test_commit_encoding(backend: &impl OpenMlsCryptoProvider) {
             .get(&group_state.ciphersuite())
             .expect("An unexpected error occurred.");
 
-        let lifetime_extension = Extension::Lifetime(LifetimeExtension::new(60));
-        let mandatory_extensions: Vec<Extension> = vec![lifetime_extension];
-
         let alice_key_package_bundle = KeyPackageBundle::new(
             &[group_state.ciphersuite()],
             alice_credential_bundle,
             backend,
-            mandatory_extensions.clone(),
+            vec![],
         )
         .expect("An unexpected error occurred.");
 

--- a/openmls/src/group/tests/test_group.rs
+++ b/openmls/src/group/tests/test_group.rs
@@ -34,35 +34,19 @@ fn create_commit_optional_path(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
     )
     .expect("An unexpected error occurred.");
 
-    // Mandatory extensions, will be fixed in #164
-    let lifetime_extension = Extension::Lifetime(LifetimeExtension::new(60));
-    let mandatory_extensions: Vec<Extension> = vec![lifetime_extension];
-
     // Generate KeyPackages
-    let alice_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite],
-        &alice_credential_bundle,
-        backend,
-        mandatory_extensions.clone(),
-    )
-    .expect("An unexpected error occurred.");
+    let alice_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite], &alice_credential_bundle, backend, vec![])
+            .expect("An unexpected error occurred.");
 
-    let bob_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite],
-        &bob_credential_bundle,
-        backend,
-        mandatory_extensions.clone(),
-    )
-    .expect("An unexpected error occurred.");
+    let bob_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite], &bob_credential_bundle, backend, vec![])
+            .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
-    let alice_update_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite],
-        &alice_credential_bundle,
-        backend,
-        mandatory_extensions,
-    )
-    .expect("An unexpected error occurred.");
+    let alice_update_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite], &alice_credential_bundle, backend, vec![])
+            .expect("An unexpected error occurred.");
     let alice_update_key_package = alice_update_key_package_bundle.key_package();
     assert!(alice_update_key_package.verify(backend,).is_ok());
 
@@ -304,26 +288,14 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     )
     .expect("An unexpected error occurred.");
 
-    // Mandatory extensions
-    let lifetime_extension = Extension::Lifetime(LifetimeExtension::new(60));
-    let mandatory_extensions: Vec<Extension> = vec![lifetime_extension];
-
     // Generate KeyPackages
-    let alice_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite],
-        &alice_credential_bundle,
-        backend,
-        mandatory_extensions.clone(),
-    )
-    .expect("An unexpected error occurred.");
+    let alice_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite], &alice_credential_bundle, backend, vec![])
+            .expect("An unexpected error occurred.");
 
-    let bob_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite],
-        &bob_credential_bundle,
-        backend,
-        mandatory_extensions.clone(),
-    )
-    .expect("An unexpected error occurred.");
+    let bob_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite], &bob_credential_bundle, backend, vec![])
+            .expect("An unexpected error occurred.");
     let bob_key_package = bob_key_package_bundle.key_package();
 
     // === Alice creates a group ===
@@ -425,13 +397,9 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
             MlsContentBody::Application(message) if message.as_slice() == &message_alice[..]));
 
     // === Bob updates and commits ===
-    let bob_update_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite],
-        &bob_credential_bundle,
-        backend,
-        mandatory_extensions.clone(),
-    )
-    .expect("Could not create key package bundle.");
+    let bob_update_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite], &bob_credential_bundle, backend, vec![])
+            .expect("Could not create key package bundle.");
 
     let update_proposal_bob = group_bob
         .create_update_proposal(
@@ -489,13 +457,9 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     }
 
     // === Alice updates and commits ===
-    let alice_update_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite],
-        &alice_credential_bundle,
-        backend,
-        mandatory_extensions.clone(),
-    )
-    .expect("Could not create key package bundle.");
+    let alice_update_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite], &alice_credential_bundle, backend, vec![])
+            .expect("Could not create key package bundle.");
 
     let update_proposal_alice = group_alice
         .create_update_proposal(
@@ -547,13 +511,9 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     }
 
     // === Bob updates and Alice commits ===
-    let bob_update_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite],
-        &bob_credential_bundle,
-        backend,
-        mandatory_extensions.clone(),
-    )
-    .expect("Could not create key package bundle.");
+    let bob_update_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite], &bob_credential_bundle, backend, vec![])
+            .expect("Could not create key package bundle.");
 
     let update_proposal_bob = group_bob
         .create_update_proposal(
@@ -626,13 +586,9 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     )
     .expect("An unexpected error occurred.");
 
-    let charlie_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite],
-        &charlie_credential_bundle,
-        backend,
-        mandatory_extensions.clone(),
-    )
-    .expect("Could not create key package bundle.");
+    let charlie_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite], &charlie_credential_bundle, backend, vec![])
+            .expect("Could not create key package bundle.");
     let charlie_key_package = charlie_key_package_bundle.key_package().clone();
 
     let add_charlie_proposal_bob = group_bob
@@ -776,13 +732,9 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         MlsContentBody::Application(message) if message.as_slice() == &message_charlie[..]));
 
     // === Charlie updates and commits ===
-    let charlie_update_key_package_bundle = KeyPackageBundle::new(
-        &[ciphersuite],
-        &charlie_credential_bundle,
-        backend,
-        mandatory_extensions,
-    )
-    .expect("Could not create key package bundle.");
+    let charlie_update_key_package_bundle =
+        KeyPackageBundle::new(&[ciphersuite], &charlie_credential_bundle, backend, vec![])
+            .expect("Could not create key package bundle.");
 
     let update_proposal_charlie = group_charlie
         .create_update_proposal(

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -104,15 +104,9 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
             // Create a number of key packages.
             let mut key_packages = Vec::new();
             for _ in 0..KEY_PACKAGE_COUNT {
-                let lifetime_extension = Extension::Lifetime(LifetimeExtension::new(60));
-                let mandatory_extensions: Vec<Extension> = vec![lifetime_extension];
-                let key_package_bundle: KeyPackageBundle = KeyPackageBundle::new(
-                    &[ciphersuite],
-                    &credential_bundle,
-                    backend,
-                    mandatory_extensions,
-                )
-                .expect("An unexpected error occurred.");
+                let key_package_bundle: KeyPackageBundle =
+                    KeyPackageBundle::new(&[ciphersuite], &credential_bundle, backend, vec![])
+                        .expect("An unexpected error occurred.");
                 key_packages.push(key_package_bundle.key_package().clone());
                 key_package_bundles.push(key_package_bundle);
             }

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -15,38 +15,10 @@ fn generate_key_package(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
     .expect("An unexpected error occurred.");
 
     // Generate a valid KeyPackage.
-    let lifetime_extension = Extension::Lifetime(LifetimeExtension::new(60));
-    let kpb = KeyPackageBundle::new(
-        &[ciphersuite],
-        &credential_bundle,
-        backend,
-        vec![lifetime_extension],
-    )
-    .expect("An unexpected error occurred.");
+    let kpb = KeyPackageBundle::new(&[ciphersuite], &credential_bundle, backend, vec![])
+        .expect("An unexpected error occurred.");
     std::thread::sleep(std::time::Duration::from_millis(1));
     assert!(kpb.key_package().verify(backend).is_ok());
-
-    // Now we add an invalid lifetime.
-    let lifetime_extension = Extension::Lifetime(LifetimeExtension::new(0));
-    let kpb = KeyPackageBundle::new(
-        &[ciphersuite],
-        &credential_bundle,
-        backend,
-        vec![lifetime_extension],
-    )
-    .expect("An unexpected error occurred.");
-    std::thread::sleep(std::time::Duration::from_millis(1));
-    assert!(kpb.key_package().verify(backend).is_err());
-
-    // Now with two lifetime extensions, the key package should be invalid.
-    let lifetime_extension = Extension::Lifetime(LifetimeExtension::new(60));
-    let kpb = KeyPackageBundle::new(
-        &[ciphersuite],
-        &credential_bundle,
-        backend,
-        vec![lifetime_extension.clone(), lifetime_extension],
-    );
-    assert!(kpb.is_err());
 }
 
 #[apply(ciphersuites_and_backends)]
@@ -58,11 +30,10 @@ fn decryption_key_index_computation(
     let credential_bundle =
         CredentialBundle::new(id, CredentialType::Basic, ciphersuite.into(), backend)
             .expect("An unexpected error occurred.");
-    let mut kpb = KeyPackageBundle::new(&[ciphersuite], &credential_bundle, backend, Vec::new())
+    let kpb = KeyPackageBundle::new(&[ciphersuite], &credential_bundle, backend, Vec::new())
         .expect("An unexpected error occurred.")
         .unsigned();
 
-    kpb.add_extension(Extension::Lifetime(LifetimeExtension::new(60)));
     let kpb = kpb
         .sign(backend, &credential_bundle)
         .expect("An unexpected error occurred.");
@@ -83,13 +54,8 @@ fn key_package_id_extension(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryp
     let credential_bundle =
         CredentialBundle::new(id, CredentialType::Basic, ciphersuite.into(), backend)
             .expect("An unexpected error occurred.");
-    let kpb = KeyPackageBundle::new(
-        &[ciphersuite],
-        &credential_bundle,
-        backend,
-        vec![Extension::Lifetime(LifetimeExtension::new(60))],
-    )
-    .expect("An unexpected error occurred.");
+    let kpb = KeyPackageBundle::new(&[ciphersuite], &credential_bundle, backend, vec![])
+        .expect("An unexpected error occurred.");
     let verification = kpb.key_package().verify(backend);
     assert!(verification.is_ok());
     let mut kpb = kpb.unsigned();

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -48,8 +48,6 @@ impl Client {
             .credentials
             .get(&ciphersuites[0])
             .ok_or(ClientError::CiphersuiteNotSupported)?;
-        let mandatory_extensions: Vec<Extension> =
-            vec![Extension::Lifetime(LifetimeExtension::new(157788000))]; // 5 years
         let credential_bundle: CredentialBundle = self
             .crypto
             .key_store()
@@ -60,13 +58,8 @@ impl Client {
                     .expect("Error serializing signature key."),
             )
             .ok_or(ClientError::NoMatchingCredential)?;
-        let kpb = KeyPackageBundle::new(
-            ciphersuites,
-            &credential_bundle,
-            &self.crypto,
-            mandatory_extensions,
-        )
-        .expect("An unexpected error occurred.");
+        let kpb = KeyPackageBundle::new(ciphersuites, &credential_bundle, &self.crypto, vec![])
+            .expect("An unexpected error occurred.");
         let kp = kpb.key_package().clone();
         self.crypto
             .key_store()
@@ -88,8 +81,6 @@ impl Client {
             .credentials
             .get(&ciphersuite)
             .ok_or(ClientError::CiphersuiteNotSupported)?;
-        let mandatory_extensions: Vec<Extension> =
-            vec![Extension::Lifetime(LifetimeExtension::new(157788000))]; // 5 years
         let credential_bundle: CredentialBundle = self
             .crypto
             .key_store()
@@ -100,13 +91,8 @@ impl Client {
                     .expect("Error serializing signature key."),
             )
             .ok_or(ClientError::NoMatchingCredential)?;
-        let kpb = KeyPackageBundle::new(
-            &[ciphersuite],
-            &credential_bundle,
-            &self.crypto,
-            mandatory_extensions,
-        )
-        .expect("An unexpected error occurred.");
+        let kpb = KeyPackageBundle::new(&[ciphersuite], &credential_bundle, &self.crypto, vec![])
+            .expect("An unexpected error occurred.");
         let key_package = kpb.key_package().clone();
         self.crypto
             .key_store()

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     ciphersuite::Secret,
     credentials::CredentialBundle,
     error::LibraryError,
-    extensions::{Extension, LifetimeExtension},
+    extensions::Extension,
     framing::SenderError,
     group::Member,
     key_packages::KeyPackageBundle,
@@ -39,7 +39,7 @@ use crate::{
 
 use self::{
     diff::{StagedTreeSyncDiff, TreeSyncDiff},
-    node::leaf_node::{Capabilities, LeafNodeSource, OpenMlsLeafNode},
+    node::leaf_node::{Capabilities, LeafNodeSource, Lifetime, OpenMlsLeafNode},
     treesync_node::{TreeSyncNode, TreeSyncNodeError},
 };
 
@@ -92,7 +92,7 @@ impl TreeSync {
         backend: &impl OpenMlsCryptoProvider,
         key_package_bundle: KeyPackageBundle,
         credential_bundle: &CredentialBundle,
-        life_time: LifetimeExtension,
+        life_time: Lifetime,
         capabilities: Capabilities,
         extensions: Vec<Extension>,
     ) -> Result<(Self, CommitSecret), LibraryError> {

--- a/openmls/src/treesync/node/leaf_node/lifetime.rs
+++ b/openmls/src/treesync/node/leaf_node/lifetime.rs
@@ -1,0 +1,99 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+
+/// This value is used as the default lifetime if no default  lifetime is configured.
+/// The value is in seconds and amounts to 3 * 28 Days, i.e. about 3 months.
+const DEFAULT_KEY_PACKAGE_LIFETIME_SECONDS: u64 = 60 * 60 * 24 * 28 * 3;
+
+/// This value is used as the default amount of time (in seconds) the lifetime
+/// of a `KeyPackage` is extended into the past to allow for skewed clocks. The
+/// value is in seconds and amounts to 1h.
+const DEFAULT_KEY_PACKAGE_LIFETIME_MARGIN_SECONDS: u64 = 60 * 60;
+
+/// The lifetime extension represents the times between which clients will
+/// consider a KeyPackage valid. This time is represented as an absolute time,
+/// measured in seconds since the Unix epoch (1970-01-01T00:00:00Z).
+/// A client MUST NOT use the data in a KeyPackage for any processing before
+/// the not_before date, or after the not_after date.
+///
+/// Applications MUST define a maximum total lifetime that is acceptable for a
+/// KeyPackage, and reject any KeyPackage where the total lifetime is longer
+/// than this duration.This extension MUST always be present in a KeyPackage.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-16
+/// struct {
+///     uint64 not_before;
+///     uint64 not_after;
+/// } Lifetime;
+/// ```
+#[derive(
+    PartialEq, Eq, Copy, Clone, Debug, TlsSerialize, TlsSize, TlsDeserialize, Serialize, Deserialize,
+)]
+pub struct Lifetime {
+    not_before: u64,
+    not_after: u64,
+}
+
+impl Lifetime {
+    /// Create a new lifetime with lifetime `t` (in seconds).
+    /// Note that the lifetime is extended 1h into the past to adapt to skewed
+    /// clocks, i.e. `not_before` is set to now - 1h.
+    pub fn new(t: u64) -> Self {
+        let lifetime_margin: u64 = DEFAULT_KEY_PACKAGE_LIFETIME_MARGIN_SECONDS;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("SystemTime before UNIX EPOCH!")
+            .as_secs();
+        let not_before = now - lifetime_margin;
+        let not_after = now + t;
+        Self {
+            not_before,
+            not_after,
+        }
+    }
+
+    /// Returns true if this lifetime is valid.
+    pub(crate) fn is_valid(&self) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("SystemTime before UNIX EPOCH!")
+            .as_secs();
+        self.not_before < now && now < self.not_after
+    }
+}
+
+impl Default for Lifetime {
+    fn default() -> Self {
+        Lifetime::new(DEFAULT_KEY_PACKAGE_LIFETIME_SECONDS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tls_codec::{Deserialize, Serialize};
+
+    use crate::treesync::node::leaf_node::Lifetime;
+
+    #[test]
+    fn lifetime() {
+        // A freshly created extensions must be valid.
+        let ext = Lifetime::default();
+        assert!(ext.is_valid());
+
+        // An extension without lifetime is invalid (waiting for 1 second).
+        let ext = Lifetime::new(0);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        assert!(!ext.is_valid());
+
+        // Test (de)serializing invalid extension
+        let serialized = ext
+            .tls_serialize_detached()
+            .expect("error encoding life time extension");
+        let ext_deserialized = Lifetime::tls_deserialize(&mut serialized.as_slice())
+            .expect("Error deserializing lifetime");
+        assert!(!ext_deserialized.is_valid());
+    }
+}

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -89,11 +89,6 @@ fn generate_key_package_bundle(
     backend: &impl OpenMlsCryptoProvider,
 ) -> Result<KeyPackage, KeyPackageBundleNewError> {
     // ANCHOR: create_key_package_bundle
-    // Define extensions
-    let extensions = vec![Extension::Lifetime(LifetimeExtension::new(
-        60 * 60 * 24 * 90, // Maximum lifetime of 90 days, expressed in seconds
-    ))];
-
     // Fetch the credential bundle from the key store
     let credential_bundle = backend
         .key_store()
@@ -107,7 +102,7 @@ fn generate_key_package_bundle(
 
     // Create the key package bundle
     let key_package_bundle =
-        KeyPackageBundle::new(ciphersuites, &credential_bundle, backend, extensions)?;
+        KeyPackageBundle::new(ciphersuites, &credential_bundle, backend, vec![])?;
     // ANCHOR_END: create_key_package_bundle
     // ANCHOR: store_key_package_bundle
     let key_package = key_package_bundle.key_package().clone();


### PR DESCRIPTION
This PR replaces #1154 to only remove the lifetime extension.
The lifetime is part of the leaf node now instead.

Note that there are different mechanisms to set the lifetime that are not aligned well. This will be cleaned up in follow ups.