### PR TITLE
upgrade rust crypto libraries

### DIFF
--- a/basic_credential/Cargo.toml
+++ b/basic_credential/Cargo.toml
@@ -15,9 +15,8 @@ tls_codec = { workspace = true }
 serde = "1.0"
 
 # Rust Crypto
-ed25519-dalek = { version = "1.0" }
+ed25519-dalek = { version = "2.0", features = ["rand_core"] }
 p256 = { version = "0.13" }
-rand-07 = {version = "0.7", package = "rand" } # only needed because of ed25519-dalek
 rand = "0.8"
 
 [features]

--- a/openmls/src/ciphersuite/tests/kat_crypto_basics.rs
+++ b/openmls/src/ciphersuite/tests/kat_crypto_basics.rs
@@ -280,21 +280,7 @@ pub fn run_test_vector(
         let mut parsed = ParsedSignWithLabel {
             key: SignatureKeyPair::from_raw(
                 ciphersuite.signature_algorithm(),
-                {
-                    if matches!(
-                        ciphersuite,
-                        Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-                            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-                            | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448
-                    ) {
-                        let mut private: Vec<u8> = private;
-                        // For the RC crypto provider we need to have the public key in here.
-                        private.append(&mut public.clone());
-                        private
-                    } else {
-                        private
-                    }
-                },
+                private,
                 public.clone(),
             ),
             content,

--- a/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
@@ -215,16 +215,7 @@ pub fn run_test_vector(
     let sender_index = LeafNodeIndex::new(1);
 
     // Set up the group, unfortunately we can't do without.
-    let signature_private_key = match ciphersuite {
-        Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-        | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 => {
-            let mut private = hex_to_bytes(&test.signature_priv);
-            private.append(&mut hex_to_bytes(&test.signature_pub));
-            private
-        }
-        Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => hex_to_bytes(&test.signature_priv),
-        _ => unimplemented!(),
-    };
+    let signature_private_key = hex_to_bytes(&test.signature_priv);
     let random_own_signature_key =
         SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
     let random_own_signature_key = random_own_signature_key.public();
@@ -253,18 +244,7 @@ pub fn run_test_vector(
         // Set up the group, unfortunately we can't do without.
         let credential =
             Credential::new(b"This is not needed".to_vec(), CredentialType::Basic).unwrap();
-        let signature_private_key = match ciphersuite {
-            Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 => {
-                let mut private = hex_to_bytes(&test.signature_priv);
-                private.append(&mut hex_to_bytes(&test.signature_pub));
-                private
-            }
-            Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => {
-                hex_to_bytes(&test.signature_priv)
-            }
-            _ => unimplemented!(),
-        };
+        let signature_private_key = hex_to_bytes(&test.signature_priv);
         let random_own_signature_key =
             SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
         let random_own_signature_key = random_own_signature_key.public();

--- a/openmls/src/treesync/tests_and_kats/kats/kat_treekem.rs
+++ b/openmls/src/treesync/tests_and_kats/kats/kat_treekem.rs
@@ -110,10 +110,7 @@ pub fn run_test_vector(test: TreeKemTest, provider: &impl OpenMlsProvider) {
                 .leaf(LeafNodeIndex::new(leaf_private_test.index))
                 .unwrap();
             let signature_key = own_leaf.signature_key();
-            let mut private_key = leaf_private_test.signature_priv.clone();
-            if ciphersuite != Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 {
-                private_key.append(&mut signature_key.as_slice().to_vec());
-            }
+            let private_key = leaf_private_test.signature_priv.clone();
             let signature_keypair = SignatureKeyPair::from_raw(
                 ciphersuite.signature_algorithm(),
                 private_key,

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -17,8 +17,7 @@ sha2 = { version = "0.10" }
 aes-gcm = { version = "0.9" }
 chacha20poly1305 = { version = "0.9" }
 hmac = { version = "0.12" }
-ed25519-dalek = { version = "1.0" }
-rand-07 = {version = "0.7", package = "rand" } # only needed because of ed25519-dalek
+ed25519-dalek = { version = "2.0" }
 p256 = { version = "0.13" }
 hkdf = { version = "0.12" }
 rand = "0.8"

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -14,15 +14,18 @@ openmls_traits = { version = "0.2.0", path = "../traits" }
 openmls_memory_keystore = { version = "0.2.0", path = "../memory_keystore" }
 # Rust Crypto dependencies
 sha2 = { version = "0.10" }
-aes-gcm = { version = "0.9" }
-chacha20poly1305 = { version = "0.9" }
+aes-gcm = { version = "0.10" }
+chacha20poly1305 = { version = "0.10" }
 hmac = { version = "0.12" }
 ed25519-dalek = { version = "2.0" }
 p256 = { version = "0.13" }
 hkdf = { version = "0.12" }
 rand = "0.8"
 rand_chacha = { version = "0.3" }
-hpke = { version = "0.1.1", package = "hpke-rs", default-features = false, features = ["hazmat", "serialization"] }
+hpke = { version = "0.1.1", package = "hpke-rs", default-features = false, features = [
+    "hazmat",
+    "serialization",
+] }
 hpke-rs-crypto = { version = "0.1.2" }
 hpke-rs-rust-crypto = { version = "0.1.2" }
 tls_codec = { workspace = true }

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -21,10 +21,7 @@ use openmls_traits::{
     },
 };
 use p256::{
-    ecdsa::{
-        signature::{Signer, Verifier},
-        Signature, SigningKey, VerifyingKey,
-    },
+    ecdsa::{signature::Verifier, Signature, SigningKey, VerifyingKey},
     EncodedPoint,
 };
 use rand::{RngCore, SeedableRng};
@@ -235,12 +232,13 @@ impl OpenMlsCrypto for RustCrypto {
                 Ok((k.to_bytes().as_slice().into(), pk))
             }
             SignatureScheme::ED25519 => {
-                // XXX: We can't use our RNG here
-                let k = ed25519_dalek::Keypair::generate(&mut rand_07::rngs::OsRng).to_bytes();
-                let pk = k[ed25519_dalek::SECRET_KEY_LENGTH..].to_vec();
-                // full key here because we need it to sign...
-                let sk_pk = k.into();
-                Ok((sk_pk, pk))
+                let mut rng = self
+                    .rng
+                    .write()
+                    .map_err(|_| CryptoError::InsufficientRandomness)?;
+                let sk = ed25519_dalek::SigningKey::generate(&mut *rng);
+                let pk = sk.verifying_key().to_bytes().into();
+                Ok((sk.to_bytes().into(), pk))
             }
             _ => Err(CryptoError::UnsupportedSignatureScheme),
         }
@@ -266,7 +264,7 @@ impl OpenMlsCrypto for RustCrypto {
                 .map_err(|_| CryptoError::InvalidSignature)
             }
             SignatureScheme::ED25519 => {
-                let k = ed25519_dalek::PublicKey::from_bytes(pk)
+                let k = ed25519_dalek::VerifyingKey::try_from(pk)
                     .map_err(|_| CryptoError::CryptoLibraryError)?;
                 if signature.len() != ed25519_dalek::SIGNATURE_LENGTH {
                     return Err(CryptoError::CryptoLibraryError);
@@ -294,7 +292,7 @@ impl OpenMlsCrypto for RustCrypto {
                 Ok(signature.to_der().to_bytes().into())
             }
             SignatureScheme::ED25519 => {
-                let k = ed25519_dalek::Keypair::from_bytes(key)
+                let k = ed25519_dalek::SigningKey::try_from(key)
                     .map_err(|_| CryptoError::CryptoLibraryError)?;
                 let signature = k.sign(data);
                 Ok(signature.to_bytes().into())

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -2,12 +2,10 @@ use std::sync::RwLock;
 
 use aes_gcm::{
     aead::{Aead, Payload},
-    Aes128Gcm, Aes256Gcm, NewAead,
+    Aes128Gcm, Aes256Gcm, KeyInit,
 };
 use chacha20poly1305::ChaCha20Poly1305;
-// See https://github.com/rust-analyzer/rust-analyzer/issues/7243
-// for the rust-analyzer issue with the following line.
-use ed25519_dalek::Signer as DalekSigner;
+use ed25519_dalek::Signer;
 use hkdf::Hkdf;
 use hpke::Hpke;
 use hpke_rs_crypto::types as hpke_types;


### PR DESCRIPTION
This PR updates the ed25519-dalek crate to version 2.0 in the rust crypto provider and basic credential crates. Due to the updated API of ed25519-dalek, we no longer need to encode the private key as a concatenation of public and private key.

This PR also updates the aes-gcm and the chacha20poly1305 crates to their newest versions.