### PR TITLE
Bump tls codec version to 0.3.0-pre.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 
 # Patching unreleased crates
 [workspace.dependencies]
-tls_codec = { version = "0.3.0-pre.2", features = ["derive", "serde", "mls"] }
+tls_codec = { version = "0.3.0-pre.3", features = ["derive", "serde", "mls"] }
 
 [patch.crates-io.hpke-rs]
 git = "https://github.com/franziskuskiefer/hpke-rs.git"


### PR DESCRIPTION
This pre-release of `tls_codec` allows the use of `SecretVLBytes`, which implements `ZeroizeOnDrop`. This will be useful in the context of #1369.