### PR TITLE
MlsMessageOut API fix

### DIFF
--- a/openmls/src/framing/message_out.rs
+++ b/openmls/src/framing/message_out.rs
@@ -87,6 +87,17 @@ impl From<PublicMessage> for MlsMessageOut {
     }
 }
 
+impl From<PrivateMessage> for MlsMessageOut {
+    fn from(private_message: PrivateMessage) -> Self {
+        Self {
+            // TODO #34: The version should be set explicitly here instead of
+            // the default.
+            version: ProtocolVersion::default(),
+            body: MlsMessageOutBody::PrivateMessage(private_message),
+        }
+    }
+}
+
 impl From<GroupInfo> for MlsMessageOut {
     fn from(group_info: GroupInfo) -> Self {
         Self {
@@ -120,7 +131,7 @@ impl MlsMessageOut {
 
     /// Create an [`MlsMessageOut`] from a [`Welcome`] message and the currently
     /// used [`ProtocolVersion`].
-    pub(crate) fn from_welcome(welcome: Welcome, version: ProtocolVersion) -> Self {
+    pub fn from_welcome(welcome: Welcome, version: ProtocolVersion) -> Self {
         MlsMessageOut {
             version,
             body: MlsMessageOutBody::Welcome(welcome),


### PR DESCRIPTION
Some conversion functions were not publicly accessible, this PR fixes that.