### PR TITLE
Remove Send + Sync requirement for key store

### DIFF
--- a/traits/src/key_store.rs
+++ b/traits/src/key_store.rs
@@ -26,7 +26,7 @@ where
 }
 
 /// The Key Store trait
-pub trait OpenMlsKeyStore: Send + Sync {
+pub trait OpenMlsKeyStore {
     /// The error type returned by the [`OpenMlsKeyStore`].
     type Error: std::error::Error + std::fmt::Debug + PartialEq;
 


### PR DESCRIPTION
The requirement might have made sense at some point, but is an unnecessary restriction now.