### PR TITLE
Relax Send + Sync from OpenMlsProvider

### DIFF
--- a/traits/src/traits.rs
+++ b/traits/src/traits.rs
@@ -13,7 +13,7 @@ pub mod types;
 ///
 /// An implementation of this trait must be passed in to the public OpenMLS API
 /// to perform randomness generation, cryptographic operations, and key storage.
-pub trait OpenMlsProvider: Send + Sync {
+pub trait OpenMlsProvider {
     type CryptoProvider: crypto::OpenMlsCrypto;
     type RandProvider: random::OpenMlsRand;
     type KeyStoreProvider: key_store::OpenMlsKeyStore;


### PR DESCRIPTION
Send + Sync was removed from `OpenMlsKeyStore` but not `OpenMlsProvider` in #1440. This PR brings the change over to OpenMlsProvider.

`OpenMlsCrypto` is still Send + Sync. Can change that in this PR too if that's desired

