### PR TITLE
Add `with_group_context_extensions` method to group builders

### DIFF
--- a/book/src/user_manual/create_group.md
+++ b/book/src/user_manual/create_group.md
@@ -29,3 +29,11 @@ If someone else already gave you a group ID, e.g., a provider server, you can al
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code.rs:alice_create_group_with_group_id}}
 ```
+
+The Builder provides methods for setting required capabilities and external senders.
+The information passed into these lands in the group context, in the form of extensions.
+Should the user want to add further extensions, they can use the `with_group_context_extensions` method:
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code.rs:alice_create_group_with_builder_with_extensions}}
+```

--- a/openmls/src/extensions/errors.rs
+++ b/openmls/src/extensions/errors.rs
@@ -92,4 +92,9 @@ pub enum InvalidExtensionError {
     /// The specified extension could not be found.
     #[error("The specified extension could not be found.")]
     NotFound,
+    /// The provided extension list contains an extension that is not allowed in group contexts
+    #[error(
+        "The provided extension list contains an extension that is not allowed in group contexts."
+    )]
+    IllegalInGroupContext,
 }

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -262,6 +262,7 @@ fn with_group_context_extensions(ciphersuite: Ciphersuite, provider: &impl OpenM
 
     let mls_group_create_config = MlsGroupCreateConfig::builder()
         .with_group_context_extensions(extensions)
+        .expect("failed to apply extensions at group config builder")
         .crypto_config(CryptoConfig::with_default_version(ciphersuite))
         .build();
 

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -211,15 +211,9 @@ impl CoreGroupBuilder {
         mut self,
         extensions: Extensions,
     ) -> Result<Self, InvalidExtensionError> {
-        let is_valid_in_group_context = extensions.application_id().is_none()
-            && extensions.ratchet_tree().is_none()
-            && extensions.external_pub().is_none();
-        if !is_valid_in_group_context {
-            return Err(InvalidExtensionError::IllegalInGroupContext);
-        }
         self.public_group_builder = self
             .public_group_builder
-            .with_group_context_extensions(extensions);
+            .with_group_context_extensions(extensions)?;
         Ok(self)
     }
 

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -200,6 +200,19 @@ impl CoreGroupBuilder {
         }
         self
     }
