### PR TITLE
Allow to pass `Capabilities` and `Extensions` when creating an `OpenMlsLeafNode`.

### DIFF
--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -19,7 +19,7 @@ use crate::{
     test_utils::*,
     tree::sender_ratchet::*,
     treesync::node::{
-        leaf_node::{LeafNodeSource, Lifetime},
+        leaf_node::{Capabilities, LeafNodeSource, Lifetime},
         Node,
     },
     versions::ProtocolVersion,
@@ -135,6 +135,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
         },
         &credential_bundle,
         LeafNodeSource::Update,
+        Capabilities::default(),
         Extensions::empty(),
         &crypto,
     )

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -22,10 +22,9 @@ use crate::{
         proposals::{AddProposal, Proposal, ProposalOrRef, RemoveProposal, UpdateProposal},
         Welcome,
     },
-    treesync::{errors::ApplyUpdatePathError, LeafNode},
+    treesync::{errors::ApplyUpdatePathError, node::leaf_node::Capabilities, LeafNode},
     versions::ProtocolVersion,
 };
-use crate::treesync::node::leaf_node::Capabilities;
 
 use super::utils::{generate_credential_bundle, generate_key_package, resign_message};
 

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -25,6 +25,7 @@ use crate::{
     treesync::{errors::ApplyUpdatePathError, LeafNode},
     versions::ProtocolVersion,
 };
+use crate::treesync::node::leaf_node::Capabilities;
 
 use super::utils::{generate_credential_bundle, generate_key_package, resign_message};
 
@@ -1728,6 +1729,7 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             version: ProtocolVersion::default(),
         },
         &new_cb,
+        Capabilities::default(),
         Extensions::default(),
         backend,
     )

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -89,7 +89,7 @@ use crate::{
     extensions::Extensions,
     group::config::CryptoConfig,
     treesync::{
-        node::leaf_node::{LeafNodeSource, Lifetime},
+        node::leaf_node::{Capabilities, LeafNodeSource, Lifetime},
         LeafNode,
     },
     versions::ProtocolVersion,
@@ -267,6 +267,7 @@ impl KeyPackage {
             config,
             credential, // FIXME
             LeafNodeSource::KeyPackage(Lifetime::default()),
+            Capabilities::default(),
             leaf_node_extensions,
             backend,
         )?;
@@ -475,6 +476,7 @@ impl KeyPackage {
             encryption_key,
             credential,
             LeafNodeSource::KeyPackage(Lifetime::default()),
+            Capabilities::default(),
             Extensions::empty(),
             backend,
         )

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -98,17 +98,15 @@ impl TreeSync {
         capabilities: Capabilities,
         extensions: Extensions,
     ) -> Result<(Self, CommitSecret), LibraryError> {
-        let mut leaf = OpenMlsLeafNode::new(
+        let leaf = OpenMlsLeafNode::new(
             config,
             // Creation of a group is considered to be from a key package.
             LeafNodeSource::KeyPackage(life_time),
             backend,
             credential_bundle,
+            capabilities,
+            extensions,
         )?;
-        leaf.add_capabilities(capabilities);
-        extensions
-            .iter()
-            .for_each(|extension| leaf.add_extension(extension.clone()));
 
         let node = Node::LeafNode(leaf);
         let path_secret: PathSecret = Secret::random(config.ciphersuite, backend, None)

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -434,6 +434,7 @@ impl LeafNode {
     pub fn generate(
         config: CryptoConfig,
         credential_bundle: &CredentialBundle,
+        capabilities: Capabilities,
         extensions: Extensions,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<Self, LibraryError> {
@@ -444,6 +445,7 @@ impl LeafNode {
             config,
             credential_bundle,
             LeafNodeSource::Update,
+            capabilities,
             extensions,
             backend,
         )?;

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -738,10 +738,6 @@ impl From<KeyPackage> for OpenMlsLeafNode {
 
 impl OpenMlsLeafNode {
     /// Generate a new [`OpenMlsLeafNode`] for a new tree.
-    ///
-    /// Note that no [`Capabilities`] or [`Extension`]s are added.
-    /// [`Capabilities`] and [`Extension`]s can be added later with
-    /// [`add_capabilities()`] and [`add_extension`].
     pub(crate) fn new(
         config: CryptoConfig,
         leaf_node_source: LeafNodeSource,

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -253,6 +253,27 @@ pub(crate) struct TreePosition {
     leaf_index: LeafNodeIndex,
 }
 
+/// Helper struct that holds additional information required to sign a leaf node.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///     // ... continued from [`LeafNodeTbs`] ...
+///
+///     select (LeafNodeTBS.leaf_node_source) {
+///         case key_package:
+///             struct{};
+///
+///         case update:
+///             opaque group_id<V>;
+///             uint32 leaf_index;
+///
+///         case commit:
+///             opaque group_id<V>;
+///             uint32 leaf_index;
+///     };
+/// } LeafNodeTBS;
+/// ```
 #[derive(Debug)]
 pub(crate) enum TreeInfoTbs {
     KeyPackage(),
@@ -306,6 +327,33 @@ struct LeafNodePayload {
     extensions: Extensions,
 }
 
+/// To-be-signed leaf node.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///     HPKEPublicKey encryption_key;
+///     SignaturePublicKey signature_key;
+///     Credential credential;
+///     Capabilities capabilities;
+///
+///     LeafNodeSource leaf_node_source;
+///     select (LeafNodeTBS.leaf_node_source) {
+///         case key_package:
+///             Lifetime lifetime;
+///
+///         case update:
+///             struct{};
+///
+///         case commit:
+///             opaque parent_hash<V>;
+///     };
+///
+///     Extension extensions<V>;
+///
+///     // ... continued in [`TreeInfoTbs`] ...
+/// } LeafNodeTBS;
+/// ```
 #[derive(Debug)]
 pub struct LeafNodeTbs {
     payload: LeafNodePayload,
@@ -351,7 +399,8 @@ impl TlsDeserializeTrait for LeafNodeTbs {
 
 /// This struct implements the MLS leaf node.
 ///
-/// ```text
+/// ```c
+/// // draft-ietf-mls-protocol-17
 /// struct {
 ///     HPKEPublicKey encryption_key;
 ///     SignaturePublicKey signature_key;


### PR DESCRIPTION
This (rather) resolves openmls/annotations#33 and resolves an `xxx:`s on the way.