### PR TITLE
update with leaf node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1117](https://github.com/openmls/openmls/pull/1117): Remove signature key indirection
 - [#1123](https://github.com/openmls/openmls/pull/1123): Rename ResumptionPsk to ResumptionPskSecret and resumption_psk to resumption_psk_secret
 - [#1155](https://github.com/openmls/openmls/pull/1155): MlsGroup.members() now returns an iterator over group members, MlsGroup.merge_staged_commit() no longer returns a Result
+- [...]: `MlsGroup.propose_self_update` takes the new `LeafNode` now instead of a `KeyPackage`. `LeafNode.generate` can be used to generate a new `LeafNode` for an update proposal.
 
 ## 0.4.1 (2022-06-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -7,27 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
 - [#902](https://github.com/openmls/openmls/pull/902): Implement External Add proposal (NewMember sender only) and replace ~~`Sender::NewMember`~~ by `Sender::NewMemberProposal` and `Sender::NewMemberCommit` for external proposals and external commits repectively
-- [#903](https://github.com/openmls/openmls/pull/903): Rename MlsGroup's resumptionn_secret to resumption_secret 
+- [#903](https://github.com/openmls/openmls/pull/903): Rename MlsGroup's resumptionn_secret to resumption_secret
 - [#1058](https://github.com/openmls/openmls/pull/1058): Rename resumption_secret to resumption_psk
 - [#900:](https://github.com/openmls/openmls/pull/900) Expose SerializedMlsGroup until issue [#245](https://github.com/openmls/openmls/issues/245) is done
 - [#1117](https://github.com/openmls/openmls/pull/1117): Remove signature key indirection
 - [#1123](https://github.com/openmls/openmls/pull/1123): Rename ResumptionPsk to ResumptionPskSecret and resumption_psk to resumption_psk_secret
 - [#1155](https://github.com/openmls/openmls/pull/1155): MlsGroup.members() now returns an iterator over group members, MlsGroup.merge_staged_commit() no longer returns a Result
-- [...]: `MlsGroup.propose_self_update` takes the new `LeafNode` now instead of a `KeyPackage`. `LeafNode.generate` can be used to generate a new `LeafNode` for an update proposal.
+- [#1193](https://github.com/openmls/openmls/pull/1193): `MlsGroup.propose_self_update` takes the new `LeafNode` now instead of a `KeyPackage`. `LeafNode.generate` can be used to generate a new `LeafNode` for an update proposal.
 
 ## 0.4.1 (2022-06-07)
 
 ### Added
- - [#873:](https://github.com/openmls/openmls/pull/873) Signature sub-module of the ciphersuite module is now public.
- - [#873:](https://github.com/openmls/openmls/pull/873) Signature keys can be imported and exported with the crypto-subtle feature.
- - [#873:](https://github.com/openmls/openmls/pull/873) BasicCredentials can now be created from existing signature keys.
+
+- [#873:](https://github.com/openmls/openmls/pull/873) Signature sub-module of the ciphersuite module is now public.
+- [#873:](https://github.com/openmls/openmls/pull/873) Signature keys can be imported and exported with the crypto-subtle feature.
+- [#873:](https://github.com/openmls/openmls/pull/873) BasicCredentials can now be created from existing signature keys.
 
 ### Changed
- -  [#890:](https://github.com/openmls/openmls/pull/890) Join group by External Commit API does not expect proposal store.
+
+- [#890:](https://github.com/openmls/openmls/pull/890) Join group by External Commit API does not expect proposal store.
 
 ## 0.4.0 (2022-02-28)
 
-* initial release
+- initial release
 
-*Please disregard any previous versions.*
+_Please disregard any previous versions._

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -696,7 +696,7 @@ impl MlsClient for MlsClientImpl {
         interop_group.group.set_configuration(&mls_group_config);
         let proposal = interop_group
             .group
-            .propose_self_update(&self.crypto_provider, Some(key_package.clone()))
+            .propose_self_update(&self.crypto_provider, Some(key_package.leaf_node().clone()))
             .map_err(into_status)?
             .to_bytes()
             .unwrap();

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -22,7 +22,7 @@ use crate::{
         proposals::{AddProposal, Proposal, ProposalOrRef, RemoveProposal, UpdateProposal},
         Welcome,
     },
-    treesync::errors::ApplyUpdatePathError,
+    treesync::{errors::ApplyUpdatePathError, LeafNode},
     versions::ProtocolVersion,
 };
 
@@ -1722,21 +1722,21 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .store(&credential_id, &new_cb)
         .expect("An unexpected error occurred.");
 
-    let update_kp = KeyPackage::builder()
-        .build(
-            CryptoConfig {
-                ciphersuite,
-                version: ProtocolVersion::default(),
-            },
-            backend,
-            &new_cb,
-        )
-        .unwrap();
+    let update_leaf_node = LeafNode::generate(
+        CryptoConfig {
+            ciphersuite,
+            version: ProtocolVersion::default(),
+        },
+        &new_cb,
+        Extensions::default(),
+        backend,
+    )
+    .unwrap();
 
     // We first go the manual route
     let update_proposal = bob_group
-        .propose_self_update(backend, Some(update_kp))
-        .expect("error while creating remove proposal");
+        .propose_self_update(backend, Some(update_leaf_node))
+        .expect("error while creating update proposal");
 
     // Have Alice process this proposal.
     if let ProcessedMessageContent::ProposalMessage(proposal) = alice_group

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -20,7 +20,7 @@ use crate::{
     group::{config::CryptoConfig, *},
     key_packages::*,
     messages::*,
-    treesync::node::Node,
+    treesync::{node::Node, LeafNode},
     versions::ProtocolVersion,
 };
 
@@ -205,7 +205,7 @@ impl Client {
         &self,
         action_type: ActionType,
         group_id: &GroupId,
-        key_package: Option<KeyPackage>,
+        leaf_node: Option<LeafNode>,
     ) -> Result<(MlsMessageOut, Option<Welcome>), ClientError> {
         let mut groups = self.groups.write().expect("An unexpected error occurred.");
         let group = groups
@@ -214,9 +214,9 @@ impl Client {
         let (msg, welcome_option) = match action_type {
             ActionType::Commit => group.self_update(
                 &self.crypto,
-                key_package.map(|kp| kp.hpke_init_key().clone()),
+                leaf_node.map(|leaf| leaf.encryption_key().clone()),
             )?,
-            ActionType::Proposal => (group.propose_self_update(&self.crypto, key_package)?, None),
+            ActionType::Proposal => (group.propose_self_update(&self.crypto, leaf_node)?, None),
         };
         Ok((
             msg,

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     group::*,
     key_packages::*,
     messages::*,
-    treesync::node::Node,
+    treesync::{node::Node, LeafNode},
 };
 use ::rand::{rngs::OsRng, RngCore};
 use openmls_rust_crypto::OpenMlsRustCrypto;
@@ -497,7 +497,7 @@ impl MlsGroupTestSetup {
         action_type: ActionType,
         group: &mut Group,
         client_id: &[u8],
-        key_pair: Option<KeyPackage>,
+        leaf_node: Option<LeafNode>,
     ) -> Result<(), SetupError> {
         let clients = self.clients.read().expect("An unexpected error occurred.");
         let client = clients
@@ -506,7 +506,7 @@ impl MlsGroupTestSetup {
             .read()
             .expect("An unexpected error occurred.");
         let (messages, welcome_option) =
-            client.self_update(action_type, &group.group_id, key_pair)?;
+            client.self_update(action_type, &group.group_id, leaf_node)?;
         self.distribute_to_members(&client.identity, group, &messages.into())?;
         if let Some(welcome) = welcome_option {
             self.deliver_welcome(welcome, group)?;

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -413,6 +413,9 @@ impl LeafNode {
         extensions: Extensions,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<Self, LibraryError> {
+        // Note that this function is supposed to be used in the public API only
+        // because it is interacting with the key store.
+
         let (leaf_node, encryption_key_pair) = Self::new(
             config,
             credential_bundle,

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -1,6 +1,7 @@
 //! This module contains the [`LeafNode`] struct and its implementation.
 use openmls_traits::{
     crypto::OpenMlsCrypto,
+    key_store::OpenMlsKeyStore,
     types::{Ciphersuite, HpkeKeyPair},
     OpenMlsCryptoProvider,
 };
@@ -397,6 +398,41 @@ impl LeafNode {
         let mut kp_key = ENCRYPTION_KEY_LABEL.to_vec();
         kp_key.extend_from_slice(id);
         kp_key
+    }
+
+    /// Generate a fresh leaf node.
+    ///
+    /// This includes generating a new encryption key pair that is stored in the
+    /// key store.
+    ///
+    /// This function can be used when generating an update. In most other cases
+    /// a leaf node should be generated as part of a new [`KeyPackage`].
+    pub fn generate(
+        config: CryptoConfig,
+        credential_bundle: &CredentialBundle,
+        extensions: Extensions,
+        backend: &impl OpenMlsCryptoProvider,
+    ) -> Result<Self, LibraryError> {
+        let (leaf_node, encryption_key_pair) = Self::new(
+            config,
+            credential_bundle,
+            LeafNodeSource::Update,
+            extensions,
+            backend,
+        )?;
+
+        // Store the encryption key pair in the key store.
+        backend
+            .key_store()
+            .store(
+                &Self::encryption_key_label(leaf_node.signature_key().as_slice()),
+                &encryption_key_pair,
+            )
+            .map_err(|_| {
+                LibraryError::custom("Unable to store private encryption key into the key store.")
+            })?;
+
+        Ok(leaf_node)
     }
 
     /// Create a new [`LeafNode`].
@@ -983,8 +1019,6 @@ impl OpenMlsLeafNode {
         leaf_node: LeafNode,
     ) -> Self {
         // Get the encryption key pair from the leaf.
-
-        use openmls_traits::key_store::OpenMlsKeyStore;
         let encryption_key_pair: crate::prelude::HpkeKeyPair = backend
             .key_store()
             .read(&LeafNode::encryption_key_label(signature_key))


### PR DESCRIPTION
Another followup to #819.

Update proposals operate on leaf nodes now, not key packages. This PR changes the API that this is reflect this. For this to work I also introduce a public `generate` function on the `LeafNode` to generate leaf nodes without key packages.