### PR TITLE
Small refactor of CoreGroup message processing

### DIFF
--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -1110,6 +1110,16 @@ impl CoreGroup {
     }
 
     #[cfg(test)]
+    pub(crate) fn message_secrets_store(&self) -> &MessageSecretsStore {
+        &self.message_secrets_store
+    }
+
+    #[cfg(test)]
+    pub(crate) fn public_group(&self) -> &PublicGroup {
+        &self.public_group
+    }
+
+    #[cfg(test)]
     pub(crate) fn set_group_context(&mut self, group_context: GroupContext) {
         self.public_group.set_group_context(group_context)
     }

--- a/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
@@ -342,15 +342,20 @@ pub fn run_test_vector(
         // TODO: wrap `proposal` into a `PublicMessage`.
 
         // check that the proposal in proposal_pub == proposal
-        let processed_unverified_message = group
-            .parse_message(
+        let decrypted_message = group
+            .decrypt_message(
                 backend,
                 proposal_pub.into_protocol_message().unwrap(),
                 &sender_ratchet_config,
             )
             .unwrap();
+
+        let processed_unverified_message = group
+            .public_group()
+            .parse_message(decrypted_message, group.message_secrets_store())
+            .unwrap();
         let processed_message: AuthenticatedContent =
-            processed_unverified_message.into_parts().0.into();
+            processed_unverified_message.verify(backend).unwrap().0;
         match processed_message.content() {
             FramedContentBody::Proposal(p) => assert_eq!(&proposal, p),
             _ => panic!("Wrong processed message content"),
@@ -399,15 +404,20 @@ pub fn run_test_vector(
         // TODO: wrap `commit` into a `PublicMessage`.
 
         // check that the proposal in proposal_pub == proposal
-        let processed_unverified_message = group
-            .parse_message(
+        let decrypted_message = group
+            .decrypt_message(
                 backend,
                 commit_pub.into_protocol_message().unwrap(),
                 &sender_ratchet_config,
             )
             .unwrap();
+
+        let processed_unverified_message = group
+            .public_group()
+            .parse_message(decrypted_message, group.message_secrets_store())
+            .unwrap();
         let processed_message: AuthenticatedContent =
-            processed_unverified_message.into_parts().0.into();
+            processed_unverified_message.verify(backend).unwrap().0;
         match processed_message.content() {
             FramedContentBody::Commit(c) => {
                 assert_eq!(&commit, c)
@@ -416,15 +426,20 @@ pub fn run_test_vector(
         }
 
         // check that the proposal in proposal_priv == proposal
-        let processed_unverified_message = group
-            .parse_message(
+        let decrypted_message = group
+            .decrypt_message(
                 backend,
                 commit_priv.into_protocol_message().unwrap(),
                 &sender_ratchet_config,
             )
             .unwrap();
+
+        let processed_unverified_message = group
+            .public_group()
+            .parse_message(decrypted_message, group.message_secrets_store())
+            .unwrap();
         let processed_message: AuthenticatedContent =
-            processed_unverified_message.into_parts().0.into();
+            processed_unverified_message.verify(backend).unwrap().0;
         match processed_message.content() {
             FramedContentBody::Commit(c) => {
                 assert_eq!(&commit, c)


### PR DESCRIPTION
This PR factors out the decryption process in `CoreGroup` message processing and adds two getters for test purposes.