### PR TITLE
Improve `PublicGroup` abstraction

### DIFF
--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -461,7 +461,7 @@ fn unknown_sender(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         create_commit_result
             .welcome_option
             .expect("An unexpected error occurred."),
-        Some(group_alice.treesync().export_nodes()),
+        Some(group_alice.public_group().export_nodes()),
         bob_key_package_bundle,
         backend,
     )
@@ -500,7 +500,7 @@ fn unknown_sender(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         create_commit_result
             .welcome_option
             .expect("An unexpected error occurred."),
-        Some(group_alice.treesync().export_nodes()),
+        Some(group_alice.public_group().export_nodes()),
         charlie_key_package_bundle,
         backend,
     )
@@ -690,7 +690,7 @@ pub(crate) fn setup_alice_bob_group(
         create_commit_result
             .welcome_option
             .expect("commit didn't return a welcome as expected"),
-        Some(group_alice.treesync().export_nodes()),
+        Some(group_alice.public_group().export_nodes()),
         bob_key_package_bundle,
         backend,
     )

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -406,7 +406,7 @@ impl CoreGroup {
                 .validate_required_capabilities(required_capabilities)?;
             // Ensure that all other leaf nodes support all the required
             // extensions as well.
-            self.treesync()
+            self.public_group()
                 .check_extension_support(required_capabilities.extension_types())?;
         }
         let proposal = GroupContextExtensionProposal::new(extensions);
