### PR TITLE
feat: Introduce `KeyPackageBuilder`.

### DIFF
--- a/cli/src/identity.rs
+++ b/cli/src/identity.rs
@@ -38,17 +38,16 @@ impl Identity {
         )
         .unwrap();
 
-        let key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            crypto,
-            &credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                crypto,
+                &credential_bundle,
+            )
+            .unwrap();
 
         store_credential_bundle_in_keystore(crypto, &credential_bundle);
         Self {
@@ -62,17 +61,16 @@ impl Identity {
     pub fn update(&mut self, crypto: &OpenMlsRustCrypto) -> KeyPackage {
         let ciphersuite = self.kp.ciphersuite();
 
-        let key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            crypto,
-            &self.credential,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                crypto,
+                &self.credential,
+            )
+            .unwrap();
 
         replace(&mut self.kp, key_package)
     }

--- a/delivery-service/ds-lib/tests/test_codec.rs
+++ b/delivery-service/ds-lib/tests/test_codec.rs
@@ -16,17 +16,16 @@ fn test_client_info() {
         crypto,
     )
     .unwrap();
-    let client_key_package = KeyPackage::create(
-        CryptoConfig {
-            ciphersuite,
-            version: ProtocolVersion::default(),
-        },
-        crypto,
-        &credential_bundle,
-        vec![],
-        vec![],
-    )
-    .unwrap();
+    let client_key_package = KeyPackage::builder()
+        .build(
+            CryptoConfig {
+                ciphersuite,
+                version: ProtocolVersion::default(),
+            },
+            crypto,
+            &credential_bundle,
+        )
+        .unwrap();
     let client_key_package = vec![(
         client_key_package
             .hash_ref(crypto.crypto())

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -44,17 +44,17 @@ fn generate_key_package(
         )
         .expect("An unexpected error occurred.");
 
-    KeyPackage::create(
-        CryptoConfig {
-            ciphersuite: ciphersuites[0],
-            version: ProtocolVersion::default(),
-        },
-        crypto_backend,
-        &credential_bundle,
-        extensions,
-        vec![],
-    )
-    .unwrap()
+    KeyPackage::builder()
+        .key_package_extensions(extensions)
+        .build(
+            CryptoConfig {
+                ciphersuite: ciphersuites[0],
+                version: ProtocolVersion::default(),
+            },
+            crypto_backend,
+            &credential_bundle,
+        )
+        .unwrap()
 }
 
 #[actix_rt::test]

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -401,17 +401,16 @@ impl MlsClient for MlsClientImpl {
         )
         .unwrap();
 
-        let key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            &self.crypto_provider,
-            &credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                &self.crypto_provider,
+                &credential_bundle,
+            )
+            .unwrap();
         let wire_format_policy = wire_format_policy(create_group_request.encrypt_handshake);
         let mls_group_config = MlsGroupConfig::builder()
             .wire_format_policy(wire_format_policy)
@@ -453,17 +452,16 @@ impl MlsClient for MlsClientImpl {
             &self.crypto_provider,
         )
         .unwrap();
-        let key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            &self.crypto_provider,
-            &credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                &self.crypto_provider,
+                &credential_bundle,
+            )
+            .unwrap();
         let mut transaction_id_map = self.transaction_id_map.lock().unwrap();
         let transaction_id = transaction_id_map.len() as u32;
         transaction_id_map.insert(
@@ -691,17 +689,16 @@ impl MlsClient for MlsClientImpl {
             .get_mut(update_proposal_request.state_id as usize)
             .ok_or_else(|| tonic::Status::new(tonic::Code::InvalidArgument, "unknown state_id"))?;
 
-        let key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite: interop_group.group.ciphersuite(),
-                version: ProtocolVersion::default(),
-            },
-            &self.crypto_provider,
-            &interop_group.credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite: interop_group.group.ciphersuite(),
+                    version: ProtocolVersion::default(),
+                },
+                &self.crypto_provider,
+                &interop_group.credential_bundle,
+            )
+            .unwrap();
         let mls_group_config = MlsGroupConfig::builder()
             .use_ratchet_tree_extension(true)
             .wire_format_policy(interop_group.wire_format_policy)

