### PR TITLE
More tree cleanup

### DIFF
--- a/openmls/src/binary_tree/array_representation/diff.rs
+++ b/openmls/src/binary_tree/array_representation/diff.rs
@@ -68,28 +68,6 @@ impl<T: Clone + Debug> StagedAbDiff<T> {
     }
 }
 
-/// A [`NodeReference`] represents the position of a node in an [`AbDiff`]. It
-/// can be used to access the node at that position or to navigate to other,
-/// neighbouring nodes via the [`AbDiff::sibling()`], [`AbDiff::left_child()`]
-/// and [`AbDiff::right_child()`] functions of the [`AbDiff`].
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) struct NodeId {
-    node_index: NodeIndex,
-}
-
-impl NodeId {
-    /// Creates a new [`NodeReference`] to a node at the given index.
-    ///
-    /// Returns an error if the given index is outside the bounds of the diff.
-    pub(super) fn try_from_node_index<T: Clone + Debug>(
-        diff: &AbDiff<T>,
-        node_index: NodeIndex,
-    ) -> Result<Self, OutOfBoundsError> {
-        diff.out_of_bounds(node_index)?;
-        Ok(NodeId { node_index })
-    }
-}
-
 /// The [`AbDiff`] represents a set of differences (i.e. a "Diff") for an
 /// [`ABinaryTree`]. It can be created from an [`ABinaryTree`] instance and then
 /// accessed mutably or immutably. Any changes are saved by the [`AbDiff`] applied
@@ -161,13 +139,12 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
         self.replace_node(node_index, new_leaf)
     }
 
-    /// Obtain a [`NodeReference`] to the leaf with the given [`LeafIndex`].
+    /// Obtain a [`NodeIndex`] to the leaf with the given [`LeafIndex`].
     ///
     /// Returns an error if the given leaf index does not correspond to a leaf
     /// in the diff.
-    pub(crate) fn leaf(&self, leaf_index: LeafIndex) -> Result<NodeId, ABinaryTreeDiffError> {
-        let node_index = to_node_index(leaf_index);
-        Ok(NodeId::try_from_node_index(self, node_index)?)
+    pub(crate) fn leaf(&self, leaf_index: LeafIndex) -> NodeIndex {
+        to_node_index(leaf_index)
     }
 
     /// Returns an iterator over a tuple of the leaf index and a reference to a
@@ -206,25 +183,16 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
     // Functions related to the direct paths of leaves
     //////////////////////////////////////////////////
 
-    /// Returns a vector of [`NodeReference`] instances, each one referencing a
+    /// Returns a vector of [`NodeIndex`] instances, each one referencing a
     /// node in the direct path of the given [`LeafIndex`], ordered from the
     /// parent of the corresponding leaf to the root of the tree.
     pub(crate) fn direct_path(
         &self,
         leaf_index: LeafIndex,
-    ) -> Result<Vec<NodeId>, OutOfBoundsError> {
+    ) -> Result<Vec<NodeIndex>, OutOfBoundsError> {
         let node_index = to_node_index(leaf_index);
         // `direct_path` only throws an error if the input index is out of bounds.
-        let direct_path_indices = direct_path(node_index, self.tree_size())
-            .map_err(|_| OutOfBoundsError::IndexOutOfBounds)?;
-        let mut direct_path = Vec::new();
-        for node_index in direct_path_indices {
-            // `direct_path` only throws an error if the input index is out of bounds.
-            let node_ref = NodeId::try_from_node_index(self, node_index)
-                .map_err(|_| OutOfBoundsError::IndexOutOfBounds)?;
-            direct_path.push(node_ref);
-        }
-        Ok(direct_path)
+        direct_path(node_index, self.tree_size()).map_err(|_| OutOfBoundsError::IndexOutOfBounds)
     }
 
     /// Sets all nodes in the direct path to a copy of the given node. This
@@ -298,7 +266,7 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
             .ok_or_else(|| LibraryError::custom("index should be in the direct path").into())
     }
 
-    /// Returns [`NodeReference`] to the copath node of the `leaf_index_1` that is
+    /// Returns [`NodeIndex`] to the copath node of the `leaf_index_1` that is
     /// in the direct path of `leaf_index_2`.
     ///
     /// Returns an error if both leaf indices are identical or if one of the
@@ -307,7 +275,7 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
         &self,
         leaf_index_1: LeafIndex,
         leaf_index_2: LeafIndex,
-    ) -> Result<NodeId, ABinaryTreeDiffError> {
+    ) -> Result<NodeIndex, ABinaryTreeDiffError> {
         self.leaf_pair_check(leaf_index_1, leaf_index_2)?;
 
         // We want to return the position of the lowest common ancestor in the
@@ -322,10 +290,10 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
             right(subtree_root_node_index, self.tree_size())?
         };
 
-        Ok(NodeId::try_from_node_index(self, copath_node_index)?)
+        Ok(copath_node_index)
     }
 
