### PR TITLE
Derive DeserializeBytes alongside Deserialize

### DIFF
--- a/basic_credential/src/lib.rs
+++ b/basic_credential/src/lib.rs
@@ -15,13 +15,15 @@ use openmls_traits::{
 use p256::ecdsa::{signature::Signer as P256Signer, Signature, SigningKey};
 
 use rand::rngs::OsRng;
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 /// A signature key pair for the basic credential.
 ///
 /// This can be used as keys to implement the MLS basic credential. It is a simple
 /// private and public key pair with corresponding signature scheme.
-#[derive(TlsSerialize, TlsSize, TlsDeserialize, serde::Serialize, serde::Deserialize)]
+#[derive(
+    TlsSerialize, TlsSize, TlsDeserialize, TlsDeserializeBytes, serde::Serialize, serde::Deserialize,
+)]
 #[cfg_attr(feature = "clonable", derive(Clone))]
 pub struct SignatureKeyPair {
     private: Vec<u8>,

--- a/delivery-service/ds-lib/src/lib.rs
+++ b/delivery-service/ds-lib/src/lib.rs
@@ -9,8 +9,8 @@ use std::collections::HashSet;
 
 use openmls::prelude::*;
 use tls_codec::{
-    TlsByteSliceU16, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8, TlsDeserialize, TlsSerialize,
-    TlsSize, TlsVecU32,
+    TlsByteSliceU16, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8, TlsDeserialize,
+    TlsDeserializeBytes, TlsSerialize, TlsSize, TlsVecU32,
 };
 
 /// Information about a client.
@@ -38,6 +38,7 @@ pub struct ClientInfo {
     PartialEq,
     TlsSerialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSize,
     serde::Serialize,
     serde::Deserialize,

--- a/openmls/src/binary_tree/array_representation/treemath.rs
+++ b/openmls/src/binary_tree/array_representation/treemath.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 pub(crate) const MAX_TREE_SIZE: u32 = 1 << 30;
 pub(crate) const MIN_TREE_SIZE: u32 = 1;
@@ -19,6 +19,7 @@ pub(crate) const MIN_TREE_SIZE: u32 = 1;
     Serialize,
     Deserialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]

--- a/openmls/src/ciphersuite/codec.rs
+++ b/openmls/src/ciphersuite/codec.rs
@@ -36,7 +36,8 @@ impl DeserializeBytes for Secret {
     where
         Self: Sized,
     {
-        let secret = Secret::tls_deserialize(&mut bytes.as_ref())?;
+        let mut bytes_ref = bytes;
+        let secret = Secret::tls_deserialize(&mut bytes_ref)?;
         let remainder = &bytes[secret.tls_serialized_len()..];
         Ok((secret, remainder))
     }

--- a/openmls/src/ciphersuite/hash_ref.rs
+++ b/openmls/src/ciphersuite/hash_ref.rs
@@ -29,7 +29,8 @@
 use openmls_traits::{crypto::OpenMlsCrypto, types::CryptoError};
 use serde::{Deserialize, Serialize};
 use tls_codec::{
-    Serialize as TlsSerializeTrait, TlsDeserialize, TlsSerialize, TlsSize, VLByteSlice, VLBytes,
+    Serialize as TlsSerializeTrait, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+    VLByteSlice, VLBytes,
 };
 
 use super::Ciphersuite;
@@ -48,6 +49,7 @@ const PROPOSAL_REF_LABEL: &[u8; 26] = b"MLS 1.0 Proposal Reference";
     PartialOrd,
     Deserialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]

--- a/openmls/src/ciphersuite/hpke.rs
+++ b/openmls/src/ciphersuite/hpke.rs
@@ -39,7 +39,7 @@ use openmls_traits::{
     types::{Ciphersuite, CryptoError, HpkeCiphertext},
 };
 use thiserror::Error;
-use tls_codec::{Serialize, TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
+use tls_codec::{Serialize, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes};
 
 use super::LABEL_PREFIX;
 
@@ -68,7 +68,7 @@ impl From<CryptoError> for Error {
     }
 }
 
-#[derive(Debug, Clone, TlsSerialize, TlsDeserialize, TlsSize)]
+#[derive(Debug, Clone, TlsSerialize, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
 pub struct EncryptContext {
     label: VLBytes,
     context: VLBytes,

--- a/openmls/src/ciphersuite/mac.rs
+++ b/openmls/src/ciphersuite/mac.rs
@@ -3,7 +3,9 @@ use super::*;
 /// 7.1 Content Authentication
 ///
 /// opaque MAC<V>;
-#[derive(Debug, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+)]
 pub(crate) struct Mac {
     pub(crate) mac_value: VLBytes,
 }

--- a/openmls/src/ciphersuite/mod.rs
+++ b/openmls/src/ciphersuite/mod.rs
@@ -4,7 +4,7 @@
 //! See `codec.rs` and `ciphersuites.rs` for internals.
 
 use crate::versions::ProtocolVersion;
-use ::tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
+use ::tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes};
 use openmls_traits::{
     crypto::OpenMlsCrypto,
     random::OpenMlsRand,

--- a/openmls/src/ciphersuite/reuse_guard.rs
+++ b/openmls/src/ciphersuite/reuse_guard.rs
@@ -3,7 +3,7 @@ use super::*;
 /// Re-use guard size.
 pub(crate) const REUSE_GUARD_BYTES: usize = 4;
 
-#[derive(Debug, Clone, Copy, TlsSerialize, TlsDeserialize, TlsSize)]
+#[derive(Debug, Clone, Copy, TlsSerialize, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct ReuseGuard {
     pub(in crate::ciphersuite) value: [u8; REUSE_GUARD_BYTES],

--- a/openmls/src/ciphersuite/signature.rs
+++ b/openmls/src/ciphersuite/signature.rs
@@ -8,7 +8,16 @@ use super::{LABEL_PREFIX, *};
 
 /// Signature.
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct Signature {
     value: VLBytes,
@@ -30,7 +39,7 @@ impl From<Vec<u8>> for Signature {
 ///     opaque content<V> = Content;
 /// } SignContent;
 /// ```
-#[derive(Debug, Clone, TlsSerialize, TlsDeserialize, TlsSize)]
+#[derive(Debug, Clone, TlsSerialize, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
 pub struct SignContent {
     label: VLBytes,
     content: VLBytes,
@@ -53,7 +62,17 @@ impl From<(&str, &[u8])> for SignContent {
 
 /// A public signature key.
 #[derive(
-    Eq, PartialEq, Hash, Debug, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Eq,
+    PartialEq,
+    Hash,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct SignaturePublicKey {
     pub(in crate::ciphersuite) value: VLBytes,

--- a/openmls/src/credentials/codec.rs
+++ b/openmls/src/credentials/codec.rs
@@ -50,7 +50,8 @@ impl DeserializeBytes for Credential {
     where
         Self: Sized,
     {
-        let credential = Credential::tls_deserialize(&mut bytes.as_ref())?;
+        let mut bytes_ref = bytes;
+        let credential = Credential::tls_deserialize(&mut bytes_ref)?;
         let remainder = &bytes[credential.tls_serialized_len()..];
         Ok((credential, remainder))
     }

--- a/openmls/src/credentials/codec.rs
+++ b/openmls/src/credentials/codec.rs
@@ -1,8 +1,10 @@
 use std::io::Read;
 
+use tls_codec::{Deserialize, DeserializeBytes, Error, Serialize, Size};
+
 use super::*;
 
-impl tls_codec::Size for Credential {
+impl Size for Credential {
     #[inline]
     fn tls_serialized_len(&self) -> usize {
         self.credential_type.tls_serialized_len()
@@ -13,32 +15,43 @@ impl tls_codec::Size for Credential {
     }
 }
 
-impl tls_codec::Serialize for Credential {
-    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+impl Serialize for Credential {
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, Error> {
         match &self.credential {
             MlsCredentialType::Basic(basic_credential) => {
                 let written = CredentialType::Basic.tls_serialize(writer)?;
                 basic_credential.tls_serialize(writer).map(|l| l + written)
             }
             // TODO #134: implement encoding for X509 certificates
-            MlsCredentialType::X509(_) => Err(tls_codec::Error::EncodingError(
+            MlsCredentialType::X509(_) => Err(Error::EncodingError(
                 "X509 certificates are not yet implemented.".to_string(),
             )),
         }
     }
 }
 
-impl tls_codec::Deserialize for Credential {
-    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error> {
+impl Deserialize for Credential {
+    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
         let val = u16::tls_deserialize(bytes)?;
         let credential_type = CredentialType::from(val);
         match credential_type {
             CredentialType::Basic => Ok(Credential::from(MlsCredentialType::Basic(
                 BasicCredential::tls_deserialize(bytes)?,
             ))),
-            _ => Err(tls_codec::Error::DecodingError(format!(
+            _ => Err(Error::DecodingError(format!(
                 "{credential_type:?} can not be deserialized."
             ))),
         }
+    }
+}
+
+impl DeserializeBytes for Credential {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
+    where
+        Self: Sized,
+    {
+        let credential = Credential::tls_deserialize(&mut bytes.as_ref())?;
+        let remainder = &bytes[credential.tls_serialized_len()..];
+        Ok((credential, remainder))
     }
 }

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -114,7 +114,8 @@ impl DeserializeBytes for CredentialType {
     where
         Self: Sized,
     {
-        let credential_type = CredentialType::tls_deserialize(&mut bytes.as_ref())?;
+        let mut bytes_ref = bytes;
+        let credential_type = CredentialType::tls_deserialize(&mut bytes_ref)?;
         let remainder = &bytes[credential_type.tls_serialized_len()..];
         Ok((credential_type, remainder))
     }

--- a/openmls/src/extensions/application_id_extension.rs
+++ b/openmls/src/extensions/application_id_extension.rs
@@ -1,4 +1,4 @@
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes};
 
 use super::{Deserialize, Serialize};
 
@@ -8,7 +8,16 @@ use super::{Deserialize, Serialize};
 /// The application id extension allows applications to add an explicit,
 /// application-defined identifier to a KeyPackage.
 #[derive(
-    PartialEq, Eq, Clone, Debug, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    PartialEq,
+    Eq,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct ApplicationIdExtension {
     key_id: VLBytes,

--- a/openmls/src/extensions/codec.rs
+++ b/openmls/src/extensions/codec.rs
@@ -130,7 +130,8 @@ impl DeserializeBytes for Extension {
     where
         Self: Sized,
     {
-        let extension = Extension::tls_deserialize(&mut bytes.as_ref())?;
+        let mut bytes_ref = bytes;
+        let extension = Extension::tls_deserialize(&mut bytes_ref)?;
         let remainder = &bytes[extension.tls_serialized_len()..];
         Ok((extension, remainder))
     }

--- a/openmls/src/extensions/codec.rs
+++ b/openmls/src/extensions/codec.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use tls_codec::{Deserialize, Serialize, Size, VLBytes};
+use tls_codec::{Deserialize, DeserializeBytes, Serialize, Size, VLBytes};
 
 use crate::extensions::{
     ApplicationIdExtension, Extension, ExtensionType, ExternalPubExtension,
@@ -122,5 +122,16 @@ impl Deserialize for Extension {
                 Extension::Unknown(unknown, UnknownExtension(extension_data.to_vec()))
             }
         })
+    }
+}
+
+impl DeserializeBytes for Extension {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let extension = Extension::tls_deserialize(&mut bytes.as_ref())?;
+        let remainder = &bytes[extension.tls_serialized_len()..];
+        Ok((extension, remainder))
     }
 }

--- a/openmls/src/extensions/external_pub_extension.rs
+++ b/openmls/src/extensions/external_pub_extension.rs
@@ -1,4 +1,4 @@
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use super::{Deserialize, Serialize};
 use crate::ciphersuite::HpkePublicKey;
@@ -10,7 +10,16 @@ use crate::ciphersuite::HpkePublicKey;
 /// } ExternalPub;
 /// ```
 #[derive(
-    PartialEq, Eq, Clone, Debug, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    PartialEq,
+    Eq,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct ExternalPubExtension {
     external_pub: HpkePublicKey,

--- a/openmls/src/extensions/external_sender_extension.rs
+++ b/openmls/src/extensions/external_sender_extension.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use crate::{ciphersuite::SignaturePublicKey, credentials::Credential};
 
@@ -13,7 +13,16 @@ use crate::{ciphersuite::SignaturePublicKey, credentials::Credential};
 /// } ExternalSender;
 /// ```
 #[derive(
-    Clone, PartialEq, Eq, Debug, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Clone,
+    PartialEq,
+    Eq,
+    Debug,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct ExternalSender {
     signature_key: SignaturePublicKey,
@@ -47,7 +56,17 @@ impl ExternalSender {
 pub type ExternalSendersExtension = Vec<ExternalSender>;
 /// Identifies an external sender in the `ExternalSendersExtension`.
 #[derive(
-    Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Copy,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct SenderExtensionIndex(u32);
 

--- a/openmls/src/extensions/last_resort.rs
+++ b/openmls/src/extensions/last_resort.rs
@@ -1,4 +1,4 @@
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use super::{Deserialize, Serialize};
 
@@ -15,6 +15,7 @@ use super::{Deserialize, Serialize};
     Deserialize,
     TlsSerialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSize,
     Default,
 )]

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -124,7 +124,8 @@ impl DeserializeBytes for ExtensionType {
     where
         Self: Sized,
     {
-        let extension_type = ExtensionType::tls_deserialize(&mut bytes.as_ref())?;
+        let mut bytes_ref = bytes;
+        let extension_type = ExtensionType::tls_deserialize(&mut bytes_ref)?;
         let remainder = &bytes[extension_type.tls_serialized_len()..];
         Ok((extension_type, remainder))
     }
@@ -251,7 +252,8 @@ impl DeserializeBytes for Extensions {
     where
         Self: Sized,
     {
-        let extensions = Extensions::tls_deserialize(&mut bytes.as_ref())?;
+        let mut bytes_ref = bytes;
+        let extensions = Extensions::tls_deserialize(&mut bytes_ref)?;
         let remainder = &bytes[extensions.tls_serialized_len()..];
         Ok((extensions, remainder))
     }

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -48,6 +48,10 @@ pub use external_sender_extension::{
 pub use last_resort::LastResortExtension;
 pub use ratchet_tree_extension::RatchetTreeExtension;
 pub use required_capabilities::RequiredCapabilitiesExtension;
+use tls_codec::{
+    Deserialize as TlsDeserializeTrait, DeserializeBytes, Error, Serialize as TlsSerializeTrait,
+    Size, TlsSize,
+};
 
 #[cfg(test)]
 mod test_extensions;
@@ -97,14 +101,14 @@ pub enum ExtensionType {
     Unknown(u16),
 }
 
-impl tls_codec::Size for ExtensionType {
+impl Size for ExtensionType {
     fn tls_serialized_len(&self) -> usize {
         2
     }
 }
 
-impl tls_codec::Deserialize for ExtensionType {
-    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error>
+impl TlsDeserializeTrait for ExtensionType {
+    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error>
     where
         Self: Sized,
     {
@@ -115,8 +119,19 @@ impl tls_codec::Deserialize for ExtensionType {
     }
 }
 
-impl tls_codec::Serialize for ExtensionType {
-    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+impl DeserializeBytes for ExtensionType {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
+    where
+        Self: Sized,
+    {
+        let extension_type = ExtensionType::tls_deserialize(&mut bytes.as_ref())?;
+        let remainder = &bytes[extension_type.tls_serialized_len()..];
+        Ok((extension_type, remainder))
+    }
+}
+
+impl TlsSerializeTrait for ExtensionType {
+    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         writer.write_all(&u16::from(*self).to_be_bytes())?;
 
         Ok(2)
@@ -209,25 +224,37 @@ pub enum Extension {
 pub struct UnknownExtension(pub Vec<u8>);
 
 /// A list of extensions with unique extension types.
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, tls_codec::TlsSize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSize)]
 pub struct Extensions {
     unique: Vec<Extension>,
 }
 
-impl tls_codec::Serialize for Extensions {
-    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+impl TlsSerializeTrait for Extensions {
+    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         self.unique.tls_serialize(writer)
     }
 }
 
-impl tls_codec::Deserialize for Extensions {
-    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error>
+impl TlsDeserializeTrait for Extensions {
+    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error>
     where
         Self: Sized,
     {
         let candidate: Vec<Extension> = Vec::tls_deserialize(bytes)?;
         Extensions::try_from(candidate)
-            .map_err(|_| tls_codec::Error::DecodingError("Found duplicate extensions".into()))
+            .map_err(|_| Error::DecodingError("Found duplicate extensions".into()))
+    }
+}
+
+impl DeserializeBytes for Extensions {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
+    where
+        Self: Sized,
+    {
+        let (candidate, remainder) = Vec::<Extension>::tls_deserialize_bytes(bytes)?;
+        Extensions::try_from(candidate)
+            .map_err(|_| Error::DecodingError("Found duplicate extensions".into()))
+            .map(|ext| (ext, remainder))
     }
 }
 

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -251,10 +251,9 @@ impl DeserializeBytes for Extensions {
     where
         Self: Sized,
     {
-        let (candidate, remainder) = Vec::<Extension>::tls_deserialize_bytes(bytes)?;
-        Extensions::try_from(candidate)
-            .map_err(|_| Error::DecodingError("Found duplicate extensions".into()))
-            .map(|ext| (ext, remainder))
+        let extensions = Extensions::tls_deserialize(&mut bytes.as_ref())?;
+        let remainder = &bytes[extensions.tls_serialized_len()..];
+        Ok((extensions, remainder))
     }
 }
 

--- a/openmls/src/extensions/ratchet_tree_extension.rs
+++ b/openmls/src/extensions/ratchet_tree_extension.rs
@@ -1,4 +1,4 @@
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use super::{Deserialize, Serialize};
 use crate::treesync::{RatchetTree, RatchetTreeIn};
@@ -13,7 +13,16 @@ use crate::treesync::{RatchetTree, RatchetTreeIn};
 /// optional<Node> ratchet_tree<V>;
 /// ```
 #[derive(
-    PartialEq, Eq, Clone, Debug, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    PartialEq,
+    Eq,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct RatchetTreeExtension {
     ratchet_tree: RatchetTreeIn,

--- a/openmls/src/extensions/required_capabilities.rs
+++ b/openmls/src/extensions/required_capabilities.rs
@@ -1,4 +1,4 @@
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use crate::{credentials::CredentialType, messages::proposals::ProposalType};
 
@@ -37,6 +37,7 @@ use super::{Deserialize, ExtensionError, ExtensionType, Serialize};
     Deserialize,
     TlsSerialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSize,
 )]
 pub struct RequiredCapabilitiesExtension {

--- a/openmls/src/framing/message_in.rs
+++ b/openmls/src/framing/message_in.rs
@@ -68,7 +68,7 @@ pub struct MlsMessageIn {
 ///     }
 /// } MLSMessage;
 /// ```
-#[derive(Debug, PartialEq, Clone, TlsDeserialize, TlsSize)]
+#[derive(Debug, PartialEq, Clone, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
 #[cfg_attr(feature = "test-utils", derive(TlsSerialize))]
 #[repr(u16)]
 pub enum MlsMessageInBody {

--- a/openmls/src/framing/mls_content_in.rs
+++ b/openmls/src/framing/mls_content_in.rs
@@ -22,7 +22,7 @@ use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite};
 use serde::{Deserialize, Serialize};
 use tls_codec::{
     Deserialize as TlsDeserializeTrait, Serialize as TlsSerializeTrait, Size, TlsDeserialize,
-    TlsSerialize, TlsSize, VLBytes,
+    TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes,
 };
 
 /// ```c
@@ -37,7 +37,15 @@ use tls_codec::{
 /// } FramedContent;
 /// ```
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub(crate) struct FramedContentIn {
     pub(super) group_id: GroupId,
@@ -91,7 +99,15 @@ impl From<AuthenticatedContentIn> for FramedContentIn {
 /// } FramedContent;
 /// ```
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 #[repr(u8)]
 pub(crate) enum FramedContentBodyIn {

--- a/openmls/src/framing/mod.rs
+++ b/openmls/src/framing/mod.rs
@@ -109,7 +109,17 @@ pub(crate) mod test_framing;
 /// | 0x0005          | mls_key_package          | Y           | RFC XXXX  |
 /// | 0xf000 - 0xffff | Reserved for Private Use | N/A         | RFC XXXX  |
 #[derive(
-    PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Debug,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 #[repr(u16)]
 pub enum WireFormat {
@@ -160,7 +170,17 @@ impl<'a> FramingParameters<'a> {
 /// } ContentType;
 /// ```
 #[derive(
-    PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Debug,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 #[repr(u8)]
 pub enum ContentType {

--- a/openmls/src/framing/private_message_in.rs
+++ b/openmls/src/framing/private_message_in.rs
@@ -1,6 +1,8 @@
 use openmls_traits::crypto::OpenMlsCrypto;
 use openmls_traits::types::Ciphersuite;
-use tls_codec::{Deserialize, Serialize, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{
+    Deserialize, Serialize, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+};
 
 use super::{
     codec::deserialize_ciphertext_content, mls_auth_content::FramedContentAuthData,
@@ -31,7 +33,9 @@ use super::*;
 ///     opaque ciphertext<V>;
 /// } PrivateMessage;
 /// ```
-#[derive(Debug, PartialEq, Eq, Clone, TlsSerialize, TlsSize, TlsDeserialize)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, TlsSerialize, TlsSize, TlsDeserialize, TlsDeserializeBytes,
+)]
 pub struct PrivateMessageIn {
     group_id: GroupId,
     epoch: GroupEpoch,

--- a/openmls/src/framing/public_message.rs
+++ b/openmls/src/framing/public_message.rs
@@ -6,7 +6,9 @@
 use std::io::Write;
 
 use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite};
-use tls_codec::{Serialize as TlsSerializeTrait, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{
+    Serialize as TlsSerializeTrait, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+};
 
 use super::{
     mls_auth_content::{AuthenticatedContent, FramedContentAuthData},
@@ -17,7 +19,15 @@ use crate::{error::LibraryError, versions::ProtocolVersion};
 
 /// Wrapper around a `Mac` used for type safety.
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub(crate) struct MembershipTag(pub(crate) Mac);
 

--- a/openmls/src/framing/public_message_in.rs
+++ b/openmls/src/framing/public_message_in.rs
@@ -236,7 +236,8 @@ impl DeserializeBytes for PublicMessageIn {
     where
         Self: Sized,
     {
-        let message = PublicMessageIn::tls_deserialize(&mut bytes.as_ref())?;
+        let mut bytes_ref = bytes;
+        let message = PublicMessageIn::tls_deserialize(&mut bytes_ref)?;
         let remainder = &bytes[message.tls_serialized_len()..];
         Ok((message, remainder))
     }

--- a/openmls/src/framing/public_message_in.rs
+++ b/openmls/src/framing/public_message_in.rs
@@ -218,7 +218,7 @@ impl<'a> TryFrom<&'a PublicMessageIn> for InterimTranscriptHashInput<'a> {
 }
 
 impl TlsDeserializeTrait for PublicMessageIn {
-    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error> {
+    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
         let content = FramedContentIn::tls_deserialize(bytes)?;
         let auth = FramedContentAuthData::deserialize(bytes, content.body.content_type())?;
         let membership_tag = if content.sender.is_member() {
@@ -228,6 +228,17 @@ impl TlsDeserializeTrait for PublicMessageIn {
         };
 
         Ok(PublicMessageIn::new(content, auth, membership_tag))
+    }
+}
+
+impl DeserializeBytes for PublicMessageIn {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
+    where
+        Self: Sized,
+    {
+        let message = PublicMessageIn::tls_deserialize(&mut bytes.as_ref())?;
+        let remainder = &bytes[message.tls_serialized_len()..];
+        Ok((message, remainder))
     }
 }
 

--- a/openmls/src/framing/sender.rs
+++ b/openmls/src/framing/sender.rs
@@ -3,7 +3,7 @@
 use crate::{binary_tree::array_representation::LeafNodeIndex, extensions::SenderExtensionIndex};
 
 use super::*;
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 /// All possible sender types according to the MLS protocol spec.
 ///
@@ -33,7 +33,16 @@ use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 /// } Sender;
 /// ```
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 #[repr(u8)]
 pub enum Sender {
@@ -77,7 +86,7 @@ impl Sender {
     }
 }
 
-#[derive(Clone, TlsDeserialize, TlsSerialize, TlsSize)]
+#[derive(Clone, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize)]
 #[cfg_attr(test, derive(Debug))]
 pub(crate) struct MlsSenderData {
     pub(crate) leaf_index: LeafNodeIndex,
@@ -100,7 +109,7 @@ impl MlsSenderData {
     }
 }
 
-#[derive(Clone, TlsDeserialize, TlsSerialize, TlsSize)]
+#[derive(Clone, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize)]
 pub(crate) struct MlsSenderDataAad {
     pub(crate) group_id: GroupId,
     pub(crate) epoch: GroupEpoch,

--- a/openmls/src/group/group_context.rs
+++ b/openmls/src/group/group_context.rs
@@ -29,7 +29,16 @@ use crate::{
 /// state agreed upon by each member of the group.
 ///```
 #[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct GroupContext {
     protocol_version: ProtocolVersion,

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -54,6 +54,7 @@ use openmls_traits::random::OpenMlsRand;
     Deserialize,
     Serialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]
@@ -105,6 +106,7 @@ impl GroupId {
     Deserialize,
     Serialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]

--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -10,7 +10,9 @@ use crate::{
 };
 use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite};
 use serde::{Deserialize, Serialize};
-use tls_codec::{Serialize as TlsSerializeTrait, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{
+    Serialize as TlsSerializeTrait, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+};
 
 use super::{
     errors::KeyPackageVerifyError, KeyPackage, KeyPackageTbs, SIGNATURE_KEY_PACKAGE_LABEL,
@@ -70,7 +72,15 @@ mod private_mod {
 /// } KeyPackageTBS;
 /// ```
 #[derive(
-    Debug, Clone, PartialEq, TlsSize, TlsSerialize, TlsDeserialize, Serialize, Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    TlsSize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    Serialize,
+    Deserialize,
 )]
 struct KeyPackageTbsIn {
     protocol_version: ProtocolVersion,
@@ -82,7 +92,15 @@ struct KeyPackageTbsIn {
 
 /// The key package struct.
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct KeyPackageIn {
     payload: KeyPackageTbsIn,

--- a/openmls/src/key_packages/lifetime.rs
+++ b/openmls/src/key_packages/lifetime.rs
@@ -1,7 +1,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 /// This value is used as the default lifetime if no default  lifetime is configured.
 /// The value is in seconds and amounts to 3 * 28 Days, i.e. about 3 months.
@@ -35,7 +35,17 @@ const MAX_LEAF_NODE_LIFETIME_RANGE_SECONDS: u64 =
 /// } Lifetime;
 /// ```
 #[derive(
-    PartialEq, Eq, Copy, Clone, Debug, TlsSerialize, TlsSize, TlsDeserialize, Serialize, Deserialize,
+    PartialEq,
+    Eq,
+    Copy,
+    Clone,
+    Debug,
+    TlsSerialize,
+    TlsSize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    Serialize,
+    Deserialize,
 )]
 pub struct Lifetime {
     not_before: u64,

--- a/openmls/src/messages/group_info.rs
+++ b/openmls/src/messages/group_info.rs
@@ -4,7 +4,9 @@ use openmls_traits::crypto::OpenMlsCrypto;
 use openmls_traits::types::Ciphersuite;
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 use thiserror::Error;
-use tls_codec::{Deserialize, Serialize, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{
+    Deserialize, Serialize, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+};
 
 use crate::{
     binary_tree::LeafNodeIndex,
@@ -24,7 +26,7 @@ const SIGNATURE_GROUP_INFO_LABEL: &str = "GroupInfoTBS";
 /// `verify(...)` with the signature key of the [`Credential`](crate::credentials::Credential).
 /// When receiving a serialized group info, it can only be deserialized into a
 /// [`VerifiableGroupInfo`], which can then be turned into a group info as described above.
-#[derive(Debug, PartialEq, Clone, TlsDeserialize, TlsSize)]
+#[derive(Debug, PartialEq, Clone, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(TlsSerialize))]
 pub struct VerifiableGroupInfo {
     payload: GroupInfoTBS,
@@ -208,7 +210,15 @@ impl From<GroupInfo> for GroupContext {
 /// } GroupInfoTBS;
 /// ```
 #[derive(
-    Debug, PartialEq, Clone, TlsDeserialize, TlsSerialize, TlsSize, SerdeSerialize, SerdeDeserialize,
+    Debug,
+    PartialEq,
+    Clone,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
+    SerdeSerialize,
+    SerdeDeserialize,
 )]
 pub(crate) struct GroupInfoTBS {
     group_context: GroupContext,

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -56,7 +56,9 @@ use self::{proposals::*, proposals_in::ProposalOrRefIn};
 ///   opaque encrypted_group_info<V>;
 /// } Welcome;
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq, TlsDeserialize, TlsSerialize, TlsSize)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+)]
 pub struct Welcome {
     cipher_suite: Ciphersuite,
     secrets: Vec<EncryptedGroupSecrets>,
@@ -103,7 +105,9 @@ impl Welcome {
 /// EncryptedGroupSecrets
 ///
 /// This is part of a [`Welcome`] message. It can be used to correlate the correct secrets with each new member.
-#[derive(Clone, Debug, Eq, PartialEq, TlsDeserialize, TlsSerialize, TlsSize)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+)]
 pub struct EncryptedGroupSecrets {
     /// Key package reference of the new member
     new_member: KeyPackageRef,
@@ -169,7 +173,15 @@ impl Commit {
 }
 
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub(crate) struct CommitIn {
     proposals: Vec<ProposalOrRefIn>,
@@ -265,7 +277,15 @@ impl From<Commit> for CommitIn {
 /// Confirmation tag field of PublicMessage. For type safety this is a wrapper
 /// around a `Mac`.
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct ConfirmationTag(pub(crate) Mac);
 
@@ -278,7 +298,9 @@ pub struct ConfirmationTag(pub(crate) Mac);
 ///   opaque path_secret<1..255>;
 /// } PathSecret;
 /// ```
-#[derive(Debug, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize)]
+#[derive(
+    Debug, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsDeserializeBytes, TlsSize,
+)]
 #[cfg_attr(any(feature = "test-utils", test), derive(PartialEq, Clone))]
 pub(crate) struct PathSecret {
     pub(crate) path_secret: Secret,
@@ -382,7 +404,7 @@ pub(crate) enum PathSecretError {
 ///   PreSharedKeyID psks<V>;
 /// } GroupSecrets;
 /// ```
-#[derive(Debug, TlsDeserialize, TlsSize)]
+#[derive(Debug, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
 pub(crate) struct GroupSecrets {
     pub(crate) joiner_secret: JoinerSecret,
     pub(crate) path_secret: Option<PathSecret>,

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -116,7 +116,8 @@ impl DeserializeBytes for ProposalType {
     where
         Self: Sized,
     {
-        let proposal_type = ProposalType::tls_deserialize(&mut bytes.as_ref())?;
+        let mut bytes_ref = bytes;
+        let proposal_type = ProposalType::tls_deserialize(&mut bytes_ref)?;
         let remainder = &bytes[proposal_type.tls_serialized_len()..];
         Ok((proposal_type, remainder))
     }

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -10,7 +10,10 @@ use std::io::{Read, Write};
 use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tls_codec::{Serialize as TlsSerializeTrait, TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
+use tls_codec::{
+    Deserialize as TlsDeserializeTrait, DeserializeBytes, Error, Serialize as TlsSerializeTrait,
+    Size, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes,
+};
 
 use crate::{
     binary_tree::array_representation::LeafNodeIndex,
@@ -82,14 +85,14 @@ pub enum ProposalType {
     Unknown(u16),
 }
 
-impl tls_codec::Size for ProposalType {
+impl Size for ProposalType {
     fn tls_serialized_len(&self) -> usize {
         2
     }
 }
 
-impl tls_codec::Deserialize for ProposalType {
-    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error>
+impl TlsDeserializeTrait for ProposalType {
+    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error>
     where
         Self: Sized,
     {
@@ -100,11 +103,22 @@ impl tls_codec::Deserialize for ProposalType {
     }
 }
 
-impl tls_codec::Serialize for ProposalType {
-    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+impl TlsSerializeTrait for ProposalType {
+    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         writer.write_all(&u16::from(*self).to_be_bytes())?;
 
         Ok(2)
+    }
+}
+
+impl DeserializeBytes for ProposalType {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
+    where
+        Self: Sized,
+    {
+        let proposal_type = ProposalType::tls_deserialize(&mut bytes.as_ref())?;
+        let remainder = &bytes[proposal_type.tls_serialized_len()..];
+        Ok((proposal_type, remainder))
     }
 }
 
@@ -291,7 +305,16 @@ impl UpdateProposal {
 /// } Remove;
 /// ```
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct RemoveProposal {
     pub(crate) removed: LeafNodeIndex,
@@ -316,7 +339,16 @@ impl RemoveProposal {
 /// } PreSharedKey;
 /// ```
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct PreSharedKeyProposal {
     psk: PreSharedKeyId,
@@ -352,7 +384,16 @@ impl PreSharedKeyProposal {
 /// } ReInit;
 /// ```
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct ReInitProposal {
     pub(crate) group_id: GroupId,
@@ -373,7 +414,16 @@ pub struct ReInitProposal {
 /// } ExternalInit;
 /// ```
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct ExternalInitProposal {
     kem_output: VLBytes,
@@ -400,7 +450,15 @@ impl From<Vec<u8>> for ExternalInitProposal {
 ///
 /// This is not yet supported.
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct AppAckProposal {
     received_ranges: Vec<MessageRange>,
@@ -418,7 +476,16 @@ pub struct AppAckProposal {
 /// } GroupContextExtensions;
 /// ```
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct GroupContextExtensionProposal {
     extensions: Extensions,
@@ -455,7 +522,16 @@ impl GroupContextExtensionProposal {
 /// We only implement the values (1, 2), other values are not valid
 /// and will yield `ProposalOrRefTypeError::UnknownValue` when decoded.
 #[derive(
-    PartialEq, Clone, Copy, Debug, TlsSerialize, TlsDeserialize, TlsSize, Serialize, Deserialize,
+    PartialEq,
+    Clone,
+    Copy,
+    Debug,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
+    Serialize,
+    Deserialize,
 )]
 #[repr(u8)]
 pub enum ProposalOrRefType {
@@ -537,7 +613,15 @@ impl ProposalRef {
 /// } MessageRange;
 /// ```
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub(crate) struct MessageRange {
     sender: KeyPackageRef,

--- a/openmls/src/messages/proposals_in.rs
+++ b/openmls/src/messages/proposals_in.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite};
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use super::proposals::{
     AddProposal, AppAckProposal, ExternalInitProposal, GroupContextExtensionProposal,
@@ -46,7 +46,15 @@ use super::proposals::{
 /// ```
 #[allow(clippy::large_enum_variant)]
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserialize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
 )]
 #[allow(missing_docs)]
 #[repr(u16)]
@@ -132,7 +140,15 @@ impl ProposalIn {
 /// } Add;
 /// ```
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct AddProposalIn {
     key_package: KeyPackageIn,
@@ -171,7 +187,16 @@ impl AddProposalIn {
 /// } Update;
 /// ```
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct UpdateProposalIn {
     leaf_node: LeafNodeIn,
@@ -214,7 +239,15 @@ impl UpdateProposalIn {
 
 /// Type of Proposal, either by value or by reference.
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 #[repr(u8)]
 #[allow(missing_docs)]

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -123,7 +123,7 @@
 
 use openmls_traits::{crypto::OpenMlsCrypto, types::*};
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use crate::{
     binary_tree::array_representation::{LeafNodeIndex, TreeSize},
@@ -345,7 +345,7 @@ impl InitSecret {
     }
 }
 
-#[derive(Debug, TlsDeserialize, TlsSerialize, TlsSize)]
+#[derive(Debug, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize)]
 pub(crate) struct JoinerSecret {
     secret: Secret,
 }

--- a/openmls/src/schedule/psk.rs
+++ b/openmls/src/schedule/psk.rs
@@ -38,6 +38,7 @@ use crate::{
     Deserialize,
     Serialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]
@@ -67,6 +68,7 @@ pub enum ResumptionPskUsage {
     Deserialize,
     Serialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]
@@ -90,7 +92,7 @@ impl ExternalPsk {
 
 /// Contains the secret part of the PSK as well as the
 /// public part that is used as a marker for injection into the key schedule.
-#[derive(Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize)]
+#[derive(Serialize, Deserialize, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize)]
 pub(crate) struct PskBundle {
     secret: Secret,
 }
@@ -110,6 +112,7 @@ impl MlsEntity for PskBundle {
     Deserialize,
     Serialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]
@@ -156,6 +159,7 @@ impl ResumptionPsk {
     Deserialize,
     Serialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]
@@ -216,6 +220,7 @@ pub enum PskType {
     Deserialize,
     Serialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -35,7 +35,7 @@ use openmls_traits::{
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use self::{
     diff::{StagedTreeSyncDiff, TreeSyncDiff},
@@ -217,7 +217,16 @@ impl RatchetTree {
 /// A ratchet tree made of unverified nodes. This is used for deserialization
 /// and verification.
 #[derive(
-    PartialEq, Eq, Clone, Debug, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    PartialEq,
+    Eq,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct RatchetTreeIn(Vec<Option<NodeIn>>);
 

--- a/openmls/src/treesync/node.rs
+++ b/openmls/src/treesync/node.rs
@@ -2,7 +2,7 @@
 //! variants of the enum are `LeafNode` and [`ParentNode`], both of which are
 //! defined in the respective [`leaf_node`] and [`parent_node`] submodules.
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use self::{leaf_node::LeafNodeIn, parent_node::ParentNode};
 
@@ -37,7 +37,16 @@ pub enum Node {
 }
 
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsSize, TlsDeserialize, TlsSerialize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
 )]
 #[repr(u8)]
 pub enum NodeIn {

--- a/openmls/src/treesync/node/codec.rs
+++ b/openmls/src/treesync/node/codec.rs
@@ -36,7 +36,8 @@ impl DeserializeBytes for UnmergedLeaves {
     where
         Self: Sized,
     {
-        let unmerged_leaves = UnmergedLeaves::tls_deserialize(&mut bytes.as_ref())?;
+        let mut bytes_ref = bytes;
+        let unmerged_leaves = UnmergedLeaves::tls_deserialize(&mut bytes_ref)?;
         let remainder = &bytes[unmerged_leaves.tls_serialized_len()..];
         Ok((unmerged_leaves, remainder))
     }

--- a/openmls/src/treesync/node/codec.rs
+++ b/openmls/src/treesync/node/codec.rs
@@ -1,9 +1,14 @@
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{
+    Deserialize, DeserializeBytes, Error, Size, TlsDeserialize, TlsDeserializeBytes, TlsSerialize,
+    TlsSize,
+};
 
 use super::parent_node::{UnmergedLeaves, UnmergedLeavesError};
 
 /// Node type. Can be either `Leaf` or `Parent`.
-#[derive(PartialEq, Clone, Copy, Debug, TlsSerialize, TlsDeserialize, TlsSize)]
+#[derive(
+    PartialEq, Clone, Copy, Debug, TlsSerialize, TlsDeserialize, TlsDeserializeBytes, TlsSize,
+)]
 #[repr(u8)]
 enum MlsNodeType {
     Leaf = 1,
@@ -12,16 +17,27 @@ enum MlsNodeType {
 
 // Implementations for `ParentNode`
 
-impl tls_codec::Deserialize for UnmergedLeaves {
-    fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, tls_codec::Error>
+impl Deserialize for UnmergedLeaves {
+    fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, Error>
     where
         Self: Sized,
     {
         let list = Vec::tls_deserialize(bytes)?;
         Self::try_from(list).map_err(|e| match e {
             UnmergedLeavesError::NotSorted => {
-                tls_codec::Error::DecodingError("Unmerged leaves not sorted".into())
+                Error::DecodingError("Unmerged leaves not sorted".into())
             }
         })
+    }
+}
+
+impl DeserializeBytes for UnmergedLeaves {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error>
+    where
+        Self: Sized,
+    {
+        let unmerged_leaves = UnmergedLeaves::tls_deserialize(&mut bytes.as_ref())?;
+        let remainder = &bytes[unmerged_leaves.tls_serialized_len()..];
+        Ok((unmerged_leaves, remainder))
     }
 }

--- a/openmls/src/treesync/node/encryption_keys.rs
+++ b/openmls/src/treesync/node/encryption_keys.rs
@@ -7,7 +7,7 @@ use openmls_traits::{
     OpenMlsProvider,
 };
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes};
 
 use crate::{
     ciphersuite::{hpke, HpkePrivateKey, HpkePublicKey, Secret},
@@ -19,7 +19,17 @@ use crate::{
 /// [`EncryptionKey`] contains an HPKE public key that allows the encryption of
 /// path secrets in MLS commits.
 #[derive(
-    Debug, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize, PartialEq, Eq, Hash,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
+    PartialEq,
+    Eq,
+    Hash,
 )]
 pub struct EncryptionKey {
     key: HpkePublicKey,
@@ -66,7 +76,9 @@ impl EncryptionKey {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize)]
+#[derive(
+    Clone, Serialize, Deserialize, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub(crate) struct EncryptionPrivateKey {
     key: HpkePrivateKey,
@@ -137,7 +149,9 @@ impl From<HpkePublicKey> for EncryptionKey {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub(crate) struct EncryptionKeyPair {
     public_key: EncryptionKey,

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -1,7 +1,10 @@
 //! This module contains the [`LeafNode`] struct and its implementation.
 use openmls_traits::{signatures::Signer, types::Ciphersuite, OpenMlsProvider};
 use serde::{Deserialize, Serialize};
-use tls_codec::{Serialize as TlsSerializeTrait, TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
+use tls_codec::{
+    Serialize as TlsSerializeTrait, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+    VLBytes,
+};
 
 #[cfg(test)]
 use openmls_traits::key_store::OpenMlsKeyStore;
@@ -509,7 +512,16 @@ impl LeafNode {
 /// } LeafNode;
 /// ```
 #[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 struct LeafNodePayload {
     encryption_key: EncryptionKey,
@@ -521,7 +533,16 @@ struct LeafNodePayload {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 #[repr(u8)]
 pub enum LeafNodeSource {
@@ -658,7 +679,16 @@ impl TreePosition {
 const LEAF_NODE_SIGNATURE_LABEL: &str = "LeafNodeTBS";
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct LeafNodeIn {
     payload: LeafNodePayload,

--- a/openmls/src/treesync/node/leaf_node/capabilities.rs
+++ b/openmls/src/treesync/node/leaf_node/capabilities.rs
@@ -1,6 +1,6 @@
 use openmls_traits::types::{Ciphersuite, VerifiableCiphersuite};
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 #[cfg(doc)]
 use super::LeafNode;
@@ -24,7 +24,16 @@ use crate::{
 /// } Capabilities;
 /// ```
 #[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct Capabilities {
     pub(super) versions: Vec<ProtocolVersion>,

--- a/openmls/src/treesync/node/parent_node.rs
+++ b/openmls/src/treesync/node/parent_node.rs
@@ -6,7 +6,7 @@ use openmls_traits::types::{Ciphersuite, HpkeCiphertext};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use thiserror::*;
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes};
 
 use super::encryption_keys::{EncryptionKey, EncryptionKeyPair};
 use crate::{
@@ -22,7 +22,16 @@ use crate::{
 /// parent hash and unmerged leaves. Additionally, it may contain the private
 /// key corresponding to the public key.
 #[derive(
-    Debug, Eq, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    Eq,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct ParentNode {
     pub(super) encryption_key: EncryptionKey,

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -12,7 +12,7 @@ use openmls_traits::{
 };
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 use super::{
     diff::TreeSyncDiff,
@@ -240,7 +240,16 @@ pub(crate) struct DecryptPathParams<'a> {
 /// } UpdatePathNode;
 /// ```
 #[derive(
-    Debug, Eq, PartialEq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+    Debug,
+    Eq,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
 )]
 pub struct UpdatePathNode {
     pub(super) public_key: EncryptionKey,
@@ -363,7 +372,16 @@ impl UpdatePath {
 }
 
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct UpdatePathIn {
     leaf_node: LeafNodeIn,

--- a/openmls/src/versions.rs
+++ b/openmls/src/versions.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
-use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 // Public types
 
@@ -29,6 +29,7 @@ use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
     Serialize,
     Deserialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -5,7 +5,9 @@
 use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
-use tls_codec::{SecretVLBytes, TlsDeserialize, TlsSerialize, TlsSize, VLBytes};
+use tls_codec::{
+    SecretVLBytes, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes,
+};
 
 use crate::key_store::{MlsEntity, MlsEntityId};
 
@@ -86,6 +88,7 @@ impl HashType {
     Deserialize,
     TlsSerialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSize,
 )]
 #[repr(u16)]
@@ -224,7 +227,16 @@ pub enum HpkeAeadType {
 /// } HPKECiphertext;
 /// ```
 #[derive(
-    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct HpkeCiphertext {
     pub kem_output: VLBytes,
@@ -233,7 +245,14 @@ pub struct HpkeCiphertext {
 
 /// A simple type for HPKE private keys.
 #[derive(
-    Debug, Clone, serde::Serialize, serde::Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Debug,
+    Clone,
+    serde::Serialize,
+    serde::Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 #[cfg_attr(feature = "test-utils", derive(PartialEq, Eq))]
 #[serde(transparent)]
@@ -292,7 +311,17 @@ impl From<Vec<u8>> for ExporterSecret {
 ///
 /// Used to accept unknown values, e.g., in `Capabilities`.
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
 )]
 pub struct VerifiableCiphersuite(u16);
 
@@ -323,6 +352,7 @@ impl From<Ciphersuite> for VerifiableCiphersuite {
     Serialize,
     Deserialize,
     TlsDeserialize,
+    TlsDeserializeBytes,
     TlsSerialize,
     TlsSize,
 )]


### PR DESCRIPTION
This PR derives `tls_codec::DeserializeBytes` for all structs and enums that already derive `tls_codec::Deserialize`. It also implements manually `DeserializeBytes` for those that implement `Deserialize`. The "manual" implementations all follow the same pattern in that they internally rely on the `Deserialize` implementation of that struct/enum.