### PR TITLE
docs/spec: Update `Proposal`s to draft-ietf-mls-protocol-17.

### DIFF
--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -419,11 +419,11 @@ impl ProposalQueue {
                         contains_external_init = true;
                     }
                 }
-                Proposal::AppAck(_) => unimplemented!("See #291"),
                 Proposal::GroupContextExtensions(_) => {
                     // TODO: Validate proposal?
                     proposal_pool.insert(queued_proposal.proposal_reference(), queued_proposal);
                 }
+                Proposal::AppAck(_) => unimplemented!("See #291"),
             }
         }
         // Check for presence of Removes and delete Updates

--- a/openmls/src/messages/codec.rs
+++ b/openmls/src/messages/codec.rs
@@ -18,10 +18,10 @@ impl tls_codec::Size for Proposal {
                 Proposal::PreSharedKey(pre_shared_key) => pre_shared_key.tls_serialized_len(),
                 Proposal::ReInit(re_init) => re_init.tls_serialized_len(),
                 Proposal::ExternalInit(external_init) => external_init.tls_serialized_len(),
-                Proposal::AppAck(app_ack) => app_ack.tls_serialized_len(),
                 Proposal::GroupContextExtensions(group_context_extensions) => {
                     group_context_extensions.tls_serialized_len()
                 }
+                Proposal::AppAck(app_ack) => app_ack.tls_serialized_len(),
             }
     }
 }
@@ -53,15 +53,15 @@ impl tls_codec::Serialize for Proposal {
                 let written = ProposalType::ExternalInit.tls_serialize(writer)?;
                 external_init.tls_serialize(writer).map(|l| l + written)
             }
-            Proposal::AppAck(app_ack) => {
-                let written = ProposalType::AppAck.tls_serialize(writer)?;
-                app_ack.tls_serialize(writer).map(|l| l + written)
-            }
             Proposal::GroupContextExtensions(group_context_extensions) => {
                 let written = ProposalType::GroupContextExtensions.tls_serialize(writer)?;
                 group_context_extensions
                     .tls_serialize(writer)
                     .map(|l| l + written)
+            }
+            Proposal::AppAck(app_ack) => {
+                let written = ProposalType::AppAck.tls_serialize(writer)?;
+                app_ack.tls_serialize(writer).map(|l| l + written)
             }
         }
     }
@@ -89,11 +89,11 @@ impl tls_codec::Deserialize for Proposal {
             ProposalType::ExternalInit => Ok(Proposal::ExternalInit(
                 ExternalInitProposal::tls_deserialize(bytes)?,
             )),
-            ProposalType::AppAck => Err(tls_codec::Error::DecodingError(
-                "App ack is not supported yet in OpenMLS.".to_string(),
-            )),
             ProposalType::GroupContextExtensions => Ok(Proposal::GroupContextExtensions(
                 GroupContextExtensionProposal::tls_deserialize(bytes)?,
+            )),
+            ProposalType::AppAck => Err(tls_codec::Error::DecodingError(
+                "App ack is not supported yet in OpenMLS.".to_string(),
             )),
         }
     }

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -105,8 +105,7 @@ impl TryFrom<u16> for ProposalType {
 /// This `enum` contains the different proposals in its variants.
 ///
 /// ```c
-/// // draft-ietf-mls-protocol-16
-///
+/// // draft-ietf-mls-protocol-17
 /// struct {
 ///     ProposalType msg_type;
 ///     select (Proposal.msg_type) {
@@ -167,7 +166,14 @@ impl Proposal {
 
 /// Add Proposal.
 ///
-/// An Add proposal requests that a client with a specified KeyPackage be added to the group.
+/// An Add proposal requests that a client with a specified [`KeyPackage`] be added to the group.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///     KeyPackage key_package;
+/// } Add;
+/// ```
 #[derive(
     Debug, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
 )]
@@ -184,8 +190,15 @@ impl AddProposal {
 
 /// Update Proposal.
 ///
-/// An Update proposal is a similar mechanism to Add with the distinction that it is the
-/// sender's leaf node in the tree which would be updated with a new [`LeafNode`].
+/// An Update proposal is a similar mechanism to [`AddProposal`] with the distinction that it
+/// replaces the sender's [`LeafNode`] in the tree instead of adding a new leaf to the tree.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///     LeafNode leaf_node;
+/// } Update;
+/// ```
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
@@ -202,7 +215,14 @@ impl UpdateProposal {
 
 /// Remove Proposal.
 ///
-/// A Remove proposal requests that the member with KeyPackageRef removed be removed from the group.
+/// A Remove proposal requests that the member with the leaf index removed be removed from the group.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///     uint32 removed;
+/// } Remove;
+/// ```
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
@@ -217,7 +237,17 @@ impl RemoveProposal {
     }
 }
 
-/// Preshared Key Proposal.
+/// PreSharedKey Proposal.
+///
+/// A PreSharedKey proposal can be used to request that a pre-shared key be injected into the key
+/// schedule in the process of advancing the epoch.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///     PreSharedKeyID psk;
+/// } PreSharedKey;
+/// ```
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
@@ -243,9 +273,21 @@ impl PreSharedKeyProposal {
     }
 }
 
-/// ReInit proposal.
+/// ReInit Proposal.
 ///
-/// This is used to re-initialize a group.
+/// A ReInit proposal represents a request to reinitialize the group with different parameters, for
+/// example, to increase the version number or to change the ciphersuite. The reinitialization is
+/// done by creating a completely new group and shutting down the old one.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///     opaque group_id<V>;
+///     ProtocolVersion version;
+///     CipherSuite cipher_suite;
+///     Extension extensions<V>;
+/// } ReInit;
+/// ```
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
@@ -258,7 +300,15 @@ pub struct ReInitProposal {
 
 /// ExternalInit Proposal.
 ///
-/// This proposal is used for External Commits only.
+/// An ExternalInit proposal is used by new members that want to join a group by using an external
+/// commit. This proposal can only be used in that context.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///   opaque kem_output<V>;
+/// } ExternalInit;
+/// ```
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
 )]
