### PR TITLE
feat: Introduce `Extensions` type.

### DIFF
--- a/openmls/src/extensions/codec.rs
+++ b/openmls/src/extensions/codec.rs
@@ -25,7 +25,7 @@ impl Size for Extension {
 impl Size for &Extension {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
-        Size::tls_serialized_len(*self)
+        Extension::tls_serialized_len(*self)
     }
 }
 

--- a/openmls/src/extensions/codec.rs
+++ b/openmls/src/extensions/codec.rs
@@ -22,6 +22,13 @@ impl Size for Extension {
     }
 }
 
+impl Size for &Extension {
+    #[inline]
+    fn tls_serialized_len(&self) -> usize {
+        Size::tls_serialized_len(*self)
+    }
+}
+
 impl Serialize for Extension {
     fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
         // First write the extension type.
@@ -45,6 +52,12 @@ impl Serialize for Extension {
         TlsSliceU32(&extension_data)
             .tls_serialize(writer)
             .map(|l| l + written)
+    }
+}
+
+impl Serialize for &Extension {
+    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+        Extension::tls_serialize(*self, writer)
     }
 }
 

--- a/openmls/src/extensions/errors.rs
+++ b/openmls/src/extensions/errors.rs
@@ -107,4 +107,7 @@ pub enum InvalidExtensionError {
     /// The provided extension list contains duplicate extensions.
     #[error("The provided extension list contains duplicate extensions.")]
     Duplicate,
+    /// The specified extension could not be found.
+    #[error("The specified extension could not be found.")]
+    NotFound,
 }

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -521,7 +521,7 @@ mod test {
             (vec![x.clone(), y.clone(), y.clone()], false),
             (vec![y.clone(), x.clone(), x.clone()], false),
             (vec![x.clone(), y.clone(), x.clone()], false),
-            (vec![y.clone(), x.clone(), y.clone()], false),
+            (vec![y.clone(), x, y], false),
         ];
 
         for (test, should_work) in tests.into_iter() {

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -171,7 +171,7 @@ pub enum Extension {
 }
 
 /// A list of extensions with unique extension types.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Extensions {
     map: HashMap<ExtensionType, Extension>,
 }
@@ -207,20 +207,6 @@ impl Extensions {
         Self {
             map: HashMap::new(),
         }
-    }
-
-    /// Create an extension list that contains a single extension.
-    pub fn single(extension: Extension) -> Self {
-        Self {
-            map: HashMap::from([(extension.extension_type(), extension)]),
-        }
-    }
-
-    /// Create an extension list that contains multiple extensions.
-    ///
-    /// This function will fail when the list of extensions contains duplicate extension types.
-    pub fn multi(extensions: Vec<Extension>) -> Result<Self, InvalidExtensionError> {
-        extensions.try_into()
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -265,12 +251,6 @@ impl Extensions {
     }
 }
 
