### PR TITLE
spec: Add `RequiredCapabilitiesExtension.credential_types` field.

### DIFF
--- a/openmls/src/extensions/required_capabilities.rs
+++ b/openmls/src/extensions/required_capabilities.rs
@@ -18,6 +18,15 @@ use super::{Deserialize, ExtensionError, ExtensionType, Serialize};
 /// extensions can be updated, a GroupContextExtensions proposal is invalid if it
 /// contains a required capabilities extension that requires capabilities not
 /// supported by all current members.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///     ExtensionType extension_types<V>;
+///     ProposalType proposal_types<V>;
+///     CredentialType credential_types<V>;
+/// } RequiredCapabilities;
+/// ```
 #[derive(
     PartialEq,
     Eq,
@@ -31,37 +40,37 @@ use super::{Deserialize, ExtensionError, ExtensionType, Serialize};
     TlsSize,
 )]
 pub struct RequiredCapabilitiesExtension {
-    extensions: Vec<ExtensionType>,
-    proposals: Vec<ProposalType>,
+    extension_types: Vec<ExtensionType>,
+    proposal_types: Vec<ProposalType>,
 }
 
 impl RequiredCapabilitiesExtension {
     /// Creates a new [`RequiredCapabilitiesExtension`] from extension and proposal types.
-    pub fn new(extensions: &[ExtensionType], proposals: &[ProposalType]) -> Self {
+    pub fn new(extension_types: &[ExtensionType], proposal_types: &[ProposalType]) -> Self {
         Self {
-            extensions: extensions.into(),
-            proposals: proposals.into(),
+            extension_types: extension_types.into(),
+            proposal_types: proposal_types.into(),
         }
     }
 
     /// Get a slice with the required extension types.
-    pub(crate) fn extensions(&self) -> &[ExtensionType] {
-        self.extensions.as_slice()
+    pub(crate) fn extension_types(&self) -> &[ExtensionType] {
+        self.extension_types.as_slice()
     }
 
     /// Get a slice with the required proposal types.
-    pub(crate) fn proposals(&self) -> &[ProposalType] {
-        self.proposals.as_slice()
+    pub(crate) fn proposal_types(&self) -> &[ProposalType] {
+        self.proposal_types.as_slice()
     }
 
     /// Check if all extension and proposal types are supported.
     pub(crate) fn check_support(&self) -> Result<(), ExtensionError> {
-        for extension in self.extensions() {
+        for extension in self.extension_types() {
             if !extension.is_supported() {
                 return Err(ExtensionError::UnsupportedExtensionType);
             }
         }
-        for proposal in self.proposals() {
+        for proposal in self.proposal_types() {
             if !proposal.is_supported() {
                 return Err(ExtensionError::UnsupportedProposalType);
             }

--- a/openmls/src/extensions/required_capabilities.rs
+++ b/openmls/src/extensions/required_capabilities.rs
@@ -1,6 +1,6 @@
 use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 
-use crate::messages::proposals::ProposalType;
+use crate::{credentials::CredentialType, messages::proposals::ProposalType};
 
 use super::{Deserialize, ExtensionError, ExtensionType, Serialize};
 
@@ -42,14 +42,20 @@ use super::{Deserialize, ExtensionError, ExtensionType, Serialize};
 pub struct RequiredCapabilitiesExtension {
     extension_types: Vec<ExtensionType>,
     proposal_types: Vec<ProposalType>,
+    credential_types: Vec<CredentialType>,
 }
 
 impl RequiredCapabilitiesExtension {
     /// Creates a new [`RequiredCapabilitiesExtension`] from extension and proposal types.
-    pub fn new(extension_types: &[ExtensionType], proposal_types: &[ProposalType]) -> Self {
+    pub fn new(
+        extension_types: &[ExtensionType],
+        proposal_types: &[ProposalType],
+        credential_types: &[CredentialType],
+    ) -> Self {
         Self {
             extension_types: extension_types.into(),
             proposal_types: proposal_types.into(),
+            credential_types: credential_types.into(),
         }
     }
 
@@ -61,6 +67,12 @@ impl RequiredCapabilitiesExtension {
     /// Get a slice with the required proposal types.
     pub(crate) fn proposal_types(&self) -> &[ProposalType] {
         self.proposal_types.as_slice()
+    }
+
+    /// Get a slice with the required credential types.
+    #[allow(unused)]
+    pub(crate) fn credential_types(&self) -> &[CredentialType] {
+        self.credential_types.as_slice()
     }
 
     /// Check if all extension and proposal types are supported.

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -190,7 +190,7 @@ fn ratchet_tree_extension(ciphersuite: Ciphersuite, backend: &impl OpenMlsCrypto
 #[test]
 fn required_capabilities() {
     // A required capabilities extension with the default values for openmls (none).
-    let extension_bytes = vec![0u8, 3, 0, 0, 0, 2, 0, 0];
+    let extension_bytes = vec![0u8, 3, 0, 0, 0, 3, 0, 0, 0];
     let mut extension_bytes_mut = &extension_bytes[..];
 
     let ext = Extension::RequiredCapabilities(RequiredCapabilitiesExtension::default());
@@ -212,9 +212,10 @@ fn required_capabilities() {
     let required_capabilities = RequiredCapabilitiesExtension::new(
         &[ExtensionType::ApplicationId, ExtensionType::RatchetTree],
         &[ProposalType::Reinit],
+        &[CredentialType::Basic],
     );
     let ext = Extension::RequiredCapabilities(required_capabilities);
-    let extension_bytes = vec![0u8, 3, 0, 0, 0, 8, 4, 0, 1, 0, 2, 2, 0, 5];
+    let extension_bytes = vec![0u8, 3, 0, 0, 0, 11, 4, 0, 1, 0, 2, 2, 0, 5, 2, 0, 1];
 
     // Test encoding and decoding
     let encoded = ext

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -208,7 +208,7 @@ impl CoreGroupBuilder {
         let capabilities = self
             .required_capabilities
             .as_ref()
-            .map(|re| re.extensions());
+            .map(|re| re.extension_types());
         let version = self.version.unwrap_or_default();
 
         debug!("Created group {:x?}", self.group_id);
@@ -437,7 +437,7 @@ impl CoreGroup {
             // Ensure that all other leaf nodes support all the required
             // extensions as well.
             self.treesync()
-                .check_extension_support(required_capabilities.extensions())?;
+                .check_extension_support(required_capabilities.extension_types())?;
         }
         let proposal = GroupContextExtensionProposal::new(extensions);
         let proposal = Proposal::GroupContextExtensions(proposal);

--- a/openmls/src/group/core_group/test_proposals.rs
+++ b/openmls/src/group/core_group/test_proposals.rs
@@ -271,7 +271,9 @@ fn test_required_unsupported_proposals(
     // Set required capabilities
     let extensions = &[];
     let proposals = &[ProposalType::GroupContextExtensions, ProposalType::AppAck];
-    let required_capabilities = RequiredCapabilitiesExtension::new(extensions, proposals);
+    let credentials = &[CredentialType::Basic];
+    let required_capabilities =
+        RequiredCapabilitiesExtension::new(extensions, proposals, credentials);
 
     // This must fail because we don't actually support AppAck proposals
     let e = CoreGroup::builder(
@@ -311,7 +313,9 @@ fn test_required_extension_key_package_mismatch(
         ProposalType::Remove,
         ProposalType::Update,
     ];
-    let required_capabilities = RequiredCapabilitiesExtension::new(extensions, proposals);
+    let credentials = &[CredentialType::Basic];
+    let required_capabilities =
+        RequiredCapabilitiesExtension::new(extensions, proposals, credentials);
 
     let alice_group = CoreGroup::builder(
         GroupId::random(backend),
@@ -353,7 +357,9 @@ fn test_group_context_extensions(ciphersuite: Ciphersuite, backend: &impl OpenMl
         ProposalType::Remove,
         ProposalType::Update,
     ];
-    let required_capabilities = RequiredCapabilitiesExtension::new(extensions, proposals);
+    let credentials = &[CredentialType::Basic];
+    let required_capabilities =
+        RequiredCapabilitiesExtension::new(extensions, proposals, credentials);
 
     let mut alice_group = CoreGroup::builder(
         GroupId::random(backend),
@@ -430,7 +436,8 @@ fn test_group_context_extension_proposal_fails(
         ProposalType::Remove,
         ProposalType::Update,
     ];
-    let required_capabilities = RequiredCapabilitiesExtension::new(&[], proposals);
+    let credentials = &[CredentialType::Basic];
+    let required_capabilities = RequiredCapabilitiesExtension::new(&[], proposals, credentials);
 
     let mut alice_group = CoreGroup::builder(
         GroupId::random(backend),
@@ -590,9 +597,12 @@ fn test_group_context_extension_proposal(
     .expect("Error joining group.");
 
     // Alice adds a required capability.
-    let required_application_id = Extension::RequiredCapabilities(
-        RequiredCapabilitiesExtension::new(&[ExtensionType::ApplicationId], &[]),
-    );
+    let required_application_id =
+        Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
+            &[ExtensionType::ApplicationId],
+            &[],
+            &[CredentialType::Basic],
+        ));
     let gce_proposal = alice_group
         .create_group_context_ext_proposal(
             framing_parameters,

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -180,7 +180,7 @@ impl Capabilities {
     ) -> bool {
         // Check if all required extensions are supported.
         if required_capabilities
-            .extensions()
+            .extension_types()
             .iter()
             .any(|e| !self.extensions().contains(e))
         {
@@ -188,7 +188,7 @@ impl Capabilities {
         }
         // Check if all required proposals are supported.
         if required_capabilities
-            .proposals()
+            .proposal_types()
             .iter()
             .any(|p| !self.proposals().contains(p))
         {
@@ -572,12 +572,12 @@ impl LeafNode {
         required_capabilities: impl Into<Option<&'a RequiredCapabilitiesExtension>>,
     ) -> Result<(), TreeSyncError> {
         if let Some(required_capabilities) = required_capabilities.into() {
-            for required_extension in required_capabilities.extensions() {
+            for required_extension in required_capabilities.extension_types() {
                 if !self.supports_extension(required_extension) {
                     return Err(TreeSyncError::UnsupportedExtension);
                 }
             }
-            for required_proposal in required_capabilities.proposals() {
+            for required_proposal in required_capabilities.proposal_types() {
                 if !self.supports_proposal(required_proposal) {
                     return Err(TreeSyncError::UnsupportedProposal);
                 }


### PR DESCRIPTION
This closes #1200.

Note: I used `CredentialType::Basic` to fixup the tests. However, this is not checked for now. I recommend to review commit-by-commit. The first commit just aligns the field names and renames the corresponding methods.