--- a/openmls/benches/benchmark.rs
+++ b/openmls/benches/benchmark.rs
@@ -27,17 +27,16 @@ fn criterion_kp_bundle(c: &mut Criterion, backend: &impl OpenMlsCryptoProvider) 
                         .expect("An unexpected error occurred.")
                     },
                     |credential_bundle: CredentialBundle| {
-                        let _key_package = KeyPackage::create(
-                            CryptoConfig {
-                                ciphersuite,
-                                version: ProtocolVersion::default(),
-                            },
-                            backend,
-                            &credential_bundle,
-                            vec![],
-                            vec![],
-                        )
-                        .expect("An unexpected error occurred.");
+                        let _key_package = KeyPackage::builder()
+                            .build(
+                                CryptoConfig {
+                                    ciphersuite,
+                                    version: ProtocolVersion::default(),
+                                },
+                                backend,
+                                &credential_bundle,
+                            )
+                            .expect("An unexpected error occurred.");
                     },
                 );
             },

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -134,17 +134,16 @@ impl CoreGroup {
             // If this is an external commit we add a fresh leaf to the diff.
             // Generate a KeyPackageBundle to generate a payload from for later
             // path generation.
-            let key_package = KeyPackage::create(
-                CryptoConfig {
-                    ciphersuite,
-                    version: self.version(),
-                },
-                backend,
-                params.credential_bundle(),
-                vec![],
-                vec![],
-            )
-            .map_err(|_| LibraryError::custom("Unexpected KeyPackage error"))?;
+            let key_package = KeyPackage::builder()
+                .build(
+                    CryptoConfig {
+                        ciphersuite,
+                        version: self.version(),
+                    },
+                    backend,
+                    params.credential_bundle(),
+                )
+                .map_err(|_| LibraryError::custom("Unexpected KeyPackage error"))?;
 
             let mut leaf_node: OpenMlsLeafNode = key_package.into();
             leaf_node.set_leaf_index(own_leaf_index);

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -53,17 +53,17 @@ fn generate_key_package(
         )
         .expect("An unexpected error occurred.");
 
-    KeyPackage::create(
-        CryptoConfig {
-            ciphersuite: ciphersuites[0],
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &credential_bundle,
-        extensions,
-        vec![],
-    )
-    .unwrap()
+    KeyPackage::builder()
+        .key_package_extensions(extensions)
+        .build(
+            CryptoConfig {
+                ciphersuite: ciphersuites[0],
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &credential_bundle,
+        )
+        .unwrap()
 }
 
 #[apply(ciphersuites_and_backends)]

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -63,28 +63,26 @@ fn test_past_secrets_in_group(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
 
         // Generate KeyPackages
 
-        let alice_key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &alice_credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
-        let bob_key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &bob_credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let alice_key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                &alice_credential_bundle,
+            )
+            .unwrap();
+        let bob_key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                &bob_credential_bundle,
+            )
+            .unwrap();
 
         // Define the MlsGroup configuration
 

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -349,28 +349,26 @@ fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         let charlie_credential_bundle =
             CredentialBundle::from_parts("Charlie".into(), charlie_signature_keypair);
 
-        let bob_key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &bob_credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
-        let charlie_key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &charlie_credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let bob_key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                &bob_credential_bundle,
+            )
+            .unwrap();
+        let charlie_key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                &charlie_credential_bundle,
+            )
+            .unwrap();
 
         // 1. Alice creates a group and tries to add Bob and Charlie to it
         let res = create_group_with_members(
@@ -430,17 +428,16 @@ fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let dave_credential_bundle =
         CredentialBundle::from_parts("Dave".into(), charlie_credential_bundle.key_pair());
 
-    let dave_key_package = KeyPackage::create(
-        CryptoConfig {
-            ciphersuite,
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &dave_credential_bundle,
-        vec![],
-        vec![],
-    )
-    .unwrap();
+    let dave_key_package = KeyPackage::builder()
+        .build(
+            CryptoConfig {
+                ciphersuite,
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &dave_credential_bundle,
+        )
+        .unwrap();
     let second_add_proposal = Proposal::Add(AddProposal {
         key_package: dave_key_package,
     });
@@ -849,41 +846,38 @@ fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             )
             .expect("An unexpected error occurred.");
 
-        let alice_key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &alice_credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let alice_key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                &alice_credential_bundle,
+            )
+            .unwrap();
 
-        let bob_key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &bob_credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let bob_key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                &bob_credential_bundle,
+            )
+            .unwrap();
 