-impl Default for Extensions {
-    fn default() -> Self {
-        Self::empty()
-    }
-}
-
 impl TryFrom<Vec<Extension>> for Extensions {
     type Error = InvalidExtensionError;
 
@@ -290,57 +270,52 @@ impl TryFrom<Vec<Extension>> for Extensions {
 impl Extensions {
     /// Get a reference to the [`ApplicationIdExtension`] if there is any.
     pub fn application_id(&self) -> Option<&ApplicationIdExtension> {
-        for extension in self.map.values() {
-            if let Extension::ApplicationId(ext) = extension {
-                return Some(ext);
-            }
-        }
-
-        None
+        self.map
+            .get(&ExtensionType::ApplicationId)
+            .and_then(|e| match e {
+                Extension::ApplicationId(e) => Some(e),
+                _ => None,
+            })
     }
 
     /// Get a reference to the [`RatchetTreeExtension`] if there is any.
     pub fn ratchet_tree(&self) -> Option<&RatchetTreeExtension> {
-        for extension in self.map.values() {
-            if let Extension::RatchetTree(ext) = extension {
-                return Some(ext);
-            }
-        }
-
-        None
+        self.map
+            .get(&ExtensionType::RatchetTree)
+            .and_then(|e| match e {
+                Extension::RatchetTree(e) => Some(e),
+                _ => None,
+            })
     }
 
     /// Get a reference to the [`RequiredCapabilitiesExtension`] if there is any.
     pub fn required_capabilities(&self) -> Option<&RequiredCapabilitiesExtension> {
-        for extension in self.map.values() {
-            if let Extension::RequiredCapabilities(ext) = extension {
-                return Some(ext);
-            }
-        }
-
-        None
+        self.map
+            .get(&ExtensionType::RequiredCapabilities)
+            .and_then(|e| match e {
+                Extension::RequiredCapabilities(e) => Some(e),
+                _ => None,
+            })
     }
 
     /// Get a reference to the [`ExternalPubExtension`] if there is any.
     pub fn external_pub(&self) -> Option<&ExternalPubExtension> {
-        for extension in self.map.values() {
-            if let Extension::ExternalPub(ext) = extension {
-                return Some(ext);
-            }
-        }
-
-        None
+        self.map
+            .get(&ExtensionType::ExternalPub)
+            .and_then(|e| match e {
+                Extension::ExternalPub(e) => Some(e),
+                _ => None,
+            })
     }
 
     /// Get a reference to the [`ExternalSendersExtension`] if there is any.
     pub fn external_senders(&self) -> Option<&ExternalSendersExtension> {
-        for extension in self.map.values() {
-            if let Extension::ExternalSenders(ext) = extension {
-                return Some(ext);
-            }
-        }
-
-        None
+        self.map
+            .get(&ExtensionType::ExternalSenders)
+            .and_then(|e| match e {
+                Extension::ExternalSenders(e) => Some(e),
+                _ => None,
+            })
     }
 }
 
@@ -485,7 +460,7 @@ mod test {
     }
 
     #[test]
-    fn add_multi_and_try_from() {
+    fn add_try_from() {
         // Create two extensions with different extension types.
         let x = Extension::ApplicationId(ApplicationIdExtension::new(b"Test"));
         let y = Extension::RequiredCapabilities(RequiredCapabilitiesExtension::default());
@@ -528,12 +503,10 @@ mod test {
                 assert_eq!(works, should_work);
             }
 
-            // Test `multi` and `try_from`.
+            // Test `try_from`.
             if should_work {
-                assert!(Extensions::multi(test.clone()).is_ok());
                 assert!(Extensions::try_from(test).is_ok());
             } else {
-                assert!(Extensions::multi(test.clone()).is_err());
                 assert!(Extensions::try_from(test).is_err());
             }
         }

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -202,15 +202,6 @@ impl tls_codec::Deserialize for Extensions {
 }
 
 impl Extensions {
-    /// Create an extension list that is empty.
-    pub fn empty() -> Self {
-        Self {
-            map: HashMap::new(),
-        }
-    }
-
-    // ---------------------------------------------------------------------------------------------
-
     /// Add an extension to the extension list.
     ///
     /// Returns an error when there already is an extension with the same extension type.
@@ -446,7 +437,7 @@ mod test {
 
     #[test]
     fn add() {
-        let mut extensions = Extensions::empty();
+        let mut extensions = Extensions::default();
         extensions
             .add(Extension::RequiredCapabilities(
                 RequiredCapabilitiesExtension::default(),
@@ -486,7 +477,7 @@ mod test {
         for (test, should_work) in tests.into_iter() {
             // Test `add`.
             {
-                let mut extensions = Extensions::empty();
+                let mut extensions = Extensions::default();
 
                 let mut works = true;
                 for ext in test.iter() {

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -21,7 +21,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{hash_map::Entry, HashMap},
     fmt::Debug,
     io::{Read, Write},
 };
@@ -229,8 +229,8 @@ impl Extensions {
     ///
     /// Returns an error when there already is an extension with the same extension type.
     pub fn add(&mut self, extension: Extension) -> Result<(), InvalidExtensionError> {
-        if !self.map.contains_key(&extension.extension_type()) {
-            self.map.insert(extension.extension_type(), extension);
+        if let Entry::Vacant(e) = self.map.entry(extension.extension_type()) {
+            e.insert(extension);
             Ok(())
         } else {
             Err(InvalidExtensionError::Duplicate)


### PR DESCRIPTION
This PR introduces an `Extensions` type that should eventually replace all instances of `Vec<Extension>` and generally unify extension handling. Specifically, `Extensions` ensures that there are no duplicate extensions. Thus, this PR is a step towards closing #720.

Some preliminary notes:

This PR only introduces the `Extensions` struct for now. The replacement of `Vec<Extension>` everywhere requires quite some mechanical changes. The last time I worked on this, I proposed to introduce a `KeyPackageBundleBuilder` first to get rid of many `Extensions::empty/default()` calls. This is why we decided to close the last PR.

The functions are a bit repetitive but I think this is worth it given that they are easy to maintain and will eventually simplify some more complex code.

As discussed offline, there doesn't seem to be anything straightforward to lookup an element by type and already "convert" it from `Extension` to, e.g., `ApplicationId`.

Edit: This PR doesn't handle unknown extensions. We can tackle this in some follow-up.

Alternative: Use a `BTreeSet`. Downside: This requires to introduce an `ExtensionWrapped` that implements `{Partial,}Ord, {Partial,}Eq` using `ExtensionType` only. Also, we would need `tls_codec::` pass-throughs, etc. We could do that but it will result in quite some more code.