### PR TITLE
spec: Use `encrypted_group_info` as context in decryption of welcome secrets.

### DIFF
--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -115,7 +115,7 @@ fn codec_ciphertext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     let mut key_schedule = KeySchedule::init(
         ciphersuite,
         backend,
-        JoinerSecret::random(ciphersuite, backend, ProtocolVersion::default()),
+        &JoinerSecret::random(ciphersuite, backend, ProtocolVersion::default()),
         PskSecret::from(Secret::zero(ciphersuite, ProtocolVersion::Mls10)),
     )
     .expect("Could not create KeySchedule.");

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -933,13 +933,23 @@ impl CoreGroup {
         )
         .map_err(LibraryError::unexpected_crypto_error)?;
 
+        // Create group secrets for later use, so we can afterwards consume the
+        // `joiner_secret`.
+        let encrypted_secrets = diff.encrypt_group_secrets(
+            &joiner_secret,
+            apply_proposals_values.invitation_list,
+            path_computation_result.plain_path.as_deref(),
+            &apply_proposals_values.presharedkeys,
+            backend,
+            self.own_leaf_index(),
+        )?;
+
         // Prepare the PskSecret
         let psk_secret =
             PskSecret::new(ciphersuite, backend, &apply_proposals_values.presharedkeys)?;
 
         // Create key schedule
-        let mut key_schedule =
-            KeySchedule::init(ciphersuite, backend, joiner_secret.clone(), psk_secret)?;
+        let mut key_schedule = KeySchedule::init(ciphersuite, backend, joiner_secret, psk_secret)?;
 
         let serialized_provisional_group_context = diff
             .group_context()
