### PR TITLE
Feedback: Introduce a typestate to track leaf node validation.

### DIFF
--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -103,9 +103,11 @@ impl CoreGroup {
                 Some(self.own_leaf_index()),
             )
             .map_err(|e| match e {
-                crate::group::errors::ApplyProposalsError::LibraryError(e) => e.into(),
-                crate::group::errors::ApplyProposalsError::MissingLeafNode => {
-                    CreateCommitError::OwnKeyNotFound
+                crate::group::errors::ApplyProposalsError::LibraryError(e) => {
+                    CreateCommitError::LibraryError(e)
+                }
+                crate::group::errors::ApplyProposalsError::LeafNodeValidation(e) => {
+                    CreateCommitError::LeafNodeValidation(e)
                 }
             })?;
         if apply_proposals_values.self_removed && params.commit_type() != CommitType::External {

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -54,7 +54,7 @@ use crate::{
     schedule::{message_secrets::*, psk::*, *},
     tree::{secret_tree::SecretTreeError, sender_ratchet::SenderRatchetConfiguration},
     treesync::{
-        node::leaf_node::{Capabilities, Lifetime, OpenMlsLeafNode},
+        node::leaf_node::{Capabilities, Lifetime, OpenMlsLeafNode, ValidUpdate},
         *,
     },
     versions::ProtocolVersion,
@@ -368,7 +368,7 @@ impl CoreGroup {
         framing_parameters: FramingParameters,
         // XXX: There's no need to own this. The [`UpdateProposal`] should
         //      operate on a reference to make this more efficient.
-        leaf_node: LeafNode,
+        leaf_node: LeafNode<ValidUpdate>,
         signer: &impl Signer,
     ) -> Result<AuthenticatedContent, LibraryError> {
         let update_proposal = UpdateProposal { leaf_node };
@@ -447,7 +447,10 @@ impl CoreGroup {
             let required_capabilities = required_extension.as_required_capabilities_extension()?;
             // Ensure we support all the capabilities.
             required_capabilities.check_support()?;
+            // TODO
             self.own_leaf_node()?
+                .leaf_node()
+                .clone()
                 .validate_required_capabilities(required_capabilities)?;
             // Ensure that all other leaf nodes support all the required
             // extensions as well.

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -15,6 +15,7 @@ use crate::{
 use openmls_traits::{types::Ciphersuite, OpenMlsCryptoProvider};
 use serde::{Deserialize, Serialize};
 use std::collections::{hash_map::Entry, HashMap, HashSet};
+use crate::treesync::node::leaf_node::ValidUpdate;
 
 /// A [ProposalStore] can store the standalone proposals that are received from the DS
 /// in between two commit messages.
@@ -524,13 +525,13 @@ impl<'a> QueuedRemoveProposal<'a> {
 /// A queued Update proposal
 #[derive(PartialEq, Eq, Debug)]
 pub struct QueuedUpdateProposal<'a> {
-    update_proposal: &'a UpdateProposal,
+    update_proposal: &'a UpdateProposal<ValidUpdate>,
     sender: &'a Sender,
 }
 
 impl<'a> QueuedUpdateProposal<'a> {
     /// Returns a reference to the proposal
-    pub fn update_proposal(&self) -> &UpdateProposal {
+    pub fn update_proposal(&self) -> &UpdateProposal<ValidUpdate> {
         self.update_proposal
     }
 

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -126,11 +126,6 @@ impl CoreGroup {
             FromCommittedProposalsError::SelfRemoval => StageCommitError::AttemptedSelfRemoval,
         })?;
 
-        let commit_update_leaf_node = commit
-            .path()
-            .as_ref()
-            .map(|update_path| update_path.leaf_node().clone());
-
         // Validate the staged proposals by doing the following checks:
         // ValSem101
         // ValSem102
@@ -142,7 +137,12 @@ impl CoreGroup {
         // ValSem108
         self.validate_remove_proposals(&proposal_queue)?;
 
-        let public_key_set = match sender {
+        let commit_update_leaf_node = commit
+            .path()
+            .as_ref()
+            .map(|update_path| update_path.leaf_node().clone());
+
+        let _public_key_set = match sender {
             Sender::Member(leaf_index) => {
                 // ValSem110
                 // ValSem111

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -5,6 +5,7 @@ use openmls_traits::{
 };
 use tls_codec::Serialize;
 
+use crate::treesync::node::leaf_node::{Unknown, ValidUpdate};
 use crate::{
     binary_tree::*,
     ciphersuite::{signable::Signable, AeadNonce},
@@ -15,7 +16,7 @@ use crate::{
     messages::{group_info::GroupInfoTBS, *},
     schedule::psk::*,
     test_utils::*,
-    treesync::errors::ApplyUpdatePathError,
+    treesync::{errors::ApplyUpdatePathError, node::leaf_node::LeafNode},
     versions::ProtocolVersion,
 };
 
@@ -202,8 +203,7 @@ fn test_update_path(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
 
     // === Bob updates and commits ===
     let bob_old_leaf = group_bob.own_leaf_node().unwrap();
-    let bob_update_leaf_node = bob_old_leaf
-        .leaf_node()
+    let bob_update_leaf_node = LeafNode::<ValidUpdate>::from(bob_old_leaf.leaf_node().clone())
         .updated(
             CryptoConfig::with_default_version(ciphersuite),
             backend,
@@ -412,8 +412,7 @@ fn test_psks(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
 
     // === Bob updates and commits ===
     let bob_old_leaf = group_bob.own_leaf_node().unwrap();
-    let bob_update_leaf_node = bob_old_leaf
-        .leaf_node()
+    let bob_update_leaf_node = LeafNode::<ValidUpdate>::from(bob_old_leaf.leaf_node().clone())
         .updated(
             CryptoConfig::with_default_version(ciphersuite),
             backend,

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -5,7 +5,7 @@ use openmls_traits::{
 };
 use tls_codec::Serialize;
 
-use crate::treesync::node::leaf_node::{Unknown, ValidUpdate};
+use crate::treesync::node::leaf_node::ValidUpdate;
 use crate::{
     binary_tree::*,
     ciphersuite::{signable::Signable, AeadNonce},

--- a/openmls/src/group/core_group/validation.rs
+++ b/openmls/src/group/core_group/validation.rs
@@ -319,7 +319,6 @@ impl CoreGroup {
     ///  - ValSem243: External Commit, inline Remove Proposal: The identity and the endpoint_id of the removed
     ///               leaf are identical to the ones in the path KeyPackage.
     // TODO(leaf_node_validation)
-    #[allow(unused)]
     pub(crate) fn validate_external_commit(
         &self,
         proposal_queue: &ProposalQueue,

--- a/openmls/src/group/core_group/validation.rs
+++ b/openmls/src/group/core_group/validation.rs
@@ -3,13 +3,14 @@
 
 use std::collections::HashSet;
 
+use crate::treesync::node::leaf_node::ValidCommit;
 use crate::{
     binary_tree::array_representation::LeafNodeIndex,
     framing::Sender,
     group::errors::ExternalCommitValidationError,
     group::errors::ValidationError,
     messages::proposals::{Proposal, ProposalOrRefType, ProposalType},
-    treesync::node::leaf_node::LeafNode,
+    treesync::node::leaf_node::{LeafNode, ValidKeyPackage},
 };
 
 use super::{
@@ -297,9 +298,11 @@ impl CoreGroup {
     /// Validate the new key package in a path
     /// TODO: #730 - There's nothing testing this function.
     /// - ValSem110
+    // TODO(leaf_node_validation)
+    #[allow(unused)]
     pub(super) fn validate_path_key_package(
         &self,
-        leaf_node: &LeafNode,
+        leaf_node: &LeafNode<ValidKeyPackage>,
         public_key_set: HashSet<Vec<u8>>,
     ) -> Result<(), ProposalValidationError> {
         // ValSem110
@@ -315,10 +318,12 @@ impl CoreGroup {
     ///  - ValSem242: External Commit must only cover inline proposal in allowlist (ExternalInit, Remove, PreSharedKey)
     ///  - ValSem243: External Commit, inline Remove Proposal: The identity and the endpoint_id of the removed
     ///               leaf are identical to the ones in the path KeyPackage.
+    // TODO(leaf_node_validation)
+    #[allow(unused)]
     pub(crate) fn validate_external_commit(
         &self,
         proposal_queue: &ProposalQueue,
-        path_leaf_node: Option<&LeafNode>,
+        path_leaf_node: Option<&LeafNode<ValidCommit>>,
     ) -> Result<(), ExternalCommitValidationError> {
         let count_external_init_proposals = proposal_queue
             .filtered_by_type(ProposalType::ExternalInit)

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -230,6 +230,9 @@ pub enum CreateCommitError<KeyStoreError> {
     /// See [`InvalidExtensionError`] for more details.
     #[error(transparent)]
     InvalidExtensionError(#[from] InvalidExtensionError),
+    /// See [`LeafNodeValidationError`] for more details.
+    #[error(transparent)]
+    LeafNodeValidation(#[from] LeafNodeValidationError),
 }
 
 /// Validation error
@@ -444,9 +447,9 @@ pub(crate) enum ApplyProposalsError {
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
-    /// Own LeafNode was not found in the key store.
-    #[error("Own LeafNode was not found in the key store.")]
-    MissingLeafNode,
+    /// See [`LeafNodeValidationError`] for more details.
+    #[error(transparent)]
+    LeafNodeValidation(#[from] LeafNodeValidationError),
 }
 
 // Core group build error

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -7,7 +7,7 @@ use openmls_traits::signatures::Signer;
 
 use crate::{
     binary_tree::array_representation::LeafNodeIndex, group::errors::CreateAddProposalError,
-    messages::group_info::GroupInfo, treesync::LeafNode,
+    messages::group_info::GroupInfo, treesync::node::leaf_node::Valid, treesync::LeafNode,
 };
 
 use super::{
@@ -90,7 +90,7 @@ impl MlsGroup {
     }
 
     /// Returns a reference to the own [`LeafNode`].
-    pub fn own_leaf(&self) -> Option<&LeafNode> {
+    pub fn own_leaf(&self) -> Option<&LeafNode<Valid>> {
         self.group
             .treesync()
             .leaf(self.group.own_leaf_index())

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -30,6 +30,7 @@ mod exporting;
 mod resumption;
 mod updates;
 
+use crate::treesync::node::leaf_node::Valid;
 use config::*;
 use errors::*;
 use resumption::*;
@@ -247,7 +248,7 @@ impl MlsGroup {
     }
 
     /// Returns the leaf node of the client in the tree owning this group.
-    pub fn own_leaf_node(&self) -> Option<&LeafNode> {
+    pub fn own_leaf_node(&self) -> Option<&LeafNode<Valid>> {
         self.group.own_leaf_node().map(|l| l.leaf_node()).ok()
     }
 

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -22,7 +22,7 @@ use crate::{
     test_utils::*,
     tree::sender_ratchet::*,
     treesync::node::{
-        leaf_node::{Capabilities, LeafNodeSource, Lifetime},
+        leaf_node::{Capabilities, LeafNodeSource, Lifetime, Unknown},
         Node,
     },
     versions::ProtocolVersion,
@@ -131,13 +131,12 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     // Create a proposal to update the user's KeyPackage
     let key_package_bundle = KeyPackageBundle::new(&crypto, ciphersuite_name, &credential_bundle);
     let key_package = key_package_bundle.key_package();
-    let (leaf_node, _encryption_key_pair) = LeafNode::new(
+    let (leaf_node, _encryption_key_pair) = LeafNode::update(
         CryptoConfig {
             ciphersuite,
             version: ProtocolVersion::Mls10,
         },
         &credential_bundle,
-        LeafNodeSource::Update,
         Capabilities::default(),
         Extensions::empty(),
         &crypto,

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -286,7 +286,8 @@ fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         leaf_node: alice_group
             .own_leaf()
             .expect("Unable to get own leaf")
-            .clone(),
+            .clone()
+            .into(),
     }));
 
     let remove_proposal = || {

--- a/openmls/src/group/tests/test_encoding.rs
+++ b/openmls/src/group/tests/test_encoding.rs
@@ -1,11 +1,19 @@
-use super::utils::*;
-use crate::{
-    binary_tree::LeafNodeIndex, framing::*, group::*, key_packages::*, messages::*, test_utils::*,
-    *,
-};
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::crypto::OpenMlsCrypto;
 use tls_codec::{Deserialize, Serialize};
+
+use crate::{
+    binary_tree::LeafNodeIndex,
+    framing::*,
+    group::*,
+    key_packages::*,
+    messages::*,
+    test_utils::*,
+    treesync::node::leaf_node::{LeafNode, Valid},
+    *,
+};
+
+use super::utils::*;
 
 /// Creates a simple test setup for various encoding tests.
 fn create_encoding_test_setup(backend: &impl OpenMlsCryptoProvider) -> TestSetup {
@@ -119,7 +127,9 @@ fn test_update_proposal_encoding(backend: &impl OpenMlsCryptoProvider) {
         let mut update: PublicMessage = group_state
             .create_update_proposal(
                 framing_parameters,
-                key_package_bundle.key_package().leaf_node().clone(),
+                // TODO: ValidKeyPackage -> ValidUpdate
+                LeafNode::<Valid>::from(key_package_bundle.key_package().leaf_node().clone())
+                    .into(),
                 &credential_with_key_and_signer.signer,
             )
             .expect("Could not create proposal.")
@@ -269,7 +279,14 @@ fn test_commit_encoding(backend: &impl OpenMlsCryptoProvider) {
         let update = group_state
             .create_update_proposal(
                 framing_parameters,
-                alice_key_package_bundle.key_package().leaf_node().clone(),
+                LeafNode::<Valid>::from(
+                    alice_key_package_bundle
+                        // TODO: ValidKeyPackage -> ValidUpdate
+                        .key_package()
+                        .leaf_node()
+                        .clone(),
+                )
+                .into(),
                 &alice_credential_with_key_and_signer.signer,
             )
             .expect("Could not create proposal.");

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -281,7 +281,14 @@ fn test_valsem242(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             *bob_credential.clone(),
         );
         ProposalOrRef::Proposal(Proposal::Update(UpdateProposal {
-            leaf_node: bob_key_package.leaf_node().clone().to_update_unchecked(),
+            leaf_node: bob_key_package
+                .leaf_node()
+                .update(
+                    CryptoConfig::with_default_version(ciphersuite),
+                    backend,
+                    &bob_credential.signer,
+                )
+                .unwrap(),
         }))
     };
 
@@ -663,6 +670,7 @@ fn test_valsem246(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             bob_new_key_package
                 .leaf_node()
                 .clone()
+                // TODO: Parent hash?
                 .to_commit_unchecked(),
         )
     }

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -14,6 +14,7 @@ use crate::{
     framing::*,
     group::{config::CryptoConfig, errors::*, tests::utils::resign_external_commit, *},
     messages::proposals::*,
+    //treesync::node::leaf_node::{LeafNode, StateValidated},
 };
 
 use super::utils::{generate_credential_bundle, generate_key_package, CredentialWithKeyAndSigner};
@@ -280,7 +281,7 @@ fn test_valsem242(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             *bob_credential.clone(),
         );
         ProposalOrRef::Proposal(Proposal::Update(UpdateProposal {
-            leaf_node: bob_key_package.leaf_node().clone(),
+            leaf_node: bob_key_package.leaf_node().clone().to_update_unchecked(),
         }))
     };
 
@@ -658,7 +659,12 @@ fn test_valsem246(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     if let Some(ref mut path) = content.path {
-        path.set_leaf_node(bob_new_key_package.leaf_node().clone())
+        path.set_leaf_node(
+            bob_new_key_package
+                .leaf_node()
+                .clone()
+                .to_commit_unchecked(),
+        )
     }
 
     plaintext.set_content(FramedContentBody::Commit(content));

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -1612,7 +1612,15 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let update_proposal = Proposal::Update(UpdateProposal {
-        leaf_node: update_kp.leaf_node().clone().to_update_unchecked(),
+        leaf_node: update_kp
+            .leaf_node()
+            .clone()
+            .update(
+                CryptoConfig::with_default_version(ciphersuite),
+                backend,
+                &alice_credential_with_key_and_signer.signer,
+            )
+            .unwrap(),
     });
 
     // We now have Alice create a commit. That commit should not contain any

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -1612,7 +1612,7 @@ fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     );
 
     let update_proposal = Proposal::Update(UpdateProposal {
-        leaf_node: update_kp.leaf_node().clone(),
+        leaf_node: update_kp.leaf_node().clone().to_update_unchecked(),
     });
 
     // We now have Alice create a commit. That commit should not contain any

--- a/openmls/src/key_packages/codec.rs
+++ b/openmls/src/key_packages/codec.rs
@@ -2,8 +2,7 @@ use std::io::Read;
 
 use openmls_traits::types::Ciphersuite;
 
-use crate::key_packages::*;
-use crate::versions::ProtocolVersion;
+use crate::{key_packages::*, versions::ProtocolVersion};
 
 impl tls_codec::Size for KeyPackage {
     #[inline]
@@ -39,14 +38,16 @@ impl tls_codec::Deserialize for KeyPackage {
         let protocol_version = ProtocolVersion::tls_deserialize(bytes)?;
         let ciphersuite = Ciphersuite::tls_deserialize(bytes)?;
         let hpke_init_key = HpkePublicKey::tls_deserialize(bytes)?;
-        let leaf_node = LeafNode::tls_deserialize(bytes)?;
+        let leaf_node = LeafNode::<Unknown>::tls_deserialize(bytes)?;
         let extensions = Extensions::tls_deserialize(bytes)?;
         let signature = Signature::tls_deserialize(bytes)?;
         let payload = KeyPackageTBS {
             protocol_version,
             ciphersuite,
             init_key: hpke_init_key,
-            leaf_node,
+            // TODO(#1210): Validation can't be done here.
+            //              We need to return a `KeyPackage<Unknown>` later.
+            leaf_node: leaf_node.to_key_package_unchecked(),
             extensions,
         };
         let kp = KeyPackage { payload, signature };

--- a/openmls/src/key_packages/errors.rs
+++ b/openmls/src/key_packages/errors.rs
@@ -4,7 +4,10 @@
 
 use thiserror::Error;
 
-use crate::{ciphersuite::signable::SignatureError, error::LibraryError};
+use crate::{
+    ciphersuite::signable::SignatureError, error::LibraryError,
+    treesync::errors::LeafNodeValidationError,
+};
 
 /// KeyPackage verify error
 #[derive(Error, Debug, PartialEq, Clone)]
@@ -49,4 +52,7 @@ pub enum KeyPackageNewError<KeyStoreError> {
     /// See [`SignatureError`] for more details.
     #[error(transparent)]
     SignatureError(#[from] SignatureError),
+    /// See [`LeafNodeValidationError`] for more details.
+    #[error(transparent)]
+    LeafNodeValidation(#[from] LeafNodeValidationError),
 }

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -14,6 +14,7 @@ use crate::{
     key_packages::*,
     prelude::LeafNode,
     schedule::psk::*,
+    treesync::node::leaf_node::ValidUpdate,
     versions::ProtocolVersion,
 };
 
@@ -218,12 +219,12 @@ impl AddProposal {
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
 pub struct UpdateProposal {
-    pub(crate) leaf_node: LeafNode,
+    pub(crate) leaf_node: LeafNode<ValidUpdate>,
 }
 
 impl UpdateProposal {
     /// Returns a reference to the key package in the proposal.
-    pub fn leaf_node(&self) -> &LeafNode {
+    pub fn leaf_node(&self) -> &LeafNode<ValidUpdate> {
         &self.leaf_node
     }
 }

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -23,7 +23,10 @@ use crate::{
     messages::{group_info::GroupInfo, *},
     prelude_test::SignaturePublicKey,
     treesync::{
-        node::{leaf_node::Capabilities, Node},
+        node::{
+            leaf_node::{Capabilities, Unknown, ValidKeyPackage},
+            Node,
+        },
         LeafNode,
     },
     versions::ProtocolVersion,
@@ -192,7 +195,7 @@ impl Client {
         &self,
         action_type: ActionType,
         group_id: &GroupId,
-        leaf_node: Option<LeafNode>,
+        leaf_node: Option<LeafNode<ValidKeyPackage>>,
     ) -> Result<(MlsMessageOut, Option<Welcome>, Option<GroupInfo>), ClientError> {
         let mut groups = self.groups.write().expect("An unexpected error occurred.");
         let group = groups

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -21,6 +21,7 @@
 //! can be manipulated manually via the `Client` struct, which contains their
 //! group states.
 
+use crate::treesync::node::leaf_node::{Unknown, ValidKeyPackage};
 use crate::{
     binary_tree::array_representation::LeafNodeIndex,
     ciphersuite::{hash_ref::KeyPackageRef, *},
@@ -505,7 +506,7 @@ impl MlsGroupTestSetup {
         action_type: ActionType,
         group: &mut Group,
         client_id: &[u8],
-        leaf_node: Option<LeafNode>,
+        leaf_node: Option<LeafNode<ValidKeyPackage>>,
     ) -> Result<(), SetupError> {
         let clients = self.clients.read().expect("An unexpected error occurred.");
         let client = clients

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -44,6 +44,7 @@ use crate::{
     group::GroupId,
     messages::PathSecret,
     schedule::CommitSecret,
+    treesync::node::leaf_node::ValidCommit,
 };
 
 pub(crate) type UpdatePathResult = (
@@ -306,7 +307,7 @@ impl<'a> TreeSyncDiff<'a> {
     }
 
     /// Set the given path as the direct path of the `sender_leaf_index` and
-    /// replace the [`KeyPackage`] in the corresponding leaf with the given one.
+    /// replace the [`LeafNode`] with the given one.
     /// The given path of ParentNodes should already include any potential path
     /// secrets.
     ///
@@ -317,7 +318,7 @@ impl<'a> TreeSyncDiff<'a> {
         backend: &impl OpenMlsCryptoProvider,
         ciphersuite: Ciphersuite,
         sender_leaf_index: LeafNodeIndex,
-        leaf_node: LeafNode,
+        leaf_node: LeafNode<ValidCommit>,
         path: Vec<ParentNode>,
     ) -> Result<(), ApplyUpdatePathError> {
         let filtered_direct_path = self.filtered_direct_path(sender_leaf_index);

--- a/openmls/src/treesync/errors.rs
+++ b/openmls/src/treesync/errors.rs
@@ -197,6 +197,9 @@ pub(crate) enum TreeKemError {
 /// Errors that can happen during leaf node validation.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum LeafNodeValidationError {
+    /// Own LeafNode was not found in the key store.
+    #[error("Own LeafNode was not found in the key store.")]
+    MissingLeafNode,
     /// Lifetime is not acceptable.
     #[error("Lifetime is not acceptable.")]
     Lifetime(LifetimeError),

--- a/openmls/src/treesync/hashes.rs
+++ b/openmls/src/treesync/hashes.rs
@@ -5,7 +5,7 @@ use tls_codec::{Serialize, TlsSerialize, TlsSize, VLByteSlice};
 
 use crate::{
     binary_tree::array_representation::LeafNodeIndex, ciphersuite::HpkePublicKey,
-    error::LibraryError,
+    error::LibraryError, treesync::node::leaf_node::Valid,
 };
 
 use super::{node::parent_node::ParentNode, LeafNode};
@@ -97,7 +97,10 @@ pub(super) struct TreeHashInput<'a> {
 
 impl<'a> TreeHashInput<'a> {
     /// Create a new [`TreeHashInput`] instance from a leaf node.
-    pub(super) fn new_leaf(leaf_index: &'a LeafNodeIndex, leaf_node: Option<&'a LeafNode>) -> Self {
+    pub(super) fn new_leaf(
+        leaf_index: &'a LeafNodeIndex,
+        leaf_node: Option<&'a LeafNode<Valid>>,
+    ) -> Self {
         Self {
             node_type: NodeType::Leaf(LeafNodeHashInput {
                 leaf_index,
@@ -149,7 +152,7 @@ impl<'a> TreeHashInput<'a> {
 #[derive(TlsSerialize, TlsSize)]
 struct LeafNodeHashInput<'a> {
     leaf_index: &'a LeafNodeIndex,
-    leaf_node: Option<&'a LeafNode>,
+    leaf_node: Option<&'a LeafNode<Valid>>,
 }
 
 /// Helper struct that can be serialized in the course of tree hash computation.

--- a/openmls/src/treesync/node/leaf_node/validation.rs
+++ b/openmls/src/treesync/node/leaf_node/validation.rs
@@ -1,0 +1,490 @@
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+
+use crate::{
+    ciphersuite::SignaturePublicKey,
+    credentials::CredentialType,
+    extensions::{Extension, RequiredCapabilitiesExtension},
+    treesync::{
+        errors::{LeafNodeValidationError, LifetimeError},
+        node::{
+            encryption_keys::EncryptionKey,
+            leaf_node::{LeafNodeSource, OpenMlsLeafNode},
+        },
+        LeafNode,
+    },
+};
+
+/// The leaf node was not validated yet.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSize, TlsDeserialize)]
+pub struct Unknown;
+
+/// The leaf node was validated in the context of a key package.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSize, TlsSerialize)]
+pub struct ValidKeyPackage;
+
+/// The leaf node was validated in the context of an add, update, or commit.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSize, TlsSerialize)]
+pub struct ValidUpdate;
+
+/// The leaf node was validated in the context of a commit's update path.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSize, TlsSerialize)]
+pub struct ValidCommit;
+
+/// The leaf node was validated in the context of a ratchet tree.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSize, TlsSerialize)]
+pub struct ValidRatchetTree;
+
+/// The leaf node was either a `ValidKeyPackage`, `ValidAddUpdateCommit`, or
+/// `ValidRatchetTree` and can be used generically now.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSize, TlsSerialize)]
+pub struct Valid;
+
+impl LeafNode<Unknown> {
+    // ----- Typestate transitions -----------------------------------------------------------------
+
+    /// Validate the leaf node in the context of a key package.
+    #[allow(unused)]
+    pub(crate) fn validate_in_key_package<'a>(
+        self,
+        required_capabilities: impl Into<Option<&'a RequiredCapabilitiesExtension>>,
+        signature_keys: &[SignaturePublicKey],
+        encryption_keys: &[EncryptionKey],
+        members_supported_credentials: &[&[CredentialType]],
+        currently_in_use: &[CredentialType],
+    ) -> Result<LeafNode<ValidKeyPackage>, LeafNodeValidationError> {
+        self.validate(
+            required_capabilities,
+            signature_keys,
+            encryption_keys,
+            members_supported_credentials,
+            currently_in_use,
+        )?;
+
+        match self.payload.leaf_node_source {
+            LeafNodeSource::KeyPackage(lifetime) => {
+                // Check that lifetime range is acceptable.
+                if !lifetime.has_acceptable_range() {
+                    return Err(LeafNodeValidationError::Lifetime(
+                        LifetimeError::RangeTooBig,
+                    ));
+                }
+
+                // Check that current time is between `Lifetime.not_before` and `Lifetime.not_after`.
+                if !lifetime.is_valid() {
+                    return Err(LeafNodeValidationError::Lifetime(LifetimeError::NotCurrent));
+                }
+
+                Ok(LeafNode::<ValidKeyPackage> {
+                    payload: self.payload,
+                    signature: self.signature,
+                    phantom: Default::default(),
+                })
+            }
+            _ => Err(LeafNodeValidationError::InvalidLeafNodeSource),
+        }
+    }
+
+    /// Validate the leaf node in the context of an update.
+    #[allow(unused)]
+    pub(crate) fn validate_in_update<'a>(
+        self,
+        required_capabilities: impl Into<Option<&'a RequiredCapabilitiesExtension>>,
+        signature_keys: &[SignaturePublicKey],
+        encryption_keys: &[EncryptionKey],
+        members_supported_credentials: &[&[CredentialType]],
+        currently_in_use: &[CredentialType],
+    ) -> Result<LeafNode<ValidUpdate>, LeafNodeValidationError> {
+        self.validate(
+            required_capabilities,
+            signature_keys,
+            encryption_keys,
+            members_supported_credentials,
+            currently_in_use,
+        )?;
+
+        match self.payload.leaf_node_source {
+            LeafNodeSource::Update => Ok(LeafNode {
+                payload: self.payload,
+                signature: self.signature,
+                phantom: Default::default(),
+            }),
+            _ => Err(LeafNodeValidationError::InvalidLeafNodeSource),
+        }
+    }
+
+    /// Validate the leaf node in the context of an update.
+    // TODO: This should not be unused. This likely comes
+    //       from the conversion to and from `OpenMlsLeafNode`.
+    #[allow(unused)]
+    pub(crate) fn validate_in_commit(
+        self,
+    ) -> Result<LeafNode<ValidCommit>, LeafNodeValidationError> {
+        // TODO(#1186)
+        // self.validate()?;
+
+        match self.payload.leaf_node_source {
+            LeafNodeSource::Commit(_) => Ok(LeafNode {
+                payload: self.payload,
+                signature: self.signature,
+                phantom: Default::default(),
+            }),
+            _ => Err(LeafNodeValidationError::InvalidLeafNodeSource),
+        }
+    }
+
+    // ----- Validation methods ------------------------------------------------------------------
+
+    /// Basic validation of leaf node called in all `validate_in_*` methods.
+    #[allow(unused)]
+    fn validate<'a>(
+        &self,
+        required_capabilities: impl Into<Option<&'a RequiredCapabilitiesExtension>>,
+        signature_keys: &[SignaturePublicKey],
+        encryption_keys: &[EncryptionKey],
+        members_supported_credentials: &[&[CredentialType]],
+        currently_in_use: &[CredentialType],
+    ) -> Result<&Self, LeafNodeValidationError> {
+        self.validate_required_capabilities(required_capabilities)?
+            .validate_that_capabilities_contain_extension_types()?
+            .validate_that_capabilities_contain_credential_type()?
+            .validate_that_signature_key_is_unique(signature_keys)?
+            .validate_that_encryption_key_is_unique(encryption_keys)?
+            .validate_against_group_credentials(members_supported_credentials)?
+            .validate_credential_in_use(currently_in_use)?;
+
+        Ok(self)
+    }
+
+    /// Check that all extensions are listed in capabilities.
+    fn validate_that_capabilities_contain_extension_types(
+        &self,
+    ) -> Result<&Self, LeafNodeValidationError> {
+        for id in self
+            .payload
+            .extensions
+            .iter()
+            .map(Extension::extension_type)
+        {
+            if !self.supports_extension(&id) {
+                return Err(LeafNodeValidationError::ExtensionsNotInCapabilities);
+            }
+        }
+
+        Ok(self)
+    }
+
+    /// Check that credential type is included in the credentials.
+    fn validate_that_capabilities_contain_credential_type(
+        &self,
+    ) -> Result<&Self, LeafNodeValidationError> {
+        if !self
+            .payload
+            .capabilities
+            .credentials
+            .contains(&self.payload.credential.credential_type())
+        {
+            return Err(LeafNodeValidationError::CredentialNotInCapabilities);
+        }
+
+        Ok(self)
+    }
+
+    /// Validate that the signature key is unique among the members of the group.
+    fn validate_that_signature_key_is_unique(
+        &self,
+        signature_keys: &[SignaturePublicKey],
+    ) -> Result<&Self, LeafNodeValidationError> {
+        if signature_keys.contains(self.signature_key()) {
+            return Err(LeafNodeValidationError::SignatureKeyAlreadyInUse);
+        }
+
+        Ok(self)
+    }
+
+    /// Validate that the encryption key is unique among the members of the group.
+    fn validate_that_encryption_key_is_unique(
+        &self,
+        encryption_keys: &[EncryptionKey],
+    ) -> Result<&Self, LeafNodeValidationError> {
+        if encryption_keys.contains(self.encryption_key()) {
+            return Err(LeafNodeValidationError::EncryptionKeyAlreadyInUse);
+        }
+
+        Ok(self)
+    }
+
+    /// Verify that the credential type is supported by all members of the group, as
+    /// specified by the capabilities field of each member's LeafNode.
+    fn validate_against_group_credentials(
+        &self,
+        members_supported_credentials: &[&[CredentialType]],
+    ) -> Result<&Self, LeafNodeValidationError> {
+        for member_supported_credentials in members_supported_credentials {
+            if !member_supported_credentials.contains(&self.credential().credential_type()) {
+                return Err(LeafNodeValidationError::LeafNodeCredentialNotSupportedByMember);
+            }
+        }
+
+        Ok(self)
+    }
+
+    /// Verify that the capabilities field of this LeafNode indicates support for all the
+    /// credential types currently in use by other members.
+    fn validate_credential_in_use(
+        &self,
+        currently_in_use: &[CredentialType],
+    ) -> Result<&Self, LeafNodeValidationError> {
+        for credential in currently_in_use {
+            if !self.payload.capabilities.credentials.contains(credential) {
+                return Err(LeafNodeValidationError::MemberCredentialNotSupportedByLeafNode);
+            }
+        }
+
+        Ok(self)
+    }
+}
+
+// ----- Conversions -------------------------------------------------------------------------------
+
+// LeafNode -> LeafNode
+
+impl From<LeafNode<ValidKeyPackage>> for LeafNode<Valid> {
+    fn from(value: LeafNode<ValidKeyPackage>) -> Self {
+        LeafNode {
+            payload: value.payload,
+            signature: value.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl From<LeafNode<ValidUpdate>> for LeafNode<Valid> {
+    fn from(value: LeafNode<ValidUpdate>) -> Self {
+        LeafNode {
+            payload: value.payload,
+            signature: value.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl From<LeafNode<ValidCommit>> for LeafNode<Valid> {
+    fn from(value: LeafNode<ValidCommit>) -> Self {
+        LeafNode {
+            payload: value.payload,
+            signature: value.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+// "Invalidate"
+
+impl From<LeafNode<Valid>> for LeafNode<ValidKeyPackage> {
+    fn from(value: LeafNode<Valid>) -> Self {
+        LeafNode {
+            payload: value.payload,
+            signature: value.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl From<LeafNode<Valid>> for LeafNode<ValidUpdate> {
+    fn from(value: LeafNode<Valid>) -> Self {
+        LeafNode {
+            payload: value.payload,
+            signature: value.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl From<LeafNode<Valid>> for LeafNode<ValidCommit> {
+    fn from(value: LeafNode<Valid>) -> Self {
+        LeafNode {
+            payload: value.payload,
+            signature: value.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl From<LeafNode<Valid>> for LeafNode<Unknown> {
+    fn from(value: LeafNode<Valid>) -> Self {
+        LeafNode {
+            payload: value.payload,
+            signature: value.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+// LeafNode -> OpenMlsLeafNode
+
+impl From<LeafNode<ValidKeyPackage>> for OpenMlsLeafNode {
+    fn from(leaf_node: LeafNode<ValidKeyPackage>) -> Self {
+        Self {
+            leaf_node: leaf_node.into(),
+            leaf_index: None,
+        }
+    }
+}
+
+impl From<LeafNode<ValidUpdate>> for OpenMlsLeafNode {
+    fn from(leaf_node: LeafNode<ValidUpdate>) -> Self {
+        Self {
+            leaf_node: leaf_node.into(),
+            leaf_index: None,
+        }
+    }
+}
+
+impl From<LeafNode<ValidCommit>> for OpenMlsLeafNode {
+    fn from(leaf_node: LeafNode<ValidCommit>) -> Self {
+        Self {
+            leaf_node: leaf_node.into(),
+            leaf_index: None,
+        }
+    }
+}
+
+impl From<LeafNode<Valid>> for OpenMlsLeafNode {
+    fn from(leaf_node: LeafNode<Valid>) -> Self {
+        Self {
+            leaf_node,
+            leaf_index: None,
+        }
+    }
+}
+
+// OpenMlsLeafNode -> LeafNode
+
+impl From<OpenMlsLeafNode> for LeafNode<Valid> {
+    fn from(value: OpenMlsLeafNode) -> Self {
+        value.leaf_node
+    }
+}
+
+impl From<OpenMlsLeafNode> for LeafNode<ValidKeyPackage> {
+    fn from(value: OpenMlsLeafNode) -> Self {
+        LeafNode {
+            payload: value.leaf_node.payload,
+            signature: value.leaf_node.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl From<OpenMlsLeafNode> for LeafNode<ValidUpdate> {
+    fn from(value: OpenMlsLeafNode) -> Self {
+        LeafNode {
+            payload: value.leaf_node.payload,
+            signature: value.leaf_node.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl From<OpenMlsLeafNode> for LeafNode<ValidCommit> {
+    fn from(value: OpenMlsLeafNode) -> Self {
+        LeafNode {
+            payload: value.leaf_node.payload,
+            signature: value.leaf_node.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl LeafNode<Unknown> {
+    /// Convert a `LeafNode<Unknown>` to `LeafNode<ValidKeyPackage>` without doing any validation.
+    /// Note: Do not use this method when possible.
+    pub(crate) fn to_key_package_unchecked(self) -> LeafNode<ValidKeyPackage> {
+        LeafNode {
+            payload: self.payload,
+            signature: self.signature,
+            phantom: Default::default(),
+        }
+    }
+
+    /// Convert a `LeafNode<Unknown>` to `LeafNode<ValidUpdate>` without doing any validation.
+    /// Note: Do not use this method when possible.
+    pub(crate) fn to_update_unchecked(self) -> LeafNode<ValidUpdate> {
+        LeafNode {
+            payload: self.payload,
+            signature: self.signature,
+            phantom: Default::default(),
+        }
+    }
+
+    /// Convert a `LeafNode<Unknown>` to `LeafNode<ValidCommit>` without doing any validation.
+    /// Note: Do not use this method when possible.
+    pub(crate) fn to_commit_unchecked(self) -> LeafNode<ValidCommit> {
+        LeafNode {
+            payload: self.payload,
+            signature: self.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl LeafNode<ValidKeyPackage> {
+    /// Convert a `LeafNode<ValidKeyPackage>` to `LeafNode<ValidUpdate>` without doing any validation.
+    // TODO: Delete this method.
+    //      `LeafNodeSource == KeyPackage` is not correct for, e.g., update proposals.
+    #[allow(unused)]
+    pub(crate) fn to_update_unchecked(self) -> LeafNode<ValidUpdate> {
+        LeafNode {
+            payload: self.payload,
+            signature: self.signature,
+            phantom: Default::default(),
+        }
+    }
+
+    /// Convert a `LeafNode<ValidKeyPackage>` to `LeafNode<ValidUpdate>` without doing any validation.
+    // TODO): Delete this method.
+    //       `LeafNodeSource == KeyPackage` is not correct for, e.g., an update path.
+    #[allow(unused)]
+    pub(crate) fn to_commit_unchecked(self) -> LeafNode<ValidCommit> {
+        LeafNode {
+            payload: self.payload,
+            signature: self.signature,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl<T> LeafNode<T> {
+    /// Check that all required capabilities are supported by this leaf node.
+    // TODO: Implement this for `LeafNode<Unknown>` only.
+    pub(crate) fn validate_required_capabilities<'a>(
+        &self,
+        required_capabilities: impl Into<Option<&'a RequiredCapabilitiesExtension>>,
+    ) -> Result<&Self, LeafNodeValidationError> {
+        // If the GroupContext has a required_capabilities extension, ...
+        if let Some(required_capabilities) = required_capabilities.into() {
+            // ... then the required extensions, ...
+            for required_extension in required_capabilities.extension_types() {
+                if !self.supports_extension(required_extension) {
+                    return Err(LeafNodeValidationError::UnsupportedExtensions);
+                }
+            }
+
+            // ... proposals, ...
+            for required_proposal in required_capabilities.proposal_types() {
+                if !self.supports_proposal(required_proposal) {
+                    return Err(LeafNodeValidationError::UnsupportedProposals);
+                }
+            }
+
+            // ... and credential types MUST be listed in the LeafNode's capabilities field.
+            for required_credential in required_capabilities.credential_types() {
+                if !self.supports_credential(required_credential) {
+                    return Err(LeafNodeValidationError::UnsupportedCredentials);
+                }
+            }
+        }
+
+        Ok(self)
+    }
+}

--- a/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
+++ b/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
@@ -1,3 +1,4 @@
+use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::{types::Ciphersuite, OpenMlsCryptoProvider};
 use rstest::*;
 use rstest_reuse::apply;
@@ -5,10 +6,14 @@ use rstest_reuse::apply;
 use crate::{
     credentials::{test_utils::new_credential, CredentialType},
     key_packages::KeyPackageBundle,
-    treesync::{node::Node, TreeSync},
+    treesync::{
+        node::{
+            leaf_node::{LeafNode, Valid},
+            Node,
+        },
+        TreeSync,
+    },
 };
-
-use openmls_rust_crypto::OpenMlsRustCrypto;
 
 // Verifies that when we add a leaf to a tree with blank leaf nodes, the leaf will be added at the leftmost free leaf index
 #[apply(ciphersuites_and_backends)]
@@ -33,7 +38,7 @@ fn test_free_leaf_computation(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
     // Build a rudimentary tree with two populated and two empty leaf nodes.
     let nodes: Vec<Option<Node>> = vec![
         Some(Node::LeafNode(
-            kpb_0.key_package().leaf_node().clone().into(),
+            LeafNode::<Valid>::from(kpb_0.key_package().leaf_node().clone()).into(),
         )), // Leaf 0
         None,
         None, // Leaf 1
@@ -41,7 +46,7 @@ fn test_free_leaf_computation(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
         None, // Leaf 2
         None,
         Some(Node::LeafNode(
-            kpb_3.key_package().leaf_node().clone().into(),
+            LeafNode::<Valid>::from(kpb_3.key_package().leaf_node().clone()).into(),
         )), // Leaf 3
     ];
 
@@ -61,7 +66,7 @@ fn test_free_leaf_computation(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
     let mut diff = tree.empty_diff();
     let free_leaf_index = diff.free_leaf_index();
     let added_leaf_index = diff
-        .add_leaf(kpb_2.key_package().leaf_node().clone().into())
+        .add_leaf(LeafNode::<Valid>::from(kpb_2.key_package().leaf_node().clone()).into())
         .expect("error adding leaf");
     assert_eq!(free_leaf_index.u32(), 1u32);
     assert_eq!(free_leaf_index, added_leaf_index);


### PR DESCRIPTION
This draft shows roughly how I imagine to proceed with leaf node validation.

Instead of having a single `LeafNode`, we would have `LeafNode<T>` where `T` serves as a compile time marker to denote what validation steps were executed. In a first step, I just replaced every instance of `LeafNode` with `LeafNode<Unvalidated>`. This was a pure refactoring. In the next step, I replaced `LeafNode<Unvalidated>` with, e.g., `LeafNode<KeyPackage>` in places were I was sure that validation should have taken place. Because the compiler treats `LeafNode<Unvalidated>` and `LeafNode<KeyPackage>` as two distinct types, it was required to convert `LeafNode<Unvalidated>` to `LeafNode<KeyPackage>`. Now, the idea is that the only way to obtain a `LeafNode<KeyPackage>` is to call `validate_in_key_package`. This way, the compiler will guide us to every place in the code where this transition is required, i.e., where it is needed to validate the leaf node.

I left a lot `unwrap`s and am unsure in some places if I use the correct typestate. So, please see this draft PR only as an early example how this idea will look like.

Regarding TLS serialization: By deriving `Tls(De)serialize` only on some (but not all) typestates, we can control what concrete types will implement `Tls(De)serialize` in the end. This could be a bit subtle but seems to work out. I am a bit worried however what implications "perfect derive" will have. We do rely here on the fact that `#derive(Foo)` implies `T: Foo` which is, from my understanding, what perfect derive will lift. So... not sure about this.