### PR TITLE
feat: wrap sensitive types in order to zero the memory on drop (#1240)

### DIFF
--- a/evercrypt_backend/Cargo.toml
+++ b/evercrypt_backend/Cargo.toml
@@ -20,3 +20,4 @@ log = { version = "0.4", features = ["std"] }
 hpke-rs-crypto = { version = "0.1.1" }
 hpke-rs-evercrypt = { version = "0.1.2" }
 thiserror = "1.0"
+tls_codec = { workspace = true }

--- a/evercrypt_backend/src/provider.rs
+++ b/evercrypt_backend/src/provider.rs
@@ -120,7 +120,7 @@ impl OpenMlsCrypto for EvercryptProvider {
         hash_type: HashType,
         salt: &[u8],
         ikm: &[u8],
-    ) -> Result<SecreVLBytes, CryptoError> {
+    ) -> Result<SecretVLBytes, CryptoError> {
         let hmac = hmac_from_hash(hash_type);
         Ok(hkdf::extract(hmac, salt, ikm).into())
     }

--- a/evercrypt_backend/src/provider.rs
+++ b/evercrypt_backend/src/provider.rs
@@ -306,7 +306,7 @@ impl OpenMlsCrypto for EvercryptProvider {
         let exported_secret = context
             .export(exporter_context, exporter_length)
             .map_err(|_| CryptoError::ExporterError)?;
-        Ok((kem_output, exported_secret))
+        Ok((kem_output, exported_secret.into()))
     }
 
     fn hpke_setup_receiver_and_export(
@@ -324,7 +324,7 @@ impl OpenMlsCrypto for EvercryptProvider {
         let exported_secret = context
             .export(exporter_context, exporter_length)
             .map_err(|_| CryptoError::ExporterError)?;
-        Ok(exported_secret)
+        Ok(exported_secret.into())
     }
 
     fn derive_hpke_keypair(

--- a/evercrypt_backend/src/provider.rs
+++ b/evercrypt_backend/src/provider.rs
@@ -21,6 +21,7 @@ use openmls_traits::{
     },
 };
 use rand::{RngCore, SeedableRng};
+use tls_codec::SecretVLBytes;
 
 /// The Evercrypt crypto provider.
 #[derive(Debug)]
@@ -119,9 +120,9 @@ impl OpenMlsCrypto for EvercryptProvider {
         hash_type: HashType,
         salt: &[u8],
         ikm: &[u8],
-    ) -> Result<Vec<u8>, CryptoError> {
+    ) -> Result<SecreVLBytes, CryptoError> {
         let hmac = hmac_from_hash(hash_type);
-        Ok(hkdf::extract(hmac, salt, ikm))
+        Ok(hkdf::extract(hmac, salt, ikm).into())
     }
 
     /// Returns `HKDF::expand` with the given parameters or an error if the HKDF
@@ -132,9 +133,9 @@ impl OpenMlsCrypto for EvercryptProvider {
         prk: &[u8],
         info: &[u8],
         okm_len: usize,
-    ) -> Result<Vec<u8>, CryptoError> {
+    ) -> Result<SecretVLBytes, CryptoError> {
         let hmac = hmac_from_hash(hash_type);
-        Ok(hkdf::expand(hmac, prk, info, okm_len))
+        Ok(hkdf::expand(hmac, prk, info, okm_len).into())
     }
 
     /// Returns the hash of `data` or an error if the hash algorithm isn't supported.

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -27,7 +27,6 @@ openmls_evercrypt = { version = "0.1.0", path = "../evercrypt_backend", optional
 openmls_basic_credential = { version = "0.1.0", path = "../basic_credential", optional = true, features = ["clonable", "test-utils"] }
 rstest = { version = "^0.16", optional = true }
 rstest_reuse = { version = "0.4", optional = true }
-zeroize = { version = "1.0", features = ["zeroize_derive"] }
 
 [features]
 default = []

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -27,6 +27,7 @@ openmls_evercrypt = { version = "0.1.0", path = "../evercrypt_backend", optional
 openmls_basic_credential = { version = "0.1.0", path = "../basic_credential", optional = true }
 rstest = { version = "^0.16", optional = true }
 rstest_reuse = { version = "0.4", optional = true }
+zeroize = { version = "1.0", features = ["zeroize_derive"] }
 
 [features]
 default = []
@@ -52,6 +53,7 @@ hex = { version = "0.4", features = ["serde"] }
 itertools = "0.10"
 lazy_static = "1.4"
 openmls = { path = ".", features = ["test-utils"] }
+openmls_traits = { version = "0.1.0", path = "../traits", features = ["test-utils"] }
 pretty_env_logger = "0.4"
 rstest = "^0.16"
 rstest_reuse = "0.4"

--- a/openmls/src/ciphersuite/codec.rs
+++ b/openmls/src/ciphersuite/codec.rs
@@ -21,7 +21,7 @@ impl tls_codec::Deserialize for Secret {
     fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, ::tls_codec::Error> {
         let value = Vec::tls_deserialize(bytes)?;
         Ok(Secret {
-            value,
+            value: value.into(),
             mls_version: ProtocolVersion::default(),
             ciphersuite: Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
         })

--- a/openmls/src/ciphersuite/mac.rs
+++ b/openmls/src/ciphersuite/mac.rs
@@ -1,17 +1,44 @@
 use super::*;
 
+/// A wrapper to contain MAC values that will be zeroed on drop.
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsSerialize,
+    TlsSize,
+    zeroize::ZeroizeOnDrop,
+)]
+pub(crate) struct MacValue(Vec<u8>);
+
+impl From<Vec<u8>> for MacValue {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
+
+impl std::ops::Deref for MacValue {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
 /// 7.1 Content Authentication
 ///
 /// opaque MAC<V>;
 #[derive(Debug, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize)]
 pub(crate) struct Mac {
-    pub(crate) mac_value: VLBytes,
+    pub(crate) mac_value: MacValue,
 }
 
 impl PartialEq for Mac {
     // Constant time comparison.
     fn eq(&self, other: &Mac) -> bool {
-        equal_ct(self.mac_value.as_slice(), other.mac_value.as_slice())
+        equal_ct(&self.mac_value, &other.mac_value)
     }
 }
 
@@ -24,21 +51,27 @@ impl Mac {
         salt: &Secret,
         ikm: &[u8],
     ) -> Result<Self, CryptoError> {
-        Ok(Mac {
-            mac_value: salt
+        let value = std::mem::take(
+            &mut salt
                 .hkdf_extract(
                     backend,
                     &Secret::from_slice(ikm, salt.mls_version, salt.ciphersuite),
                 )?
-                .value
-                .into(),
+                .value,
+        );
+        Ok(Mac {
+            mac_value: value.into(),
         })
     }
 
     #[cfg(test)]
     pub(crate) fn flip_last_byte(&mut self) {
-        let mut last_bits = self.mac_value.pop().expect("An unexpected error occurred.");
+        let mut last_bits = self
+            .mac_value
+            .0
+            .pop()
+            .expect("An unexpected error occurred.");
         last_bits ^= 0xff;
-        self.mac_value.push(last_bits);
+        self.mac_value.0.push(last_bits);
     }
 }

--- a/openmls/src/ciphersuite/mac.rs
+++ b/openmls/src/ciphersuite/mac.rs
@@ -1,44 +1,17 @@
 use super::*;
 
-/// A wrapper to contain MAC values that will be zeroed on drop.
-#[derive(
-    Debug,
-    Clone,
-    Serialize,
-    Deserialize,
-    TlsDeserialize,
-    TlsSerialize,
-    TlsSize,
-    zeroize::ZeroizeOnDrop,
-)]
-pub(crate) struct MacValue(Vec<u8>);
-
-impl From<Vec<u8>> for MacValue {
-    fn from(value: Vec<u8>) -> Self {
-        Self(value)
-    }
-}
-
-impl std::ops::Deref for MacValue {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_slice()
-    }
-}
-
 /// 7.1 Content Authentication
 ///
 /// opaque MAC<V>;
 #[derive(Debug, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize)]
 pub(crate) struct Mac {
-    pub(crate) mac_value: MacValue,
+    pub(crate) mac_value: VLBytes,
 }
 
 impl PartialEq for Mac {
     // Constant time comparison.
     fn eq(&self, other: &Mac) -> bool {
-        equal_ct(&self.mac_value, &other.mac_value)
+        equal_ct(self.mac_value.as_slice(), other.mac_value.as_slice())
     }
 }
 
@@ -51,27 +24,22 @@ impl Mac {
         salt: &Secret,
         ikm: &[u8],
     ) -> Result<Self, CryptoError> {
-        let value = std::mem::take(
-            &mut salt
+        Ok(Mac {
+            mac_value: salt
                 .hkdf_extract(
                     backend,
                     &Secret::from_slice(ikm, salt.mls_version, salt.ciphersuite),
                 )?
-                .value,
-        );
-        Ok(Mac {
-            mac_value: value.into(),
+                .value
+                .as_slice()
+                .into(),
         })
     }
 
     #[cfg(test)]
     pub(crate) fn flip_last_byte(&mut self) {
-        let mut last_bits = self
-            .mac_value
-            .0
-            .pop()
-            .expect("An unexpected error occurred.");
+        let mut last_bits = self.mac_value.pop().expect("An unexpected error occurred.");
         last_bits ^= 0xff;
-        self.mac_value.0.push(last_bits);
+        self.mac_value.push(last_bits);
     }
 }

--- a/openmls/src/ciphersuite/mod.rs
+++ b/openmls/src/ciphersuite/mod.rs
@@ -35,7 +35,6 @@ pub(crate) use reuse_guard::*;
 pub(crate) use secret::*;
 pub(crate) use signature::*;
 
-use openmls_traits::key_store::{MlsEntity, MlsEntityId};
 pub(crate) use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
@@ -45,38 +44,7 @@ const LABEL_PREFIX: &str = "MLS 1.0 ";
 
 /// A simple type for HPKE public keys using [`VLBytes`] for (de)serializing.
 pub type HpkePublicKey = VLBytes;
-
-/// A simple type for HPKE private keys using [`VLBytes`] for (de)serializing.
-#[derive(
-    Debug, Clone, serde::Serialize, serde::Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
-)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
-#[serde(transparent)]
-pub struct HpkePrivateKey(VLBytes);
-
-impl From<VLBytes> for HpkePrivateKey {
-    fn from(bytes: VLBytes) -> Self {
-        Self(bytes)
-    }
-}
-
-impl From<Vec<u8>> for HpkePrivateKey {
-    fn from(bytes: Vec<u8>) -> Self {
-        Self(bytes.into())
-    }
-}
-
-impl std::ops::Deref for HpkePrivateKey {
-    type Target = VLBytes;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl MlsEntity for HpkePrivateKey {
-    const ID: MlsEntityId = MlsEntityId::HpkePrivateKey;
-}
+pub use openmls_traits::types::HpkePrivateKey;
 
 /// Compare two byte slices in a way that's hopefully not optimised out by the
 /// compiler.

--- a/openmls/src/ciphersuite/secret.rs
+++ b/openmls/src/ciphersuite/secret.rs
@@ -146,14 +146,11 @@ impl Secret {
         );
 
         Ok(Self {
-            value: backend
-                .crypto()
-                .hkdf_extract(
-                    self.ciphersuite.hash_algorithm(),
-                    self.value.as_slice(),
-                    ikm.value.as_slice(),
-                )?
-                .into(),
+            value: backend.crypto().hkdf_extract(
+                self.ciphersuite.hash_algorithm(),
+                self.value.as_slice(),
+                ikm.value.as_slice(),
+            )?,
             mls_version: self.mls_version,
             ciphersuite: self.ciphersuite,
         })
@@ -179,7 +176,7 @@ impl Secret {
             return Err(CryptoError::InvalidLength);
         }
         Ok(Self {
-            value: key.into(),
+            value: key,
             mls_version: self.mls_version,
             ciphersuite: self.ciphersuite,
         })

--- a/openmls/src/ciphersuite/secret.rs
+++ b/openmls/src/ciphersuite/secret.rs
@@ -8,10 +8,12 @@ use super::{kdf_label::KdfLabel, *};
 ///
 /// Note: This has a hand-written `Debug` implementation.
 ///       Please update as well when changing this struct.
-#[derive(Clone, Serialize, Deserialize, Eq)]
+#[derive(Clone, Serialize, Deserialize, Eq, zeroize::ZeroizeOnDrop)]
 pub(crate) struct Secret {
+    #[zeroize(skip)]
     pub(in crate::ciphersuite) ciphersuite: Ciphersuite,
     pub(in crate::ciphersuite) value: Vec<u8>,
+    #[zeroize(skip)]
     pub(in crate::ciphersuite) mls_version: ProtocolVersion,
 }
 

--- a/openmls/src/ciphersuite/secret.rs
+++ b/openmls/src/ciphersuite/secret.rs
@@ -175,7 +175,7 @@ impl Secret {
                 okm_len,
             )
             .map_err(|_| CryptoError::CryptoLibraryError)?;
-        if key.is_empty() {
+        if key.as_slice().is_empty() {
             return Err(CryptoError::InvalidLength);
         }
         Ok(Self {

--- a/openmls/src/group/core_group/kat_passive_client.rs
+++ b/openmls/src/group/core_group/kat_passive_client.rs
@@ -494,13 +494,8 @@ pub fn generate_test_vector(cipher_suite: Ciphersuite) -> PassiveClientWelcomeTe
             .unwrap(),
 
         signature_priv: passive.signature_keypair.private().to_vec(),
-        encryption_priv: passive
-            .encryption_keypair
-            .private_key()
-            .key()
-            .as_slice()
-            .to_vec(),
-        init_priv: passive.init_keypair.private,
+        encryption_priv: passive.encryption_keypair.private_key().key().to_vec(),
+        init_priv: passive.init_keypair.private.to_vec(),
 
         welcome: mls_message_welcome.tls_serialize_detached().unwrap(),
         ratchet_tree: None,

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -28,8 +28,7 @@ impl CoreGroup {
             let external_priv = epoch_secrets
                 .external_secret()
                 .derive_external_keypair(backend.crypto(), self.ciphersuite())
-                .private
-                .into();
+                .private;
             let init_secret = InitSecret::from_kem_output(
                 backend,
                 self.ciphersuite(),

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -87,7 +87,7 @@ fn test_welcome_context_mismatch(ciphersuite: Ciphersuite, backend: &impl OpenMl
     let egs = welcome.secrets[0].clone();
 
     let group_secrets_bytes = hpke::decrypt_with_label(
-        bob_private_key.as_slice(),
+        bob_private_key,
         "Welcome",
         welcome.encrypted_group_info(),
         egs.encrypted_group_secrets(),

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -330,7 +330,7 @@ impl InitSecret {
             .hpke_setup_receiver_and_export(
                 ciphersuite.hpke_config(),
                 kem_output,
-                external_priv.as_slice(),
+                external_priv,
                 &[],
                 hpke_info_from_version(version).as_bytes(),
                 ciphersuite.hash_length(),

--- a/openmls/src/test_utils/mod.rs
+++ b/openmls/src/test_utils/mod.rs
@@ -152,7 +152,7 @@ pub(crate) fn generate_group_candidate(
                     .unwrap();
 
                 HpkeKeyPair {
-                    private: private.as_slice().to_vec(),
+                    private,
                     public: key_package.hpke_init_key().as_slice().to_vec(),
                 }
             };

--- a/openmls/src/treesync/node/encryption_keys.rs
+++ b/openmls/src/treesync/node/encryption_keys.rs
@@ -113,7 +113,7 @@ impl EncryptionPrivateKey {
     ) -> Result<Secret, hpke::Error> {
         // ValSem203: Path secrets must decrypt correctly
         hpke::decrypt_with_label(
-            self.key.as_slice(),
+            &self.key,
             "UpdatePathNode",
             group_context,
             ciphertext,
@@ -221,7 +221,7 @@ pub mod test_utils {
         let keys = EncryptionKeyPair::read_from_key_store(backend, encryption_key).unwrap();
 
         HpkeKeyPair {
-            private: keys.private_key.key.as_slice().to_vec(),
+            private: keys.private_key.key,
             public: keys.public_key.key.as_slice().to_vec(),
         }
     }

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -26,6 +26,7 @@ use p256::{
 };
 use rand::{RngCore, SeedableRng};
 use sha2::{Digest, Sha256, Sha384, Sha512};
+use tls_codec::SecretVLBytes;
 
 #[derive(Debug)]
 pub struct RustCrypto {
@@ -93,7 +94,7 @@ impl OpenMlsCrypto for RustCrypto {
         hash_type: openmls_traits::types::HashType,
         salt: &[u8],
         ikm: &[u8],
-    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+    ) -> Result<SecretVLBytes, openmls_traits::types::CryptoError> {
         match hash_type {
             HashType::Sha2_256 => Ok(Hkdf::<Sha256>::extract(Some(salt), ikm).0.as_slice().into()),
             HashType::Sha2_384 => Ok(Hkdf::<Sha384>::extract(Some(salt), ikm).0.as_slice().into()),
@@ -107,7 +108,7 @@ impl OpenMlsCrypto for RustCrypto {
         prk: &[u8],
         info: &[u8],
         okm_len: usize,
-    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+    ) -> Result<SecretVLBytes, openmls_traits::types::CryptoError> {
         match hash_type {
             HashType::Sha2_256 => {
                 let hkdf = Hkdf::<Sha256>::from_prk(prk)
@@ -115,7 +116,7 @@ impl OpenMlsCrypto for RustCrypto {
                 let mut okm = vec![0u8; okm_len];
                 hkdf.expand(info, &mut okm)
                     .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
-                Ok(okm)
+                Ok(okm.into())
             }
             HashType::Sha2_512 => {
                 let hkdf = Hkdf::<Sha512>::from_prk(prk)
@@ -123,7 +124,7 @@ impl OpenMlsCrypto for RustCrypto {
                 let mut okm = vec![0u8; okm_len];
                 hkdf.expand(info, &mut okm)
                     .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
-                Ok(okm)
+                Ok(okm.into())
             }
             HashType::Sha2_384 => {
                 let hkdf = Hkdf::<Sha384>::from_prk(prk)
@@ -131,7 +132,7 @@ impl OpenMlsCrypto for RustCrypto {
                 let mut okm = vec![0u8; okm_len];
                 hkdf.expand(info, &mut okm)
                     .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
-                Ok(okm)
+                Ok(okm.into())
             }
         }
     }

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -19,4 +19,3 @@ test-utils = []
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 tls_codec = { workspace = true }
-zeroize = { version = "1.0", features = ["zeroize_derive"] }

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -12,6 +12,11 @@ readme = "README.md"
 [lib]
 path = "src/traits.rs"
 
+[features]
+default = []
+test-utils = []
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 tls_codec = { workspace = true }
+zeroize = { version = "1.0", features = ["zeroize_derive"] }

--- a/traits/src/crypto.rs
+++ b/traits/src/crypto.rs
@@ -2,6 +2,8 @@
 //!
 //! This trait defines all cryptographic functions used by OpenMLS.
 
+use tls_codec::SecretVLBytes;
+
 use crate::types::{
     AeadType, Ciphersuite, CryptoError, ExporterSecret, HashType, HpkeCiphertext, HpkeConfig,
     HpkeKeyPair, KemOutput, SignatureScheme,
@@ -24,7 +26,7 @@ pub trait OpenMlsCrypto {
         hash_type: HashType,
         salt: &[u8],
         ikm: &[u8],
-    ) -> Result<Vec<u8>, CryptoError>;
+    ) -> Result<SecretVLBytes, CryptoError>;
 
     /// HKDF expand.
     ///
@@ -36,7 +38,7 @@ pub trait OpenMlsCrypto {
         prk: &[u8],
         info: &[u8],
         okm_len: usize,
-    ) -> Result<Vec<u8>, CryptoError>;
+    ) -> Result<SecretVLBytes, CryptoError>;
 
     /// Hash the `data`.
     ///

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -5,7 +5,7 @@
 use std::{convert::TryFrom, ops::Deref};
 
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, VLBytes, SecretVLBytes};
+use tls_codec::{SecretVLBytes, TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
 
 use crate::key_store::{MlsEntity, MlsEntityId};
 

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -5,8 +5,7 @@
 use std::{convert::TryFrom, ops::Deref};
 
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
-use zeroize::ZeroizeOnDrop;
+use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, VLBytes, SecretVLBytes};
 
 use crate::key_store::{MlsEntity, MlsEntityId};
 
@@ -234,22 +233,15 @@ pub struct HpkeCiphertext {
 
 /// A simple type for HPKE private keys.
 #[derive(
-    Debug,
-    Clone,
-    serde::Serialize,
-    serde::Deserialize,
-    TlsSerialize,
-    TlsDeserialize,
-    TlsSize,
-    ZeroizeOnDrop,
+    Debug, Clone, serde::Serialize, serde::Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
 )]
 #[cfg_attr(feature = "test-utils", derive(PartialEq, Eq))]
 #[serde(transparent)]
-pub struct HpkePrivateKey(Vec<u8>);
+pub struct HpkePrivateKey(SecretVLBytes);
 
 impl From<Vec<u8>> for HpkePrivateKey {
     fn from(bytes: Vec<u8>) -> Self {
-        Self(bytes)
+        Self(bytes.into())
     }
 }
 
@@ -279,8 +271,8 @@ pub struct HpkeKeyPair {
 }
 
 pub type KemOutput = Vec<u8>;
-#[derive(Clone, Debug, ZeroizeOnDrop)]
-pub struct ExporterSecret(Vec<u8>);
+#[derive(Clone, Debug)]
+pub struct ExporterSecret(SecretVLBytes);
 
 impl Deref for ExporterSecret {
     type Target = [u8];
@@ -292,7 +284,7 @@ impl Deref for ExporterSecret {
 
 impl From<Vec<u8>> for ExporterSecret {
     fn from(secret: Vec<u8>) -> Self {
-        Self(secret)
+        Self(secret.into())
     }
 }
 


### PR DESCRIPTION
Closes #1240 

This wraps sensitve variables into new types that will implement `Zeroize` and will zero the memory on drop. Unfortunately we can't use the `VLBytes` in that case and I had to switch to the regular `Vec<u8>`.

I've moved the `HpkePrivateKey` struct to the `traits` crate and since for testing `PartialEq` and `Eq` are required I had to introduce the `test-utils` feature in it. 