+
+    /// Set initial group context extensions. Note that RequiredCapabilities
+    /// extensions will be overwritten, and should be set using a call to
+    /// `required_capabilities`. If `ExternalSenders` extensions are provided
+    /// both in this call, and a call to `external_senders`, only the one from
+    /// the call to `external_senders` will be included.
+    pub(crate) fn with_group_context_extensions(mut self, extensions: Extensions) -> Self {
+        self.public_group_builder = self
+            .public_group_builder
+            .with_group_context_extensions(extensions);
+        self
+    }
+
     /// Set the number of past epochs the group should keep secrets.
     pub fn with_max_past_epoch_secrets(mut self, max_past_epochs: usize) -> Self {
         self.max_past_epochs = max_past_epochs;

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::{InnerState, MlsGroup, MlsGroupState};
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct MlsGroupBuilder {
     group_id: Option<GroupId>,
     mls_group_create_config_builder: MlsGroupCreateConfigBuilder,

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -2,7 +2,7 @@ use openmls_traits::{key_store::OpenMlsKeyStore, signatures::Signer, OpenMlsProv
 
 use crate::{
     credentials::CredentialWithKey,
-    extensions::ExternalSendersExtension,
+    extensions::{Extensions, ExternalSendersExtension},
     group::{
         config::CryptoConfig, public_group::errors::PublicGroupBuildError, CoreGroup,
         CoreGroupBuildError, CoreGroupConfig, GroupId, MlsGroupCreateConfig,
@@ -196,6 +196,14 @@ impl MlsGroupBuilder {
         self.mls_group_create_config_builder = self
             .mls_group_create_config_builder
             .external_senders(external_senders);
+        self
+    }
+
+    /// Sets the initial group context extensions
+    pub fn with_group_context_extensions(mut self, extensions: Extensions) -> Self {
+        self.mls_group_create_config_builder = self
+            .mls_group_create_config_builder
+            .with_group_context_extensions(extensions);
         self
     }
 }

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -72,6 +72,7 @@ impl MlsGroupBuilder {
         .with_config(group_config)
         .with_required_capabilities(mls_group_create_config.required_capabilities.clone())
         .with_external_senders(mls_group_create_config.external_senders.clone())
+        .with_group_context_extensions(mls_group_create_config.group_context_extensions.clone())
         .with_max_past_epoch_secrets(mls_group_create_config.join_config.max_past_epochs)
         .with_lifetime(*mls_group_create_config.lifetime())
         .build(provider, signer)

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -2,7 +2,7 @@ use openmls_traits::{key_store::OpenMlsKeyStore, signatures::Signer, OpenMlsProv
 
 use crate::{
     credentials::CredentialWithKey,
-    extensions::{Extensions, ExternalSendersExtension},
+    extensions::{errors::InvalidExtensionError, Extensions, ExternalSendersExtension},
     group::{
         config::CryptoConfig, public_group::errors::PublicGroupBuildError, CoreGroup,
         CoreGroupBuildError, CoreGroupConfig, GroupId, MlsGroupCreateConfig,
@@ -72,7 +72,7 @@ impl MlsGroupBuilder {
         .with_config(group_config)
         .with_required_capabilities(mls_group_create_config.required_capabilities.clone())
         .with_external_senders(mls_group_create_config.external_senders.clone())
-        .with_group_context_extensions(mls_group_create_config.group_context_extensions.clone())
+        .with_group_context_extensions(mls_group_create_config.group_context_extensions.clone())?
         .with_max_past_epoch_secrets(mls_group_create_config.join_config.max_past_epochs)
         .with_lifetime(*mls_group_create_config.lifetime())
         .build(provider, signer)
@@ -201,10 +201,13 @@ impl MlsGroupBuilder {
     }
 
     /// Sets the initial group context extensions
-    pub fn with_group_context_extensions(mut self, extensions: Extensions) -> Self {
+    pub fn with_group_context_extensions(
+        mut self,
+        extensions: Extensions,
+    ) -> Result<Self, InvalidExtensionError> {
         self.mls_group_create_config_builder = self
             .mls_group_create_config_builder
-            .with_group_context_extensions(extensions);
-        self
+            .with_group_context_extensions(extensions)?;
+        Ok(self)
     }
 }

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -93,6 +93,8 @@ pub struct MlsGroupCreateConfig {
     pub(crate) crypto_config: CryptoConfig,
     /// Configuration parameters relevant to group operation at runtime
     pub(crate) join_config: MlsGroupJoinConfig,
+    /// List of initial group context extensions
+    pub(crate) group_context_extensions: Extensions,
 }
 
 /// Builder struct for an [`MlsGroupJoinConfig`].
@@ -314,6 +316,12 @@ impl MlsGroupCreateConfigBuilder {
     /// Sets the `external_senders` property of the MlsGroupCreateConfig.
     pub fn external_senders(mut self, external_senders: ExternalSendersExtension) -> Self {
         self.config.external_senders = external_senders;
+        self
+    }
+
+    /// Sets the initial group context extensions
+    pub fn with_group_context_extensions(mut self, extensions: Extensions) -> Self {
+        self.config.group_context_extensions = extensions;
         self
     }
 

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -202,6 +202,13 @@ impl MlsGroupCreateConfig {
         &self.external_senders
     }
 
+    /// Returns the [`Extensions`] set as the initial group context.
+    /// This does not contain the initial group context extensions
+    /// added from builder calls to `external_senders` or `required_capabilities`.
+    pub fn group_context_extensions(&self) -> &Extensions {
+        &self.group_context_extensions
+    }
+
     /// Returns the [`MlsGroupCreateConfig`] lifetime configuration.
     pub fn lifetime(&self) -> &Lifetime {
         &self.lifetime

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -237,7 +237,7 @@ impl MlsGroupCreateConfig {
 }
 
 /// Builder for an [`MlsGroupCreateConfig`].
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct MlsGroupCreateConfigBuilder {
     config: MlsGroupCreateConfig,
 }

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -38,7 +38,7 @@ pub enum NewGroupError<KeyStoreError> {
     UnsupportedExtensionType,
     /// Invalid extensions set in configuration
     #[error("Invalid extensions set in configuration")]
-    InvalidExtensions(InvalidExtensionError),
+    InvalidExtensions(#[from] InvalidExtensionError),
 }
 
 /// EmptyInput error

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -170,6 +170,30 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         // Silence "unused variable" and "does not need to be mutable" warnings.
         let _ignore_mut_warning = &mut alice_group;
 
+        let external_senders_list = vec![];
+
+        // ANCHOR: alice_create_group_with_builder_with_extensions
+        // we are adding an external senders list as an example.
+        let extensions =
+            Extensions::from_vec(vec![Extension::ExternalSenders(external_senders_list)])
+                .expect("failed to create extensions list");
+
+        let mut alice_group = MlsGroup::builder()
+            .padding_size(100)
+            .sender_ratchet_configuration(SenderRatchetConfiguration::new(
+                10,   // out_of_order_tolerance
+                2000, // maximum_forward_distance
+            ))
+            .with_group_context_extensions(extensions) // NB: the builder method returns a Result
+            .expect("failed to apply group context extensions")
+            .use_ratchet_tree_extension(true)
+            .build(provider, &alice_signature_keys, alice_credential.clone())
+            .expect("An unexpected error occurred.");
+        // ANCHOR_END: alice_create_group_with_builder_with_extensions
+
+        // Silence "unused variable" and "does not need to be mutable" warnings.
+        let _ignore_mut_warning = &mut alice_group;
+
         // ANCHOR: alice_create_group_with_builder
         let mut alice_group = MlsGroup::builder()
             .padding_size(100)


### PR DESCRIPTION
Currently, only two kinds of extensions can be set for the initial group context, and they both have their own method on the builder to set them. In order to be able to add arbitrary extensions, this PR adds a method `with_group_context_extensions` to the group builders, that sets an arbitrary set of extensions. The set is of type `Extensions`, so we know that each extension is only set once.

Any RequiredCapability extension mentioned in that set will be overwritten, and if ExternalSenders is specified using the dedicated method, that one is preferred and the one provided using `with_group_context_extensions` is dropped.