-    /// Returns a vector of [`NodeReference`]s, where the first reference is to
+    /// Returns a vector of [`NodeIndex`]es, where the first reference is to
     /// the root of the shared subtree of the two given leaf indices followed by
     /// references to the nodes in the direct path of said subtree root.
     ///
@@ -335,7 +303,7 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
         &self,
         leaf_index_1: LeafIndex,
         leaf_index_2: LeafIndex,
-    ) -> Result<Vec<NodeId>, ABinaryTreeDiffError> {
+    ) -> Result<Vec<NodeIndex>, ABinaryTreeDiffError> {
         let node_index_1 = to_node_index(leaf_index_1);
         let node_index_2 = to_node_index(leaf_index_2);
 
@@ -343,12 +311,9 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
         self.out_of_bounds(node_index_2)?;
 
         let lca = lowest_common_ancestor(node_index_1, node_index_2);
-        let direct_path_indices = direct_path(lca, self.tree_size())?;
-        let mut full_path = vec![NodeId::try_from_node_index(self, lca)?];
-        for node_index in direct_path_indices {
-            let node_ref = NodeId::try_from_node_index(self, node_index)?;
-            full_path.push(node_ref);
-        }
+        let mut direct_path = direct_path(lca, self.tree_size())?;
+        let mut full_path = vec![lca];
+        full_path.append(&mut direct_path);
 
         Ok(full_path)
     }
@@ -391,82 +356,81 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
         ((self.tree_size() - 1) / 2) + 1
     }
 
-    // Functions around individual [`NodeReference`]s
+    // Functions around individual [`NodeIndex`]s
     ///////////////////////////////////////////////
 
-    /// Returns a reference to the node pointed to by the [`NodeReference`].
-    /// Returns an Error if the [`NodeReference`] points to a node outside of the
+    /// Returns a reference to the node pointed to by the [`NodeIndex`].
+    /// Returns an Error if the [`NodeIndex`] points to a node outside of the
     /// bounds of the tree. This can happen, for example, if the node was
     /// removed while shrinking the diff after the creation of the