-        let target_key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &target_credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let target_key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                &target_credential_bundle,
+            )
+            .unwrap();
 
         // 1. Alice creates a group and tries to add Bob to it
         let mut alice_group = MlsGroup::new_with_group_id(
@@ -983,17 +977,16 @@ fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         let dave_credential_bundle =
             CredentialBundle::from_parts("Dave".into(), bob_credential_bundle.key_pair());
 
-        let dave_key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &dave_credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let dave_key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                &dave_credential_bundle,
+            )
+            .unwrap();
 
         let proposals = match alice_and_bob_share_keys {
             KeyUniqueness::NegativeSameKey => {
@@ -1691,17 +1684,16 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .store(&credential_id, &new_cb)
         .expect("An unexpected error occurred.");
 
-    let update_kp = KeyPackage::create(
-        CryptoConfig {
-            ciphersuite,
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &new_cb,
-        vec![],
-        vec![],
-    )
-    .unwrap();
+    let update_kp = KeyPackage::builder()
+        .build(
+            CryptoConfig {
+                ciphersuite,
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &new_cb,
+        )
+        .unwrap();
 
     // We first go the manual route
     let update_proposal = bob_group
@@ -1850,15 +1842,13 @@ fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     //           Right now we can't do this because we don't have Bob's private
     //           key any more.
 
-    // let mut update_key_package = KeyPackage::create(
+    // let mut update_key_package = KeyPackage::builder().build(
     //     CryptoConfig {
     //         ciphersuite,
     //         version: ProtocolVersion::default(),
     //     },
     //     backend,
     //     &bob_credential_bundle,
-    //     vec![],
-    //     vec![],
     // )
     // .unwrap();
     // update_key_package.set_public_key(bob_leaf_node.encryption_key().clone());

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -364,16 +364,16 @@ pub(super) fn generate_key_package(
                 .expect("Error serializing signature key."),
         )
         .expect("An unexpected error occurred.");
-    KeyPackage::create(
-        CryptoConfig {
-            ciphersuite: ciphersuites[0],
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &credential_bundle,
-        extensions,
-        vec![], // FIXME: allow setting leaf node extensions.
-    )
+    KeyPackage::builder()
+        .key_package_extensions(extensions)
+        .build(
+            CryptoConfig {
+                ciphersuite: ciphersuites[0],
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &credential_bundle,
+        )
 }
 
 // Helper function to generate a CredentialBundle

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -41,15 +41,13 @@
 //!     &backend,
 //! )
 //! .expect("Error creating credential.");
-//! let key_package = KeyPackage::create(
+//! let key_package = KeyPackage::builder().build(
 //!     CryptoConfig {
 //!         ciphersuite,
 //!         version: ProtocolVersion::default(),
 //!     },
 //!     &backend,
 //!     &credential_bundle,
-//!     vec![],
-//!     vec![],
 //! )
 //! .unwrap();
 //! ```
@@ -211,7 +209,7 @@ impl KeyPackage {
     }
 
     /// Create a new key package for the given `ciphersuite` and `identity`.
-    pub fn create(
+    fn create(
         config: CryptoConfig,
         backend: &impl OpenMlsCryptoProvider,
         credential: &CredentialBundle, // FIXME: make credential
@@ -565,17 +563,16 @@ impl KeyPackageBundle {
         ciphersuite: Ciphersuite,
         credential_bundle: &CredentialBundle,
     ) -> Self {
-        let key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                credential_bundle,
+            )
+            .unwrap();
         let private_key: Vec<u8> = backend
             .key_store()
             .read(key_package.hpke_init_key().as_slice())

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -203,6 +203,13 @@ impl Verifiable for KeyPackage {
 
 // Public `KeyPackage` functions.
 impl KeyPackage {
+    /// Create a key package builder.
+    ///
+    /// This is provided for convenience. You can also use [`KeyPackageBuilder::new`].
+    pub fn builder() -> KeyPackageBuilder {
+        KeyPackageBuilder::new()
+    }
+
     /// Create a new key package for the given `ciphersuite` and `identity`.
     pub fn create(
         config: CryptoConfig,
@@ -477,6 +484,51 @@ impl KeyPackage {
     /// Set the [`LeafNode`].
     pub fn set_leaf_node(&mut self, leaf_node: LeafNode) {
         self.payload.leaf_node = leaf_node;
+    }
+}
+
+/// Builder that helps creating (and configuring) a [`KeyPackage`].
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct KeyPackageBuilder {
+    key_package_extensions: Option<Vec<Extension>>,
+    leaf_node_extensions: Option<Vec<Extension>>,
+}
+
+impl KeyPackageBuilder {
+    /// Create a key package builder.
+    pub fn new() -> Self {
+        Self {
+            key_package_extensions: None,
+            leaf_node_extensions: None,
+        }
+    }
+
+    /// Set the key package extensions.
+    pub fn key_package_extensions(mut self, extensions: Vec<Extension>) -> Self {
+        self.key_package_extensions = Some(extensions);
+        self
+    }
+
+    /// Set the leaf node extensions.
+    pub fn leaf_node_extensions(mut self, extensions: Vec<Extension>) -> Self {
+        self.leaf_node_extensions = Some(extensions);
+        self
+    }
+
+    /// Finalize and build the key package.
+    pub fn build(
+        self,
+        config: CryptoConfig,
+        backend: &impl OpenMlsCryptoProvider,
+        credential: &CredentialBundle,
+    ) -> Result<KeyPackage, KeyPackageNewError> {
+        KeyPackage::create(
+            config,
+            backend,
+            credential,
+            self.key_package_extensions.unwrap_or_default(),
+            self.leaf_node_extensions.unwrap_or_default(),
+        )
     }
 }
 

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -18,17 +18,16 @@ fn key_package(
     .expect("An unexpected error occurred.");
 
     // Generate a valid KeyPackage.
-    let key_package = KeyPackage::create(
-        CryptoConfig {
-            ciphersuite,
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &credential_bundle,
-        vec![],
-        vec![],
-    )
-    .expect("An unexpected error occurred.");
+    let key_package = KeyPackage::builder()
+        .build(
+            CryptoConfig {
+                ciphersuite,
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &credential_bundle,
+        )
+        .expect("An unexpected error occurred.");
 
     (key_package, credential_bundle)
 }
@@ -70,17 +69,19 @@ fn application_id_extension(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryp
 
     // Generate a valid KeyPackage.
     let id = b"application id" as &[u8];
-    let key_package = KeyPackage::create(
-        CryptoConfig {
-            ciphersuite,
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &credential_bundle,
-        vec![],
-        vec![Extension::ApplicationId(ApplicationIdExtension::new(id))],
-    )
-    .expect("An unexpected error occurred.");
+    let key_package = KeyPackage::builder()
+        .leaf_node_extensions(vec![Extension::ApplicationId(ApplicationIdExtension::new(
+            id,
+        ))])
+        .build(
+            CryptoConfig {
+                ciphersuite,
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &credential_bundle,
+        )
+        .expect("An unexpected error occurred.");
 
     assert!(key_package
         .verify_no_out(backend, credential_bundle.credential())
@@ -114,15 +115,13 @@ fn test_mismatch(backend: &impl OpenMlsCryptoProvider) {
     .expect("Could not create credential bundle");
 
     assert_eq!(
-        KeyPackage::create(
+        KeyPackage::builder().build(
             CryptoConfig {
                 ciphersuite: ciphersuite_name,
                 version: ProtocolVersion::default(),
             },
             backend,
             &credential_bundle,
-            vec![],
-            vec![],
         ),
         Err(KeyPackageNewError::CiphersuiteSignatureSchemeMismatch)
     );
@@ -140,15 +139,14 @@ fn test_mismatch(backend: &impl OpenMlsCryptoProvider) {
     )
     .expect("Could not create credential bundle");
 
-    assert!(KeyPackage::create(
-        CryptoConfig {
-            ciphersuite: ciphersuite_name,
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &credential_bundle,
-        vec![],
-        vec![],
-    )
-    .is_ok());
+    assert!(KeyPackage::builder()
+        .build(
+            CryptoConfig {
+                ciphersuite: ciphersuite_name,
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &credential_bundle,
+        )
+        .is_ok());
 }

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -53,15 +53,13 @@
 //!         .expect("An unexpected error occurred.");
 //!
 //!     // Create the key package
-//!     KeyPackage::create(
+//!     KeyPackage::builder().build(
 //!         CryptoConfig {
 //!             ciphersuite: ciphersuites[0],
 //!             version: ProtocolVersion::default(),
 //!         },
 //!         backend,
 //!         &credential_bundle,
-//!         vec![],
-//!         vec![],
 //!     )
 //!     .unwrap()
 //! }

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -85,28 +85,26 @@ fn test_welcome_ciphersuite_mismatch(
     .expect("Could not create credential bundle.");
 
     // Create key packages
-    let alice_kp = KeyPackage::create(
-        CryptoConfig {
-            ciphersuite,
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &alice_credential_bundle,
-        vec![],
-        vec![],
-    )
-    .unwrap();
-    let bob_kp = KeyPackage::create(
-        CryptoConfig {
-            ciphersuite,
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &bob_credential_bundle,
-        vec![],
-        vec![],
-    )
-    .unwrap();
+    let alice_kp = KeyPackage::builder()
+        .build(
+            CryptoConfig {
+                ciphersuite,
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &alice_credential_bundle,
+        )
+        .unwrap();
+    let bob_kp = KeyPackage::builder()
+        .build(
+            CryptoConfig {
+                ciphersuite,
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &bob_credential_bundle,
+        )
+        .unwrap();
 
     let bob_private_key: Vec<u8> = backend
         .key_store()

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -67,17 +67,16 @@ impl Client {
             )
             .ok_or(ClientError::NoMatchingCredential)?;
 
-        let key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite: ciphersuites[0],
-                version: ProtocolVersion::default(),
-            },
-            &self.crypto,
-            &credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite: ciphersuites[0],
+                    version: ProtocolVersion::default(),
+                },
+                &self.crypto,
+                &credential_bundle,
+            )
+            .unwrap();
 
         Ok(key_package)
     }
@@ -105,17 +104,16 @@ impl Client {
                     .expect("Error serializing signature key."),
             )
             .ok_or(ClientError::NoMatchingCredential)?;
-        let key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            &self.crypto,
-            &credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                &self.crypto,
+                &credential_bundle,
+            )
+            .unwrap();
         let group_state = MlsGroup::new(&self.crypto, &mls_group_config, key_package)?;
         let group_id = group_state.group_id().clone();
         self.groups

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -105,17 +105,16 @@ fn generate_key_package(
         .expect("An unexpected error occurred.");
 
     // Create the key package
-    KeyPackage::create(
-        CryptoConfig {
-            ciphersuite: ciphersuites[0],
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &credential_bundle,
-        vec![],
-        vec![],
-    )
-    .unwrap()
+    KeyPackage::builder()
+        .build(
+            CryptoConfig {
+                ciphersuite: ciphersuites[0],
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &credential_bundle,
+        )
+        .unwrap()
     // ANCHOR_END: create_key_package
 }
 

--- a/openmls/tests/key_store.rs
+++ b/openmls/tests/key_store.rs
@@ -14,17 +14,16 @@ fn test_store_key_package(ciphersuite: Ciphersuite, backend: &impl OpenMlsCrypto
     )
     .unwrap();
 
-    let key_package = KeyPackage::create(
-        config::CryptoConfig {
-            ciphersuite,
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &credential_bundle,
-        vec![],
-        vec![],
-    )
-    .unwrap();
+    let key_package = KeyPackage::builder()
+        .build(
+            config::CryptoConfig {
+                ciphersuite,
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &credential_bundle,
+        )
+        .unwrap();
     // ANCHOR_END: key_store_store
 
     // ANCHOR: key_store_delete

--- a/openmls/tests/test_external_commit.rs
+++ b/openmls/tests/test_external_commit.rs
@@ -29,17 +29,16 @@ fn test_external_commit(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             alice_cb
         };
 
-        let alice_key_package = KeyPackage::create(
-            config::CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &alice_cb,
-            vec![],
-            vec![],
-        )
-        .expect("Creation of key package failed.");
+        let alice_key_package = KeyPackage::builder()
+            .build(
+                config::CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                &alice_cb,
+            )
+            .expect("Creation of key package failed.");
 
         MlsGroup::new(backend, &group_config, alice_key_package)
             .expect("An unexpected error occurred.")

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -49,17 +49,17 @@ fn generate_key_package(
                 .expect("Error serializing signature key."),
         )
         .expect("An unexpected error occurred.");
-    KeyPackage::create(
-        CryptoConfig {
-            ciphersuite: ciphersuites[0],
-            version: ProtocolVersion::default(),
-        },
-        backend,
-        &credential_bundle,
-        extensions,
-        vec![],
-    )
-    .unwrap()
+    KeyPackage::builder()
+        .key_package_extensions(extensions)
+        .build(
+            CryptoConfig {
+                ciphersuite: ciphersuites[0],
+                version: ProtocolVersion::default(),
+            },
+            backend,
+            &credential_bundle,
+        )
+        .unwrap()
 }
 
 /// This test simulates various group operations like Add, Update, Remove in a
@@ -415,17 +415,16 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
                     .unwrap(),
             )
             .unwrap();
-        let charlies_new_key_package = KeyPackage::create(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &charlie_credential_bundle,
-            vec![],
-            vec![],
-        )
-        .unwrap();
+        let charlies_new_key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                backend,
+                &charlie_credential_bundle,
+            )
+            .unwrap();
 
         // === Charlie updates and commits ===
         let (queued_message, welcome_option) = match charlie_group.self_update(


### PR DESCRIPTION
This PR introduces a `KeyPackageBuilder`. This simplifies `KeyPackage` creation and reduces the times when we have to touch the tests. Specifically, changing all instances of `Vec<Extension>` to `Extensions` would require to touch all `KeyPackage::create` instances. After this PR is merged, this is not needed anymore. Thus, in a way, I see this as preliminary work towards closing #720.