### PR TITLE
ci: Fix coverage job.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,15 +18,13 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-
-      - name: Clean
-        run: cargo clean
+          override: true
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          timeout: "500"
-          args: "--force-clean"
+          version: "0.15.0"
+          args: "-- --test-threads 1"
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,6 @@ name: test coverage
 
 on:
   - push
-  - pull_request_target
 
 jobs:
   check:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,17 +14,27 @@ jobs:
         with:
           submodules: true
 
-      - name: Install stable toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+      - name: Run profiling tests
+        uses: actions-rs/cargo@v1
         with:
-          version: "0.15.0"
-          args: "-- --test-threads 1"
+          command: test
+          args: --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+
+      - name: Run grcov
+        id: coverage
+        uses: actions-rs/grcov@v0.1
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2
+        with:
+          files: ${{ steps.coverage.outputs.report }}


### PR DESCRIPTION
~I couldn't find a "timeout" in GitHub actions but assumed it should mean "seconds". Minutes would exceed the default `timeout-minutes: 360`, which is likely not what we want. Given that 500 seconds are roughly 10 minutes and the job is taking longer, I removed the timeout altogether. The added `version` should fix the rest. Not sure why there was a `cargo clean` but it doesn't seem necessary.~

This PR switches the coverage measurement from tarpaulin to grcov.