### PR TITLE
More LeafNode validation

### DIFF
--- a/book/src/message_validation.md
+++ b/book/src/message_validation.md
@@ -55,17 +55,18 @@ The following is a list of the individual semantic validation steps performed by
 
 | ValidationStep | Description                                                                                 | Implemented | Tested | Test File                                             |
 | -------------- | ------------------------------------------------------------------------------------------- | ----------- | ------ | ----------------------------------------------------- |
-| `ValSem101`    | Add Proposal: Signature public key in proposals must be unique among proposals              | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem102`    | Add Proposal: HPKE init key in proposals must be unique among proposals                     | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem104`    | Add Proposal: Signature public key in proposals must be unique among existing group members | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem101`    | Add Proposal: Signature public key in proposals must be unique among proposals & members    | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem102`    | Add Proposal: Init key in proposals must be unique among proposals                          | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem103`    | Add Proposal: Encryption key in proposals must be unique among proposals & members          | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem104`    | Add Proposal: Init key and encryption key must be different                                 | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem105`    | Add Proposal: Ciphersuite & protocol version must match the group                           | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
 | `ValSem106`    | Add Proposal: required capabilities                                                         | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
 | `ValSem107`    | Remove Proposal: Removed member must be unique among proposals                              | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
 | `ValSem108`    | Remove Proposal: Removed member must be an existing group member                            | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem110`    | Update Proposal: HPKE init key must be unique among existing members                        | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem109`    | Update Proposal: required capabilities                                                      | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem110`    | Update Proposal: Encryption key must be unique among proposals & members                    | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
 | `ValSem111`    | Update Proposal: The sender of a full Commit must not include own update proposals          | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
 | `ValSem112`    | Update Proposal: The sender of a standalone update proposal must be of type member          | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem113`    | Add Proposal: Init key and encryption key must be different                                 | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem114`    | Add Proposal: Encryption key must be unique in the tree                                     | ✅          | ✅     | `openmls/src/group/tests/test_proposal_validation.rs` |
 
 ### Commit message validation
 
@@ -77,6 +78,8 @@ The following is a list of the individual semantic validation steps performed by
 | `ValSem203`    | Path secrets must decrypt correctly                                                    | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
 | `ValSem204`    | Public keys from Path must be verified and match the private keys from the direct path | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
 | `ValSem205`    | Confirmation tag must be successfully verified                                         | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
