### PR TITLE
Make backtrace crate an optional dependency.

### DIFF
--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -17,7 +17,7 @@ log = { version = "0.4", features = ["std"] }
 tls_codec = { workspace = true }
 rayon = "^1.5.0"
 thiserror = "^1.0"
-backtrace = "0.3"
+backtrace = { version = "0.3", optional = true }
 # Only required for tests.
 rand = { version = "0.8", optional = true }
 serde_json = { version = "1.0", optional = true }
@@ -29,7 +29,7 @@ rstest = { version = "^0.16", optional = true }
 rstest_reuse = { version = "0.4", optional = true }
 
 [features]
-default = []
+default = ["backtrace"]
 crypto-subtle = [] # Enable subtle crypto APIs that have to be used with care.
 test-utils = [
     "dep:serde_json",

--- a/openmls/src/error.rs
+++ b/openmls/src/error.rs
@@ -75,7 +75,10 @@ impl LibraryError {
     /// A custom error (typically to avoid an unwrap())
     pub(crate) fn custom(s: &'static str) -> Self {
         #[cfg(feature = "backtrace")]
-        let display_string = format!("Error description: {s}\n Backtrace:\n{:?}", backtrace::Backtrace::new());
+        let display_string = format!(
+            "Error description: {s}\n Backtrace:\n{:?}",
+            backtrace::Backtrace::new()
+        );
         #[cfg(not(feature = "backtrace"))]
         let display_string = format!("Error description: {s}");
 

--- a/openmls/src/error.rs
+++ b/openmls/src/error.rs
@@ -36,7 +36,6 @@
 //! All errors derive [`thiserror::Error`](https://docs.rs/thiserror/latest/thiserror/) as well as
 //! [`Debug`](`std::fmt::Debug`), [`PartialEq`](`std::cmp::PartialEq`), and [`Clone`](`std::clone::Clone`).
 
-use backtrace::Backtrace;
 use openmls_traits::types::CryptoError;
 use std::fmt::Display;
 use thiserror::Error;
@@ -75,8 +74,11 @@ pub struct LibraryError {
 impl LibraryError {
     /// A custom error (typically to avoid an unwrap())
     pub(crate) fn custom(s: &'static str) -> Self {
-        let bt = Backtrace::new();
-        let display_string = format!("Error description: {s}\n Backtrace:\n{bt:?}");
+        #[cfg(feature = "backtrace")]
+        let display_string = format!("Error description: {s}\n Backtrace:\n{:?}", backtrace::Backtrace::new());
+        #[cfg(not(feature = "backtrace"))]
+        let display_string = format!("Error description: {s}");
+
         Self {
             internal: InternalLibraryError::Custom(display_string),
         }


### PR DESCRIPTION
backtrace has > 10 dependencies (transitively) which might make it difficult for applications to import it, and consequently using openmls.