### PR TITLE
fix: Remove `GroupInfo`s `tls_codec::Deserialize` implementation. 

### DIFF
--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -468,18 +468,19 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), MessagesTestVectorE
         return Err(MessagesTestVectorError::RatchetTreeEncodingMismatch);
     }
 
-    // GroupInfo
-    let tv_group_info = hex_to_bytes(&tv.group_info);
-    let my_group_info = GroupInfo::tls_deserialize(&mut tv_group_info.as_slice())
-        .expect("An unexpected error occurred.")
-        .tls_serialize_detached()
-        .expect("An unexpected error occurred.");
-    if tv_group_info != my_group_info {
-        log::error!("  GroupInfo encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_group_info);
-        log::debug!("    Expected: {:x?}", tv_group_info);
+    // VerifiableGroupInfo
+    let tv_verifiable_group_info = hex_to_bytes(&tv.group_info);
+    let my_verifiable_group_info =
+        VerifiableGroupInfo::tls_deserialize(&mut tv_verifiable_group_info.as_slice())
+            .expect("An unexpected error occurred.")
+            .tls_serialize_detached()
+            .expect("An unexpected error occurred.");
+    if tv_verifiable_group_info != my_verifiable_group_info {
+        log::error!("  VerifiableGroupInfo encoding mismatch");
+        log::debug!("    Encoded: {:x?}", my_verifiable_group_info);
+        log::debug!("    Expected: {:x?}", tv_verifiable_group_info);
         if cfg!(test) {
-            panic!("GroupInfo encoding mismatch");
+            panic!("VerifiableGroupInfo encoding mismatch");
         }
         return Err(MessagesTestVectorError::GroupInfoEncodingMismatch);
     }

--- a/openmls/src/messages/codec.rs
+++ b/openmls/src/messages/codec.rs
@@ -28,14 +28,6 @@ impl tls_codec::Serialize for GroupInfo {
     }
 }
 
-impl tls_codec::Deserialize for GroupInfo {
-    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error> {
-        let payload = GroupInfoTBS::tls_deserialize(bytes)?;
-        let signature = Signature::tls_deserialize(bytes)?;
-        Ok(GroupInfo { payload, signature })
-    }
-}
-
 impl tls_codec::Size for Proposal {
     #[inline]
     fn tls_serialized_len(&self) -> usize {

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -241,6 +241,7 @@ impl Signable for GroupInfoTBS {
 /// } GroupInfo;
 /// ```
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "test-utils", derive(TlsDeserialize))]
 pub struct GroupInfo {
     payload: GroupInfoTBS,
     signature: Signature,
@@ -260,11 +261,6 @@ impl GroupInfo {
     /// Returns the confirmation tag.
     pub(crate) fn confirmation_tag(&self) -> &ConfirmationTag {
         &self.payload.confirmation_tag
-    }
-
-    /// Returns the signer.
-    pub(crate) fn signer(&self) -> LeafNodeIndex {
-        self.payload.signer
     }
 
     #[cfg(any(feature = "test-utils", test))]

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -6,7 +6,8 @@ use crate::{
     group::{config::CryptoConfig, errors::WelcomeError, GroupId, MlsGroup, MlsGroupConfigBuilder},
     key_packages::KeyPackage,
     messages::{
-        ConfirmationTag, EncryptedGroupSecrets, GroupInfo, GroupInfoTBS, GroupSecrets, Welcome,
+        ConfirmationTag, EncryptedGroupSecrets, GroupInfoTBS, GroupSecrets, VerifiableGroupInfo,
+        Welcome,
     },
     schedule::{psk::PskSecret, KeySchedule},
     versions::ProtocolVersion,
@@ -162,23 +163,24 @@ fn test_welcome_ciphersuite_mismatch(
     let group_info_bytes = welcome_key
         .aead_open(backend, welcome.encrypted_group_info(), &[], &welcome_nonce)
         .expect("Could not decrypt GroupInfo.");
-    let mut group_info = GroupInfo::tls_deserialize(&mut group_info_bytes.as_slice())
-        .expect("Could not deserialize GroupInfo.");
+    let mut verifiable_group_info =
+        VerifiableGroupInfo::tls_deserialize(&mut group_info_bytes.as_slice())
+            .expect("Could not deserialize GroupInfo.");
 
     // Manipulate the ciphersuite in the GroupInfo
-    group_info
+    verifiable_group_info
         .payload
         .group_context
         .set_ciphersuite(mismatched_ciphersuite);
 
     // === Reconstruct the Welcome message and try to process it ===
 
-    let group_info_bytes = group_info
+    let verifiable_group_info_bytes = verifiable_group_info
         .tls_serialize_detached()
         .expect("Could not serialize GroupInfo.");
 
     let encrypted_group_info = welcome_key
-        .aead_seal(backend, &group_info_bytes, &[], &welcome_nonce)
+        .aead_seal(backend, &verifiable_group_info_bytes, &[], &welcome_nonce)
         .expect("Could not encrypt GroupInfo.");
 
     welcome.encrypted_group_info = encrypted_group_info.into();

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -164,8 +164,7 @@ fn test_welcome_ciphersuite_mismatch(
         .aead_open(backend, welcome.encrypted_group_info(), &[], &welcome_nonce)
         .expect("Could not decrypt GroupInfo.");
     let mut verifiable_group_info =
-        VerifiableGroupInfo::tls_deserialize(&mut group_info_bytes.as_slice())
-            .expect("Could not deserialize GroupInfo.");
+        VerifiableGroupInfo::tls_deserialize(&mut group_info_bytes.as_slice()).unwrap();
 
     // Manipulate the ciphersuite in the GroupInfo
     verifiable_group_info
@@ -175,15 +174,13 @@ fn test_welcome_ciphersuite_mismatch(
 
     // === Reconstruct the Welcome message and try to process it ===
 
-    let verifiable_group_info_bytes = verifiable_group_info
-        .tls_serialize_detached()
-        .expect("Could not serialize GroupInfo.");
+    let verifiable_group_info_bytes = verifiable_group_info.tls_serialize_detached().unwrap();
 
-    let encrypted_group_info = welcome_key
+    let encrypted_verifiable_group_info = welcome_key
         .aead_seal(backend, &verifiable_group_info_bytes, &[], &welcome_nonce)
-        .expect("Could not encrypt GroupInfo.");
+        .unwrap();
 
-    welcome.encrypted_group_info = encrypted_group_info.into();
+    welcome.encrypted_group_info = encrypted_verifiable_group_info.into();
 
     // Bob tries to join the group
     let err = MlsGroup::new_from_welcome(


### PR DESCRIPTION
This implementation should not exist because it can be used to bypass signature verification.

This closes #1181.