### PR TITLE
fix: EncryptionKeyPair has the wrong MlsEntityId

### DIFF
--- a/openmls/src/treesync/node/encryption_keys.rs
+++ b/openmls/src/treesync/node/encryption_keys.rs
@@ -281,5 +281,5 @@ impl From<(EncryptionKey, EncryptionPrivateKey)> for EncryptionKeyPair {
 }
 
 impl MlsEntity for EncryptionKeyPair {
-    const ID: MlsEntityId = MlsEntityId::SignatureKeyPair;
+    const ID: MlsEntityId = MlsEntityId::EncryptionKeyPair;
 }


### PR DESCRIPTION
This fixes a small bug that is unlikely to cause any real-world issues.
The EncryptionKeyPair struct has the wrong `MlsEntityId`. There's a small possibility (probably well under 0.1%) that a HPKE keypair generates the same public key as one of the signature public keys and ends up erasing it, breaking everything.