### PR TITLE
auto format book markdown

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 [Introduction](introduction.md)
+
 - [User manual](user_manual/README.md)
   - [Credentials](user_manual/identity.md)
   - [Key packages](user_manual/create_key_package.md)

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,11 +1,12 @@
 # Introduction
+
 <!-- Get the Readme without the headline until (including) the introductory sentence  -->
+
 {{#include ../../README.md:2:14}}
 OpenMLS provides a high-level API to create and manage MLS groups. It supports basic ciphersuites and an interchangeable cryptographic backend, key store, and random number generator.
 
 This book provides guidance on using OpenMLS and its `MlsGroup` API to perform basic group operations, illustrated with examples.
 
 <!-- Get the rest of the Readme -->
+
 {{#include ../../README.md:20:}}
-
-

--- a/book/src/message_validation.md
+++ b/book/src/message_validation.md
@@ -25,10 +25,10 @@ Every function in the processing chain performs several semantic validation step
 
 `.process_unverified_message()` performs all other semantic validation steps. In particular, it ensures that ...
 
-* the message is correctly authenticated by a signature (`ValSem010`), membership tag (`ValSem008`), and confirmation tag (`ValSem205`),
-* proposals are valid relative to one another and the current group state, e.g., no redundant adds or removes targeting non-members (`ValSem100`-`ValSem112`),
-* commits are valid relative to the group state and the proposals it covers (`ValSem200`-`ValSem205`) and
-* external commits are valid according to the spec (`ValSem240`-`ValSem245`, `ValSem247` is checked as part of `ValSem010`).
+- the message is correctly authenticated by a signature (`ValSem010`), membership tag (`ValSem008`), and confirmation tag (`ValSem205`),
+- proposals are valid relative to one another and the current group state, e.g., no redundant adds or removes targeting non-members (`ValSem100`-`ValSem112`),
+- commits are valid relative to the group state and the proposals it covers (`ValSem200`-`ValSem205`) and
+- external commits are valid according to the spec (`ValSem240`-`ValSem245`, `ValSem247` is checked as part of `ValSem010`).
 
 After performing these steps, messages are returned as `ProcessedMessage`s that the application can either use immediately (application messages) or inspect and decide if they find them valid according to the application's policy (proposals and commits). Proposals can then be stored in the proposal queue via `.store_pending_proposal()`, while commits can be merged into the group state via `.merge_staged_commit()`.
 
@@ -40,54 +40,54 @@ The following is a list of the individual semantic validation steps performed by
 
 | ValidationStep | Description                                                 | Implemented | Tested | Test File                                            |
 | -------------- | ----------------------------------------------------------- | ----------- | ------ | ---------------------------------------------------- |
-| `ValSem002`    | Group id                                                    | ✅           | ✅      | `openmls/src/group/tests/test_framing_validation.rs` |
-| `ValSem003`    | Epoch                                                       | ✅           | ✅      | `openmls/src/group/tests/test_framing_validation.rs` |
-| `ValSem004`    | Sender: Member: check the sender points to a non-blank leaf | ✅           | ✅      | `openmls/src/group/tests/test_framing_validation.rs` |
-| `ValSem005`    | Application messages must use ciphertext                    | ✅           | ✅      | `openmls/src/group/tests/test_framing_validation.rs` |
-| `ValSem006`    | Ciphertext: decryption needs to work                        | ✅           | ✅      | `openmls/src/group/tests/test_framing_validation.rs` |
-| `ValSem007`    | Membership tag presence                                     | ✅           | ✅      | `openmls/src/group/tests/test_framing_validation.rs` |
-| `ValSem008`    | Membership tag verification                                 | ✅           | ✅      | `openmls/src/group/tests/test_framing_validation.rs` |
-| `ValSem009`    | Confirmation tag presence                                   | ✅           | ✅      | `openmls/src/group/tests/test_framing_validation.rs` |
-| `ValSem010`    | Signature verification                                      | ✅           | ✅      | `openmls/src/group/tests/test_framing_validation.rs` |
-| `ValSem011`    | MLSCiphertextContent padding must be all-zero               | ✅           | ✅      | `openmls/src/group/tests/test_framing.rs`            |
+| `ValSem002`    | Group id                                                    | ✅          | ✅     | `openmls/src/group/tests/test_framing_validation.rs` |
+| `ValSem003`    | Epoch                                                       | ✅          | ✅     | `openmls/src/group/tests/test_framing_validation.rs` |
+| `ValSem004`    | Sender: Member: check the sender points to a non-blank leaf | ✅          | ✅     | `openmls/src/group/tests/test_framing_validation.rs` |
+| `ValSem005`    | Application messages must use ciphertext                    | ✅          | ✅     | `openmls/src/group/tests/test_framing_validation.rs` |
+| `ValSem006`    | Ciphertext: decryption needs to work                        | ✅          | ✅     | `openmls/src/group/tests/test_framing_validation.rs` |
+| `ValSem007`    | Membership tag presence                                     | ✅          | ✅     | `openmls/src/group/tests/test_framing_validation.rs` |
+| `ValSem008`    | Membership tag verification                                 | ✅          | ✅     | `openmls/src/group/tests/test_framing_validation.rs` |
+| `ValSem009`    | Confirmation tag presence                                   | ✅          | ✅     | `openmls/src/group/tests/test_framing_validation.rs` |
+| `ValSem010`    | Signature verification                                      | ✅          | ✅     | `openmls/src/group/tests/test_framing_validation.rs` |
+| `ValSem011`    | MLSCiphertextContent padding must be all-zero               | ✅          | ✅     | `openmls/src/group/tests/test_framing.rs`            |
 
 ### Semantic validation of proposals covered by a Commit
 
 | ValidationStep | Description                                                                                 | Implemented | Tested | Test File                                             |
 | -------------- | ------------------------------------------------------------------------------------------- | ----------- | ------ | ----------------------------------------------------- |
-| `ValSem100`    | Add Proposal: Identity in proposals must be unique among proposals                          | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem101`    | Add Proposal: Signature public key in proposals must be unique among proposals              | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem102`    | Add Proposal: HPKE init key in proposals must be unique among proposals                     | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem103`    | Add Proposal: Identity in proposals must be unique among existing group members             | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem104`    | Add Proposal: Signature public key in proposals must be unique among existing group members | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem105`    | Add Proposal: HPKE init key in proposals must be unique among existing group members        | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem106`    | Add Proposal: required capabilities                                                         | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem107`    | Remove Proposal: Removed member must be unique among proposals                              | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem108`    | Remove Proposal: Removed member must be an existing group member                            | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem109`    | Update Proposal: Identity must be unchanged between existing member and new proposal        | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem110`    | Update Proposal: HPKE init key must be unique among existing members                        | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem111`    | Update Proposal: The sender of a full Commit must not include own update proposals          | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem112`    | Update Proposal: The sender of a standalone update proposal must be of type member          | ✅           | ✅      | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem100`    | Add Proposal: Identity in proposals must be unique among proposals                          | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem101`    | Add Proposal: Signature public key in proposals must be unique among proposals              | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem102`    | Add Proposal: HPKE init key in proposals must be unique among proposals                     | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem103`    | Add Proposal: Identity in proposals must be unique among existing group members             | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem104`    | Add Proposal: Signature public key in proposals must be unique among existing group members | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem105`    | Add Proposal: HPKE init key in proposals must be unique among existing group members        | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem106`    | Add Proposal: required capabilities                                                         | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem107`    | Remove Proposal: Removed member must be unique among proposals                              | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem108`    | Remove Proposal: Removed member must be an existing group member                            | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem109`    | Update Proposal: Identity must be unchanged between existing member and new proposal        | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem110`    | Update Proposal: HPKE init key must be unique among existing members                        | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem111`    | Update Proposal: The sender of a full Commit must not include own update proposals          | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem112`    | Update Proposal: The sender of a standalone update proposal must be of type member          | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
 
 ### Commit message validation
 
 | ValidationStep | Description                                                                            | Implemented | Tested | Test File                                           |
 | -------------- | -------------------------------------------------------------------------------------- | ----------- | ------ | --------------------------------------------------- |
-| `ValSem200`    | Commit must not cover inline self Remove proposal                                      | ✅           | ✅      | `openmls/src/group/tests/test_commit_validation.rs` |
-| `ValSem201`    | Path must be present, if at least one proposal requires a path                         | ✅           | ✅      | `openmls/src/group/tests/test_commit_validation.rs` |
-| `ValSem202`    | Path must be the right length                                                          | ✅           | ✅      | `openmls/src/group/tests/test_commit_validation.rs` |
-| `ValSem203`    | Path secrets must decrypt correctly                                                    | ✅           | ✅      | `openmls/src/group/tests/test_commit_validation.rs` |
-| `ValSem204`    | Public keys from Path must be verified and match the private keys from the direct path | ✅           | ✅      | `openmls/src/group/tests/test_commit_validation.rs` |
-| `ValSem205`    | Confirmation tag must be successfully verified                                         | ✅           | ✅      | `openmls/src/group/tests/test_commit_validation.rs` |
+| `ValSem200`    | Commit must not cover inline self Remove proposal                                      | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
+| `ValSem201`    | Path must be present, if at least one proposal requires a path                         | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
+| `ValSem202`    | Path must be the right length                                                          | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
+| `ValSem203`    | Path secrets must decrypt correctly                                                    | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
+| `ValSem204`    | Public keys from Path must be verified and match the private keys from the direct path | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
+| `ValSem205`    | Confirmation tag must be successfully verified                                         | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
 
 ### External Commit message validation
 
 | ValidationStep | Description                                                                                       | Implemented | Tested | Test File                                                    |
 | -------------- | ------------------------------------------------------------------------------------------------- | ----------- | ------ | ------------------------------------------------------------ |
-| `ValSem240`    | External Commit must cover at least one inline ExternalInit proposal                              | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem241`    | External Commit must cover at most one inline ExternalInit proposal                               | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem242`    | External Commit must only cover inline proposal in allowlist (ExternalInit, Remove, PreSharedKey) | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem243`    | Identity of inline Remove proposal target and external committer must be the same                 | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem244`    | External Commit must not include any proposals by reference                                       | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem245`    | External Commit must contain a path                                                               | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
-| `ValSem246`    | External Commit signature must be verified using the credential in the path KeyPackage            | ✅           | ✅      | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem240`    | External Commit must cover at least one inline ExternalInit proposal                              | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem241`    | External Commit must cover at most one inline ExternalInit proposal                               | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem242`    | External Commit must only cover inline proposal in allowlist (ExternalInit, Remove, PreSharedKey) | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem243`    | Identity of inline Remove proposal target and external committer must be the same                 | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem244`    | External Commit must not include any proposals by reference                                       | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem245`    | External Commit must contain a path                                                               | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |
+| `ValSem246`    | External Commit signature must be verified using the credential in the path KeyPackage            | ✅          | ✅     | `openmls/src/group/tests/test_external_commit_validation.rs` |

--- a/book/src/performance.md
+++ b/book/src/performance.md
@@ -10,6 +10,7 @@ Check which scenarios and group sizes are enabled in the code.
 ## Real World Scenarios
 
 ### Stable group
+
 Many private groups follow this model.
 
 - Group is created by user P1
@@ -18,6 +19,7 @@ Many private groups follow this model.
 - Every X messages, one user in the group sends an update
 
 ### Somewhat stable group
+
 This can model a company or team-wide group where regularly but infrequently, users are added, and users leave.
 
 - Group is created by user P1
@@ -28,52 +30,59 @@ This can model a company or team-wide group where regularly but infrequently, us
 - Every Z messages, R users are removed
 
 ### High fluctuation group
+
 This models public groups where users frequently join and leave.
 Real-time scenarios such as [gather.town](https://gather.town) are examples of high-fluctuation groups.
 It is the same scenario as the somewhat stable group but with a very small Y and Z.
 
 ## Extreme Scenarios
+
 In addition to the three scenarios above extreme and corner cases are interesting.
 
 ### Every second leave is blank
+
 Only every second leave in the tree is non-blank.
 
 ## Use Case Scenarios
+
 A collection of common use cases/flows from everyday scenarios.
 
 ### Long-time offline device
+
 Suppose a device has been offline for a while. In that case, it has to process a large number of application and protocol messages.
 
 ## Tree scenarios
+
 In addition to the scenarios above, it is interesting to look at the same scenario but with different states of the tree.
 For example, take the stable group with N members messaging each other.
 What is the performance difference between a message sent right after group setup, i.e., each member only joined the group without other messages being sent, and a tree where every member has sent an update before the message?
 
 ## Measurements
+
 - Group creation
-    - create group
-    - create proposals
-    - create welcome
-    - apply commit
+  - create group
+  - create proposals
+  - create welcome
+  - apply commit
 - Join group
-    - create group from welcome
+  - create group from welcome
 - Send application message
 - Receive application message
 - Send update
-    - create proposal
-    - create commit
-    - apply commit
+  - create proposal
+  - create commit
+  - apply commit
 - Receive update
-    - apply commit
+  - apply commit
 - Add user sender
-    - create proposal
-    - create welcome
-    - apply commit
+  - create proposal
+  - create welcome
+  - apply commit
 - Existing user getting an add
-    - apply commit
+  - apply commit
 - Remove user sender
-    - create proposal
-    - create commit
-    - apply commit
+  - create proposal
+  - create commit
+  - apply commit
 - Existing user getting a remove
-    - apply commit
+  - apply commit

--- a/book/src/traits/traits.md
+++ b/book/src/traits/traits.md
@@ -1,6 +1,6 @@
 # OpenMLS Traits
 
-> **⚠️  These traits are responsible for all cryptographic operations and randomness
+> **⚠️ These traits are responsible for all cryptographic operations and randomness
 > within OpenMLS.
 > Please ensure you know what you're doing when implementing your own versions.**
 

--- a/book/src/traits/types.md
+++ b/book/src/traits/types.md
@@ -1,4 +1,3 @@
-
 # External Types
 
 For interoperability, this crate also defines several types and algorithm

--- a/book/src/user_manual/README.md
+++ b/book/src/user_manual/README.md
@@ -1,4 +1,4 @@
-# User manual 
+# User manual
 
 The user manual describes how to use the different parts of the OpenMLS API.
 
@@ -19,6 +19,6 @@ Thus, you can create the `backend` object for the following examples using ...
 {{#include ../../../openmls/tests/book_code.rs:create_backend_evercrypt}}
 ```
 
-[`OpenMlsCryptoProvider`]: https://docs.rs/openmls/latest/openmls/prelude/trait.OpenMlsCryptoProvider.html
+[`openmlscryptoprovider`]: https://docs.rs/openmls/latest/openmls/prelude/trait.OpenMlsCryptoProvider.html
 [openmls_rust_crypto]: https://crates.io/crates/openmls_rust_crypto
 [openmls_evercrypt]: https://crates.io/crates/openmls_evercrypt

--- a/book/src/user_manual/add_members.md
+++ b/book/src/user_manual/add_members.md
@@ -30,7 +30,7 @@ proposals are crafted by outsiders, they are always plaintext messages.
 ```
 
 It is then up to the group members to validate the proposal and commit it.
-Note that in this scenario it is up to the application to define a proper authorization policy to grant the sender. 
+Note that in this scenario it is up to the application to define a proper authorization policy to grant the sender.
 
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code.rs:decrypt_external_join_proposal}}

--- a/book/src/user_manual/create_group.md
+++ b/book/src/user_manual/create_group.md
@@ -23,4 +23,3 @@ If someone else already gave you a group ID, e.g., a backend server, you can als
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code.rs:alice_create_group_with_group_id}}
 ```
-

--- a/book/src/user_manual/create_key_package.md
+++ b/book/src/user_manual/create_key_package.md
@@ -2,11 +2,11 @@
 
 To enable the asynchronous establishment of groups through pre-publishing key material, as well as to represent clients in the group, MLS relies on key packages. Key packages hold several pieces of information:
 
-* a public HPKE encryption key to enable MLS' basic group key distribution feature
-* the lifetime throughout which the key package is valid
-* information about the client's capabilities (i.e., which features of MLS it supports)
-* any extension that the client wants to include
-* one of the client's [credentials](./identity.md), as well as a signature over the whole key package using the private key corresponding to the credential's signature public key
+- a public HPKE encryption key to enable MLS' basic group key distribution feature
+- the lifetime throughout which the key package is valid
+- information about the client's capabilities (i.e., which features of MLS it supports)
+- any extension that the client wants to include
+- one of the client's [credentials](./identity.md), as well as a signature over the whole key package using the private key corresponding to the credential's signature public key
 
 ## Creating key packages
 
@@ -34,4 +34,3 @@ After creating the key package bundle, clients should store it in the key store 
 ```
 
 All functions and structs related to key packages can be found in the [`key_packages`](https://docs.rs/crate/openmls/latest/key_packages/index.html) module.
-

--- a/book/src/user_manual/crypto-subtle.md
+++ b/book/src/user_manual/crypto-subtle.md
@@ -3,7 +3,7 @@
 This feature of the OpenMLS crate allows importing and exporting private signature keys that can be used with credentials.
 
 ⚠️ Note that no checks are performed on the keys. Use this feature at your own risk. If you create a credential from an existing key
-or export key material, you are responsible for deleting that key. If that key is kept outside OpenMLS, 
+or export key material, you are responsible for deleting that key. If that key is kept outside OpenMLS,
 updating a leaf will not be enough to achieve Forward Secrecy/Post-compromise Security.
 
 ## Importing keys
@@ -28,7 +28,7 @@ SignaturePrivateKey::as_slice(&self) -> &[u8]
 
 ## Building a BasicCredential from existing keys
 
-```rust,no_run,noplayground 
+```rust,no_run,noplayground
 let signature_scheme = SignatureScheme::ED25519;
 
 let private_key = vec![1, 2, 3]; // Sample private key as raw bytes
@@ -36,7 +36,7 @@ let public_key = vec![4, 5, 6]; // Sample public key as raw bytes
 
 let identity = vec![7, 8, 9]; // Sample identity
 
-let signature_keypair 
+let signature_keypair
     = SignatureKeypair::from_bytes(signature_scheme, public_key, private_key);
 
 let credential_bundle = CredentialBundle::from_parts(identity, signature_keypair);

--- a/book/src/user_manual/join_from_welcome.md
+++ b/book/src/user_manual/join_from_welcome.md
@@ -7,5 +7,5 @@ If the group configuration does not use the ratchet tree extension, the ratchet 
 {{#include ../../../openmls/tests/book_code.rs:bob_joins_with_welcome}}
 ```
 
-Pay attention not to forward a Welcome message to a client before its associated commit has been accepted by the 
+Pay attention not to forward a Welcome message to a client before its associated commit has been accepted by the
 Delivery Service. Otherwise, you would end up with an invalid MLS group instance.

--- a/book/src/user_manual/leaving.md
+++ b/book/src/user_manual/leaving.md
@@ -7,7 +7,8 @@ Members can indicate to other group members that they wish to leave the group us
 ```
 
 After successfully sending the proposal to the DS for fanout, there is still the possibility that the remove proposal is not covered in the following commit. The member leaving the group thus has two options:
-* tear down the local group state and ignore all subsequent messages for that group, or
-* wait for the commit to come through and process it (see also [Getting Removed](remove_members.md#getting-removed-from-a-group)).
+
+- tear down the local group state and ignore all subsequent messages for that group, or
+- wait for the commit to come through and process it (see also [Getting Removed](remove_members.md#getting-removed-from-a-group)).
 
 For details on creating Remove Proposals, see [Removing members from a group](remove_members.md).

--- a/book/src/user_manual/remove_members.md
+++ b/book/src/user_manual/remove_members.md
@@ -22,6 +22,7 @@ Members can also be removed as a proposal (without the corresponding Commit mess
 In this case, the function returns an `MlsMessageOut` that needs to be fanned out to existing group members.
 
 ## Getting removed from a group
+
 A member is removed from a group if another member commits to a remove proposal targeting the member's leaf. Once the to-be-removed member merges that commit via `merge_staged_commit()`, all other proposals in that commit will still be applied, but the group will be marked as inactive afterward. The group remains usable, e.g., to examine the membership list after the final commit was processed, but it won't be possible to create or process new messages.
 
 ```rust,no_run,noplayground


### PR DESCRIPTION
The book markdown hasn't been formatted in a while.
To avoid churn while working on it I did a pass. There should only be whitespace changes and things like `*` -> `-` here.

Review without whitespace changes.