### PR TITLE
Add credential validation section to book

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Committing to pending proposals](user_manual/commit_to_proposals.md)
   - [Processing incoming messages](user_manual/processing.md)
   - [Persistence of group state](user_manual/persistence.md)
+  - [Credential validation](user_manual/credential_validation.md)
 - [Traits & External Types](./traits/README.md)
   - [Traits](./traits/traits.md)
   - [Types](./traits/types.md)

--- a/book/src/user_manual/credential_validation.md
+++ b/book/src/user_manual/credential_validation.md
@@ -1,0 +1,12 @@
+# Credential validation
+
+Credential validation is a process that allows a member to verify the validity
+of the credentials of other members in the group.  The process is described in
+detail in the [MLS protocol
+specification](https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-credential-validation).
+
+In practice, the application should check the validity of the credentials of
+other members in two instances:
+
+ - When joining a new group (by looking at the ratchet tree)
+ - When [processing messages](./processing.md) (by looking at a StagedCommit)

--- a/book/src/user_manual/credential_validation.md
+++ b/book/src/user_manual/credential_validation.md
@@ -9,4 +9,4 @@ In practice, the application should check the validity of the credentials of
 other members in two instances:
 
  - When joining a new group (by looking at the ratchet tree)
- - When [processing messages](./processing.md) (by looking at a StagedCommit)
+ - When [processing messages](./processing.md) (by looking at a add & update proposals of a StagedCommit)


### PR DESCRIPTION
Fixes #938.

Since OpenMLS doesn't handle credentials, this is not applicable directly. However, I added a section to the book.