### PR TITLE
interop/ci: Test interop between OpenMLS and MLS++.

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -95,10 +95,14 @@ jobs:
           ./mlspp/cmd/interop/mlspp_client -live 12345&
 
           cd mls-implementations/interop
-          for scenario in {welcome_join.json,external_join.json,commit.json,application.json};
+          # TODO(#1238):
+          # * Add `commit.json` as soon as group context extensions proposals are supported.
+          # Note: It's also possible to remove GCE proposals by hand from `commit.json`.
+          #       But let's not do this in CI for now and hope that it isn't needed anymore soon.
+          for scenario in {welcome_join.json,external_join.json,application.json};
           do
             echo Running configs/$scenario
-            errors=$(./test-runner/test-runner -fail-fast -client localhost:50051 -client localhost:12345 -config=configs/$scenario | grep error --count)
+            errors=$(./test-runner/test-runner -fail-fast -client localhost:50051 -client localhost:12345 -config=configs/$scenario | grep error | wc -l)
             if [ "$errors" = "0" ];
             then
               echo "Success";

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,0 +1,109 @@
+name: Test interop between OpenMLS & MLS++
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: OpenMLS | Checkout
+        uses: actions/checkout@v3
+
+      - name: OpenMLS | Install dependencies
+        run: sudo apt-get -y install protobuf-compiler
+
+      - name: OpenMLS | Build
+        run: cargo build -p interop_client
+
+      # ---------------------------------------------------------------------------------------
+
+      - name: MLS++ | Checkout
+        run: |
+          git clone https://github.com/cisco/mlspp.git
+          cd mlspp
+          git checkout 623acd0839d1117e8665b6bd52eecad1ce05438d
+
+      - name: MLS++ | Install dependencies | 1/2
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: "${{ github.workspace }}/vcpkg"
+          vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
+          vcpkgJsonGlob: "mlspp/vcpkg.json"
+          runVcpkgInstall: true
+
+      - name: MLS++ | Install dependencies | 2/2
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: "${{ github.workspace }}/vcpkg"
+          vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
+          vcpkgJsonGlob: "mlspp/cmd/interop/vcpkg.json"
+          runVcpkgInstall: true
+
+      - name: MLS++ | Build | 1/2
+        working-directory: mlspp
+        run: |
+          cmake . -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+          make
+
+      - name: MLS++ | Build | 2/2
+        working-directory: mlspp/cmd/interop
+        run: |
+          cmake . -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+          make
+
+      # ---------------------------------------------------------------------------------------
+
+      - name: test-runner | Checkout
+        run: |
+          git clone https://github.com/mlswg/mls-implementations.git
+          cd mls-implementations
+          git checkout f07090a844ebece12c064ce94ab853fd477db12f
+
+      - name: test-runner | Install dependencies
+        run: |
+          sudo apt-get -y install protoc-gen-go
+          echo $(go env GOPATH)/bin >> $GITHUB_PATH
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+      - name: test-runner | Build
+        run: |
+          # TODO(#1366)
+          cp interop_client/docker/test-runner/main.go.patch mls-implementations/interop/test-runner
+          cd mls-implementations/interop
+          go mod tidy -e
+          make run-go || echo "Build despite errors."
+          cd test-runner
+          # TODO(#1366)
+          patch main.go main.go.patch
+          go build
+
+      # ---------------------------------------------------------------------------------------
+
+      - name: Test interoperability
+        run: |
+          ./target/debug/interop_client&
+          ./mlspp/cmd/interop/mlspp_client -live 12345&
+
+          cd mls-implementations/interop
+          for scenario in {welcome_join.json,external_join.json,commit.json,application.json};
+          do
+            echo Running configs/$scenario
+            errors=$(./test-runner/test-runner -fail-fast -client localhost:50051 -client localhost:12345 -config=configs/$scenario | grep error --count)
+            if [ "$errors" = "0" ];
+            then
+              echo "Success";
+            else
+              echo "Failed";
+              exit 1;
+            fi
+          done


### PR DESCRIPTION
I do expect the new "interop" job to fail because we don't have support for group context extensions proposals for now. Also, the job will take quite long the first time it is run (~35 minutes). Afterwards, all VCPKG's should be cached and it will take roughly a few minutes.

Edit: I should add another commit that explicitly filters the errors due to group context extensions with a `TODO`. This way, CI will be green and @augustocdias could rebase #1361 and remove the `TODO` from this job.