### PR TITLE
Fix serialization bug

### DIFF
--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -15,6 +15,7 @@ use crate::{
         AddProposal, PreSharedKeyProposal, Proposal, ProposalOrRef, ProposalOrRefType,
         ProposalType, RemoveProposal, UpdateProposal,
     },
+    utils::vector_converter,
 };
 
 /// A [ProposalStore] can store the standalone proposals that are received from the DS
@@ -177,6 +178,7 @@ pub(crate) struct ProposalQueue {
     proposal_references: Vec<ProposalRef>,
     /// `queued_proposals` contains the actual proposals in the queue. They are
     /// stored in a `HashMap` to allow for efficient access to the proposals.
+    #[serde(with = "vector_converter")]
     queued_proposals: HashMap<ProposalRef, QueuedProposal>,
 }
 

--- a/openmls/src/utils.rs
+++ b/openmls/src/utils.rs
@@ -53,3 +53,32 @@ macro_rules! log_content {
     (debug, $($arg:tt)*) => {{}};
     (trace, $($arg:tt)*) => {{}};
 }
+
+/// Helper mod that converts a objects that implement FromIterator<_,_> (like a
+/// HashMap or a BTreeMap) into a vector of tuples and vice versa.
+pub mod vector_converter {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::iter::FromIterator;
+
+    pub fn serialize<'a, T, K, V, S>(target: T, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: IntoIterator<Item = (&'a K, &'a V)>,
+        K: Serialize + 'a,
+        V: Serialize + 'a,
+    {
+        let container: Vec<_> = target.into_iter().collect();
+        serde::Serialize::serialize(&container, ser)
+    }
+
+    pub fn deserialize<'de, T, K, V, D>(des: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: FromIterator<(K, V)>,
+        K: Deserialize<'de>,
+        V: Deserialize<'de>,
+    {
+        let container: Vec<_> = serde::Deserialize::deserialize(des)?;
+        Ok(T::from_iter(container.into_iter()))
+    }
+}


### PR DESCRIPTION
Fixes #960.

`serde_json` can only deal with hash map keys that have a string representation. This converts hash maps to vectors of tuples instead.