### PR TITLE
interop: Add some fixes to interop runner + chore.

### DIFF
--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -24,6 +24,6 @@ clap_derive = "4.1"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tls_codec = { workspace = true }
-pretty_env_logger = "0.4"
 openmls_basic_credential = { version = "0.1.0", path = "../basic_credential" }
-log = { version = "0.4", features = ["std"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -26,4 +26,4 @@ serde_json = "^1.0"
 tls_codec = { workspace = true }
 openmls_basic_credential = { version = "0.1.0", path = "../basic_credential" }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/interop_client/Cargo.toml
+++ b/interop_client/Cargo.toml
@@ -25,5 +25,5 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 tls_codec = { workspace = true }
 openmls_basic_credential = { version = "0.1.0", path = "../basic_credential" }
-tracing = "0.1.37"
+tracing = "0.1"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/interop_client/README.md
+++ b/interop_client/README.md
@@ -16,6 +16,12 @@ OPTIONS:
     -p, --port <PORT>    [default: 50051]
 ```
 
+Quickstart:
+
+```sh
+RUST_LOG=interop=trace cargo run
+```
+
 See [here](https://github.com/mlswg/mls-implementations) for more information on
 MLS interop and the test harness.
 

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -174,7 +174,6 @@ impl MlsClient for MlsClientImpl {
         request: Request<SupportedCiphersuitesRequest>,
     ) -> Result<Response<SupportedCiphersuitesResponse>, Status> {
         let request = request.get_ref();
-        info!(?request, "Request");
 
         // TODO: read from backend
         let ciphersuites = &[
@@ -189,7 +188,6 @@ impl MlsClient for MlsClientImpl {
                 .collect(),
         };
 
-        info!(?response, "Response");
         Ok(Response::new(response))
     }
 
@@ -209,6 +207,9 @@ impl MlsClient for MlsClientImpl {
         signature_keys.store(backend.key_store()).unwrap();
 
         let wire_format_policy = wire_format_policy(request.encrypt_handshake);
+        // Note: We just use some values here that make live testing work.
+        //       There is nothing special about the used numbers and they
+        //       can be increased (or decreased) depending on the available scenarios.
         let mls_group_config = MlsGroupConfig::builder()
             .crypto_config(CryptoConfig::with_default_version(ciphersuite))
             .max_past_epochs(32)
@@ -341,6 +342,9 @@ impl MlsClient for MlsClientImpl {
         trace!(identity = String::from_utf8_lossy(&request.identity).to_string());
 
         let wire_format_policy = wire_format_policy(request.encrypt_handshake);
+        // Note: We just use some values here that make live testing work.
+        //       There is nothing special about the used numbers and they
+        //       can be increased (or decreased) depending on the available scenarios.
         let mls_group_config = MlsGroupConfig::builder()
             .max_past_epochs(32)
             .number_of_resumption_psks(32)
@@ -687,6 +691,9 @@ impl MlsClient for MlsClientImpl {
                 .hash_ref(interop_group.crypto_provider.crypto())
                 .unwrap()
         );
+        // Note: We just use some values here that make live testing work.
+        //       There is nothing special about the used numbers and they
+        //       can be increased (or decreased) depending on the available scenarios.
         let mls_group_config = MlsGroupConfig::builder()
             .use_ratchet_tree_extension(true)
             .max_past_epochs(32)
@@ -706,7 +713,6 @@ impl MlsClient for MlsClientImpl {
         // Store the proposal for potential future use.
         interop_group.messages_out.push(proposal.clone().into());
 
-        // trace!("   proposal: {proposal:#x?}");
         let proposal = proposal.to_bytes().unwrap();
 
         let response = ProposalResponse { proposal };
@@ -733,6 +739,9 @@ impl MlsClient for MlsClientImpl {
             String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
         );
 
+        // Note: We just use some values here that make live testing work.
+        //       There is nothing special about the used numbers and they
+        //       can be increased (or decreased) depending on the available scenarios.
         let mls_group_config = MlsGroupConfig::builder()
             .max_past_epochs(32)
             .number_of_resumption_psks(32)
@@ -784,6 +793,9 @@ impl MlsClient for MlsClientImpl {
             String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
         );
 
+        // Note: We just use some values here that make live testing work.
+        //       There is nothing special about the used numbers and they
+        //       can be increased (or decreased) depending on the available scenarios.
         let mls_group_config = MlsGroupConfig::builder()
             .max_past_epochs(32)
             .number_of_resumption_psks(32)

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -25,6 +25,8 @@ use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::OpenMlsCryptoProvider;
 use serde::{self, Serialize};
 use tonic::{async_trait, transport::Server, Code, Request, Response, Status};
+use tracing::{debug, error, info, instrument, trace, Span};
+use tracing_subscriber::EnvFilter;
 
 const IMPLEMENTATION_NAME: &str = "OpenMLS";
 
@@ -71,7 +73,7 @@ impl MlsClientImpl {
 
 fn into_status<E: Display>(e: E) -> Status {
     let message = "mls group error ".to_string() + &e.to_string();
-    log::error!("{message}");
+    error!("{message}");
     Status::new(Code::Aborted, message)
 }
 
@@ -123,22 +125,56 @@ pub fn wire_format_policy(encrypt: bool) -> WireFormatPolicy {
     }
 }
 
+fn ratchet_tree_from_config(bytes: Vec<u8>) -> Option<RatchetTree> {
+    debug!("Deserializing `RatchetTree`.");
+    if !bytes.is_empty() {
+        let ratchet_tree = RatchetTree::tls_deserialize(&mut bytes.as_slice()).unwrap();
+        debug!("Got `RatchetTree`.");
+        trace!(?ratchet_tree);
+        Some(ratchet_tree)
+    } else {
+        debug!("Skipping deserialization due to empty bytes.");
+        None
+    }
+}
+
+fn bytes_to_string<B>(bytes: B) -> String
+where
+    B: AsRef<[u8]>,
+{
+    let bytes = bytes.as_ref();
+
+    match String::from_utf8(bytes.to_vec()) {
+        Ok(string) => string,
+        Err(error) => {
+            error!(?error, "Using lossy UTF-8 conversion.");
+            String::from_utf8_lossy(bytes).to_string()
+        }
+    }
+}
+
 #[async_trait]
 impl MlsClient for MlsClientImpl {
-    async fn name(&self, _request: Request<NameRequest>) -> Result<Response<NameResponse>, Status> {
-        log::debug!("Got Name request");
+    #[instrument(skip_all)]
+    async fn name(&self, request: Request<NameRequest>) -> Result<Response<NameResponse>, Status> {
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let response = NameResponse {
             name: IMPLEMENTATION_NAME.to_string(),
         };
+
+        info!(?response, "Response");
         Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn supported_ciphersuites(
         &self,
-        _request: Request<SupportedCiphersuitesRequest>,
+        request: Request<SupportedCiphersuitesRequest>,
     ) -> Result<Response<SupportedCiphersuitesResponse>, Status> {
-        log::trace!("Got SupportedCiphersuites request");
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         // TODO: read from backend
         let ciphersuites = &[
@@ -150,35 +186,35 @@ impl MlsClient for MlsClientImpl {
             ciphersuites: ciphersuites.iter().map(|cs| *cs as u32).collect(),
         };
 
+        info!(?response, "Response");
         Ok(Response::new(response))
     }
 
+    #[instrument(skip_all, fields(actor))]
     async fn create_group(
         &self,
         request: Request<CreateGroupRequest>,
     ) -> Result<Response<CreateGroupResponse>, Status> {
-        log::debug!("Creating a new group.");
-        let create_group_request = request.get_ref();
-        let crypto_provider = OpenMlsRustCrypto::default();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
-        let ciphersuite = Ciphersuite::try_from(create_group_request.cipher_suite as u16).unwrap();
-        let credential =
-            Credential::new(create_group_request.identity.clone(), CredentialType::Basic).unwrap();
+        let backend = OpenMlsRustCrypto::default();
+
+        let ciphersuite = Ciphersuite::try_from(request.cipher_suite as u16).unwrap();
+        let credential = Credential::new(request.identity.clone(), CredentialType::Basic).unwrap();
         let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
-        signature_keys.store(crypto_provider.key_store()).unwrap();
-        log::trace!("   for {:x?}", create_group_request.identity);
+        signature_keys.store(backend.key_store()).unwrap();
 
-        let wire_format_policy = wire_format_policy(create_group_request.encrypt_handshake);
+        let wire_format_policy = wire_format_policy(request.encrypt_handshake);
         let mls_group_config = MlsGroupConfig::builder()
             .crypto_config(CryptoConfig::with_default_version(ciphersuite))
             .wire_format_policy(wire_format_policy)
-            .use_ratchet_tree_extension(true)
             .build();
         let group = MlsGroup::new_with_group_id(
-            &crypto_provider,
+            &backend,
             &signature_keys,
             &mls_group_config,
-            GroupId::from_slice(&create_group_request.group_id),
+            GroupId::from_slice(&request.group_id),
             CredentialWithKey {
                 credential,
                 signature_key: signature_keys.public().into(),
@@ -186,37 +222,46 @@ impl MlsClient for MlsClientImpl {
         )
         .map_err(into_status)?;
 
+        Span::current().record("actor", bytes_to_string(group.own_identity().unwrap()));
+        trace!(epoch=?group.epoch(), "Current group state.");
+
         let interop_group = InteropGroup {
             group,
             wire_format_policy,
             signature_keys,
             messages_out: Vec::new(),
-            crypto_provider,
+            crypto_provider: backend,
         };
 
         let mut groups = self.groups.lock().unwrap();
         let state_id = groups.len() as u32;
         groups.push(interop_group);
 
-        Ok(Response::new(CreateGroupResponse { state_id }))
+        let response = CreateGroupResponse { state_id };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn create_key_package(
         &self,
         request: Request<CreateKeyPackageRequest>,
     ) -> Result<Response<CreateKeyPackageResponse>, Status> {
-        log::debug!("Creating a new key package");
-        let create_kp_request = request.get_ref();
-        let crypto_provider = OpenMlsRustCrypto::default();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
-        let ciphersuite = *to_ciphersuite(create_kp_request.cipher_suite)?;
-        let credential =
-            Credential::new(create_kp_request.identity.clone(), CredentialType::Basic).unwrap();
-        let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
-        log::trace!(
-            "   for {:x?}",
-            String::from_utf8_lossy(&create_kp_request.identity)
+        let crypto_provider = OpenMlsRustCrypto::default();
+        let ciphersuite = *to_ciphersuite(request.cipher_suite)?;
+        let identity = request.identity.clone();
+
+        debug!(
+            r#for = String::from_utf8_lossy(&identity).to_string(),
+            "Creating key package."
         );
+
+        let credential = Credential::new(identity, CredentialType::Basic).unwrap();
+        let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
         let key_package = KeyPackage::builder()
             .leaf_node_capabilities(Capabilities::default())
@@ -261,9 +306,9 @@ impl MlsClient for MlsClientImpl {
         self.transaction_id_map
             .lock()
             .unwrap()
-            .insert(transaction_id, create_kp_request.identity.clone());
+            .insert(transaction_id, request.identity.clone());
         self.pending_state.lock().unwrap().insert(
-            create_kp_request.identity.clone(),
+            request.identity.clone(),
             (
                 key_package,
                 private_key,
@@ -274,21 +319,21 @@ impl MlsClient for MlsClientImpl {
             ),
         );
 
+        info!(?response, "Response");
         Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn join_group(
         &self,
         request: Request<JoinGroupRequest>,
     ) -> Result<Response<JoinGroupResponse>, Status> {
-        log::debug!("Joining a group");
-        let join_group_request = request.get_ref();
-        log::trace!(
-            "   {}",
-            String::from_utf8_lossy(&join_group_request.identity)
-        );
+        let request = request.get_ref();
+        info!(?request, "Request");
 
-        let wire_format_policy = wire_format_policy(join_group_request.encrypt_handshake);
+        trace!(identity = String::from_utf8_lossy(&request.identity).to_string());
+
+        let wire_format_policy = wire_format_policy(request.encrypt_handshake);
         let mls_group_config = MlsGroupConfig::builder()
             .wire_format_policy(wire_format_policy)
             .use_ratchet_tree_extension(true)
@@ -303,10 +348,10 @@ impl MlsClient for MlsClientImpl {
             my_signature_keys,
             crypto_provider,
         ) = pending_key_packages
-            .remove(&join_group_request.identity)
+            .remove(&request.identity)
             .ok_or(Status::aborted(format!(
                 "failed to find key package for identity {:x?}",
-                join_group_request.identity
+                request.identity
             )))?;
 
         // Store keys so OpenMLS can find them.
@@ -338,18 +383,14 @@ impl MlsClient for MlsClientImpl {
             .store::<HpkePrivateKey>(my_key_package.hpke_init_key().as_slice(), &private_key)
             .map_err(into_status)?;
 
-        let welcome_msg = MlsMessageIn::tls_deserialize(&mut join_group_request.welcome.as_slice())
+        let welcome_msg = MlsMessageIn::tls_deserialize(&mut request.welcome.as_slice())
             .map_err(|_| Status::aborted("failed to deserialize MlsMessage with a Welcome"))?;
 
         let welcome = welcome_msg.into_welcome().ok_or(Status::invalid_argument(
             "unable to get Welcome from MlsMessage",
         ))?;
 
-        let ratchet_tree = if join_group_request.ratchet_tree.is_empty() {
-            None
-        } else {
-            Some(RatchetTree::tls_deserialize_exact(&join_group_request.ratchet_tree).unwrap())
-        };
+        let ratchet_tree = ratchet_tree_from_config(request.ratchet_tree.clone());
 
         let group =
             MlsGroup::new_from_welcome(&crypto_provider, &mls_group_config, welcome, ratchet_tree)
@@ -362,8 +403,8 @@ impl MlsClient for MlsClientImpl {
             messages_out: Vec::new(),
             crypto_provider,
         };
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
+        trace!("   in epoch {:?}", interop_group.group.epoch());
+        trace!(
             "   actor {:x?}",
             String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
         );
@@ -378,12 +419,16 @@ impl MlsClient for MlsClientImpl {
         let state_id = groups.len() as u32;
         groups.push(interop_group);
 
-        Ok(Response::new(JoinGroupResponse {
+        let response = JoinGroupResponse {
             state_id,
             epoch_authenticator,
-        }))
+        };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all, fields(actor))]
     async fn external_join(
         &self,
         _request: Request<ExternalJoinRequest>,
@@ -394,43 +439,48 @@ impl MlsClient for MlsClientImpl {
         ))
     }
 
+    #[instrument(skip_all)]
     async fn state_auth(
         &self,
         request: Request<StateAuthRequest>,
     ) -> Result<Response<StateAuthResponse>, Status> {
-        log::debug!("Generating state authenticator secret");
-        let state_auth_request = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get(state_auth_request.state_id as usize)
+            .get(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
+        trace!("   in epoch {:?}", interop_group.group.epoch());
+        trace!(
             "   actor {:x?}",
             String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
         );
 
         let state_auth_secret = interop_group.group.epoch_authenticator();
 
-        Ok(Response::new(StateAuthResponse {
+        let response = StateAuthResponse {
             state_auth_secret: state_auth_secret.as_slice().to_vec(),
-        }))
+        };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn export(
         &self,
         request: Request<ExportRequest>,
     ) -> Result<Response<ExportResponse>, Status> {
-        log::debug!("Exporting a secret");
-        let export_request = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get(export_request.state_id as usize)
+            .get(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
+        trace!("   in epoch {:?}", interop_group.group.epoch());
+        trace!(
             "   actor {:x?}",
             String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
         );
@@ -439,68 +489,77 @@ impl MlsClient for MlsClientImpl {
             .group
             .export_secret(
                 &interop_group.crypto_provider,
-                &export_request.label,
-                &export_request.context,
-                export_request.key_length as usize,
+                &request.label,
+                &request.context,
+                request.key_length as usize,
             )
             .map_err(into_status)?;
 
-        Ok(Response::new(ExportResponse { exported_secret }))
+        let response = ExportResponse { exported_secret };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn protect(
         &self,
         request: Request<ProtectRequest>,
     ) -> Result<Response<ProtectResponse>, Status> {
-        log::debug!("Encrypting message (protect)");
-        let protect_request = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get_mut(protect_request.state_id as usize)
+            .get_mut(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
-            "   actor {:x?}",
-            String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
-        );
+        trace!(actor=String::from_utf8_lossy(interop_group.group.own_identity().unwrap()).to_string(), epoch=?interop_group.group.epoch(), "Protecting.");
 
         let ciphertext = interop_group
             .group
             .create_message(
                 &interop_group.crypto_provider,
                 &interop_group.signature_keys,
-                &protect_request.plaintext,
+                &request.plaintext,
             )
             .map_err(into_status)?
             .tls_serialize_detached()
             .map_err(|_| Status::aborted("failed to serialize ciphertext"))?;
-        Ok(Response::new(ProtectResponse { ciphertext }))
+
+        let response = ProtectResponse { ciphertext };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn unprotect(
         &self,
         request: Request<UnprotectRequest>,
     ) -> Result<Response<UnprotectResponse>, Status> {
-        log::debug!("Decrypting message (unprotect)");
-        let unprotect_request = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get_mut(unprotect_request.state_id as usize)
+            .get_mut(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
-            "   actor {:x?}",
-            String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
-        );
+        trace!(actor=String::from_utf8_lossy(interop_group.group.own_identity().unwrap()).to_string(), epoch=?interop_group.group.epoch(), "Unprotecting.");
 
-        let message = MlsMessageIn::tls_deserialize(&mut unprotect_request.ciphertext.as_slice())
+        debug!("Deserializing `MlsMessageIn`.");
+        let message = MlsMessageIn::tls_deserialize(&mut request.ciphertext.as_slice())
             .map_err(|_| Status::aborted("failed to deserialize ciphertext"))?;
+        debug!("Deserialized `MlsMessageIn`.");
+        trace!(?message);
+
+        debug!("Processing message.");
         let processed_message = interop_group
             .group
             .process_message(&interop_group.crypto_provider, message)
             .map_err(into_status)?;
+        debug!("Processed.");
+        trace!(?processed_message);
+
         let authenticated_data = processed_message.authenticated_data().to_vec();
         let plaintext = match processed_message.into_content() {
             ProcessedMessageContent::ApplicationMessage(application_message) => {
@@ -511,21 +570,25 @@ impl MlsClient for MlsClientImpl {
             ProcessedMessageContent::StagedCommitMessage(_) => unreachable!(),
         };
 
-        Ok(Response::new(UnprotectResponse {
+        let response = UnprotectResponse {
             plaintext,
             authenticated_data,
-        }))
+        };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn store_psk(
         &self,
         request: Request<StorePskRequest>,
     ) -> Result<Response<StorePskResponse>, Status> {
-        log::debug!("Store PSK");
-        let store_proposal = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
-        let raw_psk_id = store_proposal.psk_id.clone();
-        log::trace!("   psk_id {:x?}", raw_psk_id);
+        let raw_psk_id = request.psk_id.clone();
+        trace!("   psk_id {:x?}", raw_psk_id);
         let external_psk = Psk::External(ExternalPsk::new(raw_psk_id));
 
         fn store(
@@ -545,7 +608,7 @@ impl MlsClient for MlsClientImpl {
         // This might be for a transaction ID or a state ID, so either a group, or not.
         // Transaction IDs are random. We assume that if it exists, it is what we want.
         let transaction_id_map = self.transaction_id_map.lock().unwrap();
-        let pending_state_id = transaction_id_map.get(&store_proposal.state_or_transaction_id);
+        let pending_state_id = transaction_id_map.get(&request.state_or_transaction_id);
         if let Some(pending_state_id) = pending_state_id {
             let mut pending_state = self.pending_state.lock().unwrap();
             let pending_state = pending_state
@@ -556,16 +619,16 @@ impl MlsClient for MlsClientImpl {
                 pending_state.0.ciphersuite(),
                 &pending_state.5,
                 external_psk,
-                &store_proposal.psk_secret,
+                &request.psk_secret,
             )?;
         } else {
             // So we have a group
             let mut groups = self.groups.lock().unwrap();
             let interop_group = groups
-                .get_mut(store_proposal.state_or_transaction_id as usize)
+                .get_mut(request.state_or_transaction_id as usize)
                 .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-            log::trace!("   in epoch {:?}", interop_group.group.epoch());
-            log::trace!(
+            trace!("   in epoch {:?}", interop_group.group.epoch());
+            trace!(
                 "   actor {:x?}",
                 String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
             );
@@ -574,36 +637,39 @@ impl MlsClient for MlsClientImpl {
                 interop_group.group.ciphersuite(),
                 &interop_group.crypto_provider,
                 external_psk,
-                &store_proposal.psk_secret,
+                &request.psk_secret,
             )?;
         }
 
-        Ok(Response::new(StorePskResponse::default()))
+        let response = StorePskResponse::default();
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn add_proposal(
         &self,
         request: Request<AddProposalRequest>,
     ) -> Result<Response<ProposalResponse>, Status> {
-        log::debug!("Create add proposal");
-        let add_proposal_request = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get_mut(add_proposal_request.state_id as usize)
+            .get_mut(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
+        trace!("   in epoch {:?}", interop_group.group.epoch());
+        trace!(
             "   actor {:x?}",
             String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
         );
 
-        let key_package =
-            MlsMessageIn::tls_deserialize(&mut add_proposal_request.key_package.as_slice())
-                .map_err(|_| Status::aborted("failed to deserialize key package (MlsMessage)"))?
-                .into_keypackage()
-                .ok_or(Status::aborted("failed to deserialize key package"))?;
-        log::trace!(
+        let key_package = MlsMessageIn::tls_deserialize(&mut request.key_package.as_slice())
+            .map_err(|_| Status::aborted("failed to deserialize key package (MlsMessage)"))?
+            .into_keypackage()
+            .ok_or(Status::aborted("failed to deserialize key package"))?;
+        trace!(
             "   for {:#x?}",
             key_package
                 .hash_ref(interop_group.crypto_provider.crypto())
@@ -626,25 +692,29 @@ impl MlsClient for MlsClientImpl {
         // Store the proposal for potential future use.
         interop_group.messages_out.push(proposal.clone().into());
 
-        // log::trace!("   proposal: {proposal:#x?}");
+        // trace!("   proposal: {proposal:#x?}");
         let proposal = proposal.to_bytes().unwrap();
 
-        Ok(Response::new(ProposalResponse { proposal }))
+        let response = ProposalResponse { proposal };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn update_proposal(
         &self,
         request: Request<UpdateProposalRequest>,
     ) -> Result<Response<ProposalResponse>, Status> {
-        log::debug!("Creating update proposal");
-        let update_proposal_request = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get_mut(update_proposal_request.state_id as usize)
+            .get_mut(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
+        trace!("   in epoch {:?}", interop_group.group.epoch());
+        trace!(
             "   actor {:x?}",
             String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
         );
@@ -670,28 +740,30 @@ impl MlsClient for MlsClientImpl {
 
         // XXX[FK]: Make sure the new keys are accessible?
 
-        Ok(Response::new(ProposalResponse { proposal }))
+        let response = ProposalResponse { proposal };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn remove_proposal(
         &self,
         request: Request<RemoveProposalRequest>,
     ) -> Result<Response<ProposalResponse>, Status> {
-        log::debug!("Generate remove proposal");
-        let remove_proposal_request = request.get_ref();
-        let removed_credential = Credential::new(
-            remove_proposal_request.removed_id.clone(),
-            CredentialType::Basic,
-        )
-        .unwrap();
-        log::trace!("   for credential: {removed_credential:x?}");
+        let request = request.get_ref();
+        info!(?request, "Request");
+
+        let removed_credential =
+            Credential::new(request.removed_id.clone(), CredentialType::Basic).unwrap();
+        trace!("   for credential: {removed_credential:x?}");
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get_mut(remove_proposal_request.state_id as usize)
+            .get_mut(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
+        trace!("   in epoch {:?}", interop_group.group.epoch());
+        trace!(
             "   actor {:x?}",
             String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
         );
@@ -701,7 +773,7 @@ impl MlsClient for MlsClientImpl {
             .wire_format_policy(interop_group.wire_format_policy)
             .build();
         interop_group.group.set_configuration(&mls_group_config);
-        log::trace!("   prepared remove");
+        trace!("   prepared remove");
 
         let (proposal, _) = interop_group
             .group
@@ -716,58 +788,66 @@ impl MlsClient for MlsClientImpl {
         interop_group.messages_out.push(proposal.clone().into());
 
         let proposal = proposal.to_bytes().unwrap();
-        log::trace!("   generated remove proposal");
+        trace!("   generated remove proposal");
 
-        Ok(Response::new(ProposalResponse { proposal }))
+        let response = ProposalResponse { proposal };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn re_init_proposal(
         &self,
-        _request: Request<ReInitProposalRequest>,
+        request: Request<ReInitProposalRequest>,
     ) -> Result<Response<ProposalResponse>, Status> {
-        Err(Status::unimplemented("Re-init is not implemented"))
+        let request = request.get_ref();
+        info!(?request, "Request");
+
+        let response = Status::unimplemented("Re-init is not implemented");
+
+        info!(?response, "Response");
+        Err(response)
     }
 
+    #[instrument(skip_all, fields(actor))]
     async fn commit(
         &self,
         request: Request<CommitRequest>,
     ) -> Result<Response<CommitResponse>, Status> {
-        log::debug!("Create a commit");
-        let commit_request = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get_mut(commit_request.state_id as usize)
+            .get_mut(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
-            "   actor {:x?}",
-            String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
-        );
+        let group = &mut interop_group.group;
+
+        Span::current().record("actor", bytes_to_string(group.own_identity().unwrap()));
+        trace!(epoch=?group.epoch(), "Current group state.");
 
         // Proposals by reference. These proposals are standalone proposals. They should
         // be appended to the proposal store.
+        for proposal in &request.by_reference {
+            trace!("Handling proposal by reference.");
 
-        // XXX[FK] This API is pretty bad.
-
-        for proposal in &commit_request.by_reference {
-            // log::trace!("   proposals by reference ... we don't care.");
             let message = MlsMessageIn::tls_deserialize(&mut proposal.as_slice())
                 .map_err(|_| Status::aborted("failed to deserialize proposal"))?;
             if interop_group.messages_out.contains(&message) {
-                log::trace!("   skipping processing of own proposal");
+                trace!("Skipping processing of own proposal");
                 continue;
             }
-            log::trace!("   processing proposal ...");
-            let processed_message = interop_group
-                .group
+            trace!("Processing proposal ...");
+            let processed_message = group
                 .process_message(&interop_group.crypto_provider, message)
                 .map_err(into_status)?;
-            log::trace!("       done");
+            trace!("... done");
+
             match processed_message.into_content() {
                 ProcessedMessageContent::ApplicationMessage(_) => unreachable!(),
                 ProcessedMessageContent::ProposalMessage(proposal) => {
-                    interop_group.group.store_pending_proposal(*proposal);
+                    group.store_pending_proposal(*proposal);
                 }
                 ProcessedMessageContent::ExternalJoinProposalMessage(_) => unreachable!(),
                 ProcessedMessageContent::StagedCommitMessage(_) => unreachable!(),
@@ -779,14 +859,12 @@ impl MlsClient for MlsClientImpl {
 
         // TODO #692: The interop client cannot process these proposals yet.
 
-        let (commit, welcome_option, _group_info) = interop_group
-            .group
+        let (commit, welcome_option, _group_info) = group
             .commit_to_pending_proposals(
                 &interop_group.crypto_provider,
                 &interop_group.signature_keys,
             )
             .map_err(into_status)?;
-        // log::trace!("   generated Welcome: {welcome_option:?}");
 
         let commit = commit.to_bytes().unwrap();
 
@@ -798,14 +876,16 @@ impl MlsClient for MlsClientImpl {
             vec![]
         };
 
-        interop_group
-            .group
+        debug!(commit=?group.pending_commit(), "Pending commit created. (Note: Not merged yet.)");
+
+        group
             .merge_pending_commit(&interop_group.crypto_provider)
             .map_err(into_status)?;
 
-        let ratchet_tree = if commit_request.external_tree {
-            interop_group
-                .group
+        debug!("Merged pending commit.");
+
+        let ratchet_tree = if request.external_tree {
+            group
                 .export_ratchet_tree()
                 .tls_serialize_detached()
                 .map_err(|_| Status::aborted("failed to serialize ratchet tree"))?
@@ -813,164 +893,163 @@ impl MlsClient for MlsClientImpl {
             vec![]
         };
 
-        // log::trace!("   generated Welcome bytes: {welcome:x?}");
-        log::trace!("   done committing");
-
-        Ok(Response::new(CommitResponse {
+        let response = CommitResponse {
             commit,
             welcome,
             ratchet_tree,
-        }))
+        };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all, fields(actor))]
     async fn handle_commit(
         &self,
         request: Request<HandleCommitRequest>,
     ) -> Result<Response<HandleCommitResponse>, Status> {
-        log::debug!("Handling incoming commit");
-        let handle_commit_request = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get_mut(handle_commit_request.state_id as usize)
+            .get_mut(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
-            "   actor {:x?}",
-            String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
-        );
+        let group = &mut interop_group.group;
+
+        Span::current().record("actor", bytes_to_string(group.own_identity().unwrap()));
+        trace!(epoch=?group.epoch(), "Current group state.");
 
         // XXX[FK]: This is a horrible API.
 
-        for proposal in &handle_commit_request.proposal {
-            // log::trace!("   proposals by reference ... we don't care.");
+        for proposal in &request.proposal {
+            // trace!("   proposals by reference ... we don't care.");
             let message = MlsMessageIn::tls_deserialize(&mut proposal.as_slice())
                 .map_err(|_| Status::aborted("failed to deserialize proposal"))?;
             if interop_group.messages_out.contains(&message) {
-                log::trace!("   skipping processing of own proposal");
+                trace!("   skipping processing of own proposal");
                 continue;
             }
-            log::trace!("   processing proposal ...");
-            let processed_message = interop_group
-                .group
+            trace!("   processing proposal ...");
+            let processed_message = group
                 .process_message(&interop_group.crypto_provider, message)
                 .map_err(into_status)?;
-            log::trace!("       done");
+            trace!("       done");
             match processed_message.into_content() {
                 ProcessedMessageContent::ApplicationMessage(_) => unreachable!(),
                 ProcessedMessageContent::ProposalMessage(proposal) => {
-                    interop_group.group.store_pending_proposal(*proposal);
+                    group.store_pending_proposal(*proposal);
                 }
                 ProcessedMessageContent::ExternalJoinProposalMessage(_) => unreachable!(),
                 ProcessedMessageContent::StagedCommitMessage(_) => unreachable!(),
             }
         }
 
-        let message = MlsMessageIn::tls_deserialize(&mut handle_commit_request.commit.as_slice())
-            .map_err(|_| {
-            log::error!("Failed to deserialize ciphertext");
-            Status::aborted("failed to deserialize ciphertext")
-        })?;
-        let processed_message = interop_group
-            .group
+        debug!("Deserializing `MlsMessageIn`.");
+        let message =
+            MlsMessageIn::tls_deserialize(&mut request.commit.as_slice()).map_err(|_| {
+                error!("Failed to deserialize ciphertext");
+                Status::aborted("failed to deserialize ciphertext")
+            })?;
+        debug!("Deserialized.");
+        trace!(?message);
+
+        debug!("Processing message.");
+        let processed_message = group
             .process_message(&interop_group.crypto_provider, message)
             .map_err(into_status)?;
+        debug!("Processed.");
+        trace!(?processed_message);
 
         match processed_message.into_content() {
             ProcessedMessageContent::ApplicationMessage(_) => unreachable!(),
             ProcessedMessageContent::ProposalMessage(_) => unreachable!(),
             ProcessedMessageContent::ExternalJoinProposalMessage(_) => unreachable!(),
             ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
-                log::trace!("   merging pending commit");
-                interop_group
-                    .group
+                debug!(commit=?staged_commit, "Merging staged commit.");
+                group
                     .merge_staged_commit(&interop_group.crypto_provider, *staged_commit)
                     .map_err(into_status)?;
             }
         }
 
-        let epoch_authenticator = interop_group
-            .group
-            .epoch_authenticator()
-            .as_slice()
-            .to_vec();
-        log::trace!("   new epoch {:?}", interop_group.group.epoch());
+        trace!(epoch=?group.epoch(), "New group state.");
 
-        Ok(Response::new(HandleCommitResponse {
-            state_id: handle_commit_request.state_id,
+        let epoch_authenticator = group.epoch_authenticator().as_slice().to_vec();
+
+        let response = HandleCommitResponse {
+            state_id: request.state_id,
             epoch_authenticator,
-        }))
+        };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all, fields(actor))]
     async fn handle_pending_commit(
         &self,
         request: Request<HandlePendingCommitRequest>,
     ) -> Result<Response<HandleCommitResponse>, Status> {
-        log::debug!("Handling pending commit");
-        let obj = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get_mut(obj.state_id as usize)
+            .get_mut(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
-            "   actor {:x?}",
-            String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
-        );
+        let group = &mut interop_group.group;
 
-        interop_group
-            .group
+        Span::current().record("actor", bytes_to_string(group.own_identity().unwrap()));
+        trace!(epoch=?group.epoch(), "Current group state.");
+
+        trace!(commit=?group.pending_commit(), "Merging pending commit.");
+        group
             .merge_pending_commit(&interop_group.crypto_provider)
             .map_err(|e| {
-                log::trace!("   Error merging pending commits {e:?}");
+                trace!("Error merging pending commit: `{e:?}`");
                 Status::aborted("failed to apply pending commits")
             })?;
-        log::trace!("   merged pending commits.");
+        trace!(epoch=?group.epoch(), "New group state.");
 
-        let epoch_authenticator = interop_group
-            .group
-            .epoch_authenticator()
-            .as_slice()
-            .to_vec();
+        let epoch_authenticator = group.epoch_authenticator().as_slice().to_vec();
         let response = HandleCommitResponse {
-            state_id: obj.state_id,
+            state_id: request.state_id,
             epoch_authenticator,
         };
+
+        info!(?response, "Response");
         Ok(Response::new(response))
     }
 
+    #[instrument(skip_all, fields(actor))]
     async fn group_info(
         &self,
         request: Request<GroupInfoRequest>,
     ) -> Result<Response<GroupInfoResponse>, Status> {
-        log::debug!("Getting group info");
-        let obj = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get_mut(obj.state_id as usize)
+            .get_mut(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
-            "   actor {:x?}",
-            String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
-        );
+        let group = &mut interop_group.group;
 
-        let group_info = interop_group
-            .group
+        Span::current().record("actor", bytes_to_string(group.own_identity().unwrap()));
+
+        let group_info = group
             .export_group_info(
                 &interop_group.crypto_provider,
                 &interop_group.signature_keys,
-                !obj.external_tree,
+                !request.external_tree,
             )
-            .map_err(|_| Status::internal("Unable to export group info from the group"))?
-            .tls_serialize_detached()
-            .map_err(|_| Status::internal("Unable to serialize group info message."))?;
+            .unwrap();
+        debug!("Group info exported.");
+        trace!(?group_info);
 
-        let ratchet_tree = if obj.external_tree {
-            interop_group
-                .group
+        let ratchet_tree = if request.external_tree {
+            group
                 .export_ratchet_tree()
                 .tls_serialize_detached()
                 .map_err(|_| Status::internal("Unable to serialize ratchet tree."))?
@@ -978,31 +1057,35 @@ impl MlsClient for MlsClientImpl {
             vec![]
         };
 
-        Ok(Response::new(GroupInfoResponse {
-            group_info,
+        let response = GroupInfoResponse {
+            group_info: group_info.tls_serialize_detached().unwrap(),
             ratchet_tree,
-        }))
+        };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all)]
     async fn external_psk_proposal(
         &self,
         request: Request<ExternalPskProposalRequest>,
     ) -> Result<Response<ProposalResponse>, Status> {
-        log::debug!("Create external PSK proposal");
-        let psk_proposal_request = request.get_ref();
+        let request = request.get_ref();
+        info!(?request, "Request");
 
         let mut groups = self.groups.lock().unwrap();
         let interop_group = groups
-            .get_mut(psk_proposal_request.state_id as usize)
+            .get_mut(request.state_id as usize)
             .ok_or_else(|| Status::new(Code::InvalidArgument, "unknown state_id"))?;
-        log::trace!("   in epoch {:?}", interop_group.group.epoch());
-        log::trace!(
+        trace!("   in epoch {:?}", interop_group.group.epoch());
+        trace!(
             "   actor {:x?}",
             String::from_utf8_lossy(interop_group.group.own_identity().unwrap())
         );
 
-        let raw_psk_id = psk_proposal_request.psk_id.clone();
-        log::trace!("   psk_id {:x?}", raw_psk_id);
+        let raw_psk_id = request.psk_id.clone();
+        trace!("   psk_id {:x?}", raw_psk_id);
         let external_psk = Psk::External(ExternalPsk::new(raw_psk_id));
 
         let psk_id = PreSharedKeyId::new(
@@ -1019,31 +1102,34 @@ impl MlsClient for MlsClientImpl {
                 &interop_group.signature_keys,
                 psk_id,
             )
-            .map_err(|_| tonic::Status::internal("failed to generate psk proposal"))?;
+            .map_err(|_| Status::internal("failed to generate psk proposal"))?;
 
         // Store the proposal for potential future use.
         interop_group.messages_out.push(proposal.clone().into());
 
-        // log::trace!("   proposal: {proposal:#x?}");
+        // trace!("   proposal: {proposal:#x?}");
         let proposal = proposal.to_bytes().unwrap();
 
-        Ok(Response::new(ProposalResponse { proposal }))
+        let response = ProposalResponse { proposal };
+
+        info!(?response, "Response");
+        Ok(Response::new(response))
     }
 
+    #[instrument(skip_all, fields(actor))]
     async fn resumption_psk_proposal(
         &self,
-        _request: tonic::Request<ResumptionPskProposalRequest>,
-    ) -> Result<tonic::Response<ProposalResponse>, tonic::Status> {
-        Err(tonic::Status::unimplemented(
-            "Resumption PSK is not implemented",
-        ))
+        _request: Request<ResumptionPskProposalRequest>,
+    ) -> Result<Response<ProposalResponse>, Status> {
+        Err(Status::unimplemented("Resumption PSK is not implemented"))
     }
 
+    #[instrument(skip_all, fields(actor))]
     async fn group_context_extensions_proposal(
         &self,
-        _request: tonic::Request<GroupContextExtensionsProposalRequest>,
-    ) -> Result<tonic::Response<ProposalResponse>, tonic::Status> {
-        Err(tonic::Status::unimplemented(
+        _request: Request<GroupContextExtensionsProposalRequest>,
+    ) -> Result<Response<ProposalResponse>, Status> {
+        Err(Status::unimplemented(
             "Group context extension is not implemented yet",
         ))
     }
@@ -1137,13 +1223,19 @@ struct Opts {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let opts = Opts::parse();
-    pretty_env_logger::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_target(false)
+        .with_file(true)
+        .with_line_number(true)
+        .without_time()
+        .init();
 
+    let opts = Opts::parse();
     let addr = format!("{}:{}", opts.host, opts.port).parse().unwrap();
     let mls_client_impl = MlsClientImpl::new();
 
-    println!("Listening on {}", addr);
+    info!(%addr, "Listening");
 
     Server::builder()
         .add_service(MlsClientServer::new(mls_client_impl))


### PR DESCRIPTION
This PR improves the readability of the interop runner, improves the logging, adjusts AD, and adjusts the config so that the interop scenarios can pass. It is unfortunately a bit difficult to review due to some renamings. I think these are an improvement but could understand if we want to revert. The motivation behind the changes is that we can now see very well where a specifc log item is coming from. This proved to be very helpful in tracing down the cause of various mismatches.

This PR is a basis for the next ones that implement support for PSK, external join, and fix a transcript hash error. So, I hope it is one of the last PRs in this series.