+| `ValSem206`    | Path leaf node encryption key must be unique among proposals & members                 | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
+| `ValSem207`    | Path encryption keys must be unique among proposals & members                          | ✅          | ✅     | `openmls/src/group/tests/test_commit_validation.rs` |
 
 ### External Commit message validation
 

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -436,6 +436,11 @@ impl CoreGroup {
             let required_capabilities = required_extension.as_required_capabilities_extension()?;
             // Ensure we support all the capabilities.
             required_capabilities.check_support()?;
+            // TODO #566/#1361: This needs to be re-enabled once we support GCEs
+            /* self.own_leaf_node()?
+            .capabilities()
+            .supports_required_capabilities(required_capabilities)?; */
+
             // Ensure that all other leaf nodes support all the required
             // extensions as well.
             self.public_group()

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -55,7 +55,7 @@ use super::{
 
 use crate::{
     binary_tree::array_representation::{LeafNodeIndex, TreeSize},
-    ciphersuite::{signable::Signable, HpkePublicKey, SignaturePublicKey},
+    ciphersuite::{signable::Signable, HpkePublicKey},
     credentials::*,
     error::LibraryError,
     framing::{mls_auth_content::AuthenticatedContent, *},
@@ -73,10 +73,7 @@ use crate::{
     },
     tree::{secret_tree::SecretTreeError, sender_ratchet::SenderRatchetConfiguration},
     treesync::{
-        node::{
-            encryption_keys::{EncryptionKey, EncryptionKeyPair},
-            leaf_node::Lifetime,
-        },
+        node::{encryption_keys::EncryptionKeyPair, leaf_node::Lifetime},
         *,
     },
     versions::ProtocolVersion,
@@ -332,9 +329,12 @@ impl CoreGroup {
         joiner_key_package: KeyPackage,
         signer: &impl Signer,
     ) -> Result<AuthenticatedContent, CreateAddProposalError> {
-        joiner_key_package
-            .leaf_node()
-            .validate_required_capabilities(self.required_capabilities())?;
+        if let Some(required_capabilities) = self.required_capabilities() {
+            joiner_key_package
+                .leaf_node()
+                .capabilities()
+                .supports_required_capabilities(required_capabilities)?;
+        }
         let add_proposal = AddProposal {
             key_package: joiner_key_package,
         };
@@ -436,8 +436,6 @@ impl CoreGroup {
             let required_capabilities = required_extension.as_required_capabilities_extension()?;
             // Ensure we support all the capabilities.
             required_capabilities.check_support()?;
-            self.own_leaf_node()?
-                .validate_required_capabilities(required_capabilities)?;
             // Ensure that all other leaf nodes support all the required
             // extensions as well.
             self.public_group()
@@ -845,9 +843,15 @@ impl CoreGroup {
 
         // ValSem101
         // ValSem102
+        // ValSem103
         // ValSem104
-        // ValSem106
+        self.public_group
+            .validate_key_uniqueness(&proposal_queue, None)?;
+        // ValSem105
         self.public_group.validate_add_proposals(&proposal_queue)?;
+        // ValSem106
+        // ValSem109
+        self.public_group.validate_capabilities(&proposal_queue)?;
         // ValSem107
         // ValSem108
         self.public_group
@@ -1074,58 +1078,6 @@ impl CoreGroup {
     #[cfg(test)]
     pub(crate) fn own_tree_position(&self) -> TreePosition {
         TreePosition::new(self.group_id().clone(), self.own_leaf_index())
-    }
-
-    /// Return supported credentials of all members.
-    // TODO(#1186)
-    #[allow(unused)]
-    pub(crate) fn members_supported_credentials(
-        &self,
-    ) -> impl Iterator<Item = &[CredentialType]> + '_ {
-        self.public_group().members().filter_map(|member| {
-            self.public_group()
-                .leaf(member.index)
-                .map(|leaf| leaf.capabilities().credentials())
-        })
-    }
-
-    /// Return currently used credentials of all members.
-    // TODO(#1186)
-    #[allow(unused)]
-    pub(crate) fn members_used_credentials(&self) -> impl Iterator<Item = CredentialType> + '_ {
-        self.public_group()
-            .members()
-            .map(|Member { credential, .. }| credential.credential_type())
-    }
-
-    /// Return currently used signature keys of all members.
-    // TODO(#1186)
-    #[allow(unused)]
-    pub(crate) fn signature_keys(
-        &self,
-        exclude_own: bool,
-    ) -> impl Iterator<Item = SignaturePublicKey> + '_ {
-        self.public_group()
-            .members()
-            .filter(move |member| {
-                if exclude_own {
-                    member.index != self.own_leaf_index
-                } else {
-                    true
-                }
-            })
-            .map(|Member { signature_key, .. }| SignaturePublicKey::from(signature_key))
-    }
-
-    /// Return currently used encryption keys of all members.
-    // TODO(#1186)
-    #[allow(unused)]
-    pub(crate) fn encryption_keys(&self) -> impl Iterator<Item = EncryptionKey> + '_ {
-        self.public_group()
-            .members()
-            .map(|Member { encryption_key, .. }| {
-                EncryptionKey::from(HpkePublicKey::new(encryption_key))
-            })
     }
 }
 

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -107,7 +107,8 @@ impl CoreGroup {
             key_package_bundle
                 .key_package()
                 .leaf_node()
-                .validate_required_capabilities(required_capabilities)?;
+                .capabilities()
+                .supports_required_capabilities(required_capabilities)?;
         }
 
         let path_secret_option = group_secrets.path_secret;

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -326,36 +326,18 @@ pub enum ProposalValidationError {
     /// The sender could not be matched to a member of the group.
     #[error("The sender could not be matched to a member of the group.")]
     UnknownMember,
-    /// Found two add proposals with the same identity.
-    #[error("Found two add proposals with the same identity.")]
-    DuplicateIdentityAddProposal,
-    /// Found two add proposals with the same signature key.
-    #[error("Found two add proposals with the same signature key.")]
-    DuplicateSignatureKeyAddProposal,
-    /// Found two add proposals with the same HPKE public key.
-    #[error("Found two add proposals with the same HPKE public key.")]
-    DuplicatePublicKeyAddProposal,
-    /// Identity of the add proposal already existed in tree.
-    #[error("Identity of the add proposal already existed in tree.")]
-    ExistingIdentityAddProposal,
-    /// Signature key of the add proposal already existed in tree.
-    #[error("Signature key of the add proposal already existed in tree.")]
-    ExistingSignatureKeyAddProposal,
-    /// HPKE public key (init or encryption) of the add proposal already existed in tree.
-    #[error("HPKE public key (init or encryption) of the add proposal already existed in tree.")]
-    ExistingPublicKeyAddProposal,
+    /// Duplicate signature key in proposals and group.
+    #[error("Duplicate signature key in proposals and group.")]
+    DuplicateSignatureKey,
+    /// Duplicate encryption key in proposals and group.
+    #[error("Duplicate encryption key in proposals and group.")]
+    DuplicateEncryptionKey,
+    /// Duplicate init key in proposals.
+    #[error("Duplicate init key in proposals.")]
+    DuplicateInitKey,
     /// The HPKE init and encryption keys are the same.
     #[error("The HPKE init and encryption keys are the same.")]
     InitEncryptionKeyCollision,
-    /// The identity of the update proposal did not match the existing identity.
-    #[error("The identity of the update proposal did not match the existing identity.")]
-    UpdateProposalIdentityMismatch,
-    /// Signature key of the update proposal already existed in tree.
-    #[error("Signature key of the update proposal already existed in tree.")]
-    ExistingSignatureKeyUpdateProposal,
-    /// HPKE public key of the update proposal already existed in tree.
-    #[error("HPKE public key of the update proposal already existed in tree.")]
-    ExistingPublicKeyUpdateProposal,
     /// Duplicate remove proposals for the same member.
     #[error("Duplicate remove proposals for the same member.")]
     DuplicateMemberRemoval,

--- a/openmls/src/group/public_group/staged_commit.rs
+++ b/openmls/src/group/public_group/staged_commit.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use super::{super::errors::*, *};
 use crate::{
     framing::{mls_auth_content::AuthenticatedContent, mls_content::FramedContentBody, Sender},
@@ -78,10 +76,14 @@ impl PublicGroup {
         // Validate the staged proposals by doing the following checks:
         // ValSem101
         // ValSem102
+        // ValSem103
         // ValSem104
+        self.validate_key_uniqueness(&proposal_queue, Some(commit))?;
         // ValSem105
-        // ValSem106
         self.validate_add_proposals(&proposal_queue)?;
+        // ValSem106
+        // ValSem109
+        self.validate_capabilities(&proposal_queue)?;
         // ValSem107
         // ValSem108
         self.validate_remove_proposals(&proposal_queue)?;
@@ -90,12 +92,12 @@ impl PublicGroup {
         // ValSem403
         self.validate_pre_shared_key_proposals(&proposal_queue)?;
 
-        let public_key_set = match sender {
+        match sender {
             Sender::Member(leaf_index) => {
                 // ValSem110
                 // ValSem111
                 // ValSem112
-                self.validate_update_proposals(&proposal_queue, *leaf_index)?
+                self.validate_update_proposals(&proposal_queue, *leaf_index)?;
             }
             Sender::External(_) => {
                 // A commit cannot be issued by a pre-configured sender.
@@ -112,10 +114,8 @@ impl PublicGroup {
                 // ValSem243: External Commit, inline Remove Proposal: The identity and the endpoint_id of the removed
                 //            leaf are identical to the ones in the path KeyPackage.
                 self.validate_external_commit(&proposal_queue, commit_update_leaf_node.as_ref())?;
-                // Since there are no update proposals in an External Commit we have no public keys to return
-                HashSet::new()
             }
-        };
+        }
 
         // Now we can actually look at the public keys as they might have changed.
         let sender_index = match sender {
@@ -134,12 +134,6 @@ impl PublicGroup {
                 return Err(StageCommitError::SenderTypeExternal);
             }
         };
-
-        // Validation in case of path
-        if let Some(path) = commit.path.clone() {
-            // Make sure that the new path key package is valid
-            self.validate_path_key_package(path.leaf_node(), public_key_set)?;
-        }
 
         Ok((commit, proposal_queue, sender_index))
     }

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -260,7 +260,7 @@ impl PublicGroup {
         // proposals This includes the following checks:
         // - Are ciphersuite & version listed in the `Capabilities` Extension?
         // - If a `RequiredCapabilitiesExtension` is present in the group: Is
-        //   this upported by the node?
+        //   this supported by the node?
         // - Check that all extensions are contained in the capabilities.
         // - Check that the capabilities contain the leaf node's credential
         //   type.

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -111,13 +111,13 @@ impl PublicGroup {
     // === Proposals ===
 
     /// Validate key uniqueness. This function implements the following checks:
-    ///  - ValSem101
-    ///  - ValSem102
-    ///  - ValSem103
-    ///  - ValSem104
-    ///  - ValSem110
-    ///  - ValSem206
-    ///  - ValSem207
+    ///  - ValSem101: Add Proposal: Signature public key in proposals must be unique among proposals & members
+    ///  - ValSem102: Add Proposal: Init key in proposals must be unique among proposals
+    ///  - ValSem103: Add Proposal: Encryption key in proposals must be unique among proposals & members
+    ///  - ValSem104: Add Proposal: Init key and encryption key must be different
+    ///  - ValSem110: Update Proposal: Encryption key must be unique among proposals & members
+    ///  - ValSem206: Commit: Path leaf node encryption key must be unique among proposals & members
+    ///  - ValSem207: Commit: Path encryption keys must be unique among proposals & members
     pub(crate) fn validate_key_uniqueness(
         &self,
         proposal_queue: &ProposalQueue,
@@ -250,8 +250,8 @@ impl PublicGroup {
     }
 
     /// Validate capablities. This function implements the following checks:
-    /// - ValSem106
-    /// - ValSem109
+    /// - ValSem106: Add Proposal: required capabilities
+    /// - ValSem109: Update Proposal: required capabilities
     pub(crate) fn validate_capabilities(
         &self,
         proposal_queue: &ProposalQueue,
@@ -335,7 +335,7 @@ impl PublicGroup {
     }
 
     /// Validate Add proposals. This function implements the following checks:
-    ///  - ValSem105
+    ///  - ValSem105: Add Proposal: Ciphersuite & protocol version must match the group
     pub(crate) fn validate_add_proposals(
         &self,
         proposal_queue: &ProposalQueue,
@@ -354,8 +354,8 @@ impl PublicGroup {
     }
 
     /// Validate Remove proposals. This function implements the following checks:
-    ///  - ValSem107
-    ///  - ValSem108
+    ///  - ValSem107: Remove Proposal: Removed member must be unique among proposals
+    ///  - ValSem108: Remove Proposal: Removed member must be an existing group member
     pub(crate) fn validate_remove_proposals(
         &self,
         proposal_queue: &ProposalQueue,
@@ -381,8 +381,8 @@ impl PublicGroup {
     }
 
     /// Validate Update proposals. This function implements the following checks:
-    ///  - ValSem111
-    ///  - ValSem112
+    ///  - ValSem111: Update Proposal: The sender of a full Commit must not include own update proposals
+    ///  - ValSem112: Update Proposal: The sender of a standalone update proposal must be of type member
     /// TODO: #133 This validation must be updated according to Sec. 13.2
     pub(crate) fn validate_update_proposals(
         &self,
@@ -412,9 +412,9 @@ impl PublicGroup {
     ///
     /// This method implements the following checks:
     ///
-    /// * ValSem401
-    /// * ValSem402
-    /// * ValSem403
+    /// * ValSem401: The nonce of a PreSharedKeyID must have length KDF.Nh.
+    /// * ValSem402: PSK in proposal must be of type Resumption (with usage Application) or External.
+    /// * ValSem403: Proposal list must not contain multiple PreSharedKey proposals that reference the same PreSharedKeyID.
     pub(crate) fn validate_pre_shared_key_proposals(
         &self,
         proposal_queue: &ProposalQueue,

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -19,7 +19,10 @@ use crate::{
         past_secrets::MessageSecretsStore,
         Member, ProposalQueue,
     },
-    messages::proposals::{Proposal, ProposalOrRefType, ProposalType},
+    messages::{
+        proposals::{Proposal, ProposalOrRefType, ProposalType},
+        Commit,
+    },
     schedule::errors::PskError,
     treesync::node::leaf_node::LeafNode,
 };
@@ -107,112 +110,31 @@ impl PublicGroup {
 
     // === Proposals ===
 
-    /// Validate Add proposals. This function implements the following checks:
+    /// Validate key uniqueness. This function implements the following checks:
     ///  - ValSem101
     ///  - ValSem102
+    ///  - ValSem103
     ///  - ValSem104
-    ///  - ValSem106
-    pub(crate) fn validate_add_proposals(
+    ///  - ValSem110
+    ///  - ValSem206
+    ///  - ValSem207
+    pub(crate) fn validate_key_uniqueness(
         &self,
         proposal_queue: &ProposalQueue,
+        commit: Option<&Commit>,
     ) -> Result<(), ProposalValidationError> {
-        let add_proposals = proposal_queue.add_proposals();
-
         let mut signature_key_set = HashSet::new();
         let mut init_key_set = HashSet::new();
         let mut encryption_key_set = HashSet::new();
-        for add_proposal in add_proposals {
-            let signature_key = add_proposal
-                .add_proposal()
-                .key_package()
-                .leaf_node()
-                .signature_key()
-                .as_slice()
-                .to_vec();
-            // ValSem101
-            if !signature_key_set.insert(signature_key) {
-                return Err(ProposalValidationError::DuplicateSignatureKeyAddProposal);
-            }
 
-            let proposal_init_key = add_proposal
-                .add_proposal()
-                .key_package()
-                .hpke_init_key()
-                .as_slice()
-                .to_vec();
-            let proposal_encryption_key = add_proposal
-                .add_proposal()
-                .key_package()
-                .leaf_node()
-                .encryption_key();
+        let remove_proposals = HashSet::<LeafNodeIndex>::from_iter(
+            proposal_queue
+                .remove_proposals()
+                .map(|remove_proposal| remove_proposal.remove_proposal().removed),
+        );
 
-            // ValSem113
-            if proposal_init_key == proposal_encryption_key.as_slice() {
-                return Err(ProposalValidationError::InitEncryptionKeyCollision);
-            }
-
-            // ValSem102
-            if !init_key_set.insert(proposal_init_key) {
-                return Err(ProposalValidationError::DuplicatePublicKeyAddProposal);
-            }
-
-            // ValSem114
-            // Here we check that the encryption keys in the proposal are unique.
-            // Further down we check that the encryption keys in the proposals
-            // are not in the tree yet.
-            if !encryption_key_set.insert(proposal_encryption_key.as_slice().to_vec()) {
-                return Err(ProposalValidationError::DuplicatePublicKeyAddProposal);
-            }
-
-            // ValSem106: Check the required capabilities of the add proposals
-            // This includes the following checks:
-            // - Do ciphersuite and version match that of the group?
-            // - Are the two listed in the `Capabilities` Extension?
-            // - If a `RequiredCapabilitiesExtension` is present in the group:
-            //   Does the key package advertise the capabilities required by that
-            //   extension?
-
-            // Check if ciphersuite and version of the group are correct.
-            if add_proposal.add_proposal().key_package().ciphersuite() != self.ciphersuite()
-                || add_proposal.add_proposal().key_package().protocol_version() != self.version()
-            {
-                log::error!("Tried to commit an Add proposal, where either the `Ciphersuite` or the `ProtocolVersion` is not compatible with the group.");
-                log::error!("   self.ciphersuite: {:?}", self.ciphersuite());
-                log::error!(
-                    "   add_proposal.add_proposal().key_package().ciphersuite(): {:?}",
-                    add_proposal.add_proposal().key_package().ciphersuite()
-                );
-                return Err(ProposalValidationError::InvalidAddProposalCiphersuiteOrVersion);
-            }
-
-            // Check if the ciphersuite and the version of the group are
-            // supported.
-            let capabilities = add_proposal
-                .add_proposal()
-                .key_package()
-                .leaf_node()
-                .capabilities();
-            if !capabilities
-                .ciphersuites()
-                .contains(&VerifiableCiphersuite::from(self.ciphersuite()))
-                || !capabilities.versions().contains(&self.version())
-            {
-                log::error!("Tried to commit an Add proposal, where either the group's `Ciphersuite` or the group's `ProtocolVersion` is not in the `KeyPackage`'s `Capabilities`.");
-                return Err(ProposalValidationError::InsufficientCapabilities);
-            }
-            // If there is a required capabilities extension, check if that one
-            // is supported.
-            if let Some(required_capabilities) =
-                self.group_context().extensions().required_capabilities()
-            {
-                // Check if all required capabilities are supported.
-                if !capabilities.supports_required_capabilities(required_capabilities) {
-                    log::error!("Tried to commit an Add proposal, where the `Capabilities` of the given `KeyPackage` do not fulfill the `RequiredCapabilities` of the group.");
-                    return Err(ProposalValidationError::InsufficientCapabilities);
-                }
-            }
-        }
-
+        // Initialize the sets with the current members, filtered by the
+        // remove proposals.
         for Member {
             index,
             encryption_key,
@@ -220,16 +142,212 @@ impl PublicGroup {
             ..
         } in self.treesync().full_leave_members()
         {
-            let has_remove_proposal = proposal_queue
-                .remove_proposals()
-                .any(|p| p.remove_proposal().removed == index);
-            // ValSem104
-            if signature_key_set.contains(&signature_key) && !has_remove_proposal {
-                return Err(ProposalValidationError::ExistingSignatureKeyAddProposal);
+            if !remove_proposals.contains(&index) {
+                signature_key_set.insert(signature_key);
+                encryption_key_set.insert(encryption_key);
             }
-            // ValSem114
-            if encryption_key_set.contains(&encryption_key) {
-                return Err(ProposalValidationError::ExistingPublicKeyAddProposal);
+        }
+
+        // Collect signature keys from add proposals
+        let signature_keys = proposal_queue.add_proposals().map(|add_proposal| {
+            add_proposal
+                .add_proposal()
+                .key_package()
+                .leaf_node()
+                .signature_key()
+                .as_slice()
+                .to_vec()
+        });
+
+        // Collect encryption keys from add proposals, update proposals, the
+        // commit leaf node and path keys
+        let encryption_keys = proposal_queue
+            .add_proposals()
+            .map(|add_proposal| {
+                add_proposal
+                    .add_proposal()
+                    .key_package()
+                    .leaf_node()
+                    .encryption_key()
+                    .key()
+                    .as_slice()
+                    .to_vec()
+            })
+            .chain(proposal_queue.update_proposals().map(|update_proposal| {
+                update_proposal
+                    .update_proposal()
+                    .leaf_node()
+                    .encryption_key()
+                    .key()
+                    .as_slice()
+                    .to_vec()
+            }))
+            .chain(commit.and_then(|commit| {
+                commit
+                    .path
+                    .as_ref()
+                    .map(|path| path.leaf_node().encryption_key().as_slice().to_vec())
+            }))
+            .chain(
+                commit
+                    .iter()
+                    .filter_map(|commit| {
+                        commit.path.as_ref().map(|path| {
+                            path.nodes()
+                                .iter()
+                                .map(|node| node.encryption_key().as_slice().to_vec())
+                        })
+                    })
+                    .flatten(),
+            );
+
+        // Collect init keys from add proposals
+        let init_keys = proposal_queue.add_proposals().map(|add_proposal| {
+            add_proposal
+                .add_proposal()
+                .key_package()
+                .hpke_init_key()
+                .as_slice()
+                .to_vec()
+        });
+
+        // Validate uniqueness of signature keys
+        //  - ValSem101
+        for signature_key in signature_keys {
+            if !signature_key_set.insert(signature_key) {
+                return Err(ProposalValidationError::DuplicateSignatureKey);
+            }
+        }
+
+        // Validate uniqueness of encryption keys
+        //  - ValSem103
+        //  - ValSem104
+        //  - ValSem110
+        //  - ValSem206
+        //  - ValSem207
+        for encryption_key in encryption_keys {
+            if init_key_set.contains(&encryption_key) {
+                return Err(ProposalValidationError::InitEncryptionKeyCollision);
+            }
+            if !encryption_key_set.insert(encryption_key) {
+                return Err(ProposalValidationError::DuplicateEncryptionKey);
+            }
+        }
+
+        // Validate uniqueness of init keys
+        //  - ValSem102
+        //  - ValSem104
+        for init_key in init_keys {
+            if encryption_key_set.contains(&init_key) {
+                return Err(ProposalValidationError::InitEncryptionKeyCollision);
+            }
+            if !init_key_set.insert(init_key) {
+                return Err(ProposalValidationError::DuplicateInitKey);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate capablities. This function implements the following checks:
+    /// - ValSem106
+    /// - ValSem109
+    pub(crate) fn validate_capabilities(
+        &self,
+        proposal_queue: &ProposalQueue,
+    ) -> Result<(), ProposalValidationError> {
+        // ValSem106/ValSem109: Check the required capabilities of the add & update
+        // proposals This includes the following checks:
+        // - Are ciphersuite & version listed in the `Capabilities` Extension?
+        // - If a `RequiredCapabilitiesExtension` is present in the group: Is
+        //   this upported by the node?
+        // - Check that all extensions are contained in the capabilities.
+        // - Check that the capabilities contain the leaf node's credential
+        //   type.
+        // - Check that the credential type is supported by all members of the
+        //   group.
+        // - Check that the capabilities field of this LeafNode indicates
+        //   support for all the credential types currently in use by other
+        //   members.
+
+        // Extract the leaf nodes from the add & update proposals
+        let leaf_nodes = proposal_queue
+            .queued_proposals()
+            .filter_map(|p| match p.proposal() {
+                Proposal::Add(add_proposal) => Some(add_proposal.key_package().leaf_node()),
+                Proposal::Update(update_proposal) => Some(update_proposal.leaf_node()),
+                _ => None,
+            });
+
+        let mut group_leaf_nodes = self.treesync().full_leaves();
+
+        for leaf_node in leaf_nodes {
+            // Check if the ciphersuite and the version of the group are
+            // supported.
+            let capabilities = leaf_node.capabilities();
+            if !capabilities
+                .ciphersuites()
+                .contains(&VerifiableCiphersuite::from(self.ciphersuite()))
+                || !capabilities.versions().contains(&self.version())
+            {
+                return Err(ProposalValidationError::InsufficientCapabilities);
+            }
+
+            // If there is a required capabilities extension, check if that one
+            // is supported.
+            if let Some(required_capabilities) =
+                self.group_context().extensions().required_capabilities()
+            {
+                // Check if all required capabilities are supported.
+                capabilities
+                    .supports_required_capabilities(required_capabilities)
+                    .map_err(|_| ProposalValidationError::InsufficientCapabilities)?;
+            }
+
+            // Check that all extensions are contained in the capabilities.
+            if !capabilities.contain_extensions(leaf_node.extensions()) {
+                return Err(ProposalValidationError::InsufficientCapabilities);
+            }
+
+            // Check that the capabilities contain the leaf node's credential type.
+            if !capabilities.contains_credential(&leaf_node.credential().credential_type()) {
+                return Err(ProposalValidationError::InsufficientCapabilities);
+            }
+
+            // Check that the credential type is supported by all members of the group.
+            if !group_leaf_nodes.all(|node| {
+                node.capabilities()
+                    .contains_credential(&leaf_node.credential().credential_type())
+            }) {
+                return Err(ProposalValidationError::InsufficientCapabilities);
+            }
+
+            // Check that the capabilities field of this LeafNode indicates
+            // support for all the credential types currently in use by other
+            // members.
+            if !group_leaf_nodes
+                .all(|node| capabilities.contains_credential(&node.credential().credential_type()))
+            {
+                return Err(ProposalValidationError::InsufficientCapabilities);
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate Add proposals. This function implements the following checks:
+    ///  - ValSem105
+    pub(crate) fn validate_add_proposals(
+        &self,
+        proposal_queue: &ProposalQueue,
+    ) -> Result<(), ProposalValidationError> {
+        let add_proposals = proposal_queue.add_proposals();
+
+        for add_proposal in add_proposals {
+            // ValSem105: Check if ciphersuite and version of the group are correct:
+            if add_proposal.add_proposal().key_package().ciphersuite() != self.ciphersuite()
+                || add_proposal.add_proposal().key_package().protocol_version() != self.version()
+            {
+                return Err(ProposalValidationError::InvalidAddProposalCiphersuiteOrVersion);
             }
         }
         Ok(())
@@ -253,7 +371,7 @@ impl PublicGroup {
                 return Err(ProposalValidationError::DuplicateMemberRemoval);
             }
 
-            // TODO: ValSem108
+            // ValSem108
             if !self.treesync().is_leaf_in_tree(removed) {
                 return Err(ProposalValidationError::UnknownMemberRemoval);
             }
@@ -263,8 +381,6 @@ impl PublicGroup {
     }
 
     /// Validate Update proposals. This function implements the following checks:
-    ///  -
-    ///  - ValSem110
     ///  - ValSem111
     ///  - ValSem112
     /// TODO: #133 This validation must be updated according to Sec. 13.2
@@ -272,14 +388,7 @@ impl PublicGroup {
         &self,
         proposal_queue: &ProposalQueue,
         committer: LeafNodeIndex,
-    ) -> Result<HashSet<Vec<u8>>, ProposalValidationError> {
-        let mut encryption_keys = HashSet::new();
-        for leaf in self.treesync().full_leaves() {
-            // 8.3. Leaf Node Validation
-            // encryption key must be unique
-            encryption_keys.insert(leaf.encryption_key().as_slice().to_vec());
-        }
-
+    ) -> Result<(), ProposalValidationError> {
         // Check the update proposals from the proposal queue first
         let update_proposals = proposal_queue.update_proposals();
 
@@ -295,19 +404,8 @@ impl PublicGroup {
             } else {
                 return Err(ProposalValidationError::UpdateFromNonMember);
             }
-
-            let encryption_key = update_proposal
-                .update_proposal()
-                .leaf_node()
-                .encryption_key()
-                .as_slice();
-            // ValSem110
-            // HPKE init key must be unique among existing members
-            if encryption_keys.contains(encryption_key) {
-                return Err(ProposalValidationError::ExistingPublicKeyUpdateProposal);
-            }
         }
-        Ok(encryption_keys)
+        Ok(())
     }
 
     /// Validate PreSharedKey proposals.
@@ -341,21 +439,6 @@ impl PublicGroup {
             }
         }
 
-        Ok(())
-    }
-
-    /// Validate the new key package in a path
-    /// TODO: #730 - There's nothing testing this function.
-    /// - ValSem110
-    pub(crate) fn validate_path_key_package(
-        &self,
-        leaf_node: &LeafNode,
-        public_key_set: HashSet<Vec<u8>>,
-    ) -> Result<(), ProposalValidationError> {
-        // ValSem110
-        if public_key_set.contains(leaf_node.encryption_key().as_slice()) {
-            return Err(ProposalValidationError::ExistingPublicKeyUpdateProposal);
-        }
         Ok(())
     }
 

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -231,7 +231,7 @@ enum KeyUniqueness {
 /// Add Proposal:
 /// Signature public key in proposals must be unique among proposals
 #[apply(ciphersuites_and_backends)]
-fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+fn test_valsem101a(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     for bob_and_charlie_share_keys in [
         KeyUniqueness::NegativeSameKey,
         KeyUniqueness::PositiveDifferentKey,
@@ -294,7 +294,7 @@ fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
                 assert_eq!(
                     err,
                     AddMembersError::CreateCommitError(CreateCommitError::ProposalValidationError(
-                        ProposalValidationError::DuplicateSignatureKeyAddProposal
+                        ProposalValidationError::DuplicateSignatureKey
                     ))
                 );
             }
@@ -380,7 +380,7 @@ fn test_valsem101(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     assert_eq!(
         err,
         ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
-            ProposalValidationError::DuplicateSignatureKeyAddProposal
+            ProposalValidationError::DuplicateSignatureKey
         ))
     );
 
@@ -450,7 +450,7 @@ fn test_valsem102(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
                 assert_eq!(
                     err,
                     AddMembersError::CreateCommitError(CreateCommitError::ProposalValidationError(
-                        ProposalValidationError::DuplicatePublicKeyAddProposal
+                        ProposalValidationError::DuplicateInitKey
                     ))
                 );
             }
@@ -527,12 +527,12 @@ fn test_valsem102(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // Have bob process the resulting plaintext
     let err = bob_group
         .process_message(backend, update_message_in)
-        .expect_err("Could process message despite modified public key in path.");
+        .expect_err("Could process message despite modified encryption key in path.");
 
     assert_eq!(
         err,
         ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
-            ProposalValidationError::DuplicatePublicKeyAddProposal
+            ProposalValidationError::DuplicateInitKey
         ))
     );
 
@@ -546,12 +546,12 @@ fn test_valsem102(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         .expect("Unexpected error.");
 }
 
-/// ValSem104:
+/// ValSem101:
 /// Add Proposal:
 /// Signature public key in proposals must be unique among existing group
 /// members
 #[apply(ciphersuites_and_backends)]
-fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+fn test_valsem101b(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     for alice_and_bob_share_keys in [
         KeyUniqueness::NegativeSameKey,
         KeyUniqueness::PositiveDifferentKey,
@@ -626,7 +626,7 @@ fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
                 assert_eq!(
                     err,
                     AddMembersError::CreateCommitError(CreateCommitError::ProposalValidationError(
-                        ProposalValidationError::ExistingSignatureKeyAddProposal
+                        ProposalValidationError::DuplicateSignatureKey
                     ))
                 );
             }
@@ -801,12 +801,12 @@ fn test_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     } */
 }
 
-/// ValSem113:
-/// Add Proposal: HPKE init key and encryption key must be different
-/// ValSem114:
+/// ValSem103:
 /// Add Proposal: Encryption key must be unique in the tree
+/// ValSem104:
+/// Add Proposal: Init key and encryption key must be different
 #[apply(ciphersuites_and_backends)]
-fn test_valsem113_valsem114(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+fn test_valsem103_valsem104(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     for alice_and_bob_share_keys in [
         KeyUniqueness::NegativeSameKey,
         KeyUniqueness::PositiveDifferentKey,
@@ -947,7 +947,7 @@ fn test_valsem113_valsem114(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryp
     assert_eq!(
         err,
         ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
-            ProposalValidationError::ExistingPublicKeyAddProposal
+            ProposalValidationError::DuplicateEncryptionKey
         ))
     );
 
@@ -980,17 +980,16 @@ enum ProposalInclusion {
     ByReference,
 }
 
-/// ValSem106:
+/// ValSem105:
 /// Add Proposal:
-/// Required capabilities
+/// Ciphersuite & protocol version must match the group
 #[apply(ciphersuites_and_backends)]
-fn test_valsem106(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
+fn test_valsem105(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     let _ = pretty_env_logger::try_init();
 
-    // Required capabilities validation includes two types of checks on the
-    // capabilities of the `KeyPackage` in the Add proposal: One against the
-    // ciphersuite and the version of the group and one against a potential
-    // RequiredCapabilities extension present in the group.
+    // Ciphersuite & protocol version validation includes checking the
+    // ciphersuite and the version of the KeyPackage in the add proposal to make
+    // sure they match the ones from the group.
 
     // Since RequiredCapabilities can only contain non-MTI extensions and
     // proposals and OpenMLS doesn't support any of those, we can't test
@@ -1580,7 +1579,7 @@ fn test_valsem108(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
 
 /// ValSem110
 /// Update Proposal:
-/// HPKE init key must be unique among existing members
+/// Encryption key must be unique among existing members
 #[apply(ciphersuites_and_backends)]
 fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     // Before we can test creation or reception of (invalid) proposals, we set
@@ -1654,7 +1653,7 @@ fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
         err,
         CommitToPendingProposalsError::CreateCommitError(
             CreateCommitError::ProposalValidationError(
-                ProposalValidationError::ExistingPublicKeyUpdateProposal
+                ProposalValidationError::DuplicateEncryptionKey
             )
         )
     );

--- a/openmls/src/treesync/node/encryption_keys.rs
+++ b/openmls/src/treesync/node/encryption_keys.rs
@@ -19,7 +19,7 @@ use crate::{
 /// [`EncryptionKey`] contains an HPKE public key that allows the encryption of
 /// path secrets in MLS commits.
 #[derive(
-    Debug, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize, PartialEq, Eq,
+    Debug, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize, PartialEq, Eq, Hash,
 )]
 pub struct EncryptionKey {
     key: HpkePublicKey,

--- a/openmls/src/treesync/node/leaf_node/capabilities.rs
+++ b/openmls/src/treesync/node/leaf_node/capabilities.rs
@@ -6,8 +6,9 @@ use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 use super::LeafNode;
 use crate::{
     credentials::CredentialType,
-    extensions::{ExtensionType, RequiredCapabilitiesExtension},
+    extensions::{Extension, ExtensionType, Extensions, RequiredCapabilitiesExtension},
     messages::proposals::ProposalType,
+    treesync::errors::LeafNodeValidationError,
     versions::ProtocolVersion,
 };
 
@@ -112,20 +113,24 @@ impl Capabilities {
 
     // ---------------------------------------------------------------------------------------------
 
-    /// Check if these [`Capabilities`] support all the capabilities
-    /// required by the given [`RequiredCapabilities`] extension. Returns
-    /// `true` if that is the case and `false` otherwise.
+    /// Check if these [`Capabilities`] support all the capabilities required by
+    /// the given [`RequiredCapabilitiesExtension`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`LeafNodeValidationError`] error if any of the required
+    /// capabilities is not supported.
     pub(crate) fn supports_required_capabilities(
         &self,
         required_capabilities: &RequiredCapabilitiesExtension,
-    ) -> bool {
+    ) -> Result<(), LeafNodeValidationError> {
         // Check if all required extensions are supported.
         if required_capabilities
             .extension_types()
             .iter()
             .any(|e| !self.extensions().contains(e))
         {
-            return false;
+            return Err(LeafNodeValidationError::UnsupportedExtensions);
         }
         // Check if all required proposals are supported.
         if required_capabilities
@@ -133,9 +138,30 @@ impl Capabilities {
             .iter()
             .any(|p| !self.proposals().contains(p))
         {
-            return false;
+            return Err(LeafNodeValidationError::UnsupportedProposals);
         }
-        true
+        // Check if all required credential types are supported.
+        if required_capabilities
+            .credential_types()
+            .iter()
+            .any(|c| !self.credentials().contains(c))
+        {
+            return Err(LeafNodeValidationError::UnsupportedCredentials);
+        }
+        Ok(())
+    }
+
+    /// Check if these [`Capabilities`] contain all the extension.
+    pub(crate) fn contain_extensions(&self, extension: &Extensions) -> bool {
+        extension
+            .iter()
+            .map(Extension::extension_type)
+            .all(|e| self.extensions().contains(&e))
+    }
+
+    /// Check if these [`Capabilities`] contain all the credentials.
+    pub(crate) fn contains_credential(&self, credential_type: &CredentialType) -> bool {
+        self.credentials().contains(credential_type)
     }
 }
 

--- a/openmls/src/treesync/node/leaf_node/capabilities.rs
+++ b/openmls/src/treesync/node/leaf_node/capabilities.rs
@@ -151,7 +151,7 @@ impl Capabilities {
         Ok(())
     }
 
-    /// Check if these [`Capabilities`] contain all the extension.
+    /// Check if these [`Capabilities`] contain all the extensions.
     pub(crate) fn contain_extensions(&self, extension: &Extensions) -> bool {
         extension
             .iter()

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -259,7 +259,6 @@ impl UpdatePathNode {
         self.public_key.key()
     }
 
-    #[cfg(test)]
     pub(crate) fn encryption_key(&self) -> &EncryptionKey {
         &self.public_key
     }


### PR DESCRIPTION
Fixes #1186.
Fixes #412.

This PR adds more leaf node validation. In particular, it unifies how duplicate keys are detected in one test. It also introduces capabilities checks and unifies overlapping validation code.
This PR however does not introduce comprehensive testing and instead defers to #1378, #1379, #580 and #581.