### PR TITLE
Add credentials_to_verify method to StagedCommit

### DIFF
--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -435,6 +435,11 @@ impl StagedCommit {
         self.staged_proposal_queue.psk_proposals()
     }
 
+    /// Returns an iterator over all [`QueuedProposal`]s.
+    pub(crate) fn queued_proposals(&self) -> impl Iterator<Item = &QueuedProposal> {
+        self.staged_proposal_queue.queued_proposals()
+    }
+
     /// Returns the leaf node of the (optional) update path.
     pub fn update_path_leaf_node(&self) -> Option<&LeafNode> {
         match self.state {
@@ -445,9 +450,42 @@ impl StagedCommit {
         }
     }
 
-    /// Returns an iterator over all [`QueuedProposal`]s.
-    pub(crate) fn queued_proposals(&self) -> impl Iterator<Item = &QueuedProposal> {
-        self.staged_proposal_queue.queued_proposals()
+    pub fn credentials_to_verify(&self) -> impl Iterator<Item = &Credential> {
+        let update_path_leaf_node_cred = if let Some(node) = self.update_path_leaf_node() {
+            vec![node.credential()]
+        } else {
+            vec![]
+        };
+
+        update_path_leaf_node_cred.into_iter().chain(
+            self.queued_proposals()
+                .map(|proposal: &QueuedProposal| match proposal.proposal() {
+                    Proposal::Update(update_proposal) => {
+                        vec![update_proposal.leaf_node().credential()]
+                    }
+                    Proposal::Add(add_proposal) => {
+                        vec![add_proposal.key_package().leaf_node().credential()]
+                    }
+                    Proposal::GroupContextExtensions(gce_proposal) => gce_proposal
+                        .extensions()
+                        .iter()
+                        .map(|extension| {
+                            match extension {
+                                Extension::ExternalSenders(external_senders) => external_senders
+                                    .iter()
+                                    .map(|external_sender| external_sender.credential())
+                                    .collect(),
+                                _ => vec![],
+                            }
+                            .into_iter()
+                        })
+                        .flatten()
+                        .collect(),
+                    _ => vec![],
+                })
+                .into_iter()
+                .flatten(),
+        )
     }
 
     /// Returns `true` if the member was removed through a proposal covered by this Commit message

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -11,14 +11,11 @@ use crate::{
     key_packages::*,
     messages::proposals::*,
     test_utils::test_framework::{
-        errors::ClientError, ActionType::Commit, CodecUse, MlsGroupTestSetup,
+        errors::ClientError, noop_authentication_service, ActionType::Commit, CodecUse,
+        MlsGroupTestSetup,
     },
     test_utils::*,
 };
-
-fn noop_authentication_service(_cred: &Credential) -> bool {
-    true
-}
 
 #[apply(ciphersuites_and_providers)]
 fn test_mls_group_persistence(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -351,6 +351,171 @@ fn test_invalid_plaintext(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvi
 }
 
 #[apply(ciphersuites_and_providers)]
+fn test_verify_staged_commit_credentials(
+    ciphersuite: Ciphersuite,
+    provider: &impl OpenMlsProvider,
+) {
+    let group_id = GroupId::from_slice(b"Test Group");
+
+    let (alice_credential_with_key, _alice_kpb, alice_signer, _alice_pk) =
+        setup_client("Alice", ciphersuite, provider);
+    let (_bob_credential, bob_kpb, _bob_signer, _bob_pk) =
+        setup_client("Bob", ciphersuite, provider);
+
+    // Define the MlsGroup configuration
+    let mls_group_config = MlsGroupConfig::test_default(ciphersuite);
+
+    // === Alice creates a group ===
+    let mut alice_group = MlsGroup::new_with_group_id(
+        provider,
+        &alice_signer,
+        &mls_group_config,
+        group_id,
+        alice_credential_with_key.clone(),
+    )
+    .expect("An unexpected error occurred.");
+
+    // There should be no pending commit after group creation.
+    assert!(alice_group.pending_commit().is_none());
+
+    let bob_key_package = bob_kpb.key_package();
+
+    // === Alice adds Bob to the group ===
+    let (proposal, _) = alice_group
+        .propose_add_member(provider, &alice_signer, bob_key_package)
+        .expect("error creating self-update proposal");
+
+    let alice_processed_message = alice_group
+        .process_message(provider, proposal.into_protocol_message().unwrap())
+        .expect("Could not process messages.");
+    assert!(alice_group.pending_commit().is_none());
+
+    if let ProcessedMessageContent::ProposalMessage(staged_proposal) =
+        alice_processed_message.into_content()
+    {
+        alice_group.store_pending_proposal(*staged_proposal);
+    } else {
+        unreachable!("Expected a StagedCommit.");
+    }
+
+    let (_msg, welcome_option, _group_info) = alice_group
+        .self_update(provider, &alice_signer)
+        .expect("error creating self-update commit");
+
+    // Merging the pending commit should clear the pending commit and we should
+    // end up in the same state as bob.
+    alice_group
+        .merge_pending_commit(provider)
+        .expect("error merging pending commit");
+    assert!(alice_group.pending_commit().is_none());
+    assert!(alice_group.pending_proposals().next().is_none());
+
+    let mut bob_group = MlsGroup::new_from_welcome(
+        provider,
+        &mls_group_config,
+        welcome_option
+            .expect("no welcome after commit")
+            .into_welcome()
+            .expect("Unexpected message type."),
+        Some(alice_group.export_ratchet_tree().into()),
+    )
+    .expect("error creating group from welcome");
+
+    assert_eq!(
+        bob_group.export_ratchet_tree(),
+        alice_group.export_ratchet_tree()
+    );
+    assert_eq!(
+        bob_group.export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length()),
+        alice_group.export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
+    );
+    // Bob is added and the state aligns.
+
+    // === Make a new, empty commit and check that the leaf node credentials match ===
+    let (commit_msg, _welcome_option, _group_info) = alice_group
+        .self_update(provider, &alice_signer)
+        .expect("error creating self-update commit");
+
+    // empty commits should only produce a single message
+    assert!(_welcome_option.is_none());
+    assert!(_group_info.is_none());
+
+    // There should be a pending commit after issuing a self-update commit.
+    let alice_pending_commit = alice_group
+        .pending_commit()
+        .expect("alice should have the self-update as pending commit");
+
+    // The commit contains only Alice's credentials, in the update path leaf node.
+    for cred in alice_pending_commit.credentials_to_verify() {
+        assert_eq!(cred, &alice_credential_with_key.credential);
+    }
+
+    // great, they match! now commit
+    alice_group
+        .merge_pending_commit(provider)
+        .expect("alice failed to merge the pending empty commit");
+
+    // === transfer message to bob and process it ===
+
+    // this requires serializing and deserializing
+    let mut wire_msg = Vec::<u8>::new();
+    commit_msg
+        .tls_serialize(&mut wire_msg)
+        .expect("alice failed serializing her message");
+    let msg_in = MlsMessageIn::tls_deserialize(&mut &wire_msg[..])
+        .expect("bob failed deserializing alice's message");
+
+    // neither party should have pending proposals
+    assert!(alice_group.pending_proposals().next().is_none());
+    assert!(bob_group.pending_proposals().next().is_none());
+
+    // neither should have pending commits after merging and before processing
+    assert!(bob_group.pending_commit().is_none());
+    assert!(alice_group.pending_commit().is_none());
+
+    // further process the deserialized message
+    let processed_message = bob_group
+        .process_message(provider, msg_in)
+        .expect("bob failed processing alice's message");
+
+    // the processed message must be a staged commit message
+    assert!(matches!(
+        processed_message.content(),
+        ProcessedMessageContent::StagedCommitMessage(_)
+    ));
+
+    if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+        processed_message.into_content()
+    {
+        // The commit contains only Alice's credentials, in the update path leaf node.
+        for cred in staged_commit.credentials_to_verify() {
+            assert_eq!(cred, &alice_credential_with_key.credential);
+        }
+
+        // bob merges alice's message
+        bob_group
+            .merge_staged_commit(provider, *staged_commit)
+            .expect("bob failed merging alice's empty commit (staged)");
+
+        // finally, the state should match
+        assert_eq!(
+            bob_group.export_ratchet_tree(),
+            alice_group.export_ratchet_tree()
+        );
+        assert_eq!(
+            bob_group.export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length()),
+            alice_group.export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
+        );
+    } else {
+        unreachable!()
+    }
+
+    // neither should have pending commits after merging and processing
+    assert!(bob_group.pending_commit().is_none());
+    assert!(alice_group.pending_commit().is_none());
+}
+
+#[apply(ciphersuites_and_providers)]
 fn test_commit_with_update_path_leaf_node(
     ciphersuite: Ciphersuite,
     provider: &impl OpenMlsProvider,
@@ -435,7 +600,7 @@ fn test_commit_with_update_path_leaf_node(
 
     // === Make a new, empty commit and check that the leaf node credentials match ===
 
-    println!("\nCreating commit with add proposal.");
+    println!("\nCreating self-update commit.");
     let (commit_msg, _welcome_option, _group_info) = alice_group
         .self_update(provider, &alice_signer)
         .expect("error creating self-update commit");

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -5,7 +5,6 @@ use tls_codec::{Deserialize, Serialize};
 
 use crate::{
     binary_tree::LeafNodeIndex,
-    credentials::Credential,
     framing::*,
     group::{config::CryptoConfig, errors::*, *},
     key_packages::*,

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -256,7 +256,7 @@ fn test_invalid_plaintext(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvi
     );
     // Create a basic group with more than 4 members to create a tree with intermediate nodes.
     let group_id = setup
-        .create_random_group(10, ciphersuite, &noop_authentication_service)
+        .create_random_group(10, ciphersuite, noop_authentication_service)
         .expect("An unexpected error occurred.");
     let mut groups = setup.groups.write().expect("An unexpected error occurred.");
     let group = groups

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -499,6 +499,7 @@ impl GroupContextExtensionProposal {
         Self { extensions }
     }
 
+    /// Get the extensions of the proposal
     pub(crate) fn extensions(&self) -> &Extensions {
         &self.extensions
     }

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -430,6 +430,10 @@ impl GroupContextExtensionProposal {
     pub(crate) fn new(extensions: Extensions) -> Self {
         Self { extensions }
     }
+
+    pub(crate) fn extensions(&self) -> &Extensions {
+        &self.extensions
+    }
 }
 
 // Crate-only types

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -278,13 +278,14 @@ impl MlsGroupTestSetup {
     /// Distribute a set of messages sent by the sender with identity
     /// `sender_id` to their intended recipients in group `Group`. This function
     /// also verifies that all members of that group agree on the public tree.
-    pub fn distribute_to_members(
+    pub fn distribute_to_members<AS: Fn(&Credential) -> bool>(
         &self,
         // We need the sender to know a group member that we know can not have
         // been removed from the group.
         sender_id: &[u8],
         group: &mut Group,
         message: &MlsMessageIn,
+        authentication_service: &AS,
     ) -> Result<(), ClientError> {
         // Test serialization if mandated by config
         let message: ProtocolMessage = match self.use_codec {
@@ -302,7 +303,7 @@ impl MlsGroupTestSetup {
         // Distribute message to all members, except to the sender in the case of application messages
         let results: Result<Vec<_>, _> = group
             .members
-            .par_iter()
+            .iter()
             .filter_map(|(_index, member_id)| {
                 if message.content_type() == ContentType::Application && member_id == sender_id {
                     None
@@ -316,7 +317,7 @@ impl MlsGroupTestSetup {
                     .expect("An unexpected error occurred.")
                     .read()
                     .expect("An unexpected error occurred.");
-                member.receive_messages_for_group(&message, sender_id)
+                member.receive_messages_for_group(&message, sender_id, &authentication_service)
             })
             .collect();
 
@@ -352,7 +353,11 @@ impl MlsGroupTestSetup {
     /// each group member encrypt an application message and delivers all of
     /// these messages to all other members. This function panics if any of the
     /// above tests fail.
-    pub fn check_group_states(&self, group: &mut Group) {
+    pub fn check_group_states<AS: Fn(&Credential) -> bool>(
+        &self,
+        group: &mut Group,
+        authentication_service: AS,
+    ) {
         let clients = self.clients.read().expect("An unexpected error occurred.");
         let messages = group
             .members
@@ -393,7 +398,7 @@ impl MlsGroupTestSetup {
             .collect::<Vec<(Vec<u8>, MlsMessageOut)>>();
         drop(clients);
         for (sender_id, message) in messages {
-            self.distribute_to_members(&sender_id, group, &message.into())
+            self.distribute_to_members(&sender_id, group, &message.into(), &authentication_service)
                 .expect("Error sending messages to clients while checking group states.");
         }
     }
@@ -478,10 +483,11 @@ impl MlsGroupTestSetup {
     }
 
     /// Create a random group of size `group_size` and return the `GroupId`
-    pub fn create_random_group(
+    pub fn create_random_group<AS: Fn(&Credential) -> bool>(
         &self,
         target_group_size: usize,
         ciphersuite: Ciphersuite,
+        authentication_service: AS,
     ) -> Result<GroupId, SetupError> {
         // Create the initial group.
         let group_id = self.create_group(ciphersuite)?;
@@ -501,7 +507,13 @@ impl MlsGroupTestSetup {
             // Add between 1 and 5 new members.
             let number_of_adds = ((OsRng.next_u32() as usize) % 5 % new_members.len()) + 1;
             let members_to_add = new_members.drain(0..number_of_adds).collect();
-            self.add_clients(ActionType::Commit, group, &adder_id.1, members_to_add)?;
+            self.add_clients(
+                ActionType::Commit,
+                group,
+                &adder_id.1,
+                members_to_add,
+                &authentication_service,
+            )?;
         }
         Ok(group_id)
     }
@@ -509,12 +521,13 @@ impl MlsGroupTestSetup {
     /// Have the client with identity `client_id` either propose or commit
     /// (depending on `action_type`) a self update in group `group`. Will throw
     /// an error if the client is not actually a member of group `group`.
-    pub fn self_update(
+    pub fn self_update<AS: Fn(&Credential) -> bool>(
         &self,
         action_type: ActionType,
         group: &mut Group,
         client_id: &[u8],
         leaf_node: Option<LeafNode>,
+        authentication_service: &AS,
     ) -> Result<(), SetupError> {
         let clients = self.clients.read().expect("An unexpected error occurred.");
         let client = clients
@@ -524,7 +537,12 @@ impl MlsGroupTestSetup {
             .expect("An unexpected error occurred.");
         let (messages, welcome_option, _) =
             client.self_update(action_type, &group.group_id, leaf_node)?;
-        self.distribute_to_members(&client.identity, group, &messages.into())?;
+        self.distribute_to_members(
+            &client.identity,
+            group,
+            &messages.into(),
+            authentication_service,
+        )?;
         if let Some(welcome) = welcome_option {
             self.deliver_welcome(welcome, group)?;
         }
@@ -537,12 +555,13 @@ impl MlsGroupTestSetup {
     /// * the `adder` is not part of the group
     /// * the `addee` is already part of the group
     /// * the `addee` doesn't support the group's ciphersuite.
-    pub fn add_clients(
+    pub fn add_clients<AS: Fn(&Credential) -> bool>(
         &self,
         action_type: ActionType,
         group: &mut Group,
         adder_id: &[u8],
         addees: Vec<Vec<u8>>,
+        authentication_service: &AS,
     ) -> Result<(), SetupError> {
         let clients = self.clients.read().expect("An unexpected error occurred.");
         let adder = clients
@@ -570,7 +589,7 @@ impl MlsGroupTestSetup {
         let (messages, welcome_option, _) =
             adder.add_members(action_type, &group.group_id, &key_packages)?;
         for message in messages {
-            self.distribute_to_members(adder_id, group, &message.into())?;
+            self.distribute_to_members(adder_id, group, &message.into(), authentication_service)?;
         }
         if let Some(welcome) = welcome_option {
             self.deliver_welcome(welcome, group)?;
@@ -582,12 +601,13 @@ impl MlsGroupTestSetup {
     /// removal the `target_members` from the Group `group`. If the `remover` or
     /// one of the `target_members` is not part of the group, it returns an
     /// error.
-    pub fn remove_clients(
+    pub fn remove_clients<AS: Fn(&Credential) -> bool>(
         &self,
         action_type: ActionType,
         group: &mut Group,
         remover_id: &[u8],
         target_members: &[LeafNodeIndex],
+        authentication_service: AS,
     ) -> Result<(), SetupError> {
         let clients = self.clients.read().expect("An unexpected error occurred.");
         let remover = clients
@@ -598,7 +618,12 @@ impl MlsGroupTestSetup {
         let (messages, welcome_option, _) =
             remover.remove_members(action_type, &group.group_id, target_members)?;
         for message in messages {
-            self.distribute_to_members(remover_id, group, &message.into())?;
+            self.distribute_to_members(
+                remover_id,
+                group,
+                &message.into(),
+                &authentication_service,
+            )?;
         }
         if let Some(welcome) = welcome_option {
             self.deliver_welcome(welcome, group)?;
@@ -609,7 +634,11 @@ impl MlsGroupTestSetup {
     /// This function picks a random member of group `group` and has them
     /// perform a random commit- or proposal action. TODO #133: This won't work
     /// yet due to the missing proposal validation.
-    pub fn perform_random_operation(&self, group: &mut Group) -> Result<(), SetupError> {
+    pub fn perform_random_operation<AS: Fn(&Credential) -> bool>(
+        &self,
+        group: &mut Group,
+        authentication_service: &AS,
+    ) -> Result<(), SetupError> {
         // Who's going to do it?
         let member_id = group.random_group_member();
         println!("Member performing the operation: {member_id:?}");
@@ -626,7 +655,13 @@ impl MlsGroupTestSetup {
         match operation_type {
             0 => {
                 println!("Performing a self-update with action type: {action_type:?}");
-                self.self_update(action_type, group, &member_id.1, None)?;
+                self.self_update(
+                    action_type,
+                    group,
+                    &member_id.1,
+                    None,
+                    authentication_service,
+                )?;
             }
             1 => {
                 // If it's a single-member group, don't remove anyone.
@@ -683,6 +718,7 @@ impl MlsGroupTestSetup {
                         group,
                         &member_id.1,
                         &target_member_leaf_indices,
+                        authentication_service,
                     )?
                 };
             }
@@ -701,7 +737,13 @@ impl MlsGroupTestSetup {
                         .expect("An unexpected error occurred.");
                     println!("{action_type:?}: Adding new clients: {new_member_ids:?}");
                     // Have the adder add them to the group.
-                    self.add_clients(action_type, group, &member_id.1, new_member_ids)?;
+                    self.add_clients(
+                        action_type,
+                        group,
+                        &member_id.1,
+                        new_member_ids,
+                        authentication_service,
+                    )?;
                 }
             }
             _ => return Err(SetupError::Unknown),

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -751,3 +751,10 @@ impl MlsGroupTestSetup {
         Ok(())
     }
 }
+
+// This function signature is used in the callback for credential validation.
+// This particular function just accepts any credential. If you want to validate
+// credentials in your test, don't use this.
+pub fn noop_authentication_service(_cred: &Credential) -> bool {
+    true
+}

--- a/openmls/tests/test_decryption_key_index.rs
+++ b/openmls/tests/test_decryption_key_index.rs
@@ -2,15 +2,11 @@
 use openmls::{
     prelude::*,
     test_utils::{
-        test_framework::{ActionType, CodecUse, MlsGroupTestSetup},
+        test_framework::{noop_authentication_service, ActionType, CodecUse, MlsGroupTestSetup},
         *,
     },
     *,
 };
-
-fn noop_authentication_service(_cred: &Credential) -> bool {
-    true
-}
 
 #[apply(ciphersuites)]
 fn decryption_key_index_computation(ciphersuite: Ciphersuite) {

--- a/openmls/tests/test_decryption_key_index.rs
+++ b/openmls/tests/test_decryption_key_index.rs
@@ -8,6 +8,10 @@ use openmls::{
     *,
 };
 
+fn noop_authentication_service(_cred: &Credential) -> bool {
+    true
+}
+
 #[apply(ciphersuites)]
 fn decryption_key_index_computation(ciphersuite: Ciphersuite) {
     println!("Testing ciphersuite {ciphersuite:?}");
@@ -20,9 +24,10 @@ fn decryption_key_index_computation(ciphersuite: Ciphersuite) {
         number_of_clients,
         CodecUse::StructMessages,
     );
+
     // Create a basic group with more than 4 members to create a tree with intermediate nodes.
     let group_id = setup
-        .create_random_group(10, ciphersuite)
+        .create_random_group(10, ciphersuite, noop_authentication_service)
         .expect("An unexpected error occurred.");
     let mut groups = setup.groups.write().expect("An unexpected error occurred.");
     let group = groups
@@ -45,6 +50,7 @@ fn decryption_key_index_computation(ciphersuite: Ciphersuite) {
             group,
             remover_id,
             &[LeafNodeIndex::new(2)],
+            noop_authentication_service,
         )
         .expect("An unexpected error occurred.");
 
@@ -64,11 +70,12 @@ fn decryption_key_index_computation(ciphersuite: Ciphersuite) {
             group,
             remover_id,
             &[LeafNodeIndex::new(3)],
+            noop_authentication_service,
         )
         .expect("An unexpected error occurred.");
 
     // Since the decryption failure doesn't cause a panic, but only an error
     // message in the callback, we also have to check that the group states
     // match for all group members.
-    setup.check_group_states(group);
+    setup.check_group_states(group, noop_authentication_service);
 }

--- a/openmls/tests/test_interop_scenarios.rs
+++ b/openmls/tests/test_interop_scenarios.rs
@@ -59,7 +59,7 @@ fn one_to_one_join(ciphersuite: Ciphersuite) {
         .expect("Error adding Bob");
 
     // Check that group members agree on a group state.
-    setup.check_group_states(group, &noop_authentication_service);
+    setup.check_group_states(group, noop_authentication_service);
 }
 
 // # 3-party join
@@ -127,7 +127,7 @@ fn three_party_join(ciphersuite: Ciphersuite) {
         .expect("Error adding Charly");
 
     // Check that group members agree on a group state.
-    setup.check_group_states(group, &noop_authentication_service);
+    setup.check_group_states(group, noop_authentication_service);
 }
 
 // # Multiple joins at once
@@ -179,7 +179,7 @@ fn multiple_joins(ciphersuite: Ciphersuite) {
         .expect("Error adding Bob and Charly");
 
     // Check that group members agree on a group state.
-    setup.check_group_states(group, &noop_authentication_service);
+    setup.check_group_states(group, noop_authentication_service);
 }
 
 // TODO #192, #286, #289: The external join test should go here.
@@ -203,7 +203,7 @@ fn update(ciphersuite: Ciphersuite) {
 
     // Create a group with two members. Includes the process of adding Bob.
     let group_id = setup
-        .create_random_group(2, ciphersuite, &noop_authentication_service)
+        .create_random_group(2, ciphersuite, noop_authentication_service)
         .expect("Error while trying to create group.");
     let mut groups = setup.groups.write().expect("An unexpected error occurred.");
     let group = groups
@@ -227,7 +227,7 @@ fn update(ciphersuite: Ciphersuite) {
         .expect("Error self-updating.");
 
     // Check that group members agree on a group state.
-    setup.check_group_states(group, &noop_authentication_service);
+    setup.check_group_states(group, noop_authentication_service);
 }
 
 // # Remove
@@ -251,7 +251,7 @@ fn remove(ciphersuite: Ciphersuite) {
 
     // Create a group with two members. Includes the process of adding Bob.
     let group_id = setup
-        .create_random_group(2, ciphersuite, &noop_authentication_service)
+        .create_random_group(2, ciphersuite, noop_authentication_service)
         .expect("Error while trying to create group.");
     let mut groups = setup.groups.write().expect("An unexpected error occurred.");
     let group = groups
@@ -274,12 +274,12 @@ fn remove(ciphersuite: Ciphersuite) {
             group,
             &alice_id,
             &[LeafNodeIndex::new(bob_index)],
-            &noop_authentication_service,
+            noop_authentication_service,
         )
         .expect("Error removing Bob from the group.");
 
     // Check that group members agree on a group state.
-    setup.check_group_states(group, &noop_authentication_service);
+    setup.check_group_states(group, noop_authentication_service);
 }
 
 // TODO #141, #284: The external PSK, resumption and re-init tests should go
@@ -309,7 +309,7 @@ fn large_group_lifecycle(ciphersuite: Ciphersuite) {
     // a one-person group and then adding new members in bunches of up to 5,
     // each bunch by a random group member.
     let group_id = setup
-        .create_random_group(number_of_clients, ciphersuite, &noop_authentication_service)
+        .create_random_group(number_of_clients, ciphersuite, noop_authentication_service)
         .expect("Error while trying to create group.");
     let mut groups = setup.groups.write().expect("An unexpected error occurred.");
     let group = groups
@@ -345,13 +345,13 @@ fn large_group_lifecycle(ciphersuite: Ciphersuite) {
                 group,
                 &remover_id.1,
                 &[LeafNodeIndex::new(target_id.0)],
-                &noop_authentication_service,
+                noop_authentication_service,
             )
             .expect("Error while removing group member.");
         group_members = group.members().collect::<Vec<(u32, Vec<u8>)>>();
-        setup.check_group_states(group, &noop_authentication_service);
+        setup.check_group_states(group, noop_authentication_service);
     }
 
     // Check that group members agree on a group state.
-    setup.check_group_states(group, &noop_authentication_service);
+    setup.check_group_states(group, noop_authentication_service);
 }

--- a/openmls/tests/test_interop_scenarios.rs
+++ b/openmls/tests/test_interop_scenarios.rs
@@ -1,13 +1,11 @@
 use openmls::{
     prelude::*,
-    test_utils::test_framework::{ActionType, CodecUse, MlsGroupTestSetup},
+    test_utils::test_framework::{
+        noop_authentication_service, ActionType, CodecUse, MlsGroupTestSetup,
+    },
     test_utils::*,
     *,
 };
-
-fn noop_authentication_service(_cred: &Credential) -> bool {
-    true
-}
 
 // The following tests correspond to the interop test scenarios detailed here:
 // https://github.com/mlswg/mls-implementations/blob/master/test-scenarios.md

--- a/openmls/tests/test_managed_api.rs
+++ b/openmls/tests/test_managed_api.rs
@@ -21,7 +21,7 @@ fn test_mls_group_api(ciphersuite: Ciphersuite) {
     );
 
     let group_id = setup
-        .create_random_group(3, ciphersuite, &noop_authentication_service)
+        .create_random_group(3, ciphersuite, noop_authentication_service)
         .expect("An unexpected error occurred.");
     let mut groups = setup.groups.write().expect("An unexpected error occurred.");
     let group = groups
@@ -52,10 +52,10 @@ fn test_mls_group_api(ciphersuite: Ciphersuite) {
             group,
             &remover_id,
             &[LeafNodeIndex::new(target_index)],
-            &noop_authentication_service,
+            noop_authentication_service,
         )
         .expect("An unexpected error occurred.");
 
     // Check that all group members agree on the same group state.
-    setup.check_group_states(group, &noop_authentication_service);
+    setup.check_group_states(group, noop_authentication_service);
 }

--- a/openmls/tests/test_managed_api.rs
+++ b/openmls/tests/test_managed_api.rs
@@ -5,6 +5,10 @@ use openmls::{
     *,
 };
 
+fn noop_authentication_service(_cred: &Credential) -> bool {
+    true
+}
+
 #[apply(ciphersuites)]
 fn test_mls_group_api(ciphersuite: Ciphersuite) {
     // Some basic setup functions for the MlsGroup.
@@ -17,7 +21,7 @@ fn test_mls_group_api(ciphersuite: Ciphersuite) {
     );
 
     let group_id = setup
-        .create_random_group(3, ciphersuite)
+        .create_random_group(3, ciphersuite, &noop_authentication_service)
         .expect("An unexpected error occurred.");
     let mut groups = setup.groups.write().expect("An unexpected error occurred.");
     let group = groups
@@ -30,7 +34,13 @@ fn test_mls_group_api(ciphersuite: Ciphersuite) {
         .random_new_members_for_group(group, 2)
         .expect("An unexpected error occurred.");
     setup
-        .add_clients(ActionType::Commit, group, &adder_id, new_members)
+        .add_clients(
+            ActionType::Commit,
+            group,
+            &adder_id,
+            new_members,
+            &noop_authentication_service,
+        )
         .expect("An unexpected error occurred.");
 
     // Remove a member
@@ -42,9 +52,10 @@ fn test_mls_group_api(ciphersuite: Ciphersuite) {
             group,
             &remover_id,
             &[LeafNodeIndex::new(target_index)],
+            &noop_authentication_service,
         )
         .expect("An unexpected error occurred.");
 
     // Check that all group members agree on the same group state.
-    setup.check_group_states(group);
+    setup.check_group_states(group, &noop_authentication_service);
 }

--- a/openmls/tests/test_managed_api.rs
+++ b/openmls/tests/test_managed_api.rs
@@ -1,13 +1,11 @@
 use openmls::{
     prelude::*,
-    test_utils::test_framework::{ActionType, CodecUse, MlsGroupTestSetup},
+    test_utils::test_framework::{
+        noop_authentication_service, ActionType, CodecUse, MlsGroupTestSetup,
+    },
     test_utils::*,
     *,
 };
-
-fn noop_authentication_service(_cred: &Credential) -> bool {
-    true
-}
 
 #[apply(ciphersuites)]
 fn test_mls_group_api(ciphersuite: Ciphersuite) {


### PR DESCRIPTION
A StagedCommit can carry credentials in several different places,
all of which have to be verified. To make this easier on the caller,
we add the `credentials_to_verify` method on StagedCommit, which returns
an iterator over all the credentials in a StagedCommit that need to
be verified.

Also we add infrastructure in test_framework for letting the test code
decide which credentials would pass validation, by passing in a closure
that takes a &Credential and returns a bool, as well as a simple test
that serves as an example for how to use the function.

Fixes #1469 