### PR TITLE
Fix build break and warnings in interop_client

### DIFF
--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -174,6 +174,7 @@ impl MlsClient for MlsClientImpl {
         request: Request<SupportedCiphersuitesRequest>,
     ) -> Result<Response<SupportedCiphersuitesResponse>, Status> {
         let request = request.get_ref();
+        info!(?request, "Request");
 
         // TODO: read from backend
         let ciphersuites = &[
@@ -1242,7 +1243,7 @@ impl MlsClient for MlsClientImpl {
     }
 
     async fn free(&self, _request: Request<FreeRequest>) -> Result<Response<FreeResponse>, Status> {
-        log::debug!("Got Free request");
+        debug!("Got Free request");
         let response = FreeResponse {};
         Ok(Response::new(response))
     }

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -171,11 +171,8 @@ impl MlsClient for MlsClientImpl {
     #[instrument(skip_all)]
     async fn supported_ciphersuites(
         &self,
-        request: Request<SupportedCiphersuitesRequest>,
+        _request: Request<SupportedCiphersuitesRequest>,
     ) -> Result<Response<SupportedCiphersuitesResponse>, Status> {
-        let request = request.get_ref();
-        info!(?request, "Request");
-
         // TODO: read from backend
         let ciphersuites = &[
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,


### PR DESCRIPTION
Fix build break in how log is being used (introduced by merge conflict). 
Fix warning about unused variable by logging it like other methods do.