### PR TITLE
move tls_codec dependency to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ members = [
 resolver = "2"
 
 # Patching unreleased crates
-[patch.crates-io.tls_codec]
-git = "https://github.com/RustCrypto/formats.git"
+[workspace.dependencies]
+tls_codec = { version = "0.3.0-pre.1", features = ["derive", "serde", "mls"] }
 
 [patch.crates-io.hpke-rs]
 git = "https://github.com/franziskuskiefer/hpke-rs.git"

--- a/basic_credential/Cargo.toml
+++ b/basic_credential/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 openmls_traits = { version = "0.1.0", path = "../traits" }
-tls_codec = { version = "0.3.0-pre.1", features = ["derive", "serde", "mls"] }
+tls_codec = { workspace = true }
 serde = "1.0"
 
 # Rust Crypto

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,7 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 base64 = "0.13"
 log = "0.4"
 pretty_env_logger = "0.4"
-tls_codec = { version = "0.3.0-pre.1", features = ["derive", "serde"] }
+tls_codec = { workspace = true }
 
 openmls = { path = "../openmls", features = ["test-utils"] }
 ds-lib = { path = "../delivery-service/ds-lib" }

--- a/delivery-service/ds-lib/Cargo.toml
+++ b/delivery-service/ds-lib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Types to interact with the OpenMLS DS."
 
 [dependencies]
-tls_codec = { version = "0.3.0-pre.1", features = ["derive", "serde"] }
+tls_codec = { workspace = true }
 openmls = { path = "../../openmls", features = ["test-utils"] }
 openmls_traits = { path = "../../traits" }
 openmls_rust_crypto = { path = "../../openmls_rust_crypto" }

--- a/delivery-service/ds/Cargo.toml
+++ b/delivery-service/ds/Cargo.toml
@@ -18,7 +18,7 @@ serde = {version = "1.0", features = ["derive"]}
 uuid = { version = "0.8", features = ["serde", "v4"] }
 clap = "2.33"
 base64 = "0.13"
-tls_codec = { version = "0.3.0-pre.1", features = ["derive", "serde", "mls"] }
+tls_codec = { workspace = true }
 
 openmls = { path = "../../openmls", features = ["test-utils"] }
 

--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -17,7 +17,7 @@ clap = "3.1"
 clap_derive = "3.1"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-tls_codec = { version = "0.3.0-pre.1", features = ["derive", "serde"] }
+tls_codec = { workspace = true }
 pretty_env_logger = "0.4"
 
 [build-dependencies]

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -14,7 +14,7 @@ openmls_traits = { version = "0.1.0", path = "../traits" }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 log = { version = "0.4", features = ["std"] }
-tls_codec = { version = "0.3.0-pre.1", features = ["derive", "serde", "mls"] }
+tls_codec = { workspace = true }
 rayon = "^1.5.0"
 thiserror = "^1.0"
 backtrace = "0.3"

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -27,5 +27,5 @@ rand_chacha = { version = "0.3" }
 hpke = { version = "0.1.0", package = "hpke-rs", default-features = false, features = ["hazmat", "serialization"] }
 hpke-rs-crypto = { version = "0.1.1" }
 hpke-rs-rust-crypto = { version = "0.1.1" }
-tls_codec = { version = "0.3.0-pre.1", features = ["derive", "serde", "mls"] }
+tls_codec = { workspace = true }
 thiserror = "1.0"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -14,4 +14,4 @@ path = "src/traits.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tls_codec = { version = "0.3.0-pre.1", features = ["derive", "serde", "mls"] }
+tls_codec = { workspace = true }


### PR DESCRIPTION
This moves the tls_codec to the workspace to avoid specifying the version everywhere.