### PR TITLE
fix: Regression on setting KeyPackage lifetimes

### DIFF
--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -72,10 +72,7 @@ use crate::{
         *,
     },
     tree::{secret_tree::SecretTreeError, sender_ratchet::SenderRatchetConfiguration},
-    treesync::{
-        node::{encryption_keys::EncryptionKeyPair, leaf_node::Lifetime},
-        *,
-    },
+    treesync::{node::encryption_keys::EncryptionKeyPair, *},
     versions::ProtocolVersion,
 };
 

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -29,8 +29,8 @@
 
 use super::*;
 use crate::{
-    group::config::CryptoConfig, tree::sender_ratchet::SenderRatchetConfiguration,
-    treesync::node::leaf_node::Lifetime,
+    group::config::CryptoConfig, key_packages::Lifetime,
+    tree::sender_ratchet::SenderRatchetConfiguration,
 };
 use serde::{Deserialize, Serialize};
 

--- a/openmls/src/group/public_group/builder.rs
+++ b/openmls/src/group/public_group/builder.rs
@@ -9,13 +9,11 @@ use crate::{
         RequiredCapabilitiesExtension,
     },
     group::{config::CryptoConfig, GroupContext, GroupId},
+    key_packages::Lifetime,
     messages::ConfirmationTag,
     schedule::CommitSecret,
     treesync::{
-        node::{
-            encryption_keys::EncryptionKeyPair,
-            leaf_node::{Capabilities, Lifetime},
-        },
+        node::{encryption_keys::EncryptionKeyPair, leaf_node::Capabilities},
         TreeSync,
     },
 };

--- a/openmls/src/key_packages/lifetime.rs
+++ b/openmls/src/key_packages/lifetime.rs
@@ -92,7 +92,7 @@ impl Default for Lifetime {
 mod tests {
     use tls_codec::{Deserialize, Serialize};
 
-    use crate::treesync::node::leaf_node::Lifetime;
+    use super::Lifetime;
 
     #[test]
     fn lifetime() {

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -41,7 +41,7 @@ use self::{
     diff::{StagedTreeSyncDiff, TreeSyncDiff},
     node::{
         leaf_node::{
-            Capabilities, LeafNodeSource, Lifetime, NewLeafNodeParams, TreeInfoTbs, TreePosition,
+            Capabilities, LeafNodeSource, NewLeafNodeParams, TreeInfoTbs, TreePosition,
             VerifiableLeafNode,
         },
         NodeIn,
@@ -66,6 +66,7 @@ use crate::{
     extensions::Extensions,
     framing::SenderError,
     group::{config::CryptoConfig, GroupId, Member},
+    key_packages::Lifetime,
     messages::{PathSecret, PathSecretError},
     schedule::CommitSecret,
 };

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -19,7 +19,7 @@ use crate::{
     error::LibraryError,
     extensions::{ExtensionType, Extensions},
     group::{config::CryptoConfig, GroupId},
-    key_packages::KeyPackage,
+    key_packages::{KeyPackage, Lifetime},
     treesync::errors::PublicTreeError,
     versions::ProtocolVersion,
 };
@@ -29,10 +29,8 @@ use crate::treesync::errors::LeafNodeValidationError;
 
 mod capabilities;
 mod codec;
-mod lifetime;
 
 pub use capabilities::*;
-pub use lifetime::Lifetime;
 
 /// Private module to ensure protection.
 mod private_mod {


### PR DESCRIPTION
Hi!

While testing we found an API regression: It is no longer possible to set a lifetime/expiration for a KeyPackage while it was possible in 0.4.x.

This PR moves the `lifetime.rs` file within the `key_package` module, exposing it publicly, and adds the proper methods on the builder to use it.