### PR TITLE
signable with keys

### DIFF
--- a/openmls/src/ciphersuite/signature.rs
+++ b/openmls/src/ciphersuite/signature.rs
@@ -117,6 +117,13 @@ impl Signature {
     }
 }
 
+impl Signature {
+    /// Get this signature as slice.
+    pub(super) fn value(&self) -> &[u8] {
+        self.value.as_slice()
+    }
+}
+
 impl<T> SignedStruct<T> for Signature {
     fn from_payload(_payload: T, signature: Signature) -> Self {
         signature

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -119,33 +119,6 @@ pub struct Credential {
 }
 
 impl Credential {
-    /// Verifies a signature of a given payload against the public key contained
-    /// in a credential.
-    ///
-    /// Returns an error if the signature is invalid.
-    pub fn verify(
-        &self,
-        backend: &impl OpenMlsCryptoProvider,
-        payload: &[u8],
-        signature: &Signature,
-        label: &str,
-    ) -> Result<(), CredentialError> {
-        match &self.credential {
-            MlsCredentialType::Basic(basic_credential) => {
-                let signature_public_key_enriched = basic_credential
-                    .public_key
-                    .clone()
-                    .into_signature_public_key_enriched(basic_credential.signature_scheme);
-
-                signature_public_key_enriched
-                    .verify_with_label(backend, signature, &SignContent::new(label, payload.into()))
-                    .map_err(|_| CredentialError::InvalidSignature)
-            }
-            // TODO: implement verification for X509 certificates. See issue #134.
-            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
-        }
-    }
-
     /// Returns the identity of a given credential.
     pub fn identity(&self) -> &[u8] {
         match &self.credential {

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -30,10 +30,7 @@
 //! There are multiple [`CredentialType`]s, although OpenMLS currently only
 //! supports the [`BasicCredential`].
 
-use openmls_traits::{
-    types::{CryptoError, SignatureScheme},
-    OpenMlsCryptoProvider,
-};
+use openmls_traits::{types::SignatureScheme, OpenMlsCryptoProvider};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 #[cfg(test)]
@@ -271,17 +268,6 @@ impl CredentialBundle {
         (self.credential, self.signature_private_key)
     }
 
-    /// Signs the given message `msg` using the private key of the credential bundle.
-    pub(crate) fn sign(
-        &self,
-        backend: &impl OpenMlsCryptoProvider,
-        msg: &[u8],
-        label: &str,
-    ) -> Result<Signature, CryptoError> {
-        self.signature_private_key
-            .sign_with_label(backend, &SignContent::new(label, msg.into()))
-    }
-
     /// Returns the key pair of the given credential bundle.
     #[cfg(any(feature = "test-utils", test))]
     pub fn key_pair(&self) -> SignatureKeypair {
@@ -292,5 +278,10 @@ impl CredentialBundle {
             .into_signature_public_key_enriched(self.credential().signature_scheme());
         let private_key = self.signature_private_key.clone();
         SignatureKeypair::from_parts(public_key, private_key)
+    }
+
+    /// Get a reference to the signature private key of this credential bundle.
+    pub(crate) fn signature_private_key(&self) -> &SignaturePrivateKey {
+        &self.signature_private_key
     }
 }

--- a/openmls/src/framing/mls_auth_content.rs
+++ b/openmls/src/framing/mls_auth_content.rs
@@ -133,7 +133,9 @@ impl AuthenticatedContent {
             content_tbs = content_tbs.with_context(serialized_context);
         }
 
-        content_tbs.sign(backend, credential_bundle)
+        content_tbs
+            .sign(backend, credential_bundle.signature_private_key())
+            .map_err(|_| LibraryError::custom("Signing failed"))
     }
 
     /// This constructor builds an `AuthenticatedContent` containing an application
@@ -199,7 +201,9 @@ impl AuthenticatedContent {
             body,
         );
 
-        content_tbs.sign(backend, credential_bundle)
+        content_tbs
+            .sign(backend, credential_bundle.signature_private_key())
+            .map_err(|_| LibraryError::custom("Signing failed"))
     }
 
     /// This constructor builds an `PublicMessage` containing a Commit. If the

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -292,7 +292,11 @@ impl UnverifiedGroupMessage {
     ) -> Result<VerifiedMemberMessage, ValidationError> {
         // ValSem010
         self.verifiable_content
-            .verify(backend, &self.credential)
+            .verify(
+                backend,
+                self.credential.signature_key(),
+                self.credential.signature_scheme(),
+            )
             .map(|authenticated_content| VerifiedMemberMessage {
                 authenticated_content,
             })
@@ -330,7 +334,11 @@ impl UnverifiedNewMemberMessage {
         // ValSem010
         let verified_external_message = self
             .verifiable_content
-            .verify(backend, &self.credential)
+            .verify(
+                backend,
+                self.credential.signature_key(),
+                self.credential.signature_scheme(),
+            )
             .map(|authenticated_content| VerifiedExternalMessage {
                 authenticated_content,
             })

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -335,7 +335,8 @@ impl CoreGroup {
                 )
             };
             // Sign to-be-signed group info.
-            let group_info = group_info_tbs.sign(backend, params.credential_bundle())?;
+            let group_info =
+                group_info_tbs.sign(backend, params.credential_bundle().signature_private_key())?;
 
             // Encrypt GroupInfo object
             let (welcome_key, welcome_nonce) = welcome_secret

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -586,7 +586,9 @@ impl CoreGroup {
         );
 
         // Sign to-be-signed group info.
-        group_info_tbs.sign(backend, credential_bundle)
+        group_info_tbs
+            .sign(backend, credential_bundle.signature_private_key())
+            .map_err(|_| LibraryError::custom("Signing failed"))
     }
 
     /// Returns the epoch authenticator

--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -65,7 +65,11 @@ impl CoreGroup {
                 .credential();
 
             verifiable_group_info
-                .verify(backend, group_info_signer_leaf)
+                .verify(
+                    backend,
+                    group_info_signer_leaf.signature_key(),
+                    ciphersuite.signature_algorithm(),
+                )
                 .map_err(|_| ExternalCommitError::InvalidGroupInfoSignature)?
         };
 

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -158,7 +158,11 @@ impl CoreGroup {
                 .credential();
 
             verifiable_group_info
-                .verify(backend, signer_credential)
+                .verify(
+                    backend,
+                    signer_credential.signature_key(),
+                    ciphersuite.signature_algorithm(),
+                )
                 .map_err(|_| WelcomeError::InvalidGroupInfoSignature)?
         };
 

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -213,7 +213,11 @@ impl CoreGroup {
                 signature: leaf_node.signature(),
             };
             if verifiable_leaf_node
-                .verify_no_out(backend, leaf_node.credential())
+                .verify_no_out(
+                    backend,
+                    leaf_node.signature_key(),
+                    leaf_node.credential().signature_scheme(),
+                )
                 .is_err()
             {
                 debug_assert!(

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -127,7 +127,7 @@ fn test_failed_groupinfo_decryption(
     );
 
     let group_info = group_info_tbs
-        .sign(backend, &alice_credential_bundle)
+        .sign(backend, alice_credential_bundle.signature_private_key())
         .expect("Error signing group info");
 
     // Mess with the ciphertext by flipping the last byte.

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -3,6 +3,7 @@
 //! This module contains errors that originate at lower levels and are partially re-exported in errors thrown by functions of the `MlsGroup` API.
 
 use crate::{
+    ciphersuite::signable::SignatureError,
     error::LibraryError,
     extensions::errors::ExtensionError,
     framing::errors::{MessageDecryptionError, SenderError},
@@ -202,6 +203,9 @@ pub enum CreateCommitError {
     /// See [`ProposalValidationError`] for more details.
     #[error(transparent)]
     ProposalValidationError(#[from] ProposalValidationError),
+    /// See [`SignatureError`] for more details.
+    #[error(transparent)]
+    SignatureError(#[from] SignatureError),
 }
 
 /// Validation error

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -120,7 +120,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
         )
     };
     let group_info = group_info_tbs
-        .sign(&crypto, &credential_bundle)
+        .sign(&crypto, credential_bundle.signature_private_key())
         .expect("An unexpected error occurred.");
     let group_secrets =
         GroupSecrets::random_encoded(ciphersuite, &crypto, ProtocolVersion::default());

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -251,7 +251,11 @@ pub fn run_test_vector(
         .cloned()
         .expect("Confirmation tag is missing");
     let content: AuthenticatedContent = commit
-        .verify(backend, &credential)
+        .verify(
+            backend,
+            credential.signature_key(),
+            credential.signature_scheme(),
+        )
         .expect("Invalid signature on PublicMessage commit");
 
     //let my_confirmation_tag = confirmation_key.tag(&confirmed_transcript_hash_before);

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -188,7 +188,7 @@ fn test_valsem200(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     plaintext.set_content(FramedContentBody::Commit(commit_content));
 
-    let alice_credential_bundle = backend
+    let alice_credential_bundle: CredentialBundle = backend
         .key_store()
         .read(
             &alice_group
@@ -209,7 +209,7 @@ fn test_valsem200(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let tbs: FramedContentTbs = plaintext.into();
     let mut signed_plaintext: AuthenticatedContent = tbs
         .with_context(serialized_context)
-        .sign(backend, &alice_credential_bundle)
+        .sign(backend, alice_credential_bundle.signature_private_key())
         .expect("Error signing modified payload.");
 
     // Set old confirmation tag

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -11,7 +11,7 @@ use rstest_reuse::{self, *};
 
 use crate::{
     ciphersuite::{hash_ref::ProposalRef, signable::Verifiable},
-    credentials::{errors::*, *},
+    credentials::*,
     framing::*,
     group::{config::CryptoConfig, errors::*, tests::utils::resign_external_commit, *},
     messages::proposals::*,
@@ -742,10 +742,12 @@ fn test_valsem246(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         backend,
     )
     .unwrap();
-    let verification_result: Result<AuthenticatedContent, CredentialError> = decrypted_message
-        .verifiable_content()
-        .clone()
-        .verify(backend, bob_credential_bundle.credential());
+    let verification_result: Result<AuthenticatedContent, signable::Error> =
+        decrypted_message.verifiable_content().clone().verify(
+            backend,
+            bob_credential_bundle.credential().signature_key(),
+            bob_credential_bundle.credential().signature_scheme(),
+        );
     assert!(verification_result.is_ok());
 
     // Positive case

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -742,7 +742,7 @@ fn test_valsem246(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         backend,
     )
     .unwrap();
-    let verification_result: Result<AuthenticatedContent, signable::Error> =
+    let verification_result: Result<AuthenticatedContent, _> =
         decrypted_message.verifiable_content().clone().verify(
             backend,
             bob_credential_bundle.credential().signature_key(),

--- a/openmls/src/group/tests/test_framing.rs
+++ b/openmls/src/group/tests/test_framing.rs
@@ -147,7 +147,9 @@ fn bad_padding(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
                 FramedContentBody::Application(vec![4, 5, 6].into()),
             );
 
-            plaintext_tbs.sign(backend, &credential_bundle).unwrap()
+            plaintext_tbs
+                .sign(backend, credential_bundle.signature_private_key())
+                .unwrap()
         };
 
         let mut message_secrets =

--- a/openmls/src/group/tests/test_group.rs
+++ b/openmls/src/group/tests/test_group.rs
@@ -370,7 +370,11 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         .expect("An unexpected error occurred.")
         .credential();
     let mls_plaintext_bob: AuthenticatedContent = verifiable_plaintext
-        .verify(backend, credential)
+        .verify(
+            backend,
+            credential.signature_key(),
+            credential.signature_scheme(),
+        )
         .expect("An unexpected error occurred.");
 
     assert!(matches!(
@@ -678,7 +682,11 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         .credential();
 
     let mls_plaintext_alice: AuthenticatedContent = verifiable_plaintext
-        .verify(backend, credential)
+        .verify(
+            backend,
+            credential.signature_key(),
+            credential.signature_scheme(),
+        )
         .expect("An unexpected error occurred.");
 
     assert!(matches!(
@@ -700,7 +708,11 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         .expect("An unexpected error occurred.")
         .credential();
     let mls_plaintext_bob: AuthenticatedContent = verifiable_plaintext
-        .verify(backend, credential)
+        .verify(
+            backend,
+            credential.signature_key(),
+            credential.signature_scheme(),
+        )
         .expect("An unexpected error occurred.");
 
     assert!(matches!(

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -397,7 +397,7 @@ pub(crate) fn resign_message(
 ) -> PublicMessage {
     use prelude::signable::Signable;
 
-    let alice_credential_bundle = backend
+    let alice_credential_bundle: CredentialBundle = backend
         .key_store()
         .read(
             &alice_group
@@ -417,7 +417,7 @@ pub(crate) fn resign_message(
     let tbs: FramedContentTbs = plaintext.into();
     let mut signed_plaintext: AuthenticatedContent = tbs
         .with_context(serialized_context)
-        .sign(backend, &alice_credential_bundle)
+        .sign(backend, alice_credential_bundle.signature_private_key())
         .expect("Error signing modified payload.");
 
     // Set old confirmation tag
@@ -453,10 +453,10 @@ pub(crate) fn resign_external_commit(
     let tbs: FramedContentTbs = plaintext.into();
     let mut signed_plaintext: AuthenticatedContent = if let Some(context) = serialized_context {
         tbs.with_context(context)
-            .sign(backend, bob_credential_bundle)
+            .sign(backend, bob_credential_bundle.signature_private_key())
             .expect("Error signing modified payload.")
     } else {
-        tbs.sign(backend, bob_credential_bundle)
+        tbs.sign(backend, bob_credential_bundle.signature_private_key())
             .expect("Error signing modified payload.")
     };
 

--- a/openmls/src/key_packages/errors.rs
+++ b/openmls/src/key_packages/errors.rs
@@ -4,7 +4,7 @@
 
 use thiserror::Error;
 
-use crate::error::LibraryError;
+use crate::{ciphersuite::signable::SignatureError, error::LibraryError};
 
 /// KeyPackage verify error
 #[derive(Error, Debug, PartialEq, Clone)]
@@ -46,6 +46,9 @@ pub enum KeyPackageNewError {
     /// Accessing the key store failed.
     #[error("Accessing the key store failed.")]
     KeyStoreError,
+    /// See [`SignatureError`] for more details.
+    #[error(transparent)]
+    SignatureError(#[from] SignatureError),
 }
 
 /// KeyPackage new error

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -332,12 +332,16 @@ impl KeyPackage {
         }
 
         // Verify the signature on this key package.
-        <Self as Verifiable>::verify_no_out(self, backend, self.leaf_node().credential()).map_err(
-            |_| {
-                log::error!("Key package signature is invalid.");
-                KeyPackageVerifyError::InvalidSignature
-            },
+        <Self as Verifiable>::verify_no_out(
+            self,
+            backend,
+            self.leaf_node().signature_key(),
+            self.leaf_node().credential().signature_scheme(),
         )
+        .map_err(|_| {
+            log::error!("Key package signature is invalid.");
+            KeyPackageVerifyError::InvalidSignature
+        })
     }
 
     /// Get a reference to the extensions of this key package.

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -279,7 +279,7 @@ impl KeyPackage {
             extensions,
         };
 
-        let key_package = key_package.sign(backend, credential)?;
+        let key_package = key_package.sign(backend, credential.signature_private_key())?;
 
         Ok((key_package, encryption_key_pair))
     }
@@ -488,7 +488,7 @@ impl KeyPackage {
             extensions,
         };
 
-        let key_package = key_package.sign(backend, credential)?;
+        let key_package = key_package.sign(backend, credential.signature_private_key())?;
 
         // Store the key package in the key store with the hash reference as id
         // for retrieval when parsing welcome messages.
@@ -518,7 +518,7 @@ impl KeyPackage {
             extensions: self.extensions().clone(),
         };
 
-        let key_package = key_package.sign(backend, credential)?;
+        let key_package = key_package.sign(backend, credential.signature_private_key())?;
         Ok(key_package)
     }
 
@@ -531,7 +531,9 @@ impl KeyPackage {
         self.payload
             .leaf_node
             .set_credential(credential.credential().clone());
-        self.payload.sign(backend, credential).unwrap()
+        self.payload
+            .sign(backend, credential.signature_private_key())
+            .unwrap()
     }
 
     /// Replace the public key in the KeyPackage.

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -37,7 +37,11 @@ fn generate_key_package(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
     let (key_package, credential_bundle) = key_package(ciphersuite, backend);
 
     assert!(key_package
-        .verify_no_out(backend, credential_bundle.credential())
+        .verify_no_out(
+            backend,
+            credential_bundle.credential().signature_key(),
+            credential_bundle.credential().signature_scheme()
+        )
         .is_ok());
     // TODO[FK]: #819 #133 replace with `validate`
     assert!(KeyPackage::verify(&key_package, backend).is_ok());
@@ -84,7 +88,11 @@ fn application_id_extension(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryp
         .expect("An unexpected error occurred.");
 
     assert!(key_package
-        .verify_no_out(backend, credential_bundle.credential())
+        .verify_no_out(
+            backend,
+            credential_bundle.credential().signature_key(),
+            credential_bundle.credential().signature_scheme()
+        )
         .is_ok());
     // TODO[FK]: #819 #133 replace with `validate`
     assert!(KeyPackage::verify(&key_package, backend).is_ok());

--- a/openmls/src/messages/tests/test_export_group_info.rs
+++ b/openmls/src/messages/tests/test_export_group_info.rs
@@ -31,6 +31,10 @@ fn export_group_info(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvi
     };
 
     let _: GroupInfo = verifiable_group_info
-        .verify(backend, alice_credential_bundle.credential())
+        .verify(
+            backend,
+            alice_credential_bundle.credential().signature_key(),
+            alice_credential_bundle.credential().signature_scheme(),
+        )
         .expect("signature verification should succeed");
 }

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -258,7 +258,7 @@ fn test_welcome_message_with_version(
     )
     .expect("An unexpected error occurred.");
     let group_info = group_info_tbs
-        .sign(backend, &credential_bundle)
+        .sign(backend, credential_bundle.signature_private_key())
         .expect("Error signing GroupInfo");
 
     // Generate key and nonce for the symmetric cipher.

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -449,7 +449,9 @@ impl LeafNode {
             extensions,
         )?;
 
-        leaf_node_tbs.sign(backend, credential_bundle)
+        leaf_node_tbs
+            .sign(backend, credential_bundle.signature_private_key())
+            .map_err(|_| LibraryError::custom("Signing failed"))
     }
 
     /// Returns the `encryption_key`.
@@ -774,7 +776,9 @@ impl OpenMlsLeafNode {
         leaf_node_tbs.payload.credential = credential_bundle.credential().clone();
 
         // Set the new signed leaf node with the new encryption key
-        self.leaf_node = leaf_node_tbs.sign(backend, credential_bundle)?;
+        self.leaf_node = leaf_node_tbs
+            .sign(backend, credential_bundle.signature_private_key())
+            .map_err(|_| LibraryError::custom("Signing failed"))?;
         // and store the new corresponding private key.
         self.private_key = Some(new_encryption_key.0.clone());
         Ok(())
@@ -910,7 +914,9 @@ impl OpenMlsLeafNode {
                     .ok_or_else(|| LibraryError::custom("Missing leaf index in own leaf"))?,
             }),
         );
-        self.leaf_node = tbs.sign(backend, credential_bundle)?;
+        self.leaf_node = tbs
+            .sign(backend, credential_bundle.signature_private_key())
+            .map_err(|_| LibraryError::custom("Signing failed"))?;
 
         Ok(())
     }
@@ -949,7 +955,9 @@ impl OpenMlsLeafNode {
     ) {
         let mut tbs = LeafNodeTbs::from(self.leaf_node.clone(), TreeInfoTbs::KeyPackage());
         tbs.payload.encryption_key = public_key;
-        self.leaf_node = tbs.sign(backend, credential_bundle).unwrap();
+        self.leaf_node = tbs
+            .sign(backend, credential_bundle.signature_private_key())
+            .unwrap();
     }
 
     /// Replace the public key in the leaf node and re-sign.


### PR DESCRIPTION
This PR makes `sign` and `verify` operations in the `signable` module use only the keys rather than the credential. This is a step towards removing the keys from the credential structs.

Invocations still get the keys from the credential sometimes. This is in order not to have to do everything in one go and allow for other work like #1185 to proceed.