### PR TITLE
Refactor VerifiedStruct and Verifiable

### DIFF
--- a/openmls/src/ciphersuite/tests/kat_crypto_basics.rs
+++ b/openmls/src/ciphersuite/tests/kat_crypto_basics.rs
@@ -154,6 +154,8 @@ impl SignedStruct<SignWithLabelTest> for MySignature {
 }
 
 impl Verifiable for ParsedSignWithLabel {
+    type VerifiedStruct = ();
+
     fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
         Ok(self.content.clone())
     }
@@ -165,14 +167,19 @@ impl Verifiable for ParsedSignWithLabel {
     fn label(&self) -> &str {
         &self.label
     }
+
+    fn verify(
+        self,
+        crypto: &impl openmls_traits::crypto::OpenMlsCrypto,
+        pk: &crate::prelude_test::OpenMlsSignaturePublicKey,
+    ) -> Result<Self::VerifiedStruct, crate::prelude_test::signable::SignatureError> {
+        self.verify_no_out(crypto, pk)?;
+        Ok(())
+    }
 }
 
 // Dummy implementation
-impl VerifiedStruct<ParsedSignWithLabel> for () {
-    type SealingType = u8;
-
-    fn from_verifiable(_: ParsedSignWithLabel, _seal: Self::SealingType) -> Self {}
-}
+impl VerifiedStruct for () {}
 
 impl Signable for ParsedSignWithLabel {
     type SignedOutput = MySignature;
@@ -294,7 +301,7 @@ pub fn run_test_vector(
         // verify signature
         parsed
             .clone()
-            .verify::<()>(
+            .verify(
                 provider.crypto(),
                 &OpenMlsSignaturePublicKey::new(
                     public.clone().into(),
@@ -307,7 +314,7 @@ pub fn run_test_vector(
         // verify own signature
         parsed.signature = my_signature.0;
         parsed
-            .verify::<()>(
+            .verify(
                 provider.crypto(),
                 &OpenMlsSignaturePublicKey::new(public.into(), ciphersuite.signature_algorithm())
                     .unwrap(),

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -35,12 +35,6 @@ mod codec;
 
 pub use capabilities::*;
 
-/// Private module to ensure protection.
-mod private_mod {
-    #[derive(Default)]
-    pub(crate) struct Seal;
-}
-
 pub(crate) struct NewLeafNodeParams {
     pub(crate) config: CryptoConfig,
     pub(crate) credential_with_key: CredentialWithKey,
@@ -790,6 +784,8 @@ impl VerifiableKeyPackageLeafNode {
 }
 
 impl Verifiable for VerifiableKeyPackageLeafNode {
+    type VerifiedStruct = LeafNode;
+
     fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
         self.payload.tls_serialize_detached()
     }
@@ -801,18 +797,21 @@ impl Verifiable for VerifiableKeyPackageLeafNode {
     fn label(&self) -> &str {
         LEAF_NODE_SIGNATURE_LABEL
     }
-}
 
-impl VerifiedStruct<VerifiableKeyPackageLeafNode> for LeafNode {
-    fn from_verifiable(verifiable: VerifiableKeyPackageLeafNode, _seal: Self::SealingType) -> Self {
-        Self {
-            payload: verifiable.payload,
-            signature: verifiable.signature,
-        }
+    fn verify(
+        self,
+        crypto: &impl openmls_traits::crypto::OpenMlsCrypto,
+        pk: &crate::prelude_test::OpenMlsSignaturePublicKey,
+    ) -> Result<Self::VerifiedStruct, crate::prelude_test::signable::SignatureError> {
+        self.verify_no_out(crypto, pk)?;
+        Ok(LeafNode {
+            payload: self.payload,
+            signature: self.signature,
+        })
     }
-
-    type SealingType = private_mod::Seal;
 }
+
+impl VerifiedStruct for LeafNode {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct VerifiableUpdateLeafNode {
@@ -832,6 +831,8 @@ impl VerifiableUpdateLeafNode {
 }
 
 impl Verifiable for VerifiableUpdateLeafNode {
+    type VerifiedStruct = LeafNode;
+
     fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
         let tree_info_tbs = match &self.tree_position {
             Some(tree_position) => TreeInfoTbs::Commit(tree_position.clone()),
@@ -851,17 +852,18 @@ impl Verifiable for VerifiableUpdateLeafNode {
     fn label(&self) -> &str {
         LEAF_NODE_SIGNATURE_LABEL
     }
-}
 
-impl VerifiedStruct<VerifiableUpdateLeafNode> for LeafNode {
-    fn from_verifiable(verifiable: VerifiableUpdateLeafNode, _seal: Self::SealingType) -> Self {
-        Self {
-            payload: verifiable.payload,
-            signature: verifiable.signature,
-        }
+    fn verify(
+        self,
+        crypto: &impl openmls_traits::crypto::OpenMlsCrypto,
+        pk: &crate::prelude_test::OpenMlsSignaturePublicKey,
+    ) -> Result<Self::VerifiedStruct, crate::prelude_test::signable::SignatureError> {
+        self.verify_no_out(crypto, pk)?;
+        Ok(LeafNode {
+            payload: self.payload,
+            signature: self.signature,
+        })
     }
-
-    type SealingType = private_mod::Seal;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -882,6 +884,8 @@ impl VerifiableCommitLeafNode {
 }
 
 impl Verifiable for VerifiableCommitLeafNode {
+    type VerifiedStruct = LeafNode;
+
     fn unsigned_payload(&self) -> Result<Vec<u8>, tls_codec::Error> {
         let tree_info_tbs = match &self.tree_position {
             Some(tree_position) => TreeInfoTbs::Commit(tree_position.clone()),
@@ -902,17 +906,18 @@ impl Verifiable for VerifiableCommitLeafNode {
     fn label(&self) -> &str {
         LEAF_NODE_SIGNATURE_LABEL
     }
-}
 
-impl VerifiedStruct<VerifiableCommitLeafNode> for LeafNode {
-    fn from_verifiable(verifiable: VerifiableCommitLeafNode, _seal: Self::SealingType) -> Self {
-        Self {
-            payload: verifiable.payload,
-            signature: verifiable.signature,
-        }
+    fn verify(
+        self,
+        crypto: &impl openmls_traits::crypto::OpenMlsCrypto,
+        pk: &crate::prelude_test::OpenMlsSignaturePublicKey,
+    ) -> Result<Self::VerifiedStruct, crate::prelude_test::signable::SignatureError> {
+        self.verify_no_out(crypto, pk)?;
+        Ok(LeafNode {
+            payload: self.payload,
+            signature: self.signature,
+        })
     }
-
-    type SealingType = private_mod::Seal;
 }
 
 impl Signable for LeafNodeTbs {


### PR DESCRIPTION
The current version of the two traits is the way it is because it attempted to prevent the caller from being able to convert to the type implementing `VerifiedStruct` without checking the signature. However, the approach that was taken does not work.

This commit refactors the two traits and performs the conversion in the same method as the verification. Unfortunately, this means that the `verify` method has to be defined per `impl` instead of being able to rely on the default one. There probably is no straightforward way around that, so this simple solution is preferred.

Fixes #1465 