### PR TITLE
refactor: Store PSKs independently from nonce.

### DIFF
--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -4,7 +4,6 @@ use openmls_traits::key_store::OpenMlsKeyStore;
 use crate::{
     ciphersuite::hash_ref::HashReference,
     group::{core_group::*, errors::WelcomeError},
-    schedule::errors::PskError,
     treesync::{
         errors::{DerivePathError, PublicTreeError},
         node::encryption_keys::EncryptionKeyPair,
@@ -61,12 +60,7 @@ impl CoreGroup {
         )?;
 
         // Prepare the PskSecret
-        let psk_secret =
-            PskSecret::new(ciphersuite, backend, &group_secrets.psks).map_err(|e| match e {
-                PskError::LibraryError(e) => e.into(),
-                PskError::TooManyKeys => WelcomeError::PskTooManyKeys,
-                PskError::KeyNotFound => WelcomeError::PskNotFound,
-            })?;
+        let psk_secret = PskSecret::new(ciphersuite, backend, &group_secrets.psks)?;
 
         // Create key schedule
         let mut key_schedule = KeySchedule::init(

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -1,8 +1,6 @@
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
-use openmls_traits::{
-    crypto::OpenMlsCrypto, key_store::OpenMlsKeyStore, types::HpkeCiphertext, OpenMlsCryptoProvider,
-};
+use openmls_traits::{crypto::OpenMlsCrypto, types::HpkeCiphertext, OpenMlsCryptoProvider};
 use tls_codec::Serialize;
 
 use crate::{
@@ -344,15 +342,9 @@ fn test_psks(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
         PreSharedKeyId::new(ciphersuite, backend.rand(), Psk::External(external_psk))
             .expect("An unexpected error occured.");
     let psk_bundle = PskBundle::new(secret).expect("Could not create PskBundle.");
-    backend
-        .key_store()
-        .store(
-            &preshared_key_id
-                .tls_serialize_detached()
-                .expect("Error serializing signature key."),
-            &psk_bundle,
-        )
-        .expect("An unexpected error occurred.");
+    preshared_key_id
+        .write_to_key_store(backend, ciphersuite, psk_bundle.secret().as_slice())
+        .unwrap();
     let mut alice_group = CoreGroup::builder(
         GroupId::random(backend),
         config::CryptoConfig::with_default_version(ciphersuite),

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -2,6 +2,10 @@
 //!
 //! This module contains errors that originate at lower levels and are partially re-exported in errors thrown by functions of the `MlsGroup` API.
 
+use thiserror::Error;
+
+pub use super::mls_group::errors::*;
+use super::public_group::errors::{CreationFromExternalError, PublicGroupBuildError};
 use crate::{
     ciphersuite::signable::SignatureError,
     error::LibraryError,
@@ -12,12 +16,6 @@ use crate::{
     schedule::errors::PskError,
     treesync::errors::*,
 };
-use thiserror::Error;
-
-// === Public errors ===
-
-pub use super::mls_group::errors::*;
-use super::public_group::errors::{CreationFromExternalError, PublicGroupBuildError};
 
 /// Welcome error
 #[derive(Error, Debug, PartialEq, Clone)]
@@ -67,12 +65,9 @@ pub enum WelcomeError<KeyStoreError> {
     /// Unsupported extensions found in the KeyPackage of another member.
     #[error("Unsupported extensions found in the KeyPackage of another member.")]
     UnsupportedExtensions,
-    /// More than 2^16 PSKs were provided.
-    #[error("More than 2^16 PSKs were provided.")]
-    PskTooManyKeys,
-    /// The PSK could not be found in the key store.
-    #[error("The PSK could not be found in the key store.")]
-    PskNotFound,
+    /// See [`PskError`] for more details.
+    #[error(transparent)]
+    Psk(#[from] PskError),
     /// No matching encryption key was found in the key store.
     #[error("No matching encryption key was found in the key store.")]
     NoMatchingEncryptionKey,

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -268,7 +268,6 @@ fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
     let psk_proposal = || {
         let secret = Secret::random(ciphersuite, backend, None).unwrap();
-        let psk_bundle = PskBundle::new(secret).unwrap();
         let rand = backend
             .rand()
             .random_vec(ciphersuite.hash_length())
@@ -280,7 +279,7 @@ fn test_valsem201(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         )
         .unwrap();
         psk_id
-            .write_to_key_store(backend, ciphersuite, psk_bundle.secret().as_slice())
+            .write_to_key_store(backend, ciphersuite, secret.as_slice())
             .unwrap();
         queued(Proposal::PreSharedKey(PreSharedKeyProposal::new(psk_id)))
     };

--- a/openmls/src/schedule/errors.rs
+++ b/openmls/src/schedule/errors.rs
@@ -5,8 +5,6 @@ use thiserror::Error;
 
 use crate::error::LibraryError;
 
-// === Public ===
-
 /// PSK secret error
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum PskError {
@@ -19,6 +17,9 @@ pub enum PskError {
     /// The PSK could not be found in the key store.
     #[error("The PSK could not be found in the key store.")]
     KeyNotFound,
+    /// Failed to write PSK into keystore.
+    #[error("Failed to write PSK into keystore.")]
+    KeyStore,
 }
 
 // === Crate ===

--- a/openmls/src/schedule/kat_psk_secret.rs
+++ b/openmls/src/schedule/kat_psk_secret.rs
@@ -32,13 +32,11 @@
 //!   the psk_secret as described in the specification and verify that it
 //!   matches the provided psk_secret
 
-use ::serde::Deserialize;
-use openmls_traits::{crypto::OpenMlsCrypto, key_store::OpenMlsKeyStore};
-use tls_codec::Serialize;
+use openmls_traits::crypto::OpenMlsCrypto;
+use serde::Deserialize;
 
-use crate::{prelude_test::Secret, test_utils::*, versions::ProtocolVersion};
-
-use super::psk::{ExternalPsk, PreSharedKeyId, Psk, PskBundle, PskSecret};
+use super::psk::{ExternalPsk, PreSharedKeyId, Psk, PskSecret};
+use crate::test_utils::*;
 
 #[derive(Deserialize)]
 struct PskElement {
@@ -79,18 +77,9 @@ fn run_test_vector(test: TestElement, backend: &impl OpenMlsCryptoProvider) -> R
 
             let psk_id = PreSharedKeyId::new_with_nonce(psk_type, psk.psk_nonce.clone());
 
-            let psk_bundle = PskBundle::new(Secret::from_slice(
-                &psk.psk,
-                ProtocolVersion::Mls10,
-                ciphersuite,
-            ))
-            .unwrap();
-
-            backend
-                .key_store()
-                .store(&psk_id.tls_serialize_detached().unwrap(), &psk_bundle)
+            psk_id
+                .write_to_key_store(backend, ciphersuite, &psk.psk)
                 .unwrap();
-
             psk_id
         })
         .collect::<Vec<_>>();

--- a/openmls/src/schedule/unit_tests.rs
+++ b/openmls/src/schedule/unit_tests.rs
@@ -1,16 +1,10 @@
 //! Key Schedule Unit Tests
 
-use crate::test_utils::*;
 use openmls_rust_crypto::OpenMlsRustCrypto;
-use openmls_traits::key_store::OpenMlsKeyStore;
 use openmls_traits::{random::OpenMlsRand, OpenMlsCryptoProvider};
-use tls_codec::Serialize;
-
-use crate::{
-    ciphersuite::Secret, schedule::psk::PskBundle, schedule::psk::*, versions::ProtocolVersion,
-};
 
 use super::PskSecret;
+use crate::{ciphersuite::Secret, schedule::psk::*, test_utils::*, versions::ProtocolVersion};
 
 #[apply(ciphersuites_and_backends)]
 fn test_psks(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
@@ -39,16 +33,9 @@ fn test_psks(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
         })
         .zip(psk_ids.clone())
     {
-        let psk_bundle = PskBundle::new(secret).expect("Could not create PskBundle.");
-        backend
-            .key_store()
-            .store(
-                &psk_id
-                    .tls_serialize_detached()
-                    .expect("Error serializing signature key."),
-                &psk_bundle,
-            )
-            .expect("An unexpected error occured.");
+        psk_id
+            .write_to_key_store(backend, ciphersuite, secret.as_slice())
+            .unwrap();
     }
 
     let _psk_secret =


### PR DESCRIPTION
While it is certainly not the last PR that reworks PSK handling, it should unblock interoperability work. I made it a draft because there are a few `TODO`s left.