### PR TITLE
Add leaf node configuration options to MlsGroup builder

### DIFF
--- a/book/src/user_manual/group_config.md
+++ b/book/src/user_manual/group_config.md
@@ -19,6 +19,8 @@ Two very similar structs can help configure groups upon their creation: `MlsGrou
 | ------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `required_capabilities`        | `RequiredCapabilitiesExtension` | Required capabilities (extensions and proposal types).                                           |
 | `external_senders`             | `ExternalSendersExtensions`     | List credentials of non-group members that are allowed to send proposals to the group.           |
+| `capabilities` .               | `Capabilities`                  | Lists the capabilities of the group's creator.                                                   |
+| `leaf_extensions` .            | `Extensions`                    | Extensions to be included in the group creator's leaf                                            |
 
 Both ways of group configurations can be specified by using the struct's builder pattern, or choosing their default values. The default value contains safe values for all parameters and is suitable for scenarios without particular requirements.
 

--- a/openmls/src/extensions/errors.rs
+++ b/openmls/src/extensions/errors.rs
@@ -97,4 +97,9 @@ pub enum InvalidExtensionError {
         "The provided extension list contains an extension that is not allowed in group contexts."
     )]
     IllegalInGroupContext,
+    /// The provided extension list contains an extension that is not allowed in leaf nodes
+    #[error(
+        "The provided extension list contains an extension that is not allowed in leaf nodes."
+    )]
+    IllegalInLeafNodes,
 }

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -190,7 +190,7 @@ impl CoreGroupBuilder {
             .with_required_capabilities(required_capabilities);
         self
     }
-    /// Set the [`Capabilities`] of the [`CoreGroup`].
+    /// Set the [`Capabilities`] of the group's creator.
     pub(crate) fn with_capabilities(mut self, capabilities: Capabilities) -> Self {
         self.public_group_builder = self.public_group_builder.with_capabilities(capabilities);
         self

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -39,6 +39,7 @@ use tls_codec::Serialize as TlsSerializeTrait;
 
 use self::{
     create_commit_params::{CommitType, CreateCommitParams},
+    node::leaf_node::Capabilities,
     past_secrets::MessageSecretsStore,
     staged_commit::{MemberStagedCommitState, StagedCommit, StagedCommitState},
 };
@@ -189,6 +190,11 @@ impl CoreGroupBuilder {
             .with_required_capabilities(required_capabilities);
         self
     }
+    /// Set the [`Capabilities`] of the [`CoreGroup`].
+    pub(crate) fn with_capabilities(mut self, capabilities: Capabilities) -> Self {
+        self.public_group_builder = self.public_group_builder.with_capabilities(capabilities);
+        self
+    }
     /// Set the [`ExternalSendersExtension`] of the [`CoreGroup`].
     pub(crate) fn with_external_senders(
         mut self,
@@ -214,6 +220,17 @@ impl CoreGroupBuilder {
         self.public_group_builder = self
             .public_group_builder
             .with_group_context_extensions(extensions)?;
+        Ok(self)
+    }
+
+    /// Sets extensions of the group creator's [`LeafNode`].
+    pub(crate) fn with_leaf_node_extensions(
+        mut self,
+        extensions: Extensions,
+    ) -> Result<Self, InvalidExtensionError> {
+        self.public_group_builder = self
+            .public_group_builder
+            .with_leaf_node_extensions(extensions)?;
         Ok(self)
     }
 

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -221,6 +221,7 @@ impl MlsGroupBuilder {
         Ok(self)
     }
 
+    /// Sets the initial leaf node extensions
     pub fn with_leaf_node_extensions(
         mut self,
         extensions: Extensions,

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -8,7 +8,7 @@ use crate::{
         CoreGroupBuildError, CoreGroupConfig, GroupId, MlsGroupCreateConfig,
         MlsGroupCreateConfigBuilder, NewGroupError, ProposalStore, WireFormatPolicy,
     },
-    prelude::{LibraryError, Lifetime, SenderRatchetConfiguration},
+    prelude::{Capabilities, LibraryError, Lifetime, SenderRatchetConfiguration},
 };
 
 use super::{InnerState, MlsGroup, MlsGroupState};
@@ -73,6 +73,8 @@ impl MlsGroupBuilder {
         .with_required_capabilities(mls_group_create_config.required_capabilities.clone())
         .with_external_senders(mls_group_create_config.external_senders.clone())
         .with_group_context_extensions(mls_group_create_config.group_context_extensions.clone())?
+        .with_leaf_node_extensions(mls_group_create_config.leaf_node_extensions.clone())?
+        .with_capabilities(mls_group_create_config.capabilities.clone())
         .with_max_past_epoch_secrets(mls_group_create_config.join_config.max_past_epochs)
         .with_lifetime(*mls_group_create_config.lifetime())
         .build(provider, signer)
@@ -200,6 +202,14 @@ impl MlsGroupBuilder {
         self
     }
 
+    /// Sets the group creator's [`Capabilities`]
+    pub fn with_capabilities(mut self, capabilities: Capabilities) -> Self {
+        self.mls_group_create_config_builder = self
+            .mls_group_create_config_builder
+            .capabilities(capabilities);
+        self
+    }
+
     /// Sets the initial group context extensions
     pub fn with_group_context_extensions(
         mut self,
@@ -208,6 +218,16 @@ impl MlsGroupBuilder {
         self.mls_group_create_config_builder = self
             .mls_group_create_config_builder
             .with_group_context_extensions(extensions)?;
+        Ok(self)
+    }
+
+    pub fn with_leaf_node_extensions(
+        mut self,
+        extensions: Extensions,
+    ) -> Result<Self, InvalidExtensionError> {
+        self.mls_group_create_config_builder = self
+            .mls_group_create_config_builder
+            .with_leaf_node_extensions(extensions)?;
         Ok(self)
     }
 }

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -30,7 +30,7 @@
 use super::*;
 use crate::{
     extensions::errors::InvalidExtensionError, group::config::CryptoConfig, key_packages::Lifetime,
-    tree::sender_ratchet::SenderRatchetConfiguration,
+    tree::sender_ratchet::SenderRatchetConfiguration, treesync::node::leaf_node::Capabilities,
 };
 use serde::{Deserialize, Serialize};
 
@@ -85,6 +85,8 @@ impl MlsGroupJoinConfig {
 pub struct MlsGroupCreateConfig {
     /// Required capabilities (extensions and proposal types)
     pub(crate) required_capabilities: RequiredCapabilitiesExtension,
+    /// Capabilities advertised in the creator's leaf node
+    pub(crate) capabilities: Capabilities,
     /// Senders authorized to send external remove proposals
     pub(crate) external_senders: ExternalSendersExtension,
     /// Lifetime of the own leaf node
@@ -95,6 +97,8 @@ pub struct MlsGroupCreateConfig {
     pub(crate) join_config: MlsGroupJoinConfig,
     /// List of initial group context extensions
     pub(crate) group_context_extensions: Extensions,
+    /// List of initial leaf node extensions
+    pub(crate) leaf_node_extensions: Extensions,
 }
 
 /// Builder struct for an [`MlsGroupJoinConfig`].
@@ -298,6 +302,12 @@ impl MlsGroupCreateConfigBuilder {
         self
     }
 
+    /// Sets the `capabilities` of the group creator's leaf node.
+    pub fn capabilities(mut self, capabilities: Capabilities) -> Self {
+        self.config.capabilities = capabilities;
+        self
+    }
+
     /// Sets the `sender_ratchet_configuration` property of the MlsGroupCreateConfig.
     /// See [`SenderRatchetConfiguration`] for more information.
     pub fn sender_ratchet_configuration(
@@ -342,6 +352,23 @@ impl MlsGroupCreateConfigBuilder {
             return Err(InvalidExtensionError::IllegalInGroupContext);
         }
         self.config.group_context_extensions = extensions;
+        Ok(self)
+    }
+
+    /// Sets extensions of the group creator's [`LeafNode`].
+    pub fn with_leaf_node_extensions(
+        mut self,
+        extensions: Extensions,
+    ) -> Result<Self, InvalidExtensionError> {
+        // None of the default extensions are leaf node extensions, so only
+        // unknown extensions can be leaf node extensions.
+        let is_valid_in_leaf_node = extensions
+            .iter()
+            .all(|e| matches!(e.extension_type(), ExtensionType::Unknown(_)));
+        if !is_valid_in_leaf_node {
+            return Err(InvalidExtensionError::IllegalInLeafNodes);
+        }
+        self.config.leaf_node_extensions = extensions;
         Ok(self)
     }
 

--- a/openmls/src/group/public_group/builder.rs
+++ b/openmls/src/group/public_group/builder.rs
@@ -84,7 +84,7 @@ impl TempBuilderPG1 {
             .iter()
             .all(|e| matches!(e.extension_type(), ExtensionType::Unknown(_)));
         if !is_valid_in_leaf_node {
-            return Err(InvalidExtensionError::IllegalInGroupContext);
+            return Err(InvalidExtensionError::IllegalInLeafNodes);
         }
         self.leaf_node_extensions = extensions;
         Ok(self)

--- a/openmls/src/group/public_group/builder.rs
+++ b/openmls/src/group/public_group/builder.rs
@@ -8,7 +8,7 @@ use crate::{
         errors::{ExtensionError, InvalidExtensionError},
         Extension, Extensions, ExternalSendersExtension, RequiredCapabilitiesExtension,
     },
-    group::{config::CryptoConfig, GroupContext, GroupId},
+    group::{config::CryptoConfig, ExtensionType, GroupContext, GroupId},
     key_packages::Lifetime,
     messages::ConfirmationTag,
     schedule::CommitSecret,
@@ -25,9 +25,10 @@ pub(crate) struct TempBuilderPG1 {
     credential_with_key: CredentialWithKey,
     lifetime: Option<Lifetime>,
     required_capabilities: Option<RequiredCapabilitiesExtension>,
+    capabilities: Option<Capabilities>,
     external_senders: Option<ExternalSendersExtension>,
-    leaf_extensions: Option<Extensions>,
-    group_context_extensions: Option<Extensions>,
+    leaf_node_extensions: Extensions,
+    group_context_extensions: Extensions,
 }
 
 impl TempBuilderPG1 {
@@ -41,6 +42,11 @@ impl TempBuilderPG1 {
         required_capabilities: RequiredCapabilitiesExtension,
     ) -> Self {
         self.required_capabilities = Some(required_capabilities);
+        self
+    }
+
+    pub(crate) fn with_capabilities(mut self, capabilities: Capabilities) -> Self {
+        self.capabilities = Some(capabilities);
         self
     }
 
@@ -64,7 +70,23 @@ impl TempBuilderPG1 {
         if !is_valid_in_group_context {
             return Err(InvalidExtensionError::IllegalInGroupContext);
         }
-        self.group_context_extensions = Some(extensions);
+        self.group_context_extensions = extensions;
+        Ok(self)
+    }
+
+    pub(crate) fn with_leaf_node_extensions(
+        mut self,
+        extensions: Extensions,
+    ) -> Result<Self, InvalidExtensionError> {
+        // None of the default extensions are leaf node extensions, so only
+        // unknown extensions can be leaf node extensions.
+        let is_valid_in_leaf_node = extensions
+            .iter()
+            .all(|e| matches!(e.extension_type(), ExtensionType::Unknown(_)));
+        if !is_valid_in_leaf_node {
+            return Err(InvalidExtensionError::IllegalInGroupContext);
+        }
+        self.leaf_node_extensions = extensions;
         Ok(self)
     }
 
@@ -73,24 +95,30 @@ impl TempBuilderPG1 {
         provider: &impl OpenMlsProvider,
         signer: &impl Signer,
     ) -> Result<(TempBuilderPG2, CommitSecret, EncryptionKeyPair), PublicGroupBuildError> {
-        let capabilities = self
-            .required_capabilities
-            .as_ref()
-            .map(|re| re.extension_types());
+        // Capabilities are either provided by the builder or a minimal set of
+        // capabilities is created from the crypto config and the required
+        // capabilities
+        let capabilities = self.capabilities.unwrap_or(Capabilities::new(
+            Some(&[self.crypto_config.version]),
+            Some(&[self.crypto_config.ciphersuite]),
+            self.required_capabilities
+                .as_ref()
+                .map(|re| re.extension_types()),
+            self.required_capabilities
+                .as_ref()
+                .map(|re| re.proposal_types()),
+            self.required_capabilities
+                .as_ref()
+                .map(|re| re.credential_types()),
+        ));
         let (treesync, commit_secret, leaf_keypair) = TreeSync::new(
             provider,
             signer,
             self.crypto_config,
             self.credential_with_key,
             self.lifetime.unwrap_or_default(),
-            Capabilities::new(
-                Some(&[self.crypto_config.version]), // TODO: Allow more versions
-                Some(&[self.crypto_config.ciphersuite]), // TODO: allow more ciphersuites
-                capabilities,
-                None,
-                None,
-            ),
-            self.leaf_extensions.unwrap_or(Extensions::empty()),
+            capabilities,
+            self.leaf_node_extensions,
         )?;
         let required_capabilities = self.required_capabilities.unwrap_or_default();
         required_capabilities.check_support().map_err(|e| match e {
@@ -104,11 +132,7 @@ impl TempBuilderPG1 {
         })?;
         let required_capabilities = Extension::RequiredCapabilities(required_capabilities);
 
-        let mut group_context_extensions = if let Some(exts) = self.group_context_extensions {
-            exts
-        } else {
-            Extensions::empty()
-        };
+        let mut group_context_extensions = self.group_context_extensions;
         group_context_extensions.add_or_replace(required_capabilities);
         if let Some(ext_senders) = self.external_senders {
             group_context_extensions.add_or_replace(Extension::ExternalSenders(ext_senders));
@@ -191,9 +215,10 @@ impl PublicGroup {
             credential_with_key,
             lifetime: None,
             required_capabilities: None,
+            capabilities: None,
             external_senders: None,
-            leaf_extensions: None,
-            group_context_extensions: None,
+            leaf_node_extensions: Extensions::empty(),
+            group_context_extensions: Extensions::empty(),
         }
     }
 }

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -133,11 +133,24 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
             10,   // out_of_order_tolerance
             2000, // maximum_forward_distance
         ))
+        .crypto_config(CryptoConfig::with_default_version(ciphersuite))
+        .capabilities(Capabilities::new(
+            None, // Defaults to the group's protocol version
+            None, // Defaults to the group's ciphersuite
+            None, // Defaults to all basic extension types
+            None, // Defaults to all basic proposal types
+            Some(&[CredentialType::Basic]),
+        ))
+        // Example leaf extension
+        .with_leaf_node_extensions(Extensions::single(Extension::Unknown(
+            0xff00,
+            UnknownExtension(vec![0, 1, 2, 3]),
+        )))
+        .expect("failed to configure leaf extensions")
         .external_senders(vec![ExternalSender::new(
             ds_credential_with_key.signature_key.clone(),
             ds_credential_with_key.credential.clone(),
         )])
-        .crypto_config(CryptoConfig::with_default_version(ciphersuite))
         .use_ratchet_tree_extension(true)
         .build();
     // ANCHOR_END: mls_group_create_config_example


### PR DESCRIPTION
This PR adds (and tests) a way to add leaf node extensions and capabilities when creating a new group using the MlsGroup builder pattern.