### PR TITLE
Fix link to traits in openmls_rust_crypto README

### DIFF
--- a/openmls_rust_crypto/README.md
+++ b/openmls_rust_crypto/README.md
@@ -1,8 +1,8 @@
 # Rust Crypto Backend
 
-This crate implements the [OpenMLS traits](../traits/Readme.md) using the following rust crates: [hkdf], [sha2], [p256], [p384], [x25519-dalek-ng], [ed25519-dalek] [chacha20poly1305], [aes-gcm].
+This crate implements the [OpenMLS traits](../traits/README.md) using the following rust crates: [hkdf], [sha2], [p256], [p384], [x25519-dalek-ng], [ed25519-dalek] [chacha20poly1305], [aes-gcm].
 
-[hkdf]: https://docs.rs/hkdf/
+[hkdf]: https://docs.rs/hkdf
 [sha2]: https://docs.rs/sha2
 [p256]: https://docs.rs/p256
 [p384]: https://docs.rs/p384


### PR DESCRIPTION
Fixes the link to the openmls_traits crate's README. 