### PR TITLE
New approach to verifiable structs

### DIFF
--- a/openmls/src/utils.rs
+++ b/openmls/src/utils.rs
@@ -1,3 +1,6 @@
+pub const VERIFIED: bool = true;
+pub const UNVERIFIED: bool = false;
+
 // === The folowing functions aren't necessarily cryptographically secure!
 
 #[cfg(any(feature = "test-utils", test))]


### PR DESCRIPTION
This PR showcases a proposal to implement verifiable structs in a new way. We currently implement verifiable structs by maintaining two structs that have exactly the same fields. This pattern is inherited by other structs that contain verifiable structs, thus resulting in a significant amount of duplicated code.

With `LeafNode` as an example, this PR proposes to implement a verifiable struct by using a single struct with a `boolean` const generic to indicate if a struct is verified or not. We can then have different impl blocks depending on the value of the bool, i.e. the verification status.

The downside is that we currently have to manually implement `tls_codec::Deserialize` for the unverified variant, as the derive macro derives it for both variants. This can be fixed, though, by either changing the `TlsDeserialize` derive macro to be aware of this pattern, or by implementing a dedicated derive macro (e.g. `TlsDeserializeVerifiable`). The best place to do either is probably the tls_codec crate.