### PR TITLE
feat: Return group info on stage commit

### DIFF
--- a/book/src/user_manual/join_from_external_commit.md
+++ b/book/src/user_manual/join_from_external_commit.md
@@ -1,0 +1,25 @@
+# Join a group with an external commit
+
+To join a group with an external commit message, a new `MlsGroup` can be instantiated directly from the `GroupInfo`.
+The `GroupInfo`/Ratchet Tree should be shared over a secure channel.
+If the RatchetTree extension is not in the required capabilities, then the ratchet tree needs to be provided.
+
+The `GroupInfo` can be obtained either from a call to `export_group_info`from the `MlsGroup`:
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code.rs:alice_adds_bob}}
+```
+
+Or from a call to a function that results in a staged commit:
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code.rs:alice_exports_group_info}}
+```
+
+Calling `join_by_external_commit` will join the group and leave it with a commit pending to be merged.
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code.rs:charlie_joins_external_commit}}
+```
+
+The resulting external commit message needs to be fanned out to the Delivery Service and accepted by the other members before merging this external commit.

--- a/cli/src/networking.rs
+++ b/cli/src/networking.rs
@@ -10,7 +10,7 @@ pub fn post(url: &Url, msg: &impl Serialize) -> Result<Vec<u8>, String> {
     log::debug!("Post {:?}", url);
     log::trace!("Payload: {:?}", serialized_msg);
     let client = Client::new();
-    let response = client.post(&url.to_string()).body(serialized_msg).send();
+    let response = client.post(url.to_string()).body(serialized_msg).send();
     if let Ok(r) = response {
         if r.status() != StatusCode::OK {
             return Err(format!("Error status code {:?}", r.status()));
@@ -27,7 +27,7 @@ pub fn post(url: &Url, msg: &impl Serialize) -> Result<Vec<u8>, String> {
 pub fn get(url: &Url) -> Result<Vec<u8>, String> {
     log::debug!("Get {:?}", url);
     let client = Client::new();
-    let response = client.get(&url.to_string()).send();
+    let response = client.get(url.to_string()).send();
     if let Ok(r) = response {
         if r.status() != StatusCode::OK {
             return Err(format!("Error status code {:?}", r.status()));

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -294,7 +294,7 @@ impl User {
             None => return Err(format!("No group with name {} known.", group)),
         };
 
-        let (out_messages, welcome) = group
+        let (out_messages, welcome, _group_info) = group
             .mls_group
             .borrow_mut()
             .add_members(&self.crypto, &[joiner_key_package])

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -272,7 +272,7 @@ async fn test_group() {
 
     // With the key package we can invite Client2 (create proposal and merge it
     // locally.)
-    let (_out_messages, welcome_msg) = group
+    let (_out_messages, welcome_msg, _group_info) = group
         .add_members(crypto, &[client2_key_package])
         .expect("Could not add member to group.");
     group

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -793,7 +793,7 @@ impl MlsClient for MlsClientImpl {
 
         // TODO #692: The interop client cannot process these proposals yet.
 
-        let (commit, welcome_option) = interop_group
+        let (commit, welcome_option, _group_info) = interop_group
             .group
             .self_update(&self.crypto_provider, None)
             .map_err(into_status)?;

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -376,11 +376,12 @@ impl CoreGroup {
             let encrypted_group_info = welcome_key
                 .aead_seal(
                     backend,
-                    &group_info
+                    group_info
                         .as_ref()
                         .ok_or_else(|| LibraryError::custom("GroupInfo was not computed"))?
                         .tls_serialize_detached()
-                        .map_err(LibraryError::missing_bound_check)?,
+                        .map_err(LibraryError::missing_bound_check)?
+                        .as_slice(),
                     &[],
                     &welcome_nonce,
                 )

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -410,9 +410,6 @@ impl CoreGroup {
             commit_update_leaf_node,
         );
 
-        // TODO: check for the required capabilities if RatchetTree is supported and return the
-        // group info only if it supports. Right now OpenMls doesn't support specifying the
-        // required capabilities
         Ok(CreateCommitResult {
             commit,
             welcome_option,

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -79,6 +79,7 @@ pub(crate) struct CreateCommitResult {
     pub(crate) commit: AuthenticatedContent,
     pub(crate) welcome_option: Option<Welcome>,
     pub(crate) staged_commit: StagedCommit,
+    pub(crate) group_info: Option<GroupInfo>,
 }
 
 /// A member in the group is identified by this [`Member`] struct.

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -5,7 +5,7 @@
 use crate::{
     ciphersuite::signable::SignatureError,
     error::LibraryError,
-    extensions::errors::ExtensionError,
+    extensions::errors::{ExtensionError, InvalidExtensionError},
     framing::errors::{MessageDecryptionError, SenderError},
     key_packages::errors::KeyPackageExtensionSupportError,
     schedule::errors::PskError,
@@ -206,6 +206,9 @@ pub enum CreateCommitError {
     /// See [`SignatureError`] for more details.
     #[error(transparent)]
     SignatureError(#[from] SignatureError),
+    /// See [`InvalidExtensionError`] for more details.
+    #[error(transparent)]
+    InvalidExtensionError(#[from] InvalidExtensionError),
 }
 
 /// Validation error

--- a/openmls/src/group/group_context.rs
+++ b/openmls/src/group/group_context.rs
@@ -75,42 +75,42 @@ impl GroupContext {
     }
 
     /// Return the protocol version.
-    pub(crate) fn protocol_version(&self) -> ProtocolVersion {
+    pub fn protocol_version(&self) -> ProtocolVersion {
         self.protocol_version
     }
 
     /// Return the ciphersuite.
-    pub(crate) fn ciphersuite(&self) -> Ciphersuite {
+    pub fn ciphersuite(&self) -> Ciphersuite {
         self.ciphersuite
     }
 
     /// Return the group ID.
-    pub(crate) fn group_id(&self) -> &GroupId {
+    pub fn group_id(&self) -> &GroupId {
         &self.group_id
     }
 
     /// Return the epoch.
-    pub(crate) fn epoch(&self) -> GroupEpoch {
+    pub fn epoch(&self) -> GroupEpoch {
         self.epoch
     }
 
     /// Return the tree hash.
-    pub(crate) fn tree_hash(&self) -> &[u8] {
+    pub fn tree_hash(&self) -> &[u8] {
         self.tree_hash.as_slice()
     }
 
     /// Return the confirmed transcript hash.
-    pub(crate) fn confirmed_transcript_hash(&self) -> &[u8] {
+    pub fn confirmed_transcript_hash(&self) -> &[u8] {
         self.confirmed_transcript_hash.as_slice()
     }
 
     /// Return the extensions.
-    pub(crate) fn extensions(&self) -> &Extensions {
+    pub fn extensions(&self) -> &Extensions {
         &self.extensions
     }
 
     /// Get the required capabilities extension.
-    pub(crate) fn required_capabilities(&self) -> Option<&RequiredCapabilitiesExtension> {
+    pub fn required_capabilities(&self) -> Option<&RequiredCapabilitiesExtension> {
         self.extensions.required_capabilities()
     }
 }

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -27,6 +27,8 @@ impl MlsGroup {
     /// will be [Some] if the group has the `use_ratchet_tree_extension` flag set.
     ///
     /// Returns an error if there is a pending commit.
+    // FIXME: #1217
+    #[allow(clippy::type_complexity)]
     pub fn add_members<KeyStore: OpenMlsKeyStore>(
         &mut self,
         backend: &impl OpenMlsCryptoProvider<KeyStoreProvider = KeyStore>,
@@ -115,6 +117,8 @@ impl MlsGroup {
 
     ///
     /// Returns an error if there is a pending commit.
+    // FIXME: #1217
+    #[allow(clippy::type_complexity)]
     pub fn remove_members<KeyStore: OpenMlsKeyStore>(
         &mut self,
         backend: &impl OpenMlsCryptoProvider<KeyStoreProvider = KeyStore>,

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -24,7 +24,7 @@ impl MlsGroup {
     ///
     /// If successful, it returns a triple of [`MlsMessageOut`]s, where the first
     /// contains the commit, the second one the [Welcome] and the third an optional [GroupInfo] that
-    /// will be [Some] if the group has the `RatchetTree` required capability.
+    /// will be [Some] if the group has the `use_ratchet_tree_extension` flag set.
     ///
     /// Returns an error if there is a pending commit.
     pub fn add_members(
@@ -110,7 +110,7 @@ impl MlsGroup {
     /// [GroupInfo].
     /// The [Welcome] is [Some] when the queue of pending proposals contained
     /// add proposals
-    /// The [GroupInfo] is [Some] if the group has the `RatchetTree` required capability.
+    /// The [GroupInfo] is [Some] if the group has the `use_ratchet_tree_extension` flag set.
 
     ///
     /// Returns an error if there is a pending commit.

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -74,6 +74,8 @@ impl MlsGroup {
     /// currently stored in the group's [ProposalStore].
     ///
     /// Returns an error if there is a pending commit.
+    // FIXME: #1217
+    #[allow(clippy::type_complexity)]
     pub fn commit_to_pending_proposals<KeyStore: OpenMlsKeyStore>(
         &mut self,
         backend: &impl OpenMlsCryptoProvider<KeyStoreProvider = KeyStore>,

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -5,6 +5,8 @@ use std::mem;
 use core_group::{create_commit_params::CreateCommitParams, staged_commit::StagedCommit};
 use tls_codec::Serialize;
 
+use crate::messages::GroupInfo;
+
 use super::{errors::ProcessMessageError, *};
 
 impl MlsGroup {
@@ -73,7 +75,10 @@ impl MlsGroup {
     pub fn commit_to_pending_proposals(
         &mut self,
         backend: &impl OpenMlsCryptoProvider,
-    ) -> Result<(MlsMessageOut, Option<MlsMessageOut>), CommitToPendingProposalsError> {
+    ) -> Result<
+        (MlsMessageOut, Option<MlsMessageOut>, Option<GroupInfo>),
+        CommitToPendingProposalsError,
+    > {
         self.is_operational()?;
 
         let credential = self.credential()?;
@@ -114,6 +119,7 @@ impl MlsGroup {
             create_commit_result
                 .welcome_option
                 .map(|w| MlsMessageOut::from_welcome(w, self.group.version())),
+            create_commit_result.group_info,
         ))
     }
 

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -192,7 +192,7 @@ fn remover(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     .expect("An unexpected error occurred.");
 
     // === Alice adds Bob ===
-    let (_queued_message, welcome) = alice_group
+    let (_queued_message, welcome, _group_info) = alice_group
         .add_members(backend, &[bob_key_package])
         .expect("Could not add member to group.");
 
@@ -209,10 +209,9 @@ fn remover(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     .expect("Error creating group from Welcome");
 
     // === Bob adds Charlie ===
-    let (queued_messages, welcome) = match bob_group.add_members(backend, &[charlie_key_package]) {
-        Ok((qm, welcome)) => (qm, welcome),
-        Err(e) => panic!("Could not add member to group: {:?}", e),
-    };
+    let (queued_messages, welcome, _group_info) = bob_group
+        .add_members(backend, &[charlie_key_package])
+        .unwrap();
 
     let alice_processed_message = alice_group
         .process_message(
@@ -280,7 +279,7 @@ fn remover(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     }
 
     // Charlie commits
-    let (_queued_messages, _welcome) = charlie_group
+    let (_queued_messages, _welcome, _group_info) = charlie_group
         .commit_to_pending_proposals(backend)
         .expect("Could not commit proposal");
 
@@ -390,7 +389,7 @@ fn test_invalid_plaintext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCrypto
         .read()
         .expect("An unexpected error occurred.");
 
-    let (mls_message, _welcome_option) = client
+    let (mls_message, _welcome_option, _group_info) = client
         .self_update(Commit, &group_id, None)
         .expect("error creating self update");
 
@@ -523,7 +522,7 @@ fn test_pending_commit_logic(ciphersuite: Ciphersuite, backend: &impl OpenMlsCry
     assert!(alice_group.pending_commit().is_none());
 
     println!("\nCreating commit with add proposal.");
-    let (_msg, _welcome_option) = alice_group
+    let (_msg, _welcome_option, _group_info) = alice_group
         .self_update(backend, None)
         .expect("error creating self-update commit");
     println!("Done creating commit.");
@@ -588,7 +587,7 @@ fn test_pending_commit_logic(ciphersuite: Ciphersuite, backend: &impl OpenMlsCry
     assert!(alice_group.pending_commit().is_none());
 
     // Creating a new commit should commit the same proposals.
-    let (_msg, welcome_option) = alice_group
+    let (_msg, welcome_option, _group_info) = alice_group
         .self_update(backend, None)
         .expect("error creating self-update commit");
 
@@ -620,11 +619,11 @@ fn test_pending_commit_logic(ciphersuite: Ciphersuite, backend: &impl OpenMlsCry
     );
 
     // While a commit is pending, merging Bob's commit should clear the pending commit.
-    let (_msg, _welcome_option) = alice_group
+    let (_msg, _welcome_option, _group_info) = alice_group
         .self_update(backend, None)
         .expect("error creating self-update commit");
 
-    let (msg, _welcome_option) = bob_group
+    let (msg, _welcome_option, _group_info) = bob_group
         .self_update(backend, None)
         .expect("error creating self-update commit");
 
@@ -696,7 +695,7 @@ fn key_package_deletion(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
     .unwrap();
 
     // === Alice adds Bob ===
-    let (_queued_message, welcome) = alice_group
+    let (_queued_message, welcome, _group_info) = alice_group
         .add_members(backend, &[bob_key_package.clone()])
         .unwrap();
 

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -17,7 +17,7 @@ impl MlsGroup {
     /// commit), an optional [`MlsMessageOut`] (containing the [`Welcome`]) and the [GroupInfo].
     /// The [Welcome] is [Some] when the queue of pending proposals contained
     /// add proposals
-    /// The [GroupInfo] is [Some] if the group has the `RatchetTree` required capability.
+    /// The [GroupInfo] is [Some] if the group has the `use_ratchet_tree_extension` flag set.
     ///
     /// Returns an error if there is a pending commit.
     pub fn self_update(

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -19,6 +19,8 @@ impl MlsGroup {
     /// TODO #1208 : The caller should be able to optionally provide a
     /// [`LeafNode`] here, so that things like extensions can be changed via
     /// commit.
+    // FIXME: #1217
+    #[allow(clippy::type_complexity)]
     pub fn self_update<KeyStore: OpenMlsKeyStore>(
         &mut self,
         backend: &impl OpenMlsCryptoProvider<KeyStoreProvider = KeyStore>,

--- a/openmls/src/group/tests/external_proposal.rs
+++ b/openmls/src/group/tests/external_proposal.rs
@@ -81,7 +81,7 @@ fn validation_test_setup(
     )
     .expect("An unexpected error occurred.");
 
-    let (_message, welcome) = alice_group
+    let (_message, welcome, _group_info) = alice_group
         .add_members(backend, &[bob_key_package])
         .expect("error adding Bob to group");
 
@@ -187,7 +187,8 @@ fn external_add_proposal_should_succeed(
         }
 
         // and Alice will commit it
-        let (commit, welcome) = alice_group.commit_to_pending_proposals(backend).unwrap();
+        let (commit, welcome, _group_info) =
+            alice_group.commit_to_pending_proposals(backend).unwrap();
         alice_group.merge_pending_commit().unwrap();
         assert_eq!(alice_group.members().count(), 3);
 

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -92,7 +92,7 @@ fn validation_test_setup(
     )
     .expect("An unexpected error occurred.");
 
-    let (_message, welcome) = alice_group
+    let (_message, welcome, _group_info) = alice_group
         .add_members(backend, &[bob_key_package, charlie_key_package])
         .expect("error adding Bob to group");
 
@@ -739,7 +739,7 @@ fn test_partial_proposal_commit(ciphersuite: Ciphersuite, backend: &impl OpenMls
         .unwrap();
     alice_group.proposal_store.empty();
     alice_group.proposal_store.add(remaining_proposal);
-    let (commit, _) = alice_group.commit_to_pending_proposals(backend).unwrap();
+    let (commit, _, _) = alice_group.commit_to_pending_proposals(backend).unwrap();
     // Alice herself should be able to merge the commit
     alice_group
         .merge_pending_commit()

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -261,7 +261,7 @@ fn test_valsem242(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     )
     .unwrap();
 
-    let (_message, _welcome) = alice_group
+    let (_message, _welcome, _group_info) = alice_group
         .add_members(backend, &[bob_key_package])
         .unwrap();
     alice_group.merge_pending_commit().unwrap();
@@ -409,7 +409,7 @@ fn test_valsem243(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     )
     .expect("An unexpected error occurred.");
 
-    let (_message, _welcome) = alice_group
+    let (_message, _welcome, _group_info) = alice_group
         .add_members(backend, &[bob_key_package])
         .expect("Could not add member.");
 

--- a/openmls/src/group/tests/test_framing_validation.rs
+++ b/openmls/src/group/tests/test_framing_validation.rs
@@ -86,7 +86,7 @@ fn validation_test_setup(
     .expect("An unexpected error occurred.");
 
     // === Alice adds Bob & Bob joins ===
-    let (_message, welcome) = alice_group
+    let (_message, welcome, _group_info) = alice_group
         .add_members(backend, &[bob_key_package.clone()])
         .expect("Could not add member.");
 
@@ -124,7 +124,7 @@ fn test_valsem002(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_key_package: _,
     } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
-    let (message, _welcome) = alice_group
+    let (message, _welcome, _group_info) = alice_group
         .self_update(backend, None)
         .expect("Could not self-update.");
 
@@ -171,7 +171,7 @@ fn test_valsem003(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Alice needs to create a new message that Bob can process.
-    let (message, _welcome) = alice_group
+    let (message, _welcome, _group_info) = alice_group
         .self_update(backend, None)
         .expect("Could not self update.");
     alice_group.merge_pending_commit().unwrap();
@@ -193,7 +193,7 @@ fn test_valsem003(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     }
 
     // Do a second Commit to increase the epoch number
-    let (message, _welcome) = alice_group
+    let (message, _welcome, _group_info) = alice_group
         .self_update(backend, None)
         .expect("Could not add member.");
 
@@ -260,7 +260,7 @@ fn test_valsem004(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_key_package: _,
     } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
-    let (message, _welcome) = alice_group
+    let (message, _welcome, _group_info) = alice_group
         .self_update(backend, None)
         .expect("Could not self-update.");
 
@@ -320,7 +320,7 @@ fn test_valsem005(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_key_package: _,
     } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
-    let (message, _welcome) = alice_group
+    let (message, _welcome, _group_info) = alice_group
         .self_update(backend, None)
         .expect("Could not self-update.");
 
@@ -427,7 +427,7 @@ fn test_valsem007(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_key_package: _,
     } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
-    let (message, _welcome) = alice_group
+    let (message, _welcome, _group_info) = alice_group
         .self_update(backend, None)
         .expect("Could not self-update.");
 
@@ -474,7 +474,7 @@ fn test_valsem008(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Alice needs to create a new message that Bob can process.
-    let (message, _welcome) = alice_group
+    let (message, _welcome, _group_info) = alice_group
         .self_update(backend, None)
         .expect("Could not self-update.");
 
@@ -523,7 +523,7 @@ fn test_valsem009(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         _bob_key_package: _,
     } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
-    let (message, _welcome) = alice_group
+    let (message, _welcome, _group_info) = alice_group
         .self_update(backend, None)
         .expect("Could not self-update.");
 
@@ -583,7 +583,7 @@ fn test_valsem010(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend);
 
     // Alice needs to create a new message that Bob can process.
-    let (message, _welcome) = alice_group
+    let (message, _welcome, _group_info) = alice_group
         .self_update(backend, None)
         .expect("Could not self update.");
 

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -84,13 +84,13 @@ fn test_past_secrets_in_group(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
         let mut alice_group = MlsGroup::new_with_group_id(
             backend,
             &mls_group_config,
-            group_id,
+            group_id.clone(),
             alice_credential.signature_key(),
         )
         .expect("An unexpected error occurred.");
 
         // Alice adds Bob
-        let (_message, welcome) = alice_group
+        let (_message, welcome, _group_info) = alice_group
             .add_members(backend, &[bob_key_package])
             .expect("An unexpected error occurred.");
 
@@ -118,7 +118,7 @@ fn test_past_secrets_in_group(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
 
             application_messages.push(application_message.into_protocol_message().unwrap());
 
-            let (message, _welcome) = alice_group
+            let (message, _welcome, _group_info) = alice_group
                 .self_update(backend, None)
                 .expect("An unexpected error occurred.");
 

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -13,8 +13,8 @@ use crate::{
     ciphersuite::hash_ref::ProposalRef,
     credentials::*,
     framing::{
-        mls_content::FramedContentBody, MlsMessageIn, MlsMessageOut, ProcessedMessageContent,
-        ProtocolMessage, PublicMessage, Sender,
+        mls_content::FramedContentBody, MlsMessageIn, ProcessedMessageContent, ProtocolMessage,
+        PublicMessage, Sender,
     },
     group::{config::CryptoConfig, errors::*, *},
     key_packages::*,
@@ -75,14 +75,14 @@ fn create_group_with_members(
     )
     .expect("An unexpected error occurred.");
 
-    alice_group.add_members(backend, member_key_packages).map(
-        |(msg, welcome): (MlsMessageOut, MlsMessageOut)| {
+    alice_group
+        .add_members(backend, member_key_packages)
+        .map(|(msg, welcome, _group_info)| {
             (
                 msg.into(),
                 welcome.into_welcome().expect("Unexpected message type."),
             )
-        },
-    )
+        })
 }
 
 struct ProposalValidationTestSetup {
@@ -148,7 +148,7 @@ fn validation_test_setup(
     )
     .expect("An unexpected error occurred.");
 
-    let (_message, welcome) = alice_group
+    let (_message, welcome, _group_info) = alice_group
         .add_members(backend, &[bob_key_package])
         .expect("error adding Bob to group");
 
@@ -1365,9 +1365,7 @@ fn test_valsem106(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
                     }
                 }
                 ProposalInclusion::ByValue => {
-                    let result = alice_group
-                        .add_members(backend, &[test_kp.clone()])
-                        .map(|(msg, welcome)| (msg, Some(welcome)));
+                    let result = alice_group.add_members(backend, &[test_kp.clone()]);
 
                     match key_package_version {
                         KeyPackageTestVersion::ValidTestCase => {
@@ -1512,14 +1510,14 @@ fn test_valsem107(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .expect("error while creating remove proposal");
     // While this shouldn't fail, it should produce a valid commit, i.e. one
     // that contains only one remove proposal.
-    let (manual_commit, _welcome) = alice_group
+    let (manual_commit, _welcome, _group_info) = alice_group
         .commit_to_pending_proposals(backend)
         .expect("error while trying to commit to colliding remove proposals");
 
     // Clear commit to try another way of committing two identical removes.
     alice_group.clear_pending_commit();
 
-    let (combined_commit, _welcome) = alice_group
+    let (combined_commit, _welcome, _group_info) = alice_group
         .remove_members(backend, &[bob_leaf_index, bob_leaf_index])
         .expect("error while trying to remove the same member twice");
 

--- a/openmls/src/group/tests/test_remove_operation.rs
+++ b/openmls/src/group/tests/test_remove_operation.rs
@@ -73,14 +73,14 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
         let mut alice_group = MlsGroup::new_with_group_id(
             backend,
             &mls_group_config,
-            group_id,
+            group_id.clone(),
             alice_credential.signature_key(),
         )
         .expect("An unexpected error occurred.");
 
         // === Alice adds Bob & Charlie ===
 
-        let (_message, welcome) = alice_group
+        let (_message, welcome, _group_info) = alice_group
             .add_members(backend, &[bob_key_package, charlie_key_package])
             .expect("An unexpected error occurred.");
         alice_group
@@ -111,7 +111,7 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, backend: &impl OpenM
         let bob_index = bob_group.own_leaf_index();
 
         // We differentiate between the two test cases here
-        let (message, _welcome) = match test_case {
+        let (message, _welcome, _group_info) = match test_case {
             // Alice removes Bob
             TestCase::Remove => alice_group
                 .remove_members(backend, &[bob_index])

--- a/openmls/src/group/tests/test_wire_format_policy.rs
+++ b/openmls/src/group/tests/test_wire_format_policy.rs
@@ -71,7 +71,7 @@ fn receive_message(
     )
     .expect("An unexpected error occurred.");
 
-    let (_message, welcome) = alice_group
+    let (_message, welcome, _group_info) = alice_group
         .add_members(backend, &[bob_key_package])
         .expect("Could not add member.");
 
@@ -92,7 +92,7 @@ fn receive_message(
     )
     .expect("error creating bob's group from welcome");
 
-    let (message, _welcome) = bob_group
+    let (message, _welcome, _group_info) = bob_group
         .self_update(backend, None)
         .expect("An unexpected error occurred.");
     message.into()

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -107,7 +107,7 @@
 //! // ... and invites Maxim.
 //! // The key package has to be retrieved from Maxim in some way. Most likely
 //! // via a server storing key packages for users.
-//! let (mls_message_out, welcome_out) = sasha_group
+//! let (mls_message_out, welcome_out, group_info) = sasha_group
 //!     .add_members(backend, &[maxim_key_package])
 //!     .expect("Could not add members.");
 //!

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -249,12 +249,12 @@ pub struct GroupInfo {
 
 impl GroupInfo {
     /// Returns the group context.
-    pub(crate) fn group_context(&self) -> &GroupContext {
+    pub fn group_context(&self) -> &GroupContext {
         &self.payload.group_context
     }
 
     /// Returns the extensions.
-    pub(crate) fn extensions(&self) -> &Extensions {
+    pub fn extensions(&self) -> &Extensions {
         &self.payload.extensions
     }
 

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -114,7 +114,7 @@ fn test_welcome_ciphersuite_mismatch(
     )
     .expect("An unexpected error occurred.");
 
-    let (_queued_message, welcome) = alice_group
+    let (_queued_message, welcome, _group_info) = alice_group
         .add_members(backend, &[bob_kp.clone()])
         .expect("Could not add member to group.");
 

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -1076,7 +1076,6 @@ impl EpochSecrets {
     }
 
     /// External secret
-    #[cfg(any(feature = "test-utils", test))]
     pub(crate) fn external_secret(&self) -> &ExternalSecret {
         &self.external_secret
     }

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -201,26 +201,28 @@ impl Client {
     /// Optionally, a `HpkeKeyPair` can be provided, which the client will
     /// update their leaf with. Returns an error if no group with the given
     /// group id can be found or if an error occurs while creating the update.
+    #[allow(clippy::type_complexity)]
     pub fn self_update(
         &self,
         action_type: ActionType,
         group_id: &GroupId,
         leaf_node: Option<LeafNode>,
-    ) -> Result<(MlsMessageOut, Option<Welcome>), ClientError> {
+    ) -> Result<(MlsMessageOut, Option<Welcome>, Option<GroupInfo>), ClientError> {
         let mut groups = self.groups.write().expect("An unexpected error occurred.");
         let group = groups
             .get_mut(group_id)
             .ok_or(ClientError::NoMatchingGroup)?;
-        let (msg, welcome_option) = match action_type {
+        let (msg, welcome_option, group_info) = match action_type {
             ActionType::Commit => group.self_update(
                 &self.crypto,
                 leaf_node.map(|leaf| leaf.encryption_key().clone()),
             )?,
-            ActionType::Proposal => (group.propose_self_update(&self.crypto, leaf_node)?, None),
+            ActionType::Proposal => (group.propose_self_update(&self.crypto, leaf_node)?, None, None),
         };
         Ok((
             msg,
             welcome_option.map(|w| w.into_welcome().expect("Unexpected message type.")),
+            group_info,
         ))
     }
 
@@ -229,19 +231,21 @@ impl Client {
     /// group with the given group id. Returns an error if no group with the
     /// given group id can be found or if an error occurs while performing the
     /// add operation.
+    #[allow(clippy::type_complexity)]
     pub fn add_members(
         &self,
         action_type: ActionType,
         group_id: &GroupId,
         key_packages: &[KeyPackage],
-    ) -> Result<(Vec<MlsMessageOut>, Option<Welcome>), ClientError> {
+    ) -> Result<(Vec<MlsMessageOut>, Option<Welcome>, Option<GroupInfo>), ClientError> {
         let mut groups = self.groups.write().expect("An unexpected error occurred.");
         let group = groups
             .get_mut(group_id)
             .ok_or(ClientError::NoMatchingGroup)?;
         let action_results = match action_type {
             ActionType::Commit => {
-                let (messages, welcome_message) = group.add_members(&self.crypto, key_packages)?;
+                let (messages, welcome_message, group_info) =
+                    group.add_members(&self.crypto, key_packages)?;
                 (
                     vec![messages],
                     Some(
@@ -249,6 +253,7 @@ impl Client {
                             .into_welcome()
                             .expect("Unexpected message type."),
                     ),
+                    group_info,
                 )
             }
             ActionType::Proposal => {
@@ -257,7 +262,7 @@ impl Client {
                     let message = group.propose_add_member(&self.crypto, key_package)?;
                     messages.push(message);
                 }
-                (messages, None)
+                (messages, None, None)
             }
         };
         Ok(action_results)
@@ -268,22 +273,25 @@ impl Client {
     /// group with the given group id. Returns an error if no group with the
     /// given group id can be found or if an error occurs while performing the
     /// remove operation.
+    #[allow(clippy::type_complexity)]
     pub fn remove_members(
         &self,
         action_type: ActionType,
         group_id: &GroupId,
         targets: &[LeafNodeIndex],
-    ) -> Result<(Vec<MlsMessageOut>, Option<Welcome>), ClientError> {
+    ) -> Result<(Vec<MlsMessageOut>, Option<Welcome>, Option<GroupInfo>), ClientError> {
         let mut groups = self.groups.write().expect("An unexpected error occurred.");
         let group = groups
             .get_mut(group_id)
             .ok_or(ClientError::NoMatchingGroup)?;
         let action_results = match action_type {
             ActionType::Commit => {
-                let (message, welcome_option) = group.remove_members(&self.crypto, targets)?;
+                let (message, welcome_option, group_info) =
+                    group.remove_members(&self.crypto, targets)?;
                 (
                     vec![message],
                     welcome_option.map(|w| w.into_welcome().expect("Unexpected message type.")),
+                    group_info,
                 )
             }
             ActionType::Proposal => {
@@ -292,7 +300,7 @@ impl Client {
                     let message = group.propose_remove_member(&self.crypto, *target)?;
                     messages.push(message);
                 }
-                (messages, None)
+                (messages, None, None)
             }
         };
         Ok(action_results)

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -505,7 +505,7 @@ impl MlsGroupTestSetup {
             .ok_or(SetupError::UnknownClientId)?
             .read()
             .expect("An unexpected error occurred.");
-        let (messages, welcome_option) =
+        let (messages, welcome_option, _) =
             client.self_update(action_type, &group.group_id, leaf_node)?;
         self.distribute_to_members(&client.identity, group, &messages.into())?;
         if let Some(welcome) = welcome_option {
@@ -550,7 +550,7 @@ impl MlsGroupTestSetup {
             let key_package = self.get_fresh_key_package(&addee, group.ciphersuite)?;
             key_packages.push(key_package);
         }
-        let (messages, welcome_option) =
+        let (messages, welcome_option, _) =
             adder.add_members(action_type, &group.group_id, &key_packages)?;
         for message in messages {
             self.distribute_to_members(adder_id, group, &message.into())?;
@@ -578,7 +578,7 @@ impl MlsGroupTestSetup {
             .ok_or(SetupError::UnknownClientId)?
             .read()
             .expect("An unexpected error occurred.");
-        let (messages, welcome_option) =
+        let (messages, welcome_option, _) =
             remover.remove_members(action_type, &group.group_id, target_members)?;
         for message in messages {
             self.distribute_to_members(remover_id, group, &message.into())?;

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -159,6 +159,14 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     )
     .expect("An unexpected error occurred.");
 
+    let dave_credential_bundle = get_credential_bundle(
+        "Dave".into(),
+        CredentialType::Basic,
+        ciphersuite.signature_algorithm(),
+        backend,
+    )
+    .expect("An unexpected error occurred.");
+
     // Generate KeyPackages
     let bob_key_package = generate_key_package(&[ciphersuite], &bob_credential, backend);
 
@@ -201,13 +209,14 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
 
     // === Alice adds Bob ===
     // ANCHOR: alice_adds_bob
-    let (mls_message_out, welcome) = alice_group
+    let (mls_message_out, welcome, group_info) = alice_group
         .add_members(backend, &[bob_key_package])
         .expect("Could not add members.");
     // ANCHOR_END: alice_adds_bob
 
     // Suppress warning
     let _mls_message_out = mls_message_out;
+    let _group_info = group_info;
 
     // Check that we received the correct proposals
     if let Some(staged_commit) = alice_group.pending_commit() {
@@ -250,6 +259,29 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     )
     .expect("Error joining group from Welcome");
     // ANCHOR_END: bob_joins_with_welcome
+
+    // ANCHOR: alice_exports_group_info
+    let verifiable_group_info = alice_group
+        .export_group_info(backend, true)
+        .expect("Cannot export group info")
+        .into_group_info()
+        .expect("Could not get group info");
+    // ANCHOR_END: alice_exports_group_info
+
+    // ANCHOR: charlie_joins_external_commit
+    let (mut dave_group, _out) = MlsGroup::join_by_external_commit(
+        backend,
+        None,
+        verifiable_group_info,
+        &mls_group_config,
+        &[],
+        &dave_credential_bundle,
+    )
+    .expect("Error joining from external commit");
+    dave_group
+        .merge_pending_commit()
+        .expect("Cannot merge commit");
+    // ANCHOR_END: charlie_joins_external_commit
 
     // Make sure that both groups have the same members
     assert!(alice_group.members().eq(bob_group.members()));
@@ -300,7 +332,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
 
     // === Bob updates and commits ===
     // ANCHOR: self_update
-    let (mls_message_out, welcome_option) = bob_group
+    let (mls_message_out, welcome_option, _group_info) = bob_group
         .self_update(
             backend,
             None, // We don't provide a key package, it will be created on the fly instead
@@ -395,7 +427,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     }
 
     // ANCHOR: commit_to_proposals
-    let (mls_message_out, welcome_option) = alice_group
+    let (mls_message_out, welcome_option, _group_info) = alice_group
         .commit_to_pending_proposals(backend)
         .expect("Could not commit to pending proposals.");
     // ANCHOR_END: commit_to_proposals
@@ -446,10 +478,9 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     // === Bob adds Charlie ===
     let charlie_key_package = generate_key_package(&[ciphersuite], &charlie_credential, backend);
 
-    let (queued_message, welcome) = match bob_group.add_members(backend, &[charlie_key_package]) {
-        Ok((qm, welcome)) => (qm, welcome),
-        Err(e) => panic!("Could not add member to group: {:?}", e),
-    };
+    let (queued_message, welcome, _group_info) = bob_group
+        .add_members(backend, &[charlie_key_package])
+        .unwrap();
 
     let alice_processed_message = alice_group
         .process_message(
@@ -522,10 +553,8 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         .expect("Could not process message.");
 
     // === Charlie updates and commits ===
-    let (queued_message, welcome_option) = match charlie_group.self_update(backend, None) {
-        Ok(qm) => qm,
-        Err(e) => panic!("Error performing self-update: {:?}", e),
-    };
+    let (queued_message, welcome_option, _group_info) =
+        charlie_group.self_update(backend, None).unwrap();
 
     let alice_processed_message = alice_group
         .process_message(
@@ -612,7 +641,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
 
     // === Charlie removes Bob ===
     // ANCHOR: charlie_removes_bob
-    let (mls_message_out, welcome_option) = charlie_group
+    let (mls_message_out, welcome_option, _group_info) = charlie_group
         .remove_members(backend, &[bob_member.index])
         .expect("Could not remove Bob from group.");
     // ANCHOR_END: charlie_removes_bob
@@ -842,7 +871,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     }
 
     // Commit to the proposals and process it
-    let (queued_message, welcome_option) = alice_group
+    let (queued_message, welcome_option, _group_info) = alice_group
         .commit_to_pending_proposals(backend)
         .expect("Could not flush proposals");
 
@@ -991,7 +1020,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
         ))
     );
 
-    let (queued_message, _welcome_option) = alice_group
+    let (queued_message, _welcome_option, _group_info) = alice_group
         .commit_to_pending_proposals(backend)
         .expect("Could not commit to proposals.");
 
@@ -1103,7 +1132,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     match alice_processed_message.into_content() {
         ProcessedMessageContent::ExternalJoinProposalMessage(proposal) => {
             alice_group.store_pending_proposal(*proposal);
-            let (_commit, welcome) = alice_group
+            let (_commit, welcome, _group_info) = alice_group
                 .commit_to_pending_proposals(backend)
                 .expect("Could not commit");
             assert_eq!(alice_group.members().count(), 1);
@@ -1142,7 +1171,7 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     let bob_key_package = generate_key_package(&[ciphersuite], &bob_credential, backend);
 
     // Add Bob to the group
-    let (_queued_message, welcome) = alice_group
+    let (_queued_message, welcome, _group_info) = alice_group
         .add_members(backend, &[bob_key_package])
         .expect("Could not add Bob");
 

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -131,9 +131,8 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
         .expect("An unexpected error occurred.");
 
         // === Alice adds Bob ===
-        let (_queued_message, welcome) = match alice_group.add_members(backend, &[bob_key_package])
-        {
-            Ok((qm, welcome)) => (qm, welcome),
+        let welcome = match alice_group.add_members(backend, &[bob_key_package]) {
+            Ok((_, welcome, _)) => welcome,
             Err(e) => panic!("Could not add member to group: {:?}", e),
         };
 
@@ -223,7 +222,8 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
         }
 
         // === Bob updates and commits ===
-        let (queued_message, welcome_option) = bob_group.self_update(backend, None).unwrap();
+        let (queued_message, welcome_option, _group_info) =
+            bob_group.self_update(backend, None).unwrap();
 
         let alice_processed_message = alice_group
             .process_message(
@@ -318,11 +318,8 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             unreachable!("Expected a QueuedProposal.");
         }
 
-        let (queued_message, _welcome_option) =
-            match alice_group.commit_to_pending_proposals(backend) {
-                Ok(qm) => qm,
-                Err(e) => panic!("Error performing self-update: {:?}", e),
-            };
+        let (queued_message, _welcome_option, _group_info) =
+            alice_group.commit_to_pending_proposals(backend).unwrap();
 
         let bob_processed_message = bob_group
             .process_message(
@@ -381,11 +378,9 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             backend,
         );
 
-        let (queued_message, welcome) = match bob_group.add_members(backend, &[charlie_key_package])
-        {
-            Ok((qm, welcome)) => (qm, welcome),
-            Err(e) => panic!("Could not add member to group: {:?}", e),
-        };
+        let (queued_message, welcome, _group_info) = bob_group
+            .add_members(backend, &[charlie_key_package])
+            .unwrap();
 
         let alice_processed_message = alice_group
             .process_message(
@@ -479,13 +474,12 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             .unwrap();
 
         // === Charlie updates and commits ===
-        let (queued_message, welcome_option) = match charlie_group.self_update(
-            backend,
-            Some(charlies_new_key_package.hpke_init_key().clone()),
-        ) {
-            Ok(qm) => qm,
-            Err(e) => panic!("Error performing self-update: {:?}", e),
-        };
+        let (queued_message, welcome_option, _group_info) = charlie_group
+            .self_update(
+                backend,
+                Some(charlies_new_key_package.hpke_init_key().clone()),
+            )
+            .unwrap();
 
         let alice_processed_message = alice_group
             .process_message(
@@ -552,7 +546,7 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
 
         // === Charlie removes Bob ===
         println!(" >>> Charlie is removing bob");
-        let (queued_message, welcome_option) = charlie_group
+        let (queued_message, welcome_option, _group_info) = charlie_group
             .remove_members(backend, &[bob_group.own_leaf_index()])
             .expect("Could not remove member from group.");
 
@@ -736,7 +730,7 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
         }
 
         // Commit to the proposals and process it
-        let (queued_message, welcome_option) = alice_group
+        let (queued_message, welcome_option, _group_info) = alice_group
             .commit_to_pending_proposals(backend)
             .expect("Could not flush proposals");
 
@@ -869,7 +863,7 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             ))
         );
 
-        let (queued_message, _welcome_option) = alice_group
+        let (queued_message, _welcome_option, _group_info) = alice_group
             .commit_to_pending_proposals(backend)
             .expect("Could not commit to proposals.");
 
@@ -948,7 +942,7 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
         );
 
         // Add Bob to the group
-        let (_queued_message, welcome) = alice_group
+        let (_queued_message, welcome, _group_info) = alice_group
             .add_members(backend, &[bob_key_package])
             .expect("Could not add Bob");
 
@@ -1095,11 +1089,9 @@ fn mls_group_ratchet_tree_extension(
         .expect("An unexpected error occurred.");
 
         // === Alice adds Bob ===
-        let (_queued_message, welcome) =
-            match alice_group.add_members(backend, &[bob_key_package.clone()]) {
-                Ok((qm, welcome)) => (qm, welcome),
-                Err(e) => panic!("Could not add member to group: {:?}", e),
-            };
+        let (_queued_message, welcome, _group_info) = alice_group
+            .add_members(backend, &[bob_key_package.clone()])
+            .unwrap();
 
         // === Bob joins using the ratchet tree extension ===
         let _bob_group = MlsGroup::new_from_welcome(
@@ -1149,11 +1141,9 @@ fn mls_group_ratchet_tree_extension(
         .expect("An unexpected error occurred.");
 
         // === Alice adds Bob ===
-        let (_queued_message, welcome) = match alice_group.add_members(backend, &[bob_key_package])
-        {
-            Ok((qm, welcome)) => (qm, welcome),
-            Err(e) => panic!("Could not add member to group: {:?}", e),
-        };
+        let (_queued_message, welcome, _group_info) = alice_group
+            .add_members(backend, &[bob_key_package])
+            .unwrap();
 
         // === Bob tries to join without the ratchet tree extension ===
         let error = MlsGroup::new_from_welcome(


### PR DESCRIPTION
Closes #1150 

First I'm sorry for the big PR. The reason is that because of the signature change, a lot of tests were affected. 

The biggest use case for this feature is to return the `GroupInfo` in order to make a join with external commit. Docs were added to the book with an example explaining how to do it.

We have opted for returning an optional since this only makes sense if the the ratchet tree is required. OpenMls doesn't support specifying required capabilities as of now (should we open a new issue for that?) and the default behavior in the `RequiredCapabilitiesExtension` is to support everything as can be seen [here](https://github.com/openmls/openmls/blob/main/openmls/src/extensions/required_capabilities.rs#L79-L91). For that reason we opted for checking the `use_ratchet_tree_extension` instead.

We've added a test to make sure that the returned `GroupInfo` can be used to call `join_by_external_commit` and changed the rust docs in the functions that had their signature changed.