@@ -293,13 +343,16 @@ pub struct AppAckProposal {
     received_ranges: TlsVecU32<MessageRange>,
 }
 
-/// ## Group Context Extensions Proposal
+/// GroupContextExtensions Proposal.
 ///
-/// A GroupContextExtensions proposal is used to update the list of extensions
-/// in the GroupContext for the group.
+/// A GroupContextExtensions proposal is used to update the list of extensions in the GroupContext
+/// for the group.
 ///
-/// ```text
-/// struct { Extension extensions<V>; } GroupContextExtensions;
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///   Extension extensions<V>;
+/// } GroupContextExtensions;
 /// ```
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -89,9 +89,9 @@ impl ProposalType {
             | ProposalType::Remove
             | ProposalType::Presharedkey
             | ProposalType::Reinit
-            | ProposalType::ExternalInit => true,
+            | ProposalType::ExternalInit
+            | ProposalType::GroupContextExtensions => true,
             ProposalType::AppAck => false,
-            ProposalType::GroupContextExtensions => true,
         }
     }
 }
@@ -106,8 +106,8 @@ impl TryFrom<u16> for ProposalType {
             4 => Ok(ProposalType::Presharedkey),
             5 => Ok(ProposalType::Reinit),
             6 => Ok(ProposalType::ExternalInit),
-            7 => Ok(ProposalType::AppAck),
-            8 => Ok(ProposalType::GroupContextExtensions),
+            7 => Ok(ProposalType::GroupContextExtensions),
+            8 => Ok(ProposalType::AppAck),
             _ => Err("Unknown proposal type."),
         }
     }

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -28,17 +28,30 @@ use tls_codec::{
 
 /// ## MLS Proposal Types
 ///
-/// | Value            | Name                     | Recommended | Reference |
-/// |:=================|:=========================|:============|:==========|
-/// | 0x0000           | RESERVED                 | N/A         | RFC XXXX  |
-/// | 0x0001           | add                      | Y           | RFC XXXX  |
-/// | 0x0002           | update                   | Y           | RFC XXXX  |
-/// | 0x0003           | remove                   | Y           | RFC XXXX  |
-/// | 0x0004           | psk                      | Y           | RFC XXXX  |
-/// | 0x0005           | reinit                   | Y           | RFC XXXX  |
-/// | 0x0006           | external_init            | Y           | RFC XXXX  |
-/// | 0x0007           | app_ack                  | Y           | RFC XXXX  |
-/// | 0xff00  - 0xffff | Reserved for Private Use | N/A         | RFC XXXX  |
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// // See IANA registry for registered values
+/// uint16 ProposalType;
+/// ```
+///
+/// | Value           | Name                     | Recommended | Path Required | Reference |
+/// |:================|:=========================|:============|:==============|:==========|
+/// | 0x0000          | RESERVED                 | N/A         | N/A           | RFC XXXX  |
+/// | 0x0001          | add                      | Y           | N             | RFC XXXX  |
+/// | 0x0002          | update                   | Y           | Y             | RFC XXXX  |
+/// | 0x0003          | remove                   | Y           | Y             | RFC XXXX  |
+/// | 0x0004          | psk                      | Y           | N             | RFC XXXX  |
+/// | 0x0005          | reinit                   | Y           | N             | RFC XXXX  |
+/// | 0x0006          | external_init            | Y           | Y             | RFC XXXX  |
+/// | 0x0007          | group_context_extensions | Y           | Y             | RFC XXXX  |
+/// | 0xf000 - 0xffff | Reserved for Private Use | N/A         | N/A           | RFC XXXX  |
+///
+/// # Extensions
+///
+/// | Value  | Name    | Recommended | Path Required | Reference | Notes                        |
+/// |:=======|:========|:============|:==============|:==========|:=============================|
+/// | 0x0008 | app_ack | Y           | Y             | RFC XXXX  | draft-ietf-mls-extensions-00 |
 #[derive(
     PartialEq,
     Eq,
@@ -62,8 +75,8 @@ pub enum ProposalType {
     Presharedkey = 4,
     Reinit = 5,
     ExternalInit = 6,
-    AppAck = 7,
-    GroupContextExtensions = 8,
+    GroupContextExtensions = 7,
+    AppAck = 8,
 }
 
 impl ProposalType {
@@ -129,9 +142,11 @@ pub enum Proposal {
     PreSharedKey(PreSharedKeyProposal),
     ReInit(ReInitProposal),
     ExternalInit(ExternalInitProposal),
-    // TODO(#916): `AppAck` is not in draft-ietf-mls-protocol-16.
-    AppAck(AppAckProposal),
     GroupContextExtensions(GroupContextExtensionProposal),
+    // # Extensions
+    // TODO(#916): `AppAck` is not in draft-ietf-mls-protocol-17 but
+    //             was moved to `draft-ietf-mls-extensions-00`.
+    AppAck(AppAckProposal),
 }
 
 impl Proposal {


### PR DESCRIPTION
As a reminder: Everything that *has* a `draft-ietf-mls-protocol-XX` is guaranteed to be from `XX`. If `XX` is lower than we want or there is no mention we should check and update.

Edit: I also updated `Proposal`. The functional change is that `group_context_extensions` is now `0x0007` and `app_ack` is now `0x0008`. I saw this and wanted to already fix it in light of upcoming interop testing.