### PR TITLE
fix keywords for crate.io

### DIFF
--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 documentation = "https://openmls.github.io/openmls/"
 repository = "https://github.com/openmls/openmls/"
 readme = "../README.md"
-keywords = ["MLS", "Messaging-Layer-Security", "IETF", "RFC9420", "Encryption"]
+keywords = ["MLS", "IETF", "RFC9420", "Encryption", "E2EE"]
 
 [dependencies]
 openmls_traits = { version = "0.2.0", path = "../traits" }

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 documentation = "https://openmls.github.io/openmls/"
 repository = "https://github.com/openmls/openmls/"
 readme = "../README.md"
-keywords = ["MLS", "Messaging Layer Security", "IETF", "RFC9420", "RFC 9420", "End-to-end encryption", "E2EE", "Encryption"]
+keywords = ["MLS", "Messaging-Layer-Security", "IETF", "RFC9420", "Encryption"]
 
 [dependencies]
 openmls_traits = { version = "0.2.0", path = "../traits" }


### PR DESCRIPTION
As per [documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-keywords-field):
> [crates.io](https://crates.io/) has a maximum of 5 keywords. Each keyword must be ASCII text, start with a letter, and only contain letters, numbers, _ or -, and have at most 20 characters.