@@ -470,7 +470,7 @@ impl CoreGroup {
             .message_secrets_mut(private_message.epoch())
             .map_err(|_| MessageDecryptionError::AeadError)?;
         let sender_data = private_message.sender_data(message_secrets, backend, ciphersuite)?;
-        if !self.treesync().is_leaf_in_tree(sender_data.leaf_index) {
+        if self.public_group().leaf(sender_data.leaf_index).is_none() {
             return Err(MessageDecryptionError::SenderError(
                 SenderError::UnknownSender,
             ));

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -347,7 +347,7 @@ impl CoreGroup {
         removed: LeafNodeIndex,
         signer: &impl Signer,
     ) -> Result<AuthenticatedContent, ValidationError> {
-        if !self.treesync().is_leaf_in_tree(removed) {
+        if self.public_group().leaf(removed).is_none() {
             return Err(ValidationError::UnknownMember);
         }
         let remove_proposal = RemoveProposal { removed };
@@ -515,7 +515,9 @@ impl CoreGroup {
     ) -> Result<GroupInfo, LibraryError> {
         let extensions = {
             let ratchet_tree_extension = || {
-                Extension::RatchetTree(RatchetTreeExtension::new(self.treesync().export_nodes()))
+                Extension::RatchetTree(RatchetTreeExtension::new(
+                    self.public_group().export_nodes(),
+                ))
             };
 
             let external_pub_extension = || {
@@ -579,9 +581,9 @@ impl CoreGroup {
         writer.write_all(&serialized_core_group.into_bytes())
     }
 
-    /// Returns a reference to the ratchet tree
-    pub(crate) fn treesync(&self) -> &TreeSync {
-        self.public_group.treesync()
+    /// Returns a reference to the public group.
+    pub(crate) fn public_group(&self) -> &PublicGroup {
+        &self.public_group
     }
 
     /// Get the ciphersuite implementation used in this group.
@@ -632,7 +634,7 @@ impl CoreGroup {
 
     /// Get the identity of the client's [`Credential`] owning this group.
     pub(crate) fn own_identity(&self) -> Option<&[u8]> {
-        self.treesync()
+        self.public_group()
             .leaf(self.own_leaf_index)
             .map(|node| node.credential().identity())
     }
@@ -705,7 +707,7 @@ impl CoreGroup {
     }
 
     pub(crate) fn own_leaf_node(&self) -> Result<&OpenMlsLeafNode, LibraryError> {
-        self.treesync()
+        self.public_group()
             .leaf(self.own_leaf_index())
             .ok_or_else(|| LibraryError::custom("Tree has no own leaf."))
     }
@@ -1032,17 +1034,19 @@ impl CoreGroup {
     pub(crate) fn members_supported_credentials(
         &self,
     ) -> impl Iterator<Item = &[CredentialType]> + '_ {
-        self.treesync()
-            .full_leaves()
-            .map(|leaf_node| leaf_node.leaf_node().capabilities().credentials())
+        self.public_group().members().filter_map(|member| {
+            self.public_group()
+                .leaf(member.index)
+                .map(|leaf| leaf.leaf_node().capabilities().credentials())
+        })
     }
 
     /// Return currently used credentials of all members.
     // TODO(#1186)
     #[allow(unused)]
     pub(crate) fn members_used_credentials(&self) -> impl Iterator<Item = CredentialType> + '_ {
-        self.treesync()
-            .full_leave_members()
+        self.public_group()
+            .members()
             .map(|Member { credential, .. }| credential.credential_type())
     }
 
@@ -1053,8 +1057,8 @@ impl CoreGroup {
         &self,
         exclude_own: bool,
     ) -> impl Iterator<Item = SignaturePublicKey> + '_ {
-        self.treesync()
-            .full_leave_members()
+        self.public_group()
+            .members()
             .filter(move |member| {
                 if exclude_own {
                     member.index != self.own_leaf_index
@@ -1069,8 +1073,8 @@ impl CoreGroup {
     // TODO(#1186)
     #[allow(unused)]
     pub(crate) fn encryption_keys(&self) -> impl Iterator<Item = EncryptionKey> + '_ {
-        self.treesync()
-            .full_leave_members()
+        self.public_group()
+            .members()
             .map(|Member { encryption_key, .. }| {
                 EncryptionKey::from(HpkePublicKey::new(encryption_key))
             })

--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -76,7 +76,7 @@ impl CoreGroup {
             group_context
                 .tls_serialize_detached()
                 .map_err(LibraryError::missing_bound_check)?,
-            public_group.treesync().tree_size(),
+            public_group.tree_size(),
             // We use a fake own index of 0 here, as we're not going to use the
             // tree for encryption until after the first commit. This issue is
             // tracked in #767.

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -139,8 +139,20 @@ impl CoreGroup {
 
         // Find our own leaf in the tree.
         let own_leaf_index = public_group
-            .treesync()
-            .find_leaf(key_package_bundle.key_package().leaf_node().signature_key())
+            .members()
+            .find_map(|m| {
+                if m.signature_key
+                    == key_package_bundle
+                        .key_package()
+                        .leaf_node()
+                        .signature_key()
+                        .as_slice()
+                {
+                    Some(m.index)
+                } else {
+                    None
+                }
+            })
             .ok_or(WelcomeError::PublicTreeError(
                 PublicTreeError::MalformedTree,
             ))?;
@@ -184,7 +196,7 @@ impl CoreGroup {
 
         let (group_epoch_secrets, message_secrets) = epoch_secrets.split_secrets(
             serialized_group_context,
-            public_group.treesync().tree_size(),
+            public_group.tree_size(),
             own_leaf_index,
         );
 

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -243,7 +243,7 @@ impl CoreGroup {
         // Save the past epoch
         let past_epoch = self.context().epoch();
         // Get all the full leaves
-        let leaves = self.treesync().full_leave_members().collect();
+        let leaves = self.public_group().members().collect();
         // Merge the staged commit into the group state and store the secret tree from the
         // previous epoch in the message secrets store.
         if let Some(message_secrets) = self.merge_commit(backend, staged_commit)? {

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -302,8 +302,7 @@ impl CoreGroup {
 
                 // Figure out which keys we need in the new epoch.
                 let new_owned_encryption_keys = self
-                    .public_group
-                    .treesync()
+                    .public_group()
                     .owned_encryption_keys(self.own_leaf_index());
                 // From the old and new keys, keep the ones that are still relevant in the new epoch.
                 let epoch_keypairs: Vec<EncryptionKeyPair> = old_epoch_keypairs

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -397,7 +397,7 @@ fn test_psks(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     alice_group
         .merge_commit(backend, create_commit_result.staged_commit)
         .expect("error merging pending commit");
-    let ratchet_tree = alice_group.treesync().export_nodes();
+    let ratchet_tree = alice_group.public_group().export_nodes();
 
     let group_bob = CoreGroup::new_from_welcome(
         create_commit_result
@@ -491,7 +491,7 @@ fn test_staged_commit_creation(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
         create_commit_result
             .welcome_option
             .expect("An unexpected error occurred."),
-        Some(alice_group.treesync().export_nodes()),
+        Some(alice_group.public_group().export_nodes()),
         bob_key_package_bundle,
         backend,
     )
@@ -503,8 +503,8 @@ fn test_staged_commit_creation(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
         alice_group.export_secret(backend, "", b"test", ciphersuite.hash_length())
     );
     assert_eq!(
-        group_bob.treesync().export_nodes(),
-        alice_group.treesync().export_nodes()
+        group_bob.public_group().export_nodes(),
+        alice_group.public_group().export_nodes()
     )
 }
 
@@ -637,7 +637,7 @@ fn test_proposal_application_after_self_was_removed(
         .merge_commit(backend, add_commit_result.staged_commit)
         .expect("error merging pending commit");
 
-    let ratchet_tree = alice_group.treesync().export_nodes();
+    let ratchet_tree = alice_group.public_group().export_nodes();
 
     let mut bob_group = CoreGroup::new_from_welcome(
         add_commit_result
@@ -651,8 +651,8 @@ fn test_proposal_application_after_self_was_removed(
 
     // Alice adds Charlie and removes Bob in the same commit.
     let bob_index = alice_group
-        .treesync()
-        .full_leave_members()
+        .public_group()
+        .members()
         .find(
             |Member {
                  index: _,
@@ -708,7 +708,7 @@ fn test_proposal_application_after_self_was_removed(
         .merge_commit(backend, remove_add_commit_result.staged_commit)
         .expect("Error merging commit.");
 
-    let ratchet_tree = alice_group.treesync().export_nodes();
+    let ratchet_tree = alice_group.public_group().export_nodes();
 
     let charlie_group = CoreGroup::new_from_welcome(
         remove_add_commit_result
@@ -724,11 +724,11 @@ fn test_proposal_application_after_self_was_removed(
     // to his tree after he was removed by comparing membership lists. In
     // particular, Bob's list should show that he was removed and Charlie was
     // added.
-    let alice_members = alice_group.treesync().full_leave_members();
+    let alice_members = alice_group.public_group().members();
 
-    let bob_members = bob_group.treesync().full_leave_members();
+    let bob_members = bob_group.public_group().members();
 
-    let charlie_members = charlie_group.treesync().full_leave_members();
+    let charlie_members = charlie_group.public_group().members();
 
     for (alice_member, (bob_member, charlie_member)) in
         alice_members.zip(bob_members.zip(charlie_members))
@@ -750,7 +750,7 @@ fn test_proposal_application_after_self_was_removed(
         assert_eq!(charlie_member.encryption_key, alice_member.encryption_key);
     }
 
-    let mut bob_members = bob_group.treesync().full_leave_members();
+    let mut bob_members = bob_group.public_group().members();
 
     assert_eq!(bob_members.next().unwrap().credential.identity(), b"Alice");
     assert_eq!(

--- a/openmls/src/group/core_group/test_external_init.rs
+++ b/openmls/src/group/core_group/test_external_init.rs
@@ -80,8 +80,8 @@ fn test_external_init(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProv
     );
 
     assert_eq!(
-        group_charly.treesync().export_nodes(),
-        group_bob.treesync().export_nodes()
+        group_charly.public_group().export_nodes(),
+        group_bob.public_group().export_nodes()
     );
 
     // Check if charly can create valid commits
@@ -113,7 +113,7 @@ fn test_external_init(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProv
         .export_group_info(backend, &alice_signer, false)
         .unwrap()
         .into_verifiable_group_info();
-    let nodes_option = group_alice.treesync().export_nodes();
+    let nodes_option = group_alice.public_group().export_nodes();
 
     let proposal_store = ProposalStore::new();
     let params = CreateCommitParams::builder()
@@ -172,8 +172,8 @@ fn test_external_init(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProv
     );
 
     assert_eq!(
-        group_charly.treesync().export_nodes(),
-        new_group_bob.treesync().export_nodes()
+        group_charly.public_group().export_nodes(),
+        new_group_bob.public_group().export_nodes()
     );
 }
 
@@ -198,7 +198,7 @@ fn test_external_init_single_member_group(
         .export_group_info(backend, &alice_signer, false)
         .unwrap()
         .into_verifiable_group_info();
-    let nodes_option = group_alice.treesync().export_nodes();
+    let nodes_option = group_alice.public_group().export_nodes();
 
     let proposal_store = ProposalStore::new();
     let params = CreateCommitParams::builder()
@@ -234,8 +234,8 @@ fn test_external_init_single_member_group(
     );
 
     assert_eq!(
-        group_charly.treesync().export_nodes(),
-        group_alice.treesync().export_nodes()
+        group_charly.public_group().export_nodes(),
+        group_alice.public_group().export_nodes()
     );
 }
 

--- a/openmls/src/group/core_group/test_proposals.rs
+++ b/openmls/src/group/core_group/test_proposals.rs
@@ -382,7 +382,7 @@ fn test_group_context_extensions(ciphersuite: Ciphersuite, backend: &impl OpenMl
     alice_group
         .merge_commit(backend, create_commit_result.staged_commit)
         .expect("error merging own staged commit");
-    let ratchet_tree = alice_group.treesync().export_nodes();
+    let ratchet_tree = alice_group.public_group().export_nodes();
 
     // Make sure that Bob can join the group with the required extension in place
     // and Bob's key package supporting them.
@@ -478,7 +478,7 @@ fn test_group_context_extension_proposal_fails(
     alice_group
         .merge_commit(backend, create_commit_result.staged_commit)
         .expect("error merging pending commit");
-    let ratchet_tree = alice_group.treesync().export_nodes();
+    let ratchet_tree = alice_group.public_group().export_nodes();
 
     let _bob_group = CoreGroup::new_from_welcome(
         create_commit_result
@@ -558,7 +558,7 @@ fn test_group_context_extension_proposal(
         .merge_commit(backend, create_commit_results.staged_commit)
         .expect("error merging pending commit");
 
-    let ratchet_tree = alice_group.treesync().export_nodes();
+    let ratchet_tree = alice_group.public_group().export_nodes();
 
     let mut bob_group = CoreGroup::new_from_welcome(
         create_commit_results

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -92,7 +92,7 @@ impl MlsGroup {
     /// Returns a reference to the own [`LeafNode`].
     pub fn own_leaf(&self) -> Option<&LeafNode> {
         self.group
-            .treesync()
+            .public_group()
             .leaf(self.group.own_leaf_index())
             .map(|l| l.leaf_node())
     }
@@ -265,14 +265,14 @@ impl MlsGroup {
 
     /// Returns a list of [`Member`]s in the group.
     pub fn members(&self) -> impl Iterator<Item = Member> + '_ {
-        self.group.treesync().full_leave_members()
+        self.group.public_group().members()
     }
 
     /// Returns the [`Credential`] of a member corresponding to the given
     /// leaf index. Returns `None` if the member can not be found in this group.
     pub fn member(&self, leaf_index: LeafNodeIndex) -> Option<&Credential> {
         self.group
-            .treesync()
+            .public_group()
             // This will return an error if the member can't be found.
             .leaf(leaf_index)
             .map(|leaf| leaf.credential())

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -227,8 +227,9 @@ impl MlsGroup {
         if !self.is_active() {
             return Err(MlsGroupStateError::UseAfterEviction);
         }
-        let tree = self.group.treesync();
-        tree.leaf(self.own_leaf_index())
+        self.group
+            .public_group()
+            .leaf(self.own_leaf_index())
             .map(|node| node.credential())
             .ok_or_else(|| LibraryError::custom("Own leaf node missing").into())
     }
@@ -326,7 +327,7 @@ impl MlsGroup {
 
     /// Exports the Ratchet Tree.
     pub fn export_ratchet_tree(&self) -> Vec<Option<Node>> {
-        self.group.treesync().export_nodes()
+        self.group.public_group().export_nodes()
     }
 }
 
@@ -402,7 +403,7 @@ impl MlsGroup {
 
     #[cfg(any(feature = "test-utils", test))]
     pub fn tree_hash(&self) -> &[u8] {
-        self.group.treesync().tree_hash()
+        self.group.public_group().group_context().tree_hash()
     }
 
     #[cfg(any(feature = "test-utils", test))]

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -70,13 +70,13 @@ impl MlsGroup {
     ) -> Result<MlsMessageOut, ProposeSelfUpdateError<KeyStore::Error>> {
         self.is_operational()?;
 
-        let tree = self.group.treesync();
-
         // Here we clone our own leaf to rekey it such that we don't change the
         // tree.
         // The new leaf node will be applied later when the proposal is
         // committed.
-        let mut own_leaf = tree
+        let mut own_leaf = self
+            .group
+            .public_group()
             .leaf(self.own_leaf_index())
             .ok_or_else(|| LibraryError::custom("The tree is broken. Couldn't find own leaf."))?
             .clone();

--- a/openmls/src/group/public_group/mod.rs
+++ b/openmls/src/group/public_group/mod.rs
@@ -11,6 +11,11 @@
 //! To avoid duplication of code and functionality, [`CoreGroup`] internally
 //! relies on a [`PublicGroup`] as well.
 
+#[cfg(test)]
+use crate::treesync::{node::parent_node::PlainUpdatePathNode, treekem::UpdatePathNode};
+#[cfg(test)]
+use std::collections::HashSet;
+
 use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite, OpenMlsCryptoProvider};
 use serde::{Deserialize, Serialize};
 use tls_codec::Serialize as TlsSerialize;
@@ -333,5 +338,25 @@ impl PublicGroup {
 impl PublicGroup {
     pub(crate) fn context_mut(&mut self) -> &mut GroupContext {
         &mut self.group_context
+    }
+
+    #[cfg(test)]
+    pub(crate) fn encrypt_path(
+        &self,
+        backend: &impl OpenMlsCryptoProvider,
+        ciphersuite: Ciphersuite,
+        path: &[PlainUpdatePathNode],
+        group_context: &[u8],
+        exclusion_list: &HashSet<&LeafNodeIndex>,
+        own_leaf_index: LeafNodeIndex,
+    ) -> Result<Vec<UpdatePathNode>, LibraryError> {
+        self.treesync().empty_diff().encrypt_path(
+            backend,
+            ciphersuite,
+            path,
+            group_context,
+            exclusion_list,
+            own_leaf_index,
+        )
     }
 }

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -380,7 +380,7 @@ impl PublicGroup {
         Ok(())
     }
 
-    /// Returns a [`TreeSyncError::UnsupportedExtension`] if an [`ExtensionType`]
+    /// Returns a [`LeafNodeValidationError`] if an [`ExtensionType`]
     /// in `extensions` is not supported by a leaf in this tree.
     #[cfg(test)]
     pub(crate) fn check_extension_support(

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -19,6 +19,9 @@ use crate::{
     treesync::node::leaf_node::LeafNode,
 };
 
+#[cfg(test)]
+use crate::treesync::errors::LeafNodeValidationError;
+
 use super::PublicGroup;
 
 impl PublicGroup {
@@ -373,6 +376,19 @@ impl PublicGroup {
                     };
                 }
             }
+        }
+        Ok(())
+    }
+
+    /// Returns a [`TreeSyncError::UnsupportedExtension`] if an [`ExtensionType`]
+    /// in `extensions` is not supported by a leaf in this tree.
+    #[cfg(test)]
+    pub(crate) fn check_extension_support(
+        &self,
+        extensions: &[crate::extensions::ExtensionType],
+    ) -> Result<(), LeafNodeValidationError> {
+        for leaf in self.treesync().full_leaves() {
+            leaf.leaf_node().check_extension_support(extensions)?;
         }
         Ok(())
     }

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -141,7 +141,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     .build(&crypto, &alice_credential_with_key_and_signer.signer)
     .unwrap();
 
-    let alice_ratchet_tree: Vec<Option<Node>> = alice_group.treesync().export_nodes();
+    let alice_ratchet_tree: Vec<Option<Node>> = alice_group.public_group().export_nodes();
 
     let alice_group_info = alice_group
         .export_group_info(&crypto, &alice_credential_with_key_and_signer.signer, true)
@@ -275,7 +275,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
 
     let mut receiver_group = CoreGroup::new_from_welcome(
         alice_welcome.clone(),
-        Some(alice_group.treesync().export_nodes()),
+        Some(alice_group.public_group().export_nodes()),
         bob_key_package_bundle,
         &crypto,
     )

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -634,8 +634,7 @@ fn test_valsem204(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
             .collect();
         let new_nodes = alice_group
             .group()
-            .treesync()
-            .empty_diff()
+            .public_group()
             .encrypt_path(
                 backend,
                 ciphersuite,

--- a/openmls/src/group/tests/test_encoding.rs
+++ b/openmls/src/group/tests/test_encoding.rs
@@ -410,7 +410,7 @@ fn test_welcome_message_encoding(backend: &impl OpenMlsCryptoProvider) {
         // example the RatchetTreeExtension.
         assert!(CoreGroup::new_from_welcome(
             welcome,
-            Some(group_state.treesync().export_nodes()),
+            Some(group_state.public_group().export_nodes()),
             charlie_key_package_bundle,
             backend
         )

--- a/openmls/src/group/tests/test_group.rs
+++ b/openmls/src/group/tests/test_group.rs
@@ -116,7 +116,7 @@ fn create_commit_optional_path(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
     group_alice
         .merge_commit(backend, create_commit_result.staged_commit)
         .expect("error merging pending commit");
-    let ratchet_tree = group_alice.treesync().export_nodes();
+    let ratchet_tree = group_alice.public_group().export_nodes();
 
     let bob_private_key = backend
         .key_store()
@@ -141,8 +141,8 @@ fn create_commit_optional_path(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
     };
 
     assert_eq!(
-        group_alice.treesync().export_nodes(),
-        group_bob.treesync().export_nodes()
+        group_alice.public_group().export_nodes(),
+        group_bob.public_group().export_nodes()
     );
 
     // Alice updates
@@ -332,7 +332,7 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     group_alice
         .merge_commit(backend, create_commit_result.staged_commit)
         .expect("error merging own commits");
-    let ratchet_tree = group_alice.treesync().export_nodes();
+    let ratchet_tree = group_alice.public_group().export_nodes();
 
     let mut group_bob = match CoreGroup::new_from_welcome(
         create_commit_result
@@ -347,7 +347,7 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     };
 
     // Make sure that both groups have the same public tree
-    if group_alice.treesync().export_nodes() != group_bob.treesync().export_nodes() {
+    if group_alice.public_group().export_nodes() != group_bob.public_group().export_nodes() {
         print_tree(&group_alice, "Alice added Bob");
         panic!("Different public trees");
     }
@@ -449,7 +449,7 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         .expect("error merging own commits");
 
     // Make sure that both groups have the same public tree
-    if group_alice.treesync().export_nodes() != group_bob.treesync().export_nodes() {
+    if group_alice.public_group().export_nodes() != group_bob.public_group().export_nodes() {
         print_tree(&group_alice, "Alice added Bob");
         panic!("Different public trees");
     }
@@ -508,7 +508,7 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         .expect("error merging commit");
 
     // Make sure that both groups have the same public tree
-    if group_alice.treesync().export_nodes() != group_bob.treesync().export_nodes() {
+    if group_alice.public_group().export_nodes() != group_bob.public_group().export_nodes() {
         print_tree(&group_alice, "Alice added Bob");
         panic!("Different public trees");
     }
@@ -583,7 +583,7 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         .expect("error merging commit");
 
     // Make sure that both groups have the same public tree
-    if group_alice.treesync().export_nodes() != group_bob.treesync().export_nodes() {
+    if group_alice.public_group().export_nodes() != group_bob.public_group().export_nodes() {
         print_tree(&group_alice, "Alice added Bob");
         panic!("Different public trees");
     }
@@ -648,7 +648,7 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         .merge_commit(backend, create_commit_result.staged_commit)
         .expect("error merging own commits");
 
-    let ratchet_tree = group_alice.treesync().export_nodes();
+    let ratchet_tree = group_alice.public_group().export_nodes();
     let mut group_charlie = match CoreGroup::new_from_welcome(
         create_commit_result
             .welcome_option
@@ -662,11 +662,11 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     };
 
     // Make sure that all groups have the same public tree
-    if group_alice.treesync().export_nodes() != group_bob.treesync().export_nodes() {
+    if group_alice.public_group().export_nodes() != group_bob.public_group().export_nodes() {
         print_tree(&group_alice, "Bob added Charlie");
         panic!("Different public trees");
     }
-    if group_alice.treesync().export_nodes() != group_charlie.treesync().export_nodes() {
+    if group_alice.public_group().export_nodes() != group_charlie.public_group().export_nodes() {
         print_tree(&group_alice, "Bob added Charlie");
         panic!("Different public trees");
     }
@@ -792,11 +792,11 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         .expect("error merging own commits");
 
     // Make sure that all groups have the same public tree
-    if group_alice.treesync().export_nodes() != group_bob.treesync().export_nodes() {
+    if group_alice.public_group().export_nodes() != group_bob.public_group().export_nodes() {
         print_tree(&group_alice, "Charlie updated");
         panic!("Different public trees");
     }
-    if group_alice.treesync().export_nodes() != group_charlie.treesync().export_nodes() {
+    if group_alice.public_group().export_nodes() != group_charlie.public_group().export_nodes() {
         print_tree(&group_alice, "Charlie updated");
         panic!("Different public trees");
     }
@@ -852,11 +852,11 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
         .expect("error merging own commits");
 
     // Make sure that all groups have the same public tree
-    if group_alice.treesync().export_nodes() == group_bob.treesync().export_nodes() {
+    if group_alice.public_group().export_nodes() == group_bob.public_group().export_nodes() {
         print_tree(&group_alice, "Charlie removed Bob");
         panic!("Same public trees");
     }
-    if group_alice.treesync().export_nodes() != group_charlie.treesync().export_nodes() {
+    if group_alice.public_group().export_nodes() != group_charlie.public_group().export_nodes() {
         print_tree(&group_alice, "Charlie removed Bob");
         panic!("Different public trees");
     }

--- a/openmls/src/group/tests/tree_printing.rs
+++ b/openmls/src/group/tests/tree_printing.rs
@@ -37,10 +37,9 @@ fn root(size: u32) -> u32 {
 }
 
 pub(crate) fn print_tree(group: &CoreGroup, message: &str) {
-    let tree = group.treesync();
     let factor = 3;
     println!("{message}");
-    let nodes = tree.export_nodes();
+    let nodes = group.public_group().export_nodes();
     let tree_size = nodes.len() as u32;
     for (i, node) in nodes.iter().enumerate() {
         let level = level(i as u32);

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -258,7 +258,7 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
                 // Welcome.
                 let new_group = match CoreGroup::new_from_welcome(
                     welcome.clone(),
-                    Some(core_group.treesync().export_nodes()),
+                    Some(core_group.public_group().export_nodes()),
                     key_package_bundle,
                     backend,
                 ) {

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -297,29 +297,6 @@ impl TreeSync {
             })
     }
 
-    /// Returns a [`TreeSyncError::UnsupportedExtension`] if an [`ExtensionType`]
-    /// in `extensions` is not supported by a leaf in this tree.
-    #[cfg(test)]
-    pub(crate) fn check_extension_support(
-        &self,
-        extensions: &[crate::extensions::ExtensionType],
-    ) -> Result<(), TreeSyncError> {
-        if self.tree.leaves().any(|(_, tsn)| {
-            tsn.node()
-                .as_ref()
-                .map(|node| {
-                    node.leaf_node()
-                        .check_extension_support(extensions)
-                        .map_err(|_| LibraryError::custom("This is never used, so we don't care"))
-                })
-                .is_none() // Return true if this is none
-        }) {
-            Err(TreeSyncError::UnsupportedExtension)
-        } else {
-            Ok(())
-        }
-    }
-
     /// Returns the nodes in the tree ordered according to the
     /// array-representation of the underlying binary tree.
     pub fn export_nodes(&self) -> Vec<Option<Node>> {

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -38,7 +38,7 @@ use crate::{
         array_representation::{is_node_in_tree, tree::TreeNode, LeafNodeIndex, TreeSize},
         MlsBinaryTree, MlsBinaryTreeError,
     },
-    ciphersuite::{Secret, SignaturePublicKey},
+    ciphersuite::Secret,
     credentials::CredentialWithKey,
     error::LibraryError,
     extensions::Extensions,
@@ -264,22 +264,6 @@ impl TreeSync {
         self.tree
             .leaves()
             .filter_map(|(_, tsn)| tsn.node().as_ref())
-    }
-
-    /// Returns the [`LeafNodeIndex`] of the leaf that contains the given
-    /// [`SignaturePublicKey`].
-    ///
-    /// Returns `None` if no matching leaf can be found.
-    pub(crate) fn find_leaf(&self, signature_key: &SignaturePublicKey) -> Option<LeafNodeIndex> {
-        self.full_leave_members()
-            .filter_map(|m| {
-                if m.signature_key == signature_key.as_slice() {
-                    Some(m.index)
-                } else {
-                    None
-                }
-            })
-            .next()
     }
 
     /// Returns the index of the last full leaf in the tree.


### PR DESCRIPTION
This PR removes the `TreeSync` getter in `PublicGroup`, thus better enforcing the `PublicGroup` abstraction.

This PR also fixes what I believe is a small bug in `check_extension_support`, although the function is currently only used in tests.

There might be other, smaller things to clean up, but I think we should leave that for the public API grooming before the next release. I would thus say, this fixes #1255.