### PR TITLE
refactor/chore: Move `Capabilities` into own module + Improve readability of `leaf_node.rs`.

### DIFF
--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -5,7 +5,7 @@ use crate::framing::mls_content::FramedContentBody;
 use crate::treesync::errors::TreeSyncAddLeaf;
 use crate::treesync::node::encryption_keys::EncryptionKeyPair;
 use crate::treesync::node::leaf_node::{
-    LeafNodeTbs, OpenMlsLeafNode, TreeInfoTbs, VerifiableLeafNodeTbs,
+    LeafNodeTbs, OpenMlsLeafNode, TreeInfo, VerifiableLeafNodeTbs,
 };
 use crate::treesync::{diff::StagedTreeSyncDiff, treekem::DecryptPathParams};
 
@@ -210,7 +210,7 @@ impl CoreGroup {
                 //       up.
                 let tbs = LeafNodeTbs::from(
                     leaf_node.clone(),
-                    TreeInfoTbs::commit(self.group_id().clone(), sender_index),
+                    TreeInfo::commit(self.group_id().clone(), sender_index),
                 );
                 let verifiable_leaf_node = VerifiableLeafNodeTbs {
                     tbs: &tbs,

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -5,7 +5,7 @@ use crate::framing::mls_content::FramedContentBody;
 use crate::treesync::errors::TreeSyncAddLeaf;
 use crate::treesync::node::encryption_keys::EncryptionKeyPair;
 use crate::treesync::node::leaf_node::{
-    LeafNodeTbs, OpenMlsLeafNode, TreeInfo, VerifiableLeafNodeTbs,
+    LeafNodeTbs, OpenMlsLeafNode, TreeInfo, VerifiableLeafNode,
 };
 use crate::treesync::{diff::StagedTreeSyncDiff, treekem::DecryptPathParams};
 
@@ -212,7 +212,7 @@ impl CoreGroup {
                     leaf_node.clone(),
                     TreeInfo::commit(self.group_id().clone(), sender_index),
                 );
-                let verifiable_leaf_node = VerifiableLeafNodeTbs {
+                let verifiable_leaf_node = VerifiableLeafNode {
                     tbs: &tbs,
                     signature: leaf_node.signature(),
                 };

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -5,7 +5,7 @@ use crate::framing::mls_content::FramedContentBody;
 use crate::treesync::errors::TreeSyncAddLeaf;
 use crate::treesync::node::encryption_keys::EncryptionKeyPair;
 use crate::treesync::node::leaf_node::{
-    LeafNodeTbs, OpenMlsLeafNode, TreeInfo, VerifiableLeafNode,
+    LeafNodeTbs, OpenMlsLeafNode, TreeInfoTbs, VerifiableLeafNode,
 };
 use crate::treesync::{diff::StagedTreeSyncDiff, treekem::DecryptPathParams};
 
@@ -210,7 +210,7 @@ impl CoreGroup {
                 //       up.
                 let tbs = LeafNodeTbs::from(
                     leaf_node.clone(),
-                    TreeInfo::commit(self.group_id().clone(), sender_index),
+                    TreeInfoTbs::commit(self.group_id().clone(), sender_index),
                 );
                 let verifiable_leaf_node = VerifiableLeafNode {
                     tbs: &tbs,

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -438,17 +438,13 @@ impl LeafNode {
             .capabilities
             .extensions
             .contains(extension_type)
-            || capabilities::default_extensions()
-                .iter()
-                .any(|et| et == extension_type)
+            || default_extensions().iter().any(|et| et == extension_type)
     }
 
     /// Returns `true` if the [`ProposalType`] is supported by this leaf node.
     pub(crate) fn supports_proposal(&self, proposal_type: &ProposalType) -> bool {
         self.payload.capabilities.proposals.contains(proposal_type)
-            || capabilities::default_proposals()
-                .iter()
-                .any(|pt| pt == proposal_type)
+            || default_proposals().iter().any(|pt| pt == proposal_type)
     }
 
     /// Returns `true` if the [`CredentialType`] is supported by this leaf node.
@@ -565,8 +561,6 @@ pub enum LeafNodeSource {
 
 pub type ParentHash = VLBytes;
 
-// -------------------------------------------------------------------------------------------------
-
 /// To-be-signed leaf node.
 ///
 /// ```c
@@ -676,8 +670,6 @@ pub(crate) struct TreePosition {
     leaf_index: LeafNodeIndex,
 }
 
-// -------------------------------------------------------------------------------------------------
-
 const LEAF_NODE_SIGNATURE_LABEL: &str = "LeafNodeTBS";
 
 /// Helper struct to verify incoming leaf nodes.
@@ -722,8 +714,6 @@ impl<'a> Verifiable for VerifiableLeafNode<'a> {
         LEAF_NODE_SIGNATURE_LABEL
     }
 }
-
-// -------------------------------------------------------------------------------------------------
 
 /// The OpenMLS wrapper for the [`LeafNode`] that holds additional information
 /// that we need:
@@ -1004,8 +994,6 @@ impl From<KeyPackage> for OpenMlsLeafNode {
         }
     }
 }
-
-// -------------------------------------------------------------------------------------------------
 
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum LeafNodeGenerationError<KeyStoreError> {

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -599,13 +599,13 @@ pub type ParentHash = VLBytes;
 #[derive(Debug)]
 pub struct LeafNodeTbs {
     payload: LeafNodePayload,
-    tree_info: TreeInfoTbs,
+    tree_info: TreeInfo,
 }
 
 impl LeafNodeTbs {
     /// Build a [`LeafNodeTbs`] from a [`LeafNode`] and a [`TreeInfoTbs`]
     /// to update a leaf node.
-    pub(crate) fn from(leaf_node: LeafNode, tree_info: TreeInfoTbs) -> Self {
+    pub(crate) fn from(leaf_node: LeafNode, tree_info: TreeInfo) -> Self {
         Self {
             payload: leaf_node.payload,
             tree_info,
@@ -629,7 +629,7 @@ impl LeafNodeTbs {
             leaf_node_source,
             extensions,
         };
-        let tree_info = TreeInfoTbs::KeyPackage;
+        let tree_info = TreeInfo::KeyPackage;
         let tbs = LeafNodeTbs { payload, tree_info };
         Ok(tbs)
     }
@@ -657,13 +657,13 @@ impl LeafNodeTbs {
 /// } LeafNodeTBS;
 /// ```
 #[derive(Debug)]
-pub(crate) enum TreeInfoTbs {
+pub(crate) enum TreeInfo {
     KeyPackage,
     Update(TreePosition),
     Commit(TreePosition),
 }
 
-impl TreeInfoTbs {
+impl TreeInfo {
     pub(crate) fn commit(group_id: GroupId, leaf_index: LeafNodeIndex) -> Self {
         Self::Commit(TreePosition {
             group_id,
@@ -863,7 +863,7 @@ impl OpenMlsLeafNode {
     }
 
     /// Create the [`TreeInfoTbs`] for an update for this leaf.
-    fn update_tree_info(&self, group_id: GroupId) -> Result<TreeInfoTbs, LibraryError> {
+    fn update_tree_info(&self, group_id: GroupId) -> Result<TreeInfo, LibraryError> {
         debug_assert!(
             self.leaf_index.is_some(),
             "TreeInfoTbs for Update can't be created without a leaf index. \
@@ -874,7 +874,7 @@ impl OpenMlsLeafNode {
         );
         self.leaf_index
             .map(|leaf_index| {
-                TreeInfoTbs::Update(TreePosition {
+                TreeInfo::Update(TreePosition {
                     group_id,
                     leaf_index,
                 })
@@ -921,7 +921,7 @@ impl OpenMlsLeafNode {
         self.leaf_node.payload.leaf_node_source = LeafNodeSource::Commit(parent_hash.into());
         let tbs = LeafNodeTbs::from(
             self.leaf_node.clone(), // TODO: With a better setup we wouldn't have to clone here.
-            TreeInfoTbs::Commit(TreePosition {
+            TreeInfo::Commit(TreePosition {
                 group_id,
                 leaf_index: self
                     .leaf_index
@@ -955,7 +955,7 @@ impl OpenMlsLeafNode {
     /// Replace the public key in the leaf node and re-sign.
     #[cfg(any(feature = "test-utils", test))]
     pub fn set_public_key(&mut self, public_key: HpkePublicKey, signer: &impl Signer) {
-        let mut tbs = LeafNodeTbs::from(self.leaf_node.clone(), TreeInfoTbs::KeyPackage);
+        let mut tbs = LeafNodeTbs::from(self.leaf_node.clone(), TreeInfo::KeyPackage);
         tbs.payload.encryption_key = public_key.into();
         self.leaf_node = tbs.sign(signer).unwrap();
     }
@@ -1027,8 +1027,8 @@ impl TlsSerializeTrait for LeafNodeTbs {
     fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
         let written = self.payload.tls_serialize(writer)?;
         match &self.tree_info {
-            TreeInfoTbs::KeyPackage => Ok(written),
-            TreeInfoTbs::Update(p) | TreeInfoTbs::Commit(p) => {
+            TreeInfo::KeyPackage => Ok(written),
+            TreeInfo::Update(p) | TreeInfo::Commit(p) => {
                 p.tls_serialize(writer).map(|b| written + b)
             }
         }
@@ -1039,8 +1039,8 @@ impl tls_codec::Size for LeafNodeTbs {
     fn tls_serialized_len(&self) -> usize {
         let len = self.payload.tls_serialized_len();
         match &self.tree_info {
-            TreeInfoTbs::KeyPackage => len,
-            TreeInfoTbs::Update(p) | TreeInfoTbs::Commit(p) => p.tls_serialized_len() + len,
+            TreeInfo::KeyPackage => len,
+            TreeInfo::Update(p) | TreeInfo::Commit(p) => p.tls_serialized_len() + len,
         }
     }
 }
@@ -1052,9 +1052,9 @@ impl TlsDeserializeTrait for LeafNodeTbs {
     {
         let payload = LeafNodePayload::tls_deserialize(bytes)?;
         let tree_info = match payload.leaf_node_source {
-            LeafNodeSource::KeyPackage(_) => TreeInfoTbs::KeyPackage,
-            LeafNodeSource::Update => TreeInfoTbs::Update(TreePosition::tls_deserialize(bytes)?),
-            LeafNodeSource::Commit(_) => TreeInfoTbs::Commit(TreePosition::tls_deserialize(bytes)?),
+            LeafNodeSource::KeyPackage(_) => TreeInfo::KeyPackage,
+            LeafNodeSource::Update => TreeInfo::Update(TreePosition::tls_deserialize(bytes)?),
+            LeafNodeSource::Commit(_) => TreeInfo::Commit(TreePosition::tls_deserialize(bytes)?),
         };
         Ok(Self { payload, tree_info })
     }

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -593,7 +593,7 @@ pub type ParentHash = VLBytes;
 ///
 ///     Extension extensions<V>;
 ///
-///     // ... continued in [`TreeInfoTbs`] ...
+///     // ... continued in [`TreeInfo`] ...
 /// } LeafNodeTBS;
 /// ```
 #[derive(Debug)]
@@ -603,7 +603,7 @@ pub struct LeafNodeTbs {
 }
 
 impl LeafNodeTbs {
-    /// Build a [`LeafNodeTbs`] from a [`LeafNode`] and a [`TreeInfoTbs`]
+    /// Build a [`LeafNodeTbs`] from a [`LeafNode`] and a [`TreeInfo`]
     /// to update a leaf node.
     pub(crate) fn from(leaf_node: LeafNode, tree_info: TreeInfo) -> Self {
         Self {
@@ -684,7 +684,7 @@ const LEAF_NODE_SIGNATURE_LABEL: &str = "LeafNodeTBS";
 
 /// Helper struct to verify incoming leaf nodes.
 /// The [`LeafNode`] doesn't have all the information needed to verify.
-/// In particular is the [`TreeInfoTbs`] missing.
+/// In particular is the [`TreeInfo`] missing.
 pub(crate) struct VerifiableLeafNode<'a> {
     pub(crate) tbs: &'a LeafNodeTbs,
     pub(crate) signature: &'a Signature,
@@ -862,11 +862,11 @@ impl OpenMlsLeafNode {
         Ok(key_pair)
     }
 
-    /// Create the [`TreeInfoTbs`] for an update for this leaf.
+    /// Create the [`TreeInfo`] for an update for this leaf.
     fn update_tree_info(&self, group_id: GroupId) -> Result<TreeInfo, LibraryError> {
         debug_assert!(
             self.leaf_index.is_some(),
-            "TreeInfoTbs for Update can't be created without a leaf index. \
+            "TreeInfo for Update can't be created without a leaf index. \
              Leaf identity: {:?} ({})",
             self.leaf_node().credential().identity(),
             String::from_utf8(self.leaf_node().credential().identity().to_vec())
@@ -880,9 +880,7 @@ impl OpenMlsLeafNode {
                 })
             })
             .ok_or_else(|| {
-                LibraryError::custom(
-                    "TreeInfoTbs for Update can't be created without a leaf index.",
-                )
+                LibraryError::custom("TreeInfo for Update can't be created without a leaf index.")
             })
     }
 

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -685,7 +685,7 @@ const LEAF_NODE_SIGNATURE_LABEL: &str = "LeafNodeTBS";
 /// Helper struct to verify incoming leaf nodes.
 /// The [`LeafNode`] doesn't have all the information needed to verify.
 /// In particular is the [`TreeInfoTbs`] missing.
-pub(crate) struct VerifiableLeafNodeTbs<'a> {
+pub(crate) struct VerifiableLeafNode<'a> {
     pub(crate) tbs: &'a LeafNodeTbs,
     pub(crate) signature: &'a Signature,
 }
@@ -711,7 +711,7 @@ impl SignedStruct<LeafNodeTbs> for LeafNode {
     }
 }
 
-impl<'a> Verifiable for VerifiableLeafNodeTbs<'a> {
+impl<'a> Verifiable for VerifiableLeafNode<'a> {
     fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
         self.tbs.tls_serialize_detached()
     }

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -34,179 +34,6 @@ mod lifetime;
 pub use self::lifetime::Lifetime;
 pub use capabilities::*;
 
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum LeafNodeGenerationError<KeyStoreError> {
-    /// See [`LibraryError`] for more details.
-    #[error(transparent)]
-    LibraryError(#[from] LibraryError),
-    /// Error storing leaf private key in key store.
-    #[error("Error storing leaf private key in key store.")]
-    KeyStoreError(KeyStoreError),
-}
-
-pub type ParentHash = VLBytes;
-
-#[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
-)]
-#[repr(u8)]
-pub enum LeafNodeSource {
-    #[tls_codec(discriminant = 1)]
-    KeyPackage(Lifetime),
-    Update,
-    Commit(ParentHash),
-}
-
-#[derive(Debug, TlsSerialize, TlsDeserialize, TlsSize)]
-pub(crate) struct TreePosition {
-    group_id: GroupId,
-    leaf_index: LeafNodeIndex,
-}
-
-/// Helper struct that holds additional information required to sign a leaf node.
-///
-/// ```c
-/// // draft-ietf-mls-protocol-17
-/// struct {
-///     // ... continued from [`LeafNodeTbs`] ...
-///
-///     select (LeafNodeTBS.leaf_node_source) {
-///         case key_package:
-///             struct{};
-///
-///         case update:
-///             opaque group_id<V>;
-///             uint32 leaf_index;
-///
-///         case commit:
-///             opaque group_id<V>;
-///             uint32 leaf_index;
-///     };
-/// } LeafNodeTBS;
-/// ```
-#[derive(Debug)]
-pub(crate) enum TreeInfoTbs {
-    KeyPackage,
-    Update(TreePosition),
-    Commit(TreePosition),
-}
-
-impl TreeInfoTbs {
-    pub(crate) fn commit(group_id: GroupId, leaf_index: LeafNodeIndex) -> Self {
-        Self::Commit(TreePosition {
-            group_id,
-            leaf_index,
-        })
-    }
-}
-
-/// The payload of a [`LeafNode`]
-///
-/// ```text
-/// struct {
-///     HPKEPublicKey encryption_key;
-///     SignaturePublicKey signature_key;
-///     Credential credential;
-///     Capabilities capabilities;
-///
-///     LeafNodeSource leaf_node_source;
-///     select (LeafNode.leaf_node_source) {
-///         case key_package:
-///             Lifetime lifetime;
-///
-///         case update:
-///             struct{};
-///
-///         case commit:
-///             opaque parent_hash<V>;
-///     };
-///
-///     Extension extensions<V>;
-///     ...
-/// } LeafNode;
-/// ```
-#[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
-)]
-struct LeafNodePayload {
-    encryption_key: EncryptionKey,
-    signature_key: SignaturePublicKey,
-    credential: Credential,
-    capabilities: Capabilities,
-    leaf_node_source: LeafNodeSource,
-    extensions: Extensions,
-}
-
-/// To-be-signed leaf node.
-///
-/// ```c
-/// // draft-ietf-mls-protocol-17
-/// struct {
-///     HPKEPublicKey encryption_key;
-///     SignaturePublicKey signature_key;
-///     Credential credential;
-///     Capabilities capabilities;
-///
-///     LeafNodeSource leaf_node_source;
-///     select (LeafNodeTBS.leaf_node_source) {
-///         case key_package:
-///             Lifetime lifetime;
-///
-///         case update:
-///             struct{};
-///
-///         case commit:
-///             opaque parent_hash<V>;
-///     };
-///
-///     Extension extensions<V>;
-///
-///     // ... continued in [`TreeInfoTbs`] ...
-/// } LeafNodeTBS;
-/// ```
-#[derive(Debug)]
-pub struct LeafNodeTbs {
-    payload: LeafNodePayload,
-    tree_info: TreeInfoTbs,
-}
-
-impl TlsSerializeTrait for LeafNodeTbs {
-    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
-        let written = self.payload.tls_serialize(writer)?;
-        match &self.tree_info {
-            TreeInfoTbs::KeyPackage => Ok(written),
-            TreeInfoTbs::Update(p) | TreeInfoTbs::Commit(p) => {
-                p.tls_serialize(writer).map(|b| written + b)
-            }
-        }
-    }
-}
-
-impl tls_codec::Size for LeafNodeTbs {
-    fn tls_serialized_len(&self) -> usize {
-        let len = self.payload.tls_serialized_len();
-        match &self.tree_info {
-            TreeInfoTbs::KeyPackage => len,
-            TreeInfoTbs::Update(p) | TreeInfoTbs::Commit(p) => p.tls_serialized_len() + len,
-        }
-    }
-}
-
-impl TlsDeserializeTrait for LeafNodeTbs {
-    fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, tls_codec::Error>
-    where
-        Self: Sized,
-    {
-        let payload = LeafNodePayload::tls_deserialize(bytes)?;
-        let tree_info = match payload.leaf_node_source {
-            LeafNodeSource::KeyPackage(_) => TreeInfoTbs::KeyPackage,
-            LeafNodeSource::Update => TreeInfoTbs::Update(TreePosition::tls_deserialize(bytes)?),
-            LeafNodeSource::Commit(_) => TreeInfoTbs::Commit(TreePosition::tls_deserialize(bytes)?),
-        };
-        Ok(Self { payload, tree_info })
-    }
-}
-
 /// This struct implements the MLS leaf node.
 ///
 /// ```c
@@ -240,12 +67,6 @@ impl TlsDeserializeTrait for LeafNodeTbs {
 pub struct LeafNode {
     payload: LeafNodePayload,
     signature: Signature,
-}
-
-impl From<OpenMlsLeafNode> for LeafNode {
-    fn from(leaf: OpenMlsLeafNode) -> Self {
-        leaf.leaf_node
-    }
 }
 
 impl LeafNode {
@@ -641,9 +462,9 @@ impl LeafNode {
     }
 }
 
+#[cfg(test)]
 impl LeafNode {
     /// Expose [`new_with_key`] for tests.
-    #[cfg(test)]
     pub(crate) fn create_new_with_key(
         encryption_key: EncryptionKey,
         credential_with_key: CredentialWithKey,
@@ -662,21 +483,13 @@ impl LeafNode {
         )
     }
 
-    /// Replace the credential in the KeyPackage.
-    #[cfg(any(feature = "test-utils", test))]
-    pub(crate) fn set_credential(&mut self, credential: Credential) {
-        self.payload.credential = credential;
-    }
-
     /// Return a mutable reference to [`Capabilities`].
-    #[cfg(test)]
     pub fn capabilities_mut(&mut self) -> &mut Capabilities {
         &mut self.payload.capabilities
     }
 
     /// Check whether the this leaf node supports all the required extensions
     /// in the provided list.
-    #[cfg(test)]
     pub(crate) fn check_extension_support(
         &self,
         extensions: &[ExtensionType],
@@ -690,49 +503,103 @@ impl LeafNode {
     }
 }
 
-const LEAF_NODE_SIGNATURE_LABEL: &str = "LeafNodeTBS";
-
-impl Signable for LeafNodeTbs {
-    type SignedOutput = LeafNode;
-
-    fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
-        self.tls_serialize_detached()
-    }
-
-    fn label(&self) -> &str {
-        LEAF_NODE_SIGNATURE_LABEL
+#[cfg(any(feature = "test-utils", test))]
+impl LeafNode {
+    /// Replace the credential in the KeyPackage.
+    pub(crate) fn set_credential(&mut self, credential: Credential) {
+        self.payload.credential = credential;
     }
 }
 
-impl SignedStruct<LeafNodeTbs> for LeafNode {
-    fn from_payload(tbs: LeafNodeTbs, signature: Signature) -> Self {
-        Self {
-            payload: tbs.payload,
-            signature,
-        }
+impl From<OpenMlsLeafNode> for LeafNode {
+    fn from(leaf: OpenMlsLeafNode) -> Self {
+        leaf.leaf_node
     }
 }
 
-/// Helper struct to verify incoming leaf nodes.
-/// The [`LeafNode`] doesn't have all the information needed to verify.
-/// In particular is the [`TreeInfoTbs`] missing.
-pub(crate) struct VerifiableLeafNodeTbs<'a> {
-    pub(crate) tbs: &'a LeafNodeTbs,
-    pub(crate) signature: &'a Signature,
+/// The payload of a [`LeafNode`]
+///
+/// ```text
+/// struct {
+///     HPKEPublicKey encryption_key;
+///     SignaturePublicKey signature_key;
+///     Credential credential;
+///     Capabilities capabilities;
+///
+///     LeafNodeSource leaf_node_source;
+///     select (LeafNode.leaf_node_source) {
+///         case key_package:
+///             Lifetime lifetime;
+///
+///         case update:
+///             struct{};
+///
+///         case commit:
+///             opaque parent_hash<V>;
+///     };
+///
+///     Extension extensions<V>;
+///     ...
+/// } LeafNode;
+/// ```
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+)]
+struct LeafNodePayload {
+    encryption_key: EncryptionKey,
+    signature_key: SignaturePublicKey,
+    credential: Credential,
+    capabilities: Capabilities,
+    leaf_node_source: LeafNodeSource,
+    extensions: Extensions,
 }
 
-impl<'a> Verifiable for VerifiableLeafNodeTbs<'a> {
-    fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
-        self.tbs.tls_serialize_detached()
-    }
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+)]
+#[repr(u8)]
+pub enum LeafNodeSource {
+    #[tls_codec(discriminant = 1)]
+    KeyPackage(Lifetime),
+    Update,
+    Commit(ParentHash),
+}
 
-    fn signature(&self) -> &Signature {
-        self.signature
-    }
+pub type ParentHash = VLBytes;
 
-    fn label(&self) -> &str {
-        LEAF_NODE_SIGNATURE_LABEL
-    }
+// -------------------------------------------------------------------------------------------------
+
+/// To-be-signed leaf node.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///     HPKEPublicKey encryption_key;
+///     SignaturePublicKey signature_key;
+///     Credential credential;
+///     Capabilities capabilities;
+///
+///     LeafNodeSource leaf_node_source;
+///     select (LeafNodeTBS.leaf_node_source) {
+///         case key_package:
+///             Lifetime lifetime;
+///
+///         case update:
+///             struct{};
+///
+///         case commit:
+///             opaque parent_hash<V>;
+///     };
+///
+///     Extension extensions<V>;
+///
+///     // ... continued in [`TreeInfoTbs`] ...
+/// } LeafNodeTBS;
+/// ```
+#[derive(Debug)]
+pub struct LeafNodeTbs {
+    payload: LeafNodePayload,
+    tree_info: TreeInfoTbs,
 }
 
 impl LeafNodeTbs {
@@ -768,6 +635,98 @@ impl LeafNodeTbs {
     }
 }
 
+/// Helper struct that holds additional information required to sign a leaf node.
+///
+/// ```c
+/// // draft-ietf-mls-protocol-17
+/// struct {
+///     // ... continued from [`LeafNodeTbs`] ...
+///
+///     select (LeafNodeTBS.leaf_node_source) {
+///         case key_package:
+///             struct{};
+///
+///         case update:
+///             opaque group_id<V>;
+///             uint32 leaf_index;
+///
+///         case commit:
+///             opaque group_id<V>;
+///             uint32 leaf_index;
+///     };
+/// } LeafNodeTBS;
+/// ```
+#[derive(Debug)]
+pub(crate) enum TreeInfoTbs {
+    KeyPackage,
+    Update(TreePosition),
+    Commit(TreePosition),
+}
+
+impl TreeInfoTbs {
+    pub(crate) fn commit(group_id: GroupId, leaf_index: LeafNodeIndex) -> Self {
+        Self::Commit(TreePosition {
+            group_id,
+            leaf_index,
+        })
+    }
+}
+
+#[derive(Debug, TlsSerialize, TlsDeserialize, TlsSize)]
+pub(crate) struct TreePosition {
+    group_id: GroupId,
+    leaf_index: LeafNodeIndex,
+}
+
+// -------------------------------------------------------------------------------------------------
+
+const LEAF_NODE_SIGNATURE_LABEL: &str = "LeafNodeTBS";
+
+/// Helper struct to verify incoming leaf nodes.
+/// The [`LeafNode`] doesn't have all the information needed to verify.
+/// In particular is the [`TreeInfoTbs`] missing.
+pub(crate) struct VerifiableLeafNodeTbs<'a> {
+    pub(crate) tbs: &'a LeafNodeTbs,
+    pub(crate) signature: &'a Signature,
+}
+
+impl Signable for LeafNodeTbs {
+    type SignedOutput = LeafNode;
+
+    fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        self.tls_serialize_detached()
+    }
+
+    fn label(&self) -> &str {
+        LEAF_NODE_SIGNATURE_LABEL
+    }
+}
+
+impl SignedStruct<LeafNodeTbs> for LeafNode {
+    fn from_payload(tbs: LeafNodeTbs, signature: Signature) -> Self {
+        Self {
+            payload: tbs.payload,
+            signature,
+        }
+    }
+}
+
+impl<'a> Verifiable for VerifiableLeafNodeTbs<'a> {
+    fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        self.tbs.tls_serialize_detached()
+    }
+
+    fn signature(&self) -> &Signature {
+        self.signature
+    }
+
+    fn label(&self) -> &str {
+        LEAF_NODE_SIGNATURE_LABEL
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
 /// The OpenMLS wrapper for the [`LeafNode`] that holds additional information
 /// that we need:
 /// * the HPKE private key for to the public key that's in the [`LeafNode`].
@@ -778,24 +737,6 @@ impl LeafNodeTbs {
 pub struct OpenMlsLeafNode {
     pub(in crate::treesync) leaf_node: LeafNode,
     leaf_index: Option<LeafNodeIndex>,
-}
-
-impl From<LeafNode> for OpenMlsLeafNode {
-    fn from(leaf_node: LeafNode) -> Self {
-        Self {
-            leaf_node,
-            leaf_index: None,
-        }
-    }
-}
-
-impl From<KeyPackage> for OpenMlsLeafNode {
-    fn from(key_package: KeyPackage) -> Self {
-        Self {
-            leaf_node: key_package.leaf_node().clone(),
-            leaf_index: None,
-        }
-    }
 }
 
 impl OpenMlsLeafNode {
@@ -860,7 +801,7 @@ impl OpenMlsLeafNode {
             leaf_node_tbs.payload.encryption_key = new_encryption_key;
         } else {
             return Err(LibraryError::custom(
-                    "update_and_re_sign needs to be called with a new leaf node or a new encryption key. Neither was the case.").into());
+                "update_and_re_sign needs to be called with a new leaf node or a new encryption key. Neither was the case.").into());
         }
 
         // Set the new signed leaf node with the new encryption key
@@ -1047,5 +988,74 @@ impl OpenMlsLeafNode {
     /// Get a list of supported cipher suites.
     pub fn ciphersuites(&self) -> &[Ciphersuite] {
         &self.leaf_node.payload.capabilities.ciphersuites
+    }
+}
+
+impl From<LeafNode> for OpenMlsLeafNode {
+    fn from(leaf_node: LeafNode) -> Self {
+        Self {
+            leaf_node,
+            leaf_index: None,
+        }
+    }
+}
+
+impl From<KeyPackage> for OpenMlsLeafNode {
+    fn from(key_package: KeyPackage) -> Self {
+        Self {
+            leaf_node: key_package.leaf_node().clone(),
+            leaf_index: None,
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum LeafNodeGenerationError<KeyStoreError> {
+    /// See [`LibraryError`] for more details.
+    #[error(transparent)]
+    LibraryError(#[from] LibraryError),
+    /// Error storing leaf private key in key store.
+    #[error("Error storing leaf private key in key store.")]
+    KeyStoreError(KeyStoreError),
+}
+
+// -------------------------------------------------------------------------------------------------
+
+impl TlsSerializeTrait for LeafNodeTbs {
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+        let written = self.payload.tls_serialize(writer)?;
+        match &self.tree_info {
+            TreeInfoTbs::KeyPackage => Ok(written),
+            TreeInfoTbs::Update(p) | TreeInfoTbs::Commit(p) => {
+                p.tls_serialize(writer).map(|b| written + b)
+            }
+        }
+    }
+}
+
+impl tls_codec::Size for LeafNodeTbs {
+    fn tls_serialized_len(&self) -> usize {
+        let len = self.payload.tls_serialized_len();
+        match &self.tree_info {
+            TreeInfoTbs::KeyPackage => len,
+            TreeInfoTbs::Update(p) | TreeInfoTbs::Commit(p) => p.tls_serialized_len() + len,
+        }
+    }
+}
+
+impl TlsDeserializeTrait for LeafNodeTbs {
+    fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let payload = LeafNodePayload::tls_deserialize(bytes)?;
+        let tree_info = match payload.leaf_node_source {
+            LeafNodeSource::KeyPackage(_) => TreeInfoTbs::KeyPackage,
+            LeafNodeSource::Update => TreeInfoTbs::Update(TreePosition::tls_deserialize(bytes)?),
+            LeafNodeSource::Commit(_) => TreeInfoTbs::Commit(TreePosition::tls_deserialize(bytes)?),
+        };
+        Ok(Self { payload, tree_info })
     }
 }

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -29,8 +29,8 @@ mod capabilities;
 mod codec;
 mod lifetime;
 
-pub use self::lifetime::Lifetime;
 pub use capabilities::*;
+pub use lifetime::Lifetime;
 
 /// This struct implements the MLS leaf node.
 ///

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -4,10 +4,7 @@ use openmls_traits::{
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tls_codec::{
-    Deserialize as TlsDeserializeTrait, Serialize as TlsSerializeTrait, TlsDeserialize,
-    TlsSerialize, TlsSize, VLBytes,
-};
+use tls_codec::{Serialize as TlsSerializeTrait, TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
 
 use crate::{
     binary_tree::array_representation::LeafNodeIndex,
@@ -29,6 +26,7 @@ use crate::{
 use super::encryption_keys::{EncryptionKey, EncryptionKeyPair};
 
 mod capabilities;
+mod codec;
 mod lifetime;
 
 pub use self::lifetime::Lifetime;
@@ -1017,43 +1015,4 @@ pub enum LeafNodeGenerationError<KeyStoreError> {
     /// Error storing leaf private key in key store.
     #[error("Error storing leaf private key in key store.")]
     KeyStoreError(KeyStoreError),
-}
-
-// -------------------------------------------------------------------------------------------------
-
-impl TlsSerializeTrait for LeafNodeTbs {
-    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
-        let written = self.payload.tls_serialize(writer)?;
-        match &self.tree_info {
-            TreeInfo::KeyPackage => Ok(written),
-            TreeInfo::Update(p) | TreeInfo::Commit(p) => {
-                p.tls_serialize(writer).map(|b| written + b)
-            }
-        }
-    }
-}
-
-impl tls_codec::Size for LeafNodeTbs {
-    fn tls_serialized_len(&self) -> usize {
-        let len = self.payload.tls_serialized_len();
-        match &self.tree_info {
-            TreeInfo::KeyPackage => len,
-            TreeInfo::Update(p) | TreeInfo::Commit(p) => p.tls_serialized_len() + len,
-        }
-    }
-}
-
-impl TlsDeserializeTrait for LeafNodeTbs {
-    fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, tls_codec::Error>
-    where
-        Self: Sized,
-    {
-        let payload = LeafNodePayload::tls_deserialize(bytes)?;
-        let tree_info = match payload.leaf_node_source {
-            LeafNodeSource::KeyPackage(_) => TreeInfo::KeyPackage,
-            LeafNodeSource::Update => TreeInfo::Update(TreePosition::tls_deserialize(bytes)?),
-            LeafNodeSource::Commit(_) => TreeInfo::Commit(TreePosition::tls_deserialize(bytes)?),
-        };
-        Ok(Self { payload, tree_info })
-    }
 }

--- a/openmls/src/treesync/node/leaf_node/capabilities.rs
+++ b/openmls/src/treesync/node/leaf_node/capabilities.rs
@@ -1,0 +1,194 @@
+use openmls_traits::types::Ciphersuite;
+use serde::{Deserialize, Serialize};
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+
+use crate::{
+    credentials::CredentialType,
+    extensions::{ExtensionType, RequiredCapabilitiesExtension},
+    messages::proposals::ProposalType,
+    versions::ProtocolVersion,
+};
+
+/// Capabilities of [`LeafNode`]s.
+///
+/// ```text
+/// struct {
+///     ProtocolVersion versions<V>;
+///     CipherSuite ciphersuites<V>;
+///     ExtensionType extensions<V>;
+///     ProposalType proposals<V>;
+///     CredentialType credentials<V>;
+/// } Capabilities;
+/// ```
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+)]
+pub struct Capabilities {
+    pub(super) versions: Vec<ProtocolVersion>,
+    pub(super) ciphersuites: Vec<Ciphersuite>,
+    pub(super) extensions: Vec<ExtensionType>,
+    pub(super) proposals: Vec<ProposalType>,
+    pub(super) credentials: Vec<CredentialType>,
+}
+
+impl Capabilities {
+    /// Create a new [`Capabilities`] struct with the given configuration.
+    /// Any argument that is `None` is filled with the default values from the
+    /// global configuration.
+    // TODO(#1232)
+    pub fn new(
+        versions: Option<&[ProtocolVersion]>,
+        ciphersuites: Option<&[Ciphersuite]>,
+        extensions: Option<&[ExtensionType]>,
+        proposals: Option<&[ProposalType]>,
+        credentials: Option<&[CredentialType]>,
+    ) -> Self {
+        Self {
+            versions: match versions {
+                Some(v) => v.into(),
+                None => default_versions(),
+            },
+            ciphersuites: match ciphersuites {
+                Some(c) => c.into(),
+                None => default_ciphersuites(),
+            },
+            extensions: match extensions {
+                Some(e) => e.into(),
+                None => vec![],
+            },
+            proposals: match proposals {
+                Some(p) => p.into(),
+                None => vec![],
+            },
+            credentials: match credentials {
+                Some(c) => c.into(),
+                None => default_credentials(),
+            },
+        }
+    }
+
+    /// Create new empty [`Capabilities`].
+    pub fn empty() -> Self {
+        Self {
+            versions: Vec::new(),
+            ciphersuites: Vec::new(),
+            extensions: Vec::new(),
+            proposals: Vec::new(),
+            credentials: Vec::new(),
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /// Get a reference to the list of versions in this extension.
+    pub fn versions(&self) -> &[ProtocolVersion] {
+        &self.versions
+    }
+
+    /// Get a reference to the list of ciphersuites in this extension.
+    pub fn ciphersuites(&self) -> &[Ciphersuite] {
+        &self.ciphersuites
+    }
+
+    /// Get a reference to the list of supported extensions.
+    pub fn extensions(&self) -> &[ExtensionType] {
+        &self.extensions
+    }
+
+    /// Get a reference to the list of supported proposals.
+    pub fn proposals(&self) -> &[ProposalType] {
+        &self.proposals
+    }
+
+    /// Get a reference to the list of supported credential types.
+    pub fn credentials(&self) -> &[CredentialType] {
+        &self.credentials
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /// Check if these [`Capabilities`] support all the capabilities
+    /// required by the given [`RequiredCapabilities`] extension. Returns
+    /// `true` if that is the case and `false` otherwise.
+    pub(crate) fn supports_required_capabilities(
+        &self,
+        required_capabilities: &RequiredCapabilitiesExtension,
+    ) -> bool {
+        // Check if all required extensions are supported.
+        if required_capabilities
+            .extension_types()
+            .iter()
+            .any(|e| !self.extensions().contains(e))
+        {
+            return false;
+        }
+        // Check if all required proposals are supported.
+        if required_capabilities
+            .proposal_types()
+            .iter()
+            .any(|p| !self.proposals().contains(p))
+        {
+            return false;
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+impl Capabilities {
+    /// Set the versions list.
+    pub fn set_versions(&mut self, versions: Vec<ProtocolVersion>) {
+        self.versions = versions;
+    }
+
+    /// Set the ciphersuites list.
+    pub fn set_ciphersuites(&mut self, ciphersuites: Vec<Ciphersuite>) {
+        self.ciphersuites = ciphersuites;
+    }
+}
+
+impl Default for Capabilities {
+    fn default() -> Self {
+        Capabilities {
+            versions: default_versions(),
+            ciphersuites: default_ciphersuites(),
+            extensions: default_extensions(),
+            proposals: default_proposals(),
+            credentials: default_credentials(),
+        }
+    }
+}
+
+pub(super) fn default_versions() -> Vec<ProtocolVersion> {
+    vec![ProtocolVersion::Mls10]
+}
+
+pub(super) fn default_ciphersuites() -> Vec<Ciphersuite> {
+    vec![
+        Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+        Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
+        Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+    ]
+}
+
+/// All extensions defined in the MLS spec are considered "default" by the spec.
+pub(super) fn default_extensions() -> Vec<ExtensionType> {
+    vec![ExtensionType::ApplicationId]
+}
+
+/// All proposals defined in the MLS spec are considered "default" by the spec.
+pub(super) fn default_proposals() -> Vec<ProposalType> {
+    vec![
+        ProposalType::Add,
+        ProposalType::Update,
+        ProposalType::Remove,
+        ProposalType::Presharedkey,
+        ProposalType::Reinit,
+        ProposalType::GroupContextExtensions,
+    ]
+}
+
+// TODO(#1231)
+pub(super) fn default_credentials() -> Vec<CredentialType> {
+    vec![CredentialType::Basic]
+}

--- a/openmls/src/treesync/node/leaf_node/codec.rs
+++ b/openmls/src/treesync/node/leaf_node/codec.rs
@@ -1,0 +1,43 @@
+use std::io::{Read, Write};
+
+use tls_codec::{Deserialize, Serialize, Size};
+
+use super::{LeafNodePayload, LeafNodeSource, LeafNodeTbs, TreeInfo, TreePosition};
+
+impl Serialize for LeafNodeTbs {
+    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+        let written = self.payload.tls_serialize(writer)?;
+        match &self.tree_info {
+            TreeInfo::KeyPackage => Ok(written),
+            TreeInfo::Update(p) | TreeInfo::Commit(p) => {
+                p.tls_serialize(writer).map(|b| written + b)
+            }
+        }
+    }
+}
+
+impl Size for LeafNodeTbs {
+    fn tls_serialized_len(&self) -> usize {
+        let len = self.payload.tls_serialized_len();
+        match &self.tree_info {
+            TreeInfo::KeyPackage => len,
+            TreeInfo::Update(p) | TreeInfo::Commit(p) => p.tls_serialized_len() + len,
+        }
+    }
+}
+
+impl Deserialize for LeafNodeTbs {
+    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let payload = LeafNodePayload::tls_deserialize(bytes)?;
+        let tree_info = match payload.leaf_node_source {
+            LeafNodeSource::KeyPackage(_) => TreeInfo::KeyPackage,
+            LeafNodeSource::Update => TreeInfo::Update(TreePosition::tls_deserialize(bytes)?),
+            LeafNodeSource::Commit(_) => TreeInfo::Commit(TreePosition::tls_deserialize(bytes)?),
+        };
+
+        Ok(Self { payload, tree_info })
+    }
+}


### PR DESCRIPTION
This is a pure refactoring. Thus, I used `pub use capabilities::*` to re-export and `pub(crate)` for access control. Edit: Also added two `TODO`s. Edit: While at it, I also improved the readability of the `leaf_node.rs` file. I'll split the file into distinct typestate modules in a follow-up. (This PR is best reviewed commit-by-commit.)