### PR TITLE
Duesee/make interop work 1

### DIFF
--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Forward feature to openmls.
+crypto-debug = ["openmls/crypto-debug"]
+
 [dependencies]
 openmls = { path = "../openmls", features = ["test-utils"]}
 openmls_rust_crypto = { path = "../openmls_rust_crypto" }

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -1038,6 +1038,83 @@ impl MlsClient for MlsClientImpl {
             "Group context extension is not implemented yet",
         ))
     }
+
+    async fn re_init_commit(
+        &self,
+        _: Request<CommitRequest>,
+    ) -> Result<Response<CommitResponse>, Status> {
+        todo!()
+    }
+
+    async fn handle_pending_re_init_commit(
+        &self,
+        _: Request<HandlePendingCommitRequest>,
+    ) -> Result<Response<HandleReInitCommitResponse>, Status> {
+        todo!()
+    }
+
+    async fn handle_re_init_commit(
+        &self,
+        _: Request<HandleCommitRequest>,
+    ) -> Result<Response<HandleReInitCommitResponse>, Status> {
+        todo!()
+    }
+
+    async fn re_init_welcome(
+        &self,
+        _: Request<ReInitWelcomeRequest>,
+    ) -> Result<Response<CreateSubgroupResponse>, Status> {
+        todo!()
+    }
+
+    async fn handle_re_init_welcome(
+        &self,
+        _: Request<HandleReInitWelcomeRequest>,
+    ) -> Result<Response<JoinGroupResponse>, Status> {
+        todo!()
+    }
+
+    async fn create_branch(
+        &self,
+        _: Request<CreateBranchRequest>,
+    ) -> Result<Response<CreateSubgroupResponse>, Status> {
+        todo!()
+    }
+
+    async fn handle_branch(
+        &self,
+        _: Request<HandleBranchRequest>,
+    ) -> Result<Response<HandleBranchResponse>, Status> {
+        todo!()
+    }
+
+    async fn new_member_add_proposal(
+        &self,
+        _: Request<NewMemberAddProposalRequest>,
+    ) -> Result<Response<NewMemberAddProposalResponse>, Status> {
+        todo!()
+    }
+
+    async fn create_external_signer(
+        &self,
+        _: Request<CreateExternalSignerRequest>,
+    ) -> Result<Response<CreateExternalSignerResponse>, Status> {
+        todo!()
+    }
+
+    async fn add_external_signer(
+        &self,
+        _: Request<AddExternalSignerRequest>,
+    ) -> Result<Response<ProposalResponse>, Status> {
+        todo!()
+    }
+
+    async fn external_signer_proposal(
+        &self,
+        _: Request<ExternalSignerProposalRequest>,
+    ) -> Result<Response<ProposalResponse>, Status> {
+        todo!()
+    }
 }
 
 #[derive(Parser)]

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -47,7 +47,7 @@ impl ProposalStore {
         self.queued_proposals.is_empty()
     }
     pub(crate) fn empty(&mut self) {
-        self.queued_proposals = Vec::new();
+        self.queued_proposals.clear();
     }
 
     /// Removes a proposal from the store using its reference. It will return None if it wasn't

--- a/openmls/src/group/group_context.rs
+++ b/openmls/src/group/group_context.rs
@@ -65,14 +65,8 @@ impl GroupContext {
         tree_hash: Vec<u8>,
         extensions: Extensions,
     ) -> Self {
-        Self::new(
-            ciphersuite,
-            group_id,
-            0,
-            tree_hash,
-            zero(ciphersuite.hash_length()),
-            extensions,
-        )
+        // Note: Confirmed transcript hash is "The zero-length octet string."
+        Self::new(ciphersuite, group_id, 0, tree_hash, vec![], extensions)
     }
 
     /// Increment the current [`GroupEpoch`] by one.

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -7,6 +7,7 @@ mod group_context;
 #[cfg(test)]
 use crate::ciphersuite::*;
 use crate::extensions::*;
+#[cfg(test)]
 use crate::utils::*;
 
 use openmls_traits::OpenMlsCryptoProvider;

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -267,8 +267,8 @@ impl From<Secret> for InitSecret {
 /// proposal. TODO: #628.
 fn hpke_info_from_version(version: ProtocolVersion) -> &'static str {
     match version {
-        ProtocolVersion::Mls10 => "MLS 1.0 external init",
-        ProtocolVersion::Mls10Draft11 => "MLS 1.0 Draft 11 external init",
+        ProtocolVersion::Mls10 => "MLS 1.0 external init secret",
+        ProtocolVersion::Mls10Draft11 => "<OpenMLS reserved; Don't use this.>",
     }
 }
 

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -8,6 +8,7 @@ use tls_codec::{
     Serialize as TlsSerializeTrait, Size, TlsDeserialize, TlsSerialize, TlsSize, VLBytes,
 };
 
+use super::encryption_keys::{EncryptionKey, EncryptionKeyPair};
 use crate::{
     binary_tree::array_representation::LeafNodeIndex,
     ciphersuite::{
@@ -24,8 +25,6 @@ use crate::{
     treesync::errors::{LeafNodeValidationError, LifetimeError},
     versions::ProtocolVersion,
 };
-
-use super::encryption_keys::{EncryptionKey, EncryptionKeyPair};
 
 mod capabilities;
 mod codec;
@@ -806,6 +805,8 @@ impl OpenMlsLeafNode {
             leaf_node_tbs.payload.credential = leaf_node.credential().clone();
             leaf_node_tbs.payload.encryption_key = leaf_node.encryption_key().clone();
         } else if let Some(new_encryption_key) = new_encryption_key.into() {
+            leaf_node_tbs.payload.leaf_node_source = LeafNodeSource::Update;
+
             // If there's no new leaf, the encryption key must be provided
             // explicitly.
             leaf_node_tbs.payload.encryption_key = new_encryption_key;

--- a/openmls/src/utils.rs
+++ b/openmls/src/utils.rs
@@ -20,6 +20,7 @@ pub fn random_u8() -> u8 {
     b[0]
 }
 
+#[cfg(test)]
 pub(crate) fn zero(length: usize) -> Vec<u8> {
     vec![0u8; length]
 }


### PR DESCRIPTION
This PR introduces some fixes in OpenMLS to interop with other implementations. There is one test failing and I can't really trace down what the cause is. At some point Bob and the Public Group disagree about the confirmed_transcript_hash (`b''`) for public group, something for Bob. But I'm a bit puzzled about this because it appears to me that `b''` is correct. But this would mean Bob or Alice do something wrong, which would mean that interop shouldn't work. I'll need some more time (and better tracing) to figure this out.