-    /// [`NodeReference`].
-    pub(crate) fn node(&self, node_ref: NodeId) -> Result<&T, ABinaryTreeDiffError> {
-        self.node_by_index(node_ref.node_index)
+    /// [`NodeIndex`].
+    pub(crate) fn node(&self, node_index: NodeIndex) -> Result<&T, ABinaryTreeDiffError> {
+        self.node_by_index(node_index)
     }
 
     /// Returns a mutable reference to the node pointed to by the
-    /// [`NodeReference`]. Returns an Error if the [`NodeReference`] points to a
+    /// [`NodeIndex`]. Returns an Error if the [`NodeIndex`] points to a
     /// node outside of the bounds of the tree. This can happen, for example, if
     /// the node was removed while shrinking the diff after the creation of the
-    /// [`NodeReference`].
-    pub(crate) fn node_mut(&mut self, node_ref: NodeId) -> Result<&mut T, ABinaryTreeDiffError> {
-        self.node_mut_by_index(node_ref.node_index)
+    /// [`NodeIndex`].
+    pub(crate) fn node_mut(
+        &mut self,
+        node_index: NodeIndex,
+    ) -> Result<&mut T, ABinaryTreeDiffError> {
+        self.node_mut_by_index(node_index)
     }
 
-    /// Return a [`NodeReference`] to the root node of the diff. Since the diff
+    /// Return a [`NodeIndex`] to the root node of the diff. Since the diff
     /// always consists of at least one node, this operation cannot fail.
-    pub(crate) fn root(&self) -> NodeId {
-        let root_index = root(self.tree_size());
-        // We create the reference directly instead of via self.new_reference,
-        // since due to the minimum tree size of one node, the root is always
-        // within bounds.
-        NodeId {
-            node_index: root_index,
-        }
+    pub(crate) fn root(&self) -> NodeIndex {
+        root(self.tree_size())
     }
 
-    /// Returns true if the given [`NodeReference`] points to a leaf and [`false`]
+    /// Returns true if the given [`NodeIndex`] points to a leaf and [`false`]
     /// otherwise.
-    pub(crate) fn is_leaf(&self, node_ref: NodeId) -> bool {
-        node_ref.node_index % 2 == 0
+    pub(crate) fn is_leaf(&self, node_index: NodeIndex) -> bool {
+        node_index % 2 == 0
     }
 
-    /// Returns a [`NodeReference`] to the parent of the referenced node. Returns
-    /// an error when the given [`NodeReference`] points to the root node or to a
+    /// Returns a [`NodeIndex`] to the parent of the referenced node. Returns
+    /// an error when the given [`NodeIndex`] points to the root node or to a
     /// node not in the tree.
-    pub(crate) fn parent(&self, node_ref: NodeId) -> Result<NodeId, ABinaryTreeDiffError> {
-        let parent_index = parent(node_ref.node_index, self.tree_size())?;
-        Ok(NodeId::try_from_node_index(self, parent_index)?)
+    pub(crate) fn parent(&self, node_index: NodeIndex) -> Result<NodeIndex, ABinaryTreeDiffError> {
+        Ok(parent(node_index, self.tree_size())?)
     }
 
-    /// Returns a [`NodeReference`] to the sibling of the referenced node. Returns
-    /// an error when the given [`NodeReference`] points to the root node or to a
+    /// Returns a [`NodeIndex`] to the sibling of the referenced node. Returns
+    /// an error when the given [`NodeIndex`] points to the root node or to a
     /// node not in the tree.
-    pub(crate) fn sibling(&self, node_ref: NodeId) -> Result<NodeId, ABinaryTreeDiffError> {
-        let sibling_index = sibling(node_ref.node_index, self.tree_size())?;
-        Ok(NodeId::try_from_node_index(self, sibling_index)?)
+    pub(crate) fn sibling(&self, node_index: NodeIndex) -> Result<NodeIndex, ABinaryTreeDiffError> {
+        Ok(sibling(node_index, self.tree_size())?)
     }
 
-    /// Returns a [`NodeReference`] to the left child of the referenced node.
-    /// Returns an error when the given [`NodeReference`] points to a leaf node or
+    /// Returns a [`NodeIndex`] to the left child of the referenced node.
+    /// Returns an error when the given [`NodeIndex`] points to a leaf node or
     /// to a node not in the tree.
-    pub(crate) fn left_child(&self, node_ref: NodeId) -> Result<NodeId, ABinaryTreeDiffError> {
-        let left_child_index = left(node_ref.node_index)?;
-        Ok(NodeId::try_from_node_index(self, left_child_index)?)
+    pub(crate) fn left_child(
+        &self,
+        node_index: NodeIndex,
+    ) -> Result<NodeIndex, ABinaryTreeDiffError> {
+        Ok(left(node_index)?)
     }
 
-    /// Returns a [`NodeReference`] to the right child of the referenced node.
-    /// Returns an error when the given [`NodeReference`] points to a leaf node or
+    /// Returns a [`NodeIndex`] to the right child of the referenced node.
+    /// Returns an error when the given [`NodeIndex`] points to a leaf node or
     /// to a node not in the tree.
-    pub(crate) fn right_child(&self, node_ref: NodeId) -> Result<NodeId, ABinaryTreeDiffError> {
-        let right_child_index = right(node_ref.node_index, self.tree_size())?;
-        Ok(NodeId::try_from_node_index(self, right_child_index)?)
+    pub(crate) fn right_child(
+        &self,
+        node_index: NodeIndex,
+    ) -> Result<NodeIndex, ABinaryTreeDiffError> {
+        Ok(right(node_index, self.tree_size())?)
     }
 
     /// Returns the [`LeafIndex`] of the referenced node. If the referenced node
     /// is not a leaf, [`None`] is returned.
-    pub(crate) fn leaf_index(&self, node_ref: NodeId) -> Option<LeafIndex> {
-        if self.is_leaf(node_ref) {
-            Some(node_ref.node_index / 2)
+    pub(crate) fn leaf_index(&self, node_index: NodeIndex) -> Option<LeafIndex> {
+        if self.is_leaf(node_index) {
+            Some(node_index / 2)
         } else {
             None
         }
@@ -596,11 +560,11 @@ impl<'a, T: Clone + Debug> AbDiff<'a, T> {
     #[cfg(test)]
     pub(crate) fn deref_vec(
         &self,
-        node_ref_vec: Vec<NodeId>,
+        node_index_vec: Vec<NodeIndex>,
     ) -> Result<Vec<&T>, ABinaryTreeDiffError> {
         let mut node_vec = Vec::new();
-        for node_ref in node_ref_vec {
-            let node = self.node(node_ref)?;
+        for node_index in node_index_vec {
+            let node = self.node(node_index)?;
             node_vec.push(node);
         }
         Ok(node_vec)
@@ -614,15 +578,13 @@ pub(crate) struct DiffIterator<'a, T: Clone + Debug> {
 }
 
 impl<'a, T: Clone + Debug> Iterator for DiffIterator<'a, T> {
-    type Item = NodeId;
+    type Item = NodeIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.diff.node_by_index(self.current_index).is_ok() {
-            let node_ref_option = Some(NodeId {
-                node_index: self.current_index,
-            });
+            let current_index_opt = Some(self.current_index);
             self.current_index += 1;
-            node_ref_option
+            current_index_opt
         } else {
             None
         }

--- a/openmls/src/binary_tree/array_representation/mod.rs
+++ b/openmls/src/binary_tree/array_representation/mod.rs
@@ -12,6 +12,7 @@
 
 // Crate
 pub(crate) mod diff;
+pub(crate) mod sorted_iter;
 pub(crate) mod tree;
 
 pub(super) mod treemath;

--- a/openmls/src/binary_tree/array_representation/sorted_iter.rs
+++ b/openmls/src/binary_tree/array_representation/sorted_iter.rs
@@ -1,0 +1,132 @@
+//! Sorted iterator
+//!
+//! The [`SortedIter`] struct represents an iterator that produces a sorted
+//! sequence of elements from two sorted input iterators, `a` and `b`. The
+//! elements in the output sequence are sorted according to a comparison
+//! function `cmp` that is provided as an argument to the [`sorted_iter`]
+//! function, which creates an instance of [`SortedIter`].
+//!
+//! The resulting iteraor iterates over all unique elements from both input
+//! vectors. If an element is present in both input vectors, only the element
+//! from iterator `a` is returned.
+//!
+//! Note that the two iterators must be sorted. Using this with unsroted
+//! iterators will result in an incorrect output.
+
+use std::cmp::Ordering;
+use std::iter::Peekable;
+
+/// Iterator that produces a sorted sequence of elements from two input
+/// iterators.
+pub struct SortedIter<I, E, F>
+where
+    I: Iterator,
+    E: Ord,
+    F: Fn(&I::Item) -> E,
+{
+    a: Peekable<I>,
+    b: Peekable<I>,
+    cmp: F,
+}
+
+impl<I, E, F> Iterator for SortedIter<I, E, F>
+where
+    I: Iterator,
+    E: Ord,
+    F: Fn(&I::Item) -> E,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let a_next = self.a.peek();
+        let b_next = self.b.peek();
+        match (a_next, b_next) {
+            // Both iterators have elements, compare the next elements
+            (Some(a), Some(b)) => match (self.cmp)(a).cmp(&(self.cmp)(b)) {
+                // Return next element from a, since it is smaller than the
+                // element from b
+                Ordering::Less => self.a.next(),
+                // Return next element from a, since it is equal to b and drop
+                // the element from b
+                Ordering::Equal => {
+                    self.b.next();
+                    self.a.next()
+                }
+                // Return next element from b, since it is smaller than the
+                // element from a
+                Ordering::Greater => self.b.next(),
+            },
+            // Iterator b is empty, return next element from a
+            (Some(_), None) => self.a.next(),
+            // Iterator a is empty, return next element from b
+            (None, Some(_)) => self.b.next(),
+            // Both iterators are empty, return None
+            (None, None) => None,
+        }
+    }
+}
+
+/// Create a new [`SortedIter`] from two input iterators.
+pub fn sorted_iter<I, E, F>(a: I, b: I, cmp: F) -> SortedIter<I, E, F>
+where
+    I: Iterator,
+    E: Ord,
+    F: Fn(&I::Item) -> E,
+{
+    SortedIter {
+        a: a.peekable(),
+        b: b.peekable(),
+        cmp,
+    }
+}
+
+// Test the [`SortedIter`] iterator
+#[test]
+fn test_sorted_iter() {
+    // Test empty input
+    let a: Vec<i32> = Vec::new();
+    let b: Vec<i32> = Vec::new();
+    let cmp = |x: &i32| *x;
+    let s = sorted_iter(a.into_iter(), b.into_iter(), cmp);
+    let result: Vec<i32> = s.collect();
+    assert_eq!(result, Vec::<i32>::new());
+
+    // Test input with only one element
+    let a = vec![1];
+    let b: Vec<i32> = Vec::new();
+    let cmp = |x: &i32| *x;
+    let iter = sorted_iter(a.into_iter(), b.into_iter(), cmp);
+    let result: Vec<i32> = iter.collect();
+    assert_eq!(result, vec![1]);
+
+    let a: Vec<i32> = Vec::new();
+    let b = vec![1];
+    let cmp = |x: &i32| *x;
+    let iter = sorted_iter(a.into_iter(), b.into_iter(), cmp);
+    let result: Vec<i32> = iter.collect();
+    assert_eq!(result, vec![1]);
+
+    // Test input with two elements, sorted in ascending order
+    let a = vec![1, 2];
+    let b = vec![3, 4];
+    let cmp = |x: &i32| *x;
+    let iter = sorted_iter(a.into_iter(), b.into_iter(), cmp);
+    let result: Vec<i32> = iter.collect();
+    assert_eq!(result, vec![1, 2, 3, 4]);
+
+    // Test input with two elements, one in each iterator, sorted in ascending order
+    let a = vec![1, 2, 3, 4, 5, 6];
+    let b = vec![4, 5, 6, 7, 8, 9, 10];
+    let cmp = |x: &i32| *x;
+    let iter = sorted_iter(a.into_iter(), b.into_iter(), cmp);
+    let result: Vec<i32> = iter.collect();
+    assert_eq!(result, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+    // Test with tuples
+    let a = vec![(1, 1), (2, 1), (3, 1)];
+    let b = vec![(1, 2), (2, 2), (4, 2)];
+    let cmp = |x: &(i32, i32)| x.0;
+    let iter = sorted_iter(a.into_iter(), b.into_iter(), cmp);
+    let result: Vec<(i32, i32)> = iter.collect();
+    assert_eq!(result, vec![(1, 1), (2, 1), (3, 1), (4, 2)]);
+}

--- a/openmls/src/binary_tree/array_representation/sorted_iter.rs
+++ b/openmls/src/binary_tree/array_representation/sorted_iter.rs
@@ -6,13 +6,13 @@
 //! function `cmp` that is provided as an argument to the [`sorted_iter`]
 //! function, which creates an instance of [`SortedIter`].
 //!
-//! The resulting iteraor iterates over all unique elements from both input
+//! The resulting iterator iterates over all unique elements from both input
 //! vectors. If an element is present in both input vectors, only the element
 //! from iterator `a` is returned.
 //!
 //! The iterator stops after the maximum `size` is reached.
 //!
-//! Note that the two iterators must be sorted. Using this with unsroted
+//! Note that the two iterators must be sorted. Using this with unsorted
 //! iterators will result in an incorrect output.
 
 use std::cmp::Ordering;

--- a/openmls/src/binary_tree/array_representation/tree.rs
+++ b/openmls/src/binary_tree/array_representation/tree.rs
@@ -84,6 +84,16 @@ impl<T: Clone + Debug> ABinaryTree<T> {
         ((self.size() - 1) / 2) + 1
     }
 
+    /// Returns an iterator over a tuple of the node index and a reference to a
+    /// node, sorted according to their position in the tree from left to right.
+    pub(crate) fn nodes(&self) -> impl Iterator<Item = (NodeIndex, &T)> {
+        self.nodes.iter().enumerate().map(|(index, node)| {
+            // We can cast the index to a NodeIndex, because the maximum size of
+            // a tree is 2^32.
+            ((index as NodeIndex), node)
+        })
+    }
+
     /// Returns an iterator over a tuple of the leaf index and a reference to a
     /// leaf, sorted according to their position in the tree from left to right.
     pub(crate) fn leaves(&self) -> impl Iterator<Item = (LeafIndex, &T)> {
@@ -129,11 +139,6 @@ impl<T: Clone + Debug> ABinaryTree<T> {
                 self.nodes[node_index as usize] = diff_node;
             }
         }
-    }
-
-    /// Export the nodes of the tree in the array representation.
-    pub(crate) fn nodes(&self) -> &[T] {
-        &self.nodes
     }
 
     /// Return a reference to the leaf at the given `LeafIndex`.

--- a/openmls/src/binary_tree/test_binary_tree.rs
+++ b/openmls/src/binary_tree/test_binary_tree.rs
@@ -40,7 +40,7 @@ fn test_tree_basics() {
     }
 
     // Test node export
-    let exported_nodes = tree1.nodes().to_vec();
+    let exported_nodes = tree1.nodes().map(|(_, node)| *node).collect();
     let tree2 =
         MlsBinaryTree::new(exported_nodes).expect("error when creating tree from exported nodes.");
 
@@ -732,9 +732,7 @@ fn test_export_diff_nodes() {
 
     let diff = tree.empty_diff();
 
-    let nodes = diff
-        .export_nodes()
-        .expect("error exporting nodes from diff");
+    let nodes = diff.nodes().map(|(_, node)| *node).collect();
 
     // If we re-export the nodes into a tree, we should end up with the same tree.
     let new_tree = MlsBinaryTree::new(nodes).expect("error creating tree from exported nodes");

--- a/openmls/src/binary_tree/test_binary_tree.rs
+++ b/openmls/src/binary_tree/test_binary_tree.rs
@@ -102,23 +102,17 @@ fn test_node_references() {
 
     // Node access and node references
     let diff = tree.empty_diff();
-    let leaf_reference = diff.leaf(0).expect("error obtaining leaf reference.");
-
-    assert_eq!(
-        diff.leaf(1)
-            .expect_err("no error when accessing leaf outside of tree"),
-        MlsBinaryTreeDiffError::IndexOutOfBounds(OutOfBoundsError::IndexOutOfBounds)
-    );
+    let leaf = diff.leaf(0);
 
     let leaf_index = diff
-        .leaf_index(leaf_reference)
+        .leaf_index(leaf)
         .expect("leaf reference without a leaf index.");
 
     assert_eq!(leaf_index, 0);
-    assert!(diff.is_leaf(leaf_reference));
+    assert!(diff.is_leaf(leaf));
 
     let leaf = diff
-        .node(leaf_reference)
+        .node(leaf)
         .expect("error dereferencing valid node reference");
 
     assert_eq!(leaf, &0);
@@ -132,20 +126,17 @@ fn test_node_references() {
         MlsBinaryTreeDiffError::IndexOutOfBounds(OutOfBoundsError::IndexOutOfBounds)
     );
 
-    let leaf_reference = diff.leaf(0).expect("error obtaining leaf reference.");
-
+    let leaf = diff.leaf(0);
     let leaf_mut = diff
-        .node_mut(leaf_reference)
+        .node_mut(leaf)
         .expect("error dereferencing valid node reference");
 
     assert_eq!(leaf_mut, &1);
 
     *leaf_mut = 2;
 
-    let leaf_reference = diff.leaf(0).expect("error obtaining leaf reference.");
-
     let leaf = diff
-        .node(leaf_reference)
+        .node(leaf)
         .expect("error dereferencing valid node reference");
 
     assert_eq!(leaf, &2);
@@ -165,10 +156,10 @@ fn test_node_references() {
 
     assert_eq!(new_leaf_index, 1);
 
-    let leaf_reference = diff.leaf(1).expect("error obtaining leaf reference.");
+    let leaf = diff.leaf(1);
 
     let leaf = diff
-        .node(leaf_reference)
+        .node(leaf)
         .expect("error dereferencing valid node reference");
 
     assert_eq!(leaf, &4);
@@ -386,12 +377,6 @@ fn test_direct_path_manipulation() {
         .expect("error setting direct path in small tree.");
     // Nothing should have changed.
     assert_eq!(st_diff.tree_size(), 1);
-    assert_eq!(
-        st_diff
-            .node(st_diff.leaf(0).expect("error getting leaf reference"))
-            .expect("error dereferencing"),
-        &0
-    );
 
     // Setting the direct path to a given path.
     st_diff
@@ -399,12 +384,6 @@ fn test_direct_path_manipulation() {
         .expect("error setting direct path in small tree.");
     // Nothing should have changed.
     assert_eq!(st_diff.tree_size(), 1);
-    assert_eq!(
-        st_diff
-            .node(st_diff.leaf(0).expect("error getting leaf reference"))
-            .expect("error dereferencing"),
-        &0
-    );
 
     // Medium tree
     let medium_tree = MlsBinaryTree::new((0..3).collect()).expect("error creating tree");

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -891,9 +891,8 @@ impl<'a> TreeSyncDiff<'a> {
     pub(crate) fn export_nodes(&self) -> Result<Vec<Option<Node>>, LibraryError> {
         let nodes = self
             .diff
-            .export_nodes()?
-            .into_iter()
-            .map(|ts_node| ts_node.node().to_owned())
+            .nodes()
+            .map(|(_, ts_node)| ts_node.node().to_owned())
             .collect();
         Ok(nodes)
     }

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -34,9 +34,7 @@ use super::{
 };
 
 use crate::{
-    binary_tree::{
-        array_representation::diff::NodeId, LeafIndex, MlsBinaryTreeDiff, StagedMlsBinaryTreeDiff,
-    },
+    binary_tree::{LeafIndex, MlsBinaryTreeDiff, StagedMlsBinaryTreeDiff},
     ciphersuite::{HpkePrivateKey, HpkePublicKey, Secret},
     credentials::CredentialBundle,
     error::LibraryError,
@@ -94,11 +92,11 @@ impl<'a> TreeSyncDiff<'a> {
         if self.leaf_count() == 1 {
             return Ok(());
         }
-        let mut leaf_id = self.diff.leaf(self.leaf_count() - 1)?;
-        let mut parent_id = self.diff.parent(leaf_id)?;
+        let mut leaf_index = self.diff.leaf(self.leaf_count() - 1);
+        let mut parent_index = self.diff.parent(leaf_index)?;
         // Trim only if the parent node is blank as well;.
-        while self.diff.node(leaf_id)?.node().is_none()
-            && self.diff.node(parent_id)?.node().is_none()
+        while self.diff.node(leaf_index)?.node().is_none()
+            && self.diff.node(parent_index)?.node().is_none()
         {
             self.diff.remove_leaf()?;
             // If there's only one leaf left, it won't have a parent, so we'll
@@ -106,8 +104,8 @@ impl<'a> TreeSyncDiff<'a> {
             if self.leaf_count() == 1 {
                 return Ok(());
             }
-            leaf_id = self.diff.leaf(self.leaf_count() - 1)?;
-            parent_id = self.diff.parent(leaf_id)?;
+            leaf_index = self.diff.leaf(self.leaf_count() - 1);
+            parent_index = self.diff.parent(leaf_index)?;
         }
         Ok(())
     }
@@ -179,7 +177,7 @@ impl<'a> TreeSyncDiff<'a> {
         }
         // Add new unmerged leaves entry to all nodes in direct path. Also, wipe
         // the cached tree hash.
-        for node_id in self
+        for node_index in self
             .diff
             .direct_path(leaf_index)
             // We checked the leaf index is in the tree
@@ -188,7 +186,7 @@ impl<'a> TreeSyncDiff<'a> {
             // We know that the nodes from the direct path are in the tree
             let tsn = self
                 .diff
-                .node_mut(node_id)
+                .node_mut(node_index)
                 .map_err(|_| LibraryError::custom("Expected a node"))?;
             if let Some(ref mut node) = tsn.node_mut() {
                 // We know that nodes in the direct path are always parent nodes
@@ -209,11 +207,7 @@ impl<'a> TreeSyncDiff<'a> {
             .map_err(|_| LibraryError::custom("Root was not in tree."))?
             .erase_tree_hash();
         self.diff
-            .node_mut(
-                self.diff
-                    .leaf(self.own_leaf_index())
-                    .map_err(|_| LibraryError::custom("Node was not in tree."))?,
-            )
+            .node_mut(self.diff.leaf(self.own_leaf_index()))
             .map_err(|_| LibraryError::custom("Node was not in tree."))?
             .erase_tree_hash();
         Ok(())
@@ -383,11 +377,11 @@ impl<'a> TreeSyncDiff<'a> {
             .diff
             .subtree_path(self.own_leaf_index, sender_index)
             .map_err(|_| LibraryError::custom("Expected both nodes to be in the tree"))?;
-        for node_id in subtree_path {
+        for node_index in subtree_path {
             // We know the node is in the diff, since it is in the subtree path
             let tsn = self
                 .diff
-                .node_mut(node_id)
+                .node_mut(node_index)
                 .map_err(|_| LibraryError::custom("Expected the node to be in the diff"))?;
             // We only care about non-blank nodes.
             if let Some(ref mut node) = tsn.node_mut() {
@@ -429,13 +423,9 @@ impl<'a> TreeSyncDiff<'a> {
         resolution: &mut Vec<HpkePublicKey>,
     ) -> Result<(), LibraryError> {
         for leaf_index in parent_node.unmerged_leaves() {
-            let leaf_id = self
-                .diff
-                .leaf(*leaf_index)
-                .map_err(|_| LibraryError::custom("Unmerged leaf not in tree"))?;
             let leaf = self
                 .diff
-                .node(leaf_id)
+                .node(self.diff.leaf(*leaf_index))
                 .map_err(|_| LibraryError::custom("Unmerged leaf not in tree"))?;
             // All unmerged leaves should be non-blank.
             let leaf_node = leaf
@@ -511,18 +501,18 @@ impl<'a> TreeSyncDiff<'a> {
     /// In case node_id is not in the tree a LibraryError is returned.
     fn resolution(
         &self,
-        node_id: NodeId,
+        node_index: u32,
         excluded_indices: &HashSet<&LeafIndex>,
     ) -> Result<Vec<HpkePublicKey>, LibraryError> {
         // First, check if the node is blank or not.
         if let Some(node) = self
             .diff
-            .node(node_id)
+            .node(node_index)
             .map_err(|_| LibraryError::custom("Expected node to be in the tree"))?
             .node()
         {
             // If it's a full node, check if it's a leaf.
-            if let Some(leaf_index) = self.diff.leaf_index(node_id) {
+            if let Some(leaf_index) = self.diff.leaf_index(node_index) {
                 // If the node is a leaf, check if it is in the exclusion list.
                 if excluded_indices.contains(&leaf_index) {
                     Ok(vec![])
@@ -541,13 +531,9 @@ impl<'a> TreeSyncDiff<'a> {
                     .unmerged_leaves()
                 {
                     if !excluded_indices.contains(leaf_index) {
-                        let leaf_id = self
-                            .diff
-                            .leaf(*leaf_index)
-                            .map_err(|_| LibraryError::custom("Expected leaf to be in the tree"))?;
                         let leaf = self
                             .diff
-                            .node(leaf_id)
+                            .node(self.diff.leaf(*leaf_index))
                             .map_err(|_| LibraryError::custom("Expected node to be in the tree"))?;
                         // TODO #800: unmerged leaves should be checked
                         let leaf_node = leaf
@@ -561,7 +547,7 @@ impl<'a> TreeSyncDiff<'a> {
             }
         } else {
             // If it's a blank, also check if it's a leaf
-            if self.diff.is_leaf(node_id) {
+            if self.diff.is_leaf(node_index) {
                 // If it is, just return an empty vector.
                 Ok(vec![])
             } else {
@@ -569,11 +555,11 @@ impl<'a> TreeSyncDiff<'a> {
                 let mut resolution = Vec::new();
                 let left_child = self
                     .diff
-                    .left_child(node_id)
+                    .left_child(node_index)
                     .map_err(|_| LibraryError::custom("Expected a parent node"))?;
                 let right_child = self
                     .diff
-                    .right_child(node_id)
+                    .right_child(node_index)
                     .map_err(|_| LibraryError::custom("Expected a parent node"))?;
                 resolution.append(&mut self.resolution(left_child, excluded_indices)?);
                 resolution.append(&mut self.resolution(right_child, excluded_indices)?);
@@ -595,11 +581,7 @@ impl<'a> TreeSyncDiff<'a> {
         leaf_index: LeafIndex,
         excluded_indices: &HashSet<&LeafIndex>,
     ) -> Result<Vec<Vec<HpkePublicKey>>, LibraryError> {
-        let leaf = self
-            .diff
-            .leaf(leaf_index)
-            .map_err(|_| LibraryError::custom("Expected leaf to be in tree"))?;
-
+        let leaf = self.diff.leaf(leaf_index);
         // If we're the only node in the tree, there's no copath.
         if leaf == self.diff.root() {
             return Ok(vec![]);
@@ -620,11 +602,11 @@ impl<'a> TreeSyncDiff<'a> {
         full_path.append(&mut direct_path);
 
         let mut copath_resolutions = Vec::new();
-        for node_id in &full_path {
+        for node_index in &full_path {
             // If sibling is not a blank, return its HpkePublicKey.
             let sibling_id = self
                 .diff
-                .sibling(*node_id)
+                .sibling(*node_index)
                 // The root should not be there anymore, hence sibling cannot fail
                 .map_err(|_| LibraryError::custom("Expected root to be removed"))?;
             let resolution = self.resolution(sibling_id, excluded_indices)?;
@@ -643,22 +625,22 @@ impl<'a> TreeSyncDiff<'a> {
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: Ciphersuite,
     ) -> Result<(), TreeSyncParentHashError> {
-        for node_id in self.diff.iter() {
+        for node_index in self.diff.iter() {
             // Continue early if node is blank.
             if let Some(Node::ParentNode(parent_node)) = self
                 .diff
-                .node(node_id)
+                .node(node_index)
                 .map_err(|_| LibraryError::custom("Node not in tree"))?
                 .node()
             {
                 // We don't care about leaf nodes.
                 let left_child_id = self
                     .diff
-                    .left_child(node_id)
+                    .left_child(node_index)
                     .map_err(|_| LibraryError::custom("Expected parent node"))?;
                 let mut right_child_id = self
                     .diff
-                    .right_child(node_id)
+                    .right_child(node_index)
                     .map_err(|_| LibraryError::custom("Expected parent node"))?;
                 // If the left child is blank, we continue with the next step
                 // in the verification algorithm.
@@ -764,13 +746,13 @@ impl<'a> TreeSyncDiff<'a> {
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: Ciphersuite,
-        node_id: NodeId,
+        node_index: u32,
     ) -> Result<Vec<u8>, LibraryError> {
         // Check if this is a leaf.
-        if let Some(leaf_index) = self.diff.leaf_index(node_id) {
+        if let Some(leaf_index) = self.diff.leaf_index(node_index) {
             let leaf = self
                 .diff
-                .node_mut(node_id)
+                .node_mut(node_index)
                 .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
             let tree_hash =
                 leaf.compute_tree_hash(backend, ciphersuite, Some(leaf_index), vec![], vec![])?;
@@ -788,19 +770,19 @@ impl<'a> TreeSyncDiff<'a> {
         // Compute left hash.
         let left_child = self
             .diff
-            .left_child(node_id)
+            .left_child(node_index)
             .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
         let left_hash = self.compute_tree_hash(backend, ciphersuite, left_child)?;
         // Compute right hash.
         let right_child = self
             .diff
-            .right_child(node_id)
+            .right_child(node_index)
             .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
         let right_hash = self.compute_tree_hash(backend, ciphersuite, right_child)?;
 
         let node = self
             .diff
-            .node_mut(node_id)
+            .node_mut(node_index)
             .map_err(|_| LibraryError::custom("Expected node to be in tree"))?;
         let tree_hash =
             node.compute_tree_hash(backend, ciphersuite, None, left_hash, right_hash)?;
@@ -815,8 +797,8 @@ impl<'a> TreeSyncDiff<'a> {
 
     /// Return a reference to our own leaf.
     pub(crate) fn own_leaf(&self) -> Result<&OpenMlsLeafNode, TreeSyncDiffError> {
-        let leaf_id = self.diff.leaf(self.own_leaf_index)?;
-        let node = self.diff.node(leaf_id)?;
+        let node_index = self.diff.leaf(self.own_leaf_index);
+        let node = self.diff.node(node_index)?;
         match node.node() {
             Some(node) => Ok(node.as_leaf_node()?),
             None => Err(LibraryError::custom("Node was empty.").into()),
@@ -825,8 +807,8 @@ impl<'a> TreeSyncDiff<'a> {
 
     /// Return a mutable reference to our own leaf.
     pub(crate) fn own_leaf_mut(&mut self) -> Result<&mut OpenMlsLeafNode, TreeSyncDiffError> {
-        let leaf_id = self.diff.leaf(self.own_leaf_index)?;
-        let node = self.diff.node_mut(leaf_id)?;
+        let node_index = self.diff.leaf(self.own_leaf_index);
+        let node = self.diff.node_mut(node_index)?;
         match node.node_mut() {
             Some(node) => Ok(node.as_leaf_node_mut()?),
             None => Err(LibraryError::custom("Node was empty.").into()),
@@ -881,7 +863,7 @@ impl<'a> TreeSyncDiff<'a> {
         // Get all of the public keys that we have secret keys for, i.e. our own
         // leaf pk, as well as potentially a number of public keys from our
         // direct path.
-        let mut own_node_ids = vec![self.diff.leaf(self.own_leaf_index)?];
+        let mut own_node_ids = vec![self.diff.leaf(self.own_leaf_index)];
 
         own_node_ids.append(&mut self.diff.direct_path(self.own_leaf_index)?);
         for node_id in own_node_ids {

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -423,8 +423,7 @@ impl TreeSync {
     pub fn export_nodes(&self) -> Vec<Option<Node>> {
         self.tree
             .nodes()
-            .iter()
-            .map(|ts_node| ts_node.node_without_private_key())
+            .map(|(_, ts_node)| ts_node.node_without_private_key())
             .collect()
     }
 


### PR DESCRIPTION
This is a follow-up PR to #1155.

It removes `NodeId` in the binary tree & introduces a new iterator for more efficient node/leaf inspection.