### PR TITLE
Set documented default value of `out_of_order_tolerance` to value used in code

### DIFF
--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -24,7 +24,7 @@ pub(crate) type Generation = u32;
 /// This parameter defines a window for which decryption secrets are kept.
 /// This is useful in case the DS cannot guarantee that all application messages have total order within an epoch.
 /// Use this carefully, since keeping decryption secrets affects forward secrecy within an epoch.
-/// The default value is 0.
+/// The default value is 5.
 ///  - maximum_forward_distance:
 /// This parameter defines how many incoming messages can be skipped. This is useful if the DS
 /// drops application messages. The default value is 1000.


### PR DESCRIPTION
Currently the documented value for `out_of_order_tolerance` in `SenderRatchetConfiguration` is different from the actually used value:

https://github.com/comawill/openmls/blob/246c96b827099701cf4a2fef022e93c6f1c0afd2/openmls/src/tree/sender_ratchet.rs#L58

This PR updates the documented value to `5` to align with the used value.

Setting the value in the code to a value below 5 leads to CI tests failing.

With default setting `out_of_order_tolerance < 5` the following tests fail:

* tree::tests_and_kats::unit_tests::test_secret_tree::test_boundaries::case_1_rust_crypto_MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
* tree::tests_and_kats::unit_tests::test_secret_tree::test_boundaries::case_2_rust_crypto_MLS_128_DHKEMP256_AES128GCM_SHA256_P256
* tree::tests_and_kats::unit_tests::test_secret_tree::test_boundaries::case_3_rust_crypto_MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519

With default setting `out_of_order_tolerance = 0` the following tests fail:

* tree::tests_and_kats::unit_tests::test_secret_tree::test_boundaries::case_1_rust_crypto_MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
* tree::tests_and_kats::unit_tests::test_secret_tree::test_boundaries::case_2_rust_crypto_MLS_128_DHKEMP256_AES128GCM_SHA256_P256
* tree::tests_and_kats::unit_tests::test_secret_tree::test_boundaries::case_3_rust_crypto_MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
* tree::tests_and_kats::unit_tests::test_sender_ratchet::test_forward_secrecy::case_1_rust_crypto_MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
* tree::tests_and_kats::unit_tests::test_sender_ratchet::test_forward_secrecy::case_2_rust_crypto_MLS_128_DHKEMP256_AES128GCM_SHA256_P256
* tree::tests_and_kats::unit_tests::test_sender_ratchet::test_forward_secrecy::case_3_rust_crypto_MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
* tree::tests_and_kats::unit_tests::test_sender_ratchet::test_out_of_order_generations::case_1_rust_crypto_MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
* tree::tests_and_kats::unit_tests::test_sender_ratchet::test_out_of_order_generations::case_2_rust_crypto_MLS_128_DHKEMP256_AES128GCM_SHA256_P256
* tree::tests_and_kats::unit_tests::test_sender_ratchet::test_out_of_order_generations::case_3_rust_crypto_MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519