@@ -968,7 +978,7 @@ impl CoreGroup {
         diff.update_interim_transcript_hash(ciphersuite, backend, confirmation_tag.clone())?;
 
         // only computes the group info if necessary
-        let group_info = {
+        let group_info = if !encrypted_secrets.is_empty() || self.use_ratchet_tree_extension {
             // Create the ratchet tree extension if necessary
             let external_pub = provisional_epoch_secrets
                 .external_secret()
@@ -996,10 +1006,12 @@ impl CoreGroup {
             };
             // Sign to-be-signed group info.
             Some(group_info_tbs.sign(signer)?)
+        } else {
+            None
         };
 
         // Check if new members were added and, if so, create welcome messages
-        let welcome_option = {
+        let welcome_option = if !encrypted_secrets.is_empty() {
             // Encrypt GroupInfo object
             let (welcome_key, welcome_nonce) = welcome_secret
                 .derive_welcome_key_nonce(backend)
@@ -1017,27 +1029,11 @@ impl CoreGroup {
                     &welcome_nonce,
                 )
                 .map_err(LibraryError::unexpected_crypto_error)?;
-
-            // Create group secrets for later use, so we can afterwards consume the
-            // `joiner_secret`.
-            let encrypted_secrets = diff.encrypt_group_secrets(
-                &joiner_secret,
-                apply_proposals_values.invitation_list,
-                path_computation_result.plain_path.as_deref(),
-                &apply_proposals_values.presharedkeys,
-                &encrypted_group_info,
-                backend,
-                self.own_leaf_index(),
-            )?;
-
-            if !encrypted_secrets.is_empty() {
-                // Create welcome message
-                let welcome =
-                    Welcome::new(self.ciphersuite(), encrypted_secrets, encrypted_group_info);
-                Some(welcome)
-            } else {
-                None
-            }
+            // Create welcome message
+            let welcome = Welcome::new(self.ciphersuite(), encrypted_secrets, encrypted_group_info);
+            Some(welcome)
+        } else {
+            None
         };
 
         let (provisional_group_epoch_secrets, provisional_message_secrets) =

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -78,7 +78,7 @@ impl CoreGroup {
             })?;
 
         // Create key schedule
-        let mut key_schedule = KeySchedule::init(ciphersuite, backend, joiner_secret, psk_secret)?;
+        let mut key_schedule = KeySchedule::init(ciphersuite, backend, &joiner_secret, psk_secret)?;
 
         // Derive welcome key & nonce from the key schedule
         let (welcome_key, welcome_nonce) = key_schedule

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -56,7 +56,7 @@ impl CoreGroup {
         let group_secrets_bytes = hpke::decrypt_with_label(
             key_package_bundle.private_key.as_slice(),
             "Welcome",
-            &[],
+            welcome.encrypted_group_info(),
             egs.encrypted_group_secrets(),
             ciphersuite,
             backend.crypto(),
@@ -93,10 +93,6 @@ impl CoreGroup {
         let verifiable_group_info =
             VerifiableGroupInfo::tls_deserialize(&mut group_info_bytes.as_slice())
                 .map_err(|_| WelcomeError::MalformedWelcomeMessage)?;
-
-        if ciphersuite != verifiable_group_info.ciphersuite() {
-            return Err(WelcomeError::GroupInfoCiphersuiteMismatch);
-        }
 
         // Make sure that we can support the required capabilities in the group info.
         if let Some(required_capabilities) =

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -62,7 +62,7 @@ impl CoreGroup {
 
         // Create key schedule
         let mut key_schedule =
-            KeySchedule::init(self.ciphersuite(), backend, joiner_secret, psk_secret)?;
+            KeySchedule::init(self.ciphersuite(), backend, &joiner_secret, psk_secret)?;
 
         key_schedule
             .add_context(backend, serialized_provisional_group_context)

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -27,9 +27,6 @@ pub enum WelcomeError<KeyStoreError> {
     /// Ciphersuites in Welcome and key package bundle don't match.
     #[error("Ciphersuites in Welcome and key package bundle don't match.")]
     CiphersuiteMismatch,
-    /// Ciphersuites in Welcome/GroupInfo and key package bundle don't match.
-    #[error("Ciphersuites in Welcome/GroupInfo and key package bundle don't match.")]
-    GroupInfoCiphersuiteMismatch,
     /// No joiner secret found in the Welcome message.
     #[error("No joiner secret found in the Welcome message.")]
     JoinerSecretNotFound,

--- a/openmls/src/group/public_group/diff.rs
+++ b/openmls/src/group/public_group/diff.rs
@@ -73,6 +73,7 @@ impl<'a> PublicGroupDiff<'a> {
     ///  - the invited members are not part of the tree yet
     ///  - the leaf index of a new member is identical to the own leaf index
     ///  - the plain path does not contain the correct secrets
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn encrypt_group_secrets(
         &self,
         joiner_secret: &JoinerSecret,

--- a/openmls/src/group/public_group/diff.rs
+++ b/openmls/src/group/public_group/diff.rs
@@ -79,6 +79,7 @@ impl<'a> PublicGroupDiff<'a> {
         invited_members: Vec<(LeafNodeIndex, AddProposal)>,
         plain_path_option: Option<&[PlainUpdatePathNode]>,
         presharedkeys: &[PreSharedKeyId],
+        encrypted_group_info: &[u8],
         backend: &impl OpenMlsCryptoProvider,
         leaf_index: LeafNodeIndex,
     ) -> Result<Vec<EncryptedGroupSecrets>, LibraryError> {
@@ -87,6 +88,7 @@ impl<'a> PublicGroupDiff<'a> {
             invited_members,
             plain_path_option,
             presharedkeys,
+            encrypted_group_info,
             backend,
             leaf_index,
         )

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -101,7 +101,7 @@ fn test_welcome_context_mismatch(ciphersuite: Ciphersuite, backend: &impl OpenMl
         .expect("Could not create PskSecret.");
 
     // Create key schedule
-    let key_schedule = KeySchedule::init(ciphersuite, backend, joiner_secret, psk_secret)
+    let key_schedule = KeySchedule::init(ciphersuite, backend, &joiner_secret, psk_secret)
         .expect("Could not create KeySchedule.");
 
     // Derive welcome key & nonce from the key schedule

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -26,15 +26,14 @@ use openmls_traits::{
 };
 use tls_codec::{Deserialize, Serialize};
 
-/// This test detects discrepancies between ciphersuites in the GroupInfo of a
-/// Welcome message and the KeyPackage of a new member. We expect that to fail
-/// as the ciphersuite should be identical in the Welcome message, the GroupInfo
-/// and the KeyPackage.
+/// This test detects if the decryption of the encrypted group secrets fails due to a change in
+/// the encrypted group info. As the group info is part of the decryption context of the encrypted
+/// group info, it is not possible to generate a matching encrypted group context with different
+/// parameters.
 #[apply(ciphersuites_and_backends)]
-fn test_welcome_ciphersuite_mismatch(
-    ciphersuite: Ciphersuite,
-    backend: &impl OpenMlsCryptoProvider,
-) {
+fn test_welcome_context_mismatch(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+    let _ = pretty_env_logger::try_init();
+
     // We need a ciphersuite that is different from the current one to create
     // the mismatch
     let mismatched_ciphersuite = match ciphersuite {
@@ -86,7 +85,7 @@ fn test_welcome_ciphersuite_mismatch(
     let group_secrets_bytes = hpke::decrypt_with_label(
         bob_private_key.as_slice(),
         "Welcome",
-        &[],
+        welcome.encrypted_group_info(),
         egs.encrypted_group_secrets(),
         ciphersuite,
         backend.crypto(),
@@ -150,7 +149,7 @@ fn test_welcome_ciphersuite_mismatch(
     )
     .expect_err("Created a group from an invalid Welcome.");
 
-    assert_eq!(err, WelcomeError::GroupInfoCiphersuiteMismatch);
+    assert_eq!(err, WelcomeError::UnableToDecrypt);
 
     // === Process the original Welcome ===
 

--- a/openmls/src/schedule/kat_key_schedule.rs
+++ b/openmls/src/schedule/kat_key_schedule.rs
@@ -116,7 +116,7 @@ fn generate(
     let mut key_schedule = KeySchedule::init(
         ciphersuite,
         &crypto,
-        joiner_secret.clone(),
+        &joiner_secret,
         psk_secret.clone(),
     )
     .expect("Could not create KeySchedule.");
@@ -329,9 +329,8 @@ pub fn run_test_vector(
         );
         let psk_secret = PskSecret::from(psk_secret_inner);
 
-        let mut key_schedule =
-            KeySchedule::init(ciphersuite, backend, joiner_secret.clone(), psk_secret)
-                .expect("Could not create KeySchedule.");
+        let mut key_schedule = KeySchedule::init(ciphersuite, backend, &joiner_secret, psk_secret)
+            .expect("Could not create KeySchedule.");
         let welcome_secret = key_schedule
             .welcome(backend)
             .expect("An unexpected error occurred.");

--- a/openmls/src/schedule/kat_key_schedule.rs
+++ b/openmls/src/schedule/kat_key_schedule.rs
@@ -113,13 +113,9 @@ fn generate(
         &group_context.tls_serialize_detached().unwrap(),
     )
     .expect("Could not create JoinerSecret.");
-    let mut key_schedule = KeySchedule::init(
-        ciphersuite,
-        &crypto,
-        &joiner_secret,
-        psk_secret.clone(),
-    )
-    .expect("Could not create KeySchedule.");
+    let mut key_schedule =
+        KeySchedule::init(ciphersuite, &crypto, &joiner_secret, psk_secret.clone())
+            .expect("Could not create KeySchedule.");
     let welcome_secret = key_schedule
         .welcome(&crypto)
         .expect("An unexpected error occurred.");

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -431,7 +431,7 @@ impl KeySchedule {
     pub(crate) fn init(
         ciphersuite: Ciphersuite,
         backend: &impl OpenMlsCryptoProvider,
-        joiner_secret: JoinerSecret,
+        joiner_secret: &JoinerSecret,
         psk: PskSecret,
     ) -> Result<Self, LibraryError> {
         log::debug!("Initializing the key schedule with {:?} ...", ciphersuite);

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -547,7 +547,7 @@ impl IntermediateSecret {
         joiner_secret: &JoinerSecret,
         psk: PskSecret,
     ) -> Result<Self, CryptoError> {
-        log_crypto!(trace, "PSK input: {:x?}", psk.as_ref().map(|p| p.secret()));
+        log_crypto!(trace, "PSK input: {:x?}", psk.as_slice());
         let secret = joiner_secret.secret.hkdf_extract(backend, psk.secret())?;
         log_crypto!(trace, "Intermediate secret: {:x?}", secret);
         Ok(Self { secret })

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -388,13 +388,6 @@ impl JoinerSecret {
     }
 
     #[cfg(any(feature = "test-utils", test))]
-    pub(crate) fn clone(&self) -> Self {
-        Self {
-            secret: self.secret.clone(),
-        }
-    }
-
-    #[cfg(any(feature = "test-utils", test))]
     pub(crate) fn as_slice(&self) -> &[u8] {
         self.secret.as_slice()
     }
@@ -440,7 +433,7 @@ impl KeySchedule {
             "  joiner_secret: {:x?}",
             joiner_secret.secret.as_slice()
         );
-        let intermediate_secret = IntermediateSecret::new(backend, &joiner_secret, psk)
+        let intermediate_secret = IntermediateSecret::new(backend, joiner_secret, psk)
             .map_err(LibraryError::unexpected_crypto_error)?;
         Ok(Self {
             ciphersuite,

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -162,6 +162,7 @@ impl<'a> TreeSyncDiff<'a> {
     ///  - the invited members are not part of the tree yet
     ///  - the leaf index of a new member is identical to the own leaf index
     ///  - the plain path does not contain the correct secrets
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn encrypt_group_secrets(
         &self,
         joiner_secret: &JoinerSecret,

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -168,6 +168,7 @@ impl<'a> TreeSyncDiff<'a> {
         invited_members: Vec<(LeafNodeIndex, AddProposal)>,
         plain_path_option: Option<&[PlainUpdatePathNode]>,
         presharedkeys: &[PreSharedKeyId],
+        encrypted_group_info: &[u8],
         backend: &impl OpenMlsCryptoProvider,
         encryptor_leaf_index: LeafNodeIndex,
     ) -> Result<Vec<EncryptedGroupSecrets>, LibraryError> {
@@ -200,7 +201,7 @@ impl<'a> TreeSyncDiff<'a> {
             let ciphertext = hpke::encrypt_with_label(
                 key_package.hpke_init_key().as_slice(),
                 "Welcome",
-                &[],
+                encrypted_group_info,
                 &group_secrets_bytes,
                 key_package.ciphersuite(),
                 backend.crypto(),


### PR DESCRIPTION
This PR makes it so that the decryption of the encrypted group secrets takes the encrypted group info as context. Notably, it was required to adapt a test because it can now not happen that the ciphersuite mismatches.