### PR TITLE
Add free method to MlsClient to match proto

### DIFF
--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -1124,6 +1124,11 @@ impl MlsClient for MlsClientImpl {
     ) -> Result<Response<ProposalResponse>, Status> {
         todo!()
     }
+    async fn free(&self, _request: Request<FreeRequest>) -> Result<Response<FreeResponse>, Status> {
+        log::debug!("Got Free request");
+        let response = FreeResponse {};
+        Ok(Response::new(response))
+    }
 }
 
 #[derive(Parser)]

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -1124,6 +1124,7 @@ impl MlsClient for MlsClientImpl {
     ) -> Result<Response<ProposalResponse>, Status> {
         todo!()
     }
+
     async fn free(&self, _request: Request<FreeRequest>) -> Result<Response<FreeResponse>, Status> {
         log::debug!("Got Free request");
         let response = FreeResponse {};


### PR DESCRIPTION
The MlsClient proto added a free method, add it to the implementation so all tests can compile and run.