### PR TITLE
fix: Store MlsGroup state in keystore

### DIFF
--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -12,7 +12,6 @@ readme = "../README.md"
 [dependencies]
 openmls_traits = { version = "0.1.0", path = "../traits" }
 serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
 log = { version = "0.4", features = ["std"] }
 tls_codec = { workspace = true }
 rayon = "^1.5.0"
@@ -20,11 +19,12 @@ thiserror = "^1.0"
 backtrace = "0.3"
 # Only required for tests.
 rand = { version = "0.8", optional = true }
+serde_json = { version = "1.0", optional = true }
 # Crypto backends required for KAT and testing - "test-utils" feature
 itertools = { version = "0.10", optional = true }
 openmls_rust_crypto = { version = "0.1.0", path = "../openmls_rust_crypto", optional = true }
 openmls_evercrypt = { version = "0.1.0", path = "../evercrypt_backend", optional = true }
-openmls_basic_credential = { version = "0.1.0", path = "../basic_credential", optional = true }
+openmls_basic_credential = { version = "0.1.0", path = "../basic_credential", optional = true, features = ["clonable", "test-utils"] }
 rstest = { version = "^0.16", optional = true }
 rstest_reuse = { version = "0.4", optional = true }
 
@@ -32,21 +32,21 @@ rstest_reuse = { version = "0.4", optional = true }
 default = []
 crypto-subtle = [] # Enable subtle crypto APIs that have to be used with care.
 test-utils = [
-    "itertools",
-    "openmls_rust_crypto",
-    "rand",
-    "rstest",
-    "rstest_reuse",
-    "openmls_basic_credential",
-    "openmls_basic_credential/clonable",
-    "openmls_basic_credential/test-utils",
+    "dep:serde_json",
+    "dep:itertools",
+    "dep:openmls_rust_crypto",
+    "dep:rand",
+    "dep:rstest",
+    "dep:rstest_reuse",
+    "dep:openmls_basic_credential",
 ]
-evercrypt = ["openmls_evercrypt"] # Evercrypt needs to be enabled individually
+evercrypt = ["dep:openmls_evercrypt"] # Evercrypt needs to be enabled individually
 crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
 
 [dev-dependencies]
 backtrace = "0.3"
+
 criterion = "^0.4"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.10"

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -29,7 +29,7 @@ fn test_mls_group_persistence(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
         backend,
         &alice_signer,
         &mls_group_config,
-        group_id,
+        group_id.clone(),
         alice_credential_with_key,
     )
     .expect("An unexpected error occurred.");
@@ -37,15 +37,12 @@ fn test_mls_group_persistence(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
     // Check the internal state has changed
     assert_eq!(alice_group.state_changed(), InnerState::Changed);
 
-    let mut file_out = tempfile::NamedTempFile::new().expect("Could not create file");
     alice_group
-        .save(&mut file_out)
+        .save(backend)
         .expect("Could not write group state to file");
 
-    let file_in = file_out
-        .reopen()
-        .expect("Error re-opening serialized group state file");
-    let alice_group_deserialized = MlsGroup::load(file_in).expect("Could not deserialize MlsGroup");
+    let alice_group_deserialized =
+        MlsGroup::load(&group_id, backend).expect("Could not deserialize MlsGroup");
 
     assert_eq!(
         (

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -4,14 +4,7 @@ use openmls::{
     *,
 };
 
-use lazy_static::lazy_static;
 use openmls_traits::{key_store::OpenMlsKeyStore, signatures::Signer, OpenMlsCryptoProvider};
-use std::fs::File;
-
-lazy_static! {
-    static ref TEMP_DIR: tempfile::TempDir =
-        tempfile::tempdir().expect("Error creating temp directory");
-}
 
 fn generate_key_package<KeyStore: OpenMlsKeyStore>(
     ciphersuite: Ciphersuite,
@@ -96,7 +89,7 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
             backend,
             &alice_signer,
             &mls_group_config,
-            group_id,
+            group_id.clone(),
             alice_credential.clone(),
         )
         .expect("An unexpected error occurred.");
@@ -905,27 +898,14 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
         assert_eq!(bob_group.state_changed(), InnerState::Changed);
         //save(&mut bob_group);
 
-        let name = bytes_to_hex(
-            bob_group
-                .own_leaf_node()
-                .unwrap()
-                .signature_key()
-                .as_slice(),
-        )
-        .to_lowercase();
-        let path = TEMP_DIR
-            .path()
-            .join(format!("test_mls_group_{}.json", &name));
-        let out_file = &mut File::create(path.clone()).expect("Could not create file");
         bob_group
-            .save(out_file)
+            .save(backend)
             .expect("Could not write group state to file");
 
         // Check that the state flag gets reset when saving
         assert_eq!(bob_group.state_changed(), InnerState::Persisted);
 
-        let file = File::open(path).expect("Could not open file");
-        let bob_group = MlsGroup::load(file).expect("Could not load group from file");
+        let bob_group = MlsGroup::load(&group_id, backend).expect("Could not load group from file");
 
         // Make sure the state is still the same
         assert_eq!(

--- a/traits/src/key_store.rs
+++ b/traits/src/key_store.rs
@@ -7,6 +7,7 @@ pub enum MlsEntityId {
     KeyPackage,
     PskBundle,
     EncryptionKeyPair,
+    GroupState,
 }
 
 /// To implement by any struct owned by openmls aiming to be persisted in [OpenMlsKeyStore]


### PR DESCRIPTION
Hi everyone,

In order to fix #245 once and for all, we could opt to store `MlsGroup`s within the backing Keystore.

This allows three things: 
* To solve the serialization format issues as it is deferred to the Keystore's `store|read` implementations - Becomes a non-concern openmls-wise
* To remove the runtime dependency on `serde_json` (goes to dev-dependencies)
* Remove the only possible surface-level API that returns a system-dependent IO error

What do you think?