### PR TITLE
Clean up `MlsGroup*` builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#1464](https://github.com/openmls/openmls/pull/1464): Add builder pattern for `MlsGroup`; split `MlsGroupJoinConfig` into `MlsGroupCreateConfig` and `MlsGroupJoinConfig`
+- [#1473](https://github.com/openmls/openmls/pull/1473): Allow setting group context extensions when building an MlsGroup(Config).
+- [#1475](https://github.com/openmls/openmls/pull/1475): Fully process GroupContextExtension proposals
+- [#1477](https://github.com/openmls/openmls/pull/1477): Allow setting leaf node extensions and capabilities of the group creator when creating an MlsGroup(Config)
+- [#1478](https://github.com/openmls/openmls/pull/1478): Remove explicit functions to set `RequiredCapabilitiesExtension` and `ExternalSendersExtension` when building an MlsGroup(Config) in favor of the more general function to set group context extensions
 
 ## 0.5.0 (XXXX-XX-XX)
 

--- a/book/src/user_manual/group_config.md
+++ b/book/src/user_manual/group_config.md
@@ -17,8 +17,7 @@ Two very similar structs can help configure groups upon their creation: `MlsGrou
 
 | Name                           | Type                            | Explanation                                                                                      |
 | ------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `required_capabilities`        | `RequiredCapabilitiesExtension` | Required capabilities (extensions and proposal types).                                           |
-| `external_senders`             | `ExternalSendersExtensions`     | List credentials of non-group members that are allowed to send proposals to the group.           |
+| `group_context_extensions`     | `Extensions`                    | Optional group-level extensions, e.g. `RequiredCapabilitiesExtension`.                           |
 
 Both ways of group configurations can be specified by using the struct's builder pattern, or choosing their default values. The default value contains safe values for all parameters and is suitable for scenarios without particular requirements.
 

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -179,28 +179,6 @@ impl CoreGroupBuilder {
         self.psk_ids = psk_ids;
         self
     }
-    /// Set the [`RequiredCapabilitiesExtension`] of the [`CoreGroup`].
-    pub(crate) fn with_required_capabilities(
-        mut self,
-        required_capabilities: RequiredCapabilitiesExtension,
-    ) -> Self {
-        self.public_group_builder = self
-            .public_group_builder
-            .with_required_capabilities(required_capabilities);
-        self
-    }
-    /// Set the [`ExternalSendersExtension`] of the [`CoreGroup`].
-    pub(crate) fn with_external_senders(
-        mut self,
-        external_senders: ExternalSendersExtension,
-    ) -> Self {
-        if !external_senders.is_empty() {
-            self.public_group_builder = self
-                .public_group_builder
-                .with_external_senders(external_senders);
-        }
-        self
-    }
 
     /// Sets initial group context extensions. Note that RequiredCapabilities
     /// extensions will be overwritten, and should be set using a call to

--- a/openmls/src/group/core_group/test_proposals.rs
+++ b/openmls/src/group/core_group/test_proposals.rs
@@ -298,7 +298,10 @@ fn test_required_unsupported_proposals(ciphersuite: Ciphersuite, provider: &impl
         CryptoConfig::with_default_version(ciphersuite),
         alice_credential,
     )
-    .with_required_capabilities(required_capabilities)
+    .with_group_context_extensions(Extensions::single(Extension::RequiredCapabilities(
+        required_capabilities,
+    )))
+    .unwrap()
     .build(provider, &alice_signer)
     .expect_err(
         "CoreGroup creation must fail because AppAck proposals aren't supported in OpenMLS yet.",
@@ -339,7 +342,10 @@ fn test_group_context_extensions(ciphersuite: Ciphersuite, provider: &impl OpenM
         CryptoConfig::with_default_version(ciphersuite),
         alice_credential,
     )
-    .with_required_capabilities(required_capabilities)
+    .with_group_context_extensions(Extensions::single(Extension::RequiredCapabilities(
+        required_capabilities,
+    )))
+    .unwrap()
     .build(provider, &alice_signer)
     .expect("Error creating CoreGroup.");
 
@@ -417,7 +423,10 @@ fn test_group_context_extension_proposal_fails(
         CryptoConfig::with_default_version(ciphersuite),
         alice_credential,
     )
-    .with_required_capabilities(required_capabilities)
+    .with_group_context_extensions(Extensions::single(Extension::RequiredCapabilities(
+        required_capabilities,
+    )))
+    .unwrap()
     .build(provider, &alice_signer)
     .expect("Error creating CoreGroup.");
 

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -2,7 +2,7 @@ use openmls_traits::{key_store::OpenMlsKeyStore, signatures::Signer, OpenMlsProv
 
 use crate::{
     credentials::CredentialWithKey,
-    extensions::{errors::InvalidExtensionError, Extensions, ExternalSendersExtension},
+    extensions::{errors::InvalidExtensionError, Extensions},
     group::{
         config::CryptoConfig, public_group::errors::PublicGroupBuildError, CoreGroup,
         CoreGroupBuildError, CoreGroupConfig, GroupId, MlsGroupCreateConfig,
@@ -70,8 +70,6 @@ impl MlsGroupBuilder {
             credential_with_key,
         )
         .with_config(group_config)
-        .with_required_capabilities(mls_group_create_config.required_capabilities.clone())
-        .with_external_senders(mls_group_create_config.external_senders.clone())
         .with_group_context_extensions(mls_group_create_config.group_context_extensions.clone())?
         .with_max_past_epoch_secrets(mls_group_create_config.join_config.max_past_epochs)
         .with_lifetime(*mls_group_create_config.lifetime())
@@ -189,14 +187,6 @@ impl MlsGroupBuilder {
     pub fn crypto_config(mut self, config: CryptoConfig) -> Self {
         self.mls_group_create_config_builder =
             self.mls_group_create_config_builder.crypto_config(config);
-        self
-    }
-
-    /// Sets the `external_senders` property of the MlsGroup.
-    pub fn external_senders(mut self, external_senders: ExternalSendersExtension) -> Self {
-        self.mls_group_create_config_builder = self
-            .mls_group_create_config_builder
-            .external_senders(external_senders);
         self
     }
 

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -307,11 +307,7 @@ impl MlsGroupCreateConfigBuilder {
         self
     }
 
-    /// Sets initial group context extensions. Note that RequiredCapabilities
-    /// extensions will be overwritten, and should be set using a call to
-    /// `required_capabilities`. If `ExternalSenders` extensions are provided
-    /// both in this call, and a call to `external_senders`, only the one from
-    /// the call to `external_senders` will be included.
+    /// Sets initial group context extensions.
     pub fn with_group_context_extensions(
         mut self,
         extensions: Extensions,

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -83,10 +83,6 @@ impl MlsGroupJoinConfig {
 /// more information about the different configuration values.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MlsGroupCreateConfig {
-    /// Required capabilities (extensions and proposal types)
-    pub(crate) required_capabilities: RequiredCapabilitiesExtension,
-    /// Senders authorized to send external remove proposals
-    pub(crate) external_senders: ExternalSendersExtension,
     /// Lifetime of the own leaf node
     pub(crate) lifetime: Lifetime,
     /// Ciphersuite and protocol version
@@ -187,19 +183,9 @@ impl MlsGroupCreateConfig {
         self.join_config.use_ratchet_tree_extension
     }
 
-    /// Returns the [`MlsGroupCreateConfig`] required capabilities extension.
-    pub fn required_capabilities(&self) -> &RequiredCapabilitiesExtension {
-        &self.required_capabilities
-    }
-
     /// Returns the [`MlsGroupCreateConfig`] sender ratchet configuration.
     pub fn sender_ratchet_configuration(&self) -> &SenderRatchetConfiguration {
         &self.join_config.sender_ratchet_configuration
-    }
-
-    /// Returns the [`MlsGroupCreateConfig`] external senders extension
-    pub fn external_senders(&self) -> &ExternalSendersExtension {
-        &self.external_senders
     }
 
     /// Returns the [`Extensions`] set as the initial group context.
@@ -289,15 +275,6 @@ impl MlsGroupCreateConfigBuilder {
         self
     }
 
-    /// Sets the `required_capabilities` property of the MlsGroupCreateConfig.
-    pub fn required_capabilities(
-        mut self,
-        required_capabilities: RequiredCapabilitiesExtension,
-    ) -> Self {
-        self.config.required_capabilities = required_capabilities;
-        self
-    }
-
     /// Sets the `sender_ratchet_configuration` property of the MlsGroupCreateConfig.
     /// See [`SenderRatchetConfiguration`] for more information.
     pub fn sender_ratchet_configuration(
@@ -317,12 +294,6 @@ impl MlsGroupCreateConfigBuilder {
     /// Sets the `crypto_config` property of the MlsGroupCreateConfig.
     pub fn crypto_config(mut self, config: CryptoConfig) -> Self {
         self.config.crypto_config = config;
-        self
-    }
-
-    /// Sets the `external_senders` property of the MlsGroupCreateConfig.
-    pub fn external_senders(mut self, external_senders: ExternalSendersExtension) -> Self {
-        self.config.external_senders = external_senders;
         self
     }
 

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -1014,14 +1014,12 @@ fn group_context_extensions_proposal(ciphersuite: Ciphersuite, provider: &impl O
         .build(provider, &alice_signer, alice_credential_with_key)
         .expect("error creating group using builder");
 
-    let required_capabilities = alice_group
+    // No required capabilities, so no specifically required extensions.
+    assert!(alice_group
         .group()
         .group_context_extensions()
         .required_capabilities()
-        .expect("couldn't get required_capabilities");
-
-    // no required extensions
-    assert!(required_capabilities.extension_types().is_empty());
+        .is_none());
 
     let new_extensions = Extensions::single(Extension::RequiredCapabilities(
         RequiredCapabilitiesExtension::new(&[ExtensionType::RequiredCapabilities], &[], &[]),
@@ -1115,7 +1113,10 @@ fn builder_pattern(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         .with_group_id(test_group_id.clone())
         .padding_size(test_padding_size)
         .sender_ratchet_configuration(test_sender_ratchet_config.clone())
-        .external_senders(test_external_senders.clone())
+        .with_group_context_extensions(Extensions::single(Extension::ExternalSenders(
+            test_external_senders.clone(),
+        )))
+        .unwrap()
         .crypto_config(test_crypto_config)
         .with_wire_format_policy(test_wire_format_policy)
         .lifetime(test_lifetime)

--- a/openmls/src/group/public_group/builder.rs
+++ b/openmls/src/group/public_group/builder.rs
@@ -6,7 +6,7 @@ use crate::{
     error::LibraryError,
     extensions::{
         errors::{ExtensionError, InvalidExtensionError},
-        Extension, Extensions, ExternalSendersExtension, RequiredCapabilitiesExtension,
+        Extensions,
     },
     group::{config::CryptoConfig, GroupContext, GroupId},
     key_packages::Lifetime,
@@ -24,33 +24,13 @@ pub(crate) struct TempBuilderPG1 {
     crypto_config: CryptoConfig,
     credential_with_key: CredentialWithKey,
     lifetime: Option<Lifetime>,
-    required_capabilities: Option<RequiredCapabilitiesExtension>,
-    external_senders: Option<ExternalSendersExtension>,
-    leaf_extensions: Option<Extensions>,
-    group_context_extensions: Option<Extensions>,
+    leaf_extensions: Extensions,
+    group_context_extensions: Extensions,
 }
 
 impl TempBuilderPG1 {
     pub(crate) fn with_lifetime(mut self, lifetime: Lifetime) -> Self {
         self.lifetime = Some(lifetime);
-        self
-    }
-
-    pub(crate) fn with_required_capabilities(
-        mut self,
-        required_capabilities: RequiredCapabilitiesExtension,
-    ) -> Self {
-        self.required_capabilities = Some(required_capabilities);
-        self
-    }
-
-    pub(crate) fn with_external_senders(
-        mut self,
-        external_senders: ExternalSendersExtension,
-    ) -> Self {
-        if !external_senders.is_empty() {
-            self.external_senders = Some(external_senders);
-        }
         self
     }
 
@@ -64,7 +44,7 @@ impl TempBuilderPG1 {
         if !is_valid_in_group_context {
             return Err(InvalidExtensionError::IllegalInGroupContext);
         }
-        self.group_context_extensions = Some(extensions);
+        self.group_context_extensions = extensions;
         Ok(self)
     }
 
@@ -73,52 +53,53 @@ impl TempBuilderPG1 {
         provider: &impl OpenMlsProvider,
         signer: &impl Signer,
     ) -> Result<(TempBuilderPG2, CommitSecret, EncryptionKeyPair), PublicGroupBuildError> {
-        let capabilities = self
-            .required_capabilities
-            .as_ref()
-            .map(|re| re.extension_types());
+        // If there are no capabilities, we want to provide a default version
+        // plus anything in the required capabilities.
+        let (required_extensions, required_proposals, required_credentials) =
+            if let Some(required_capabilities) =
+                self.group_context_extensions.required_capabilities()
+            {
+                // Also, while we're at it, check if we support all required
+                // capabilities ourselves.
+                required_capabilities.check_support().map_err(|e| match e {
+                    ExtensionError::UnsupportedProposalType => {
+                        PublicGroupBuildError::UnsupportedProposalType
+                    }
+                    ExtensionError::UnsupportedExtensionType => {
+                        PublicGroupBuildError::UnsupportedExtensionType
+                    }
+                    _ => LibraryError::custom("Unexpected ExtensionError").into(),
+                })?;
+                (
+                    Some(required_capabilities.extension_types()),
+                    Some(required_capabilities.proposal_types()),
+                    Some(required_capabilities.credential_types()),
+                )
+            } else {
+                (None, None, None)
+            };
+        let capabilities = Capabilities::new(
+            Some(&[self.crypto_config.version]),
+            Some(&[self.crypto_config.ciphersuite]),
+            required_extensions,
+            required_proposals,
+            required_credentials,
+        );
         let (treesync, commit_secret, leaf_keypair) = TreeSync::new(
             provider,
             signer,
             self.crypto_config,
             self.credential_with_key,
             self.lifetime.unwrap_or_default(),
-            Capabilities::new(
-                Some(&[self.crypto_config.version]), // TODO: Allow more versions
-                Some(&[self.crypto_config.ciphersuite]), // TODO: allow more ciphersuites
-                capabilities,
-                None,
-                None,
-            ),
-            self.leaf_extensions.unwrap_or(Extensions::empty()),
+            capabilities,
+            self.leaf_extensions,
         )?;
-        let required_capabilities = self.required_capabilities.unwrap_or_default();
-        required_capabilities.check_support().map_err(|e| match e {
-            ExtensionError::UnsupportedProposalType => {
-                PublicGroupBuildError::UnsupportedProposalType
-            }
-            ExtensionError::UnsupportedExtensionType => {
-                PublicGroupBuildError::UnsupportedExtensionType
-            }
-            _ => LibraryError::custom("Unexpected ExtensionError").into(),
-        })?;
-        let required_capabilities = Extension::RequiredCapabilities(required_capabilities);
-
-        let mut group_context_extensions = if let Some(exts) = self.group_context_extensions {
-            exts
-        } else {
-            Extensions::empty()
-        };
-        group_context_extensions.add_or_replace(required_capabilities);
-        if let Some(ext_senders) = self.external_senders {
-            group_context_extensions.add_or_replace(Extension::ExternalSenders(ext_senders));
-        }
 
         let group_context = GroupContext::create_initial_group_context(
             self.crypto_config.ciphersuite,
             self.group_id,
             treesync.tree_hash().to_vec(),
-            group_context_extensions,
+            self.group_context_extensions,
         );
         let next_builder = TempBuilderPG2 {
             treesync,
@@ -190,10 +171,8 @@ impl PublicGroup {
             crypto_config,
             credential_with_key,
             lifetime: None,
-            required_capabilities: None,
-            external_senders: None,
-            leaf_extensions: None,
-            group_context_extensions: None,
+            leaf_extensions: Extensions::empty(),
+            group_context_extensions: Extensions::empty(),
         }
     }
 }

--- a/openmls/src/group/tests/external_remove_proposal.rs
+++ b/openmls/src/group/tests/external_remove_proposal.rs
@@ -30,7 +30,10 @@ fn new_test_group(
     let mls_group_config = MlsGroupCreateConfig::builder()
         .wire_format_policy(wire_format_policy)
         .crypto_config(CryptoConfig::with_default_version(ciphersuite))
-        .external_senders(external_senders)
+        .with_group_context_extensions(Extensions::single(Extension::ExternalSenders(
+            external_senders,
+        )))
+        .unwrap()
         .build();
 
     (
@@ -336,6 +339,6 @@ fn external_remove_proposal_should_fail_when_no_external_senders(
         .unwrap_err();
     assert_eq!(
         error,
-        ProcessMessageError::ValidationError(ValidationError::NoExternalSendersExtension)
+        ProcessMessageError::ValidationError(ValidationError::UnauthorizedExternalSender)
     );
 }

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -133,10 +133,13 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
             10,   // out_of_order_tolerance
             2000, // maximum_forward_distance
         ))
-        .external_senders(vec![ExternalSender::new(
-            ds_credential_with_key.signature_key.clone(),
-            ds_credential_with_key.credential.clone(),
-        )])
+        .with_group_context_extensions(Extensions::single(Extension::ExternalSenders(vec![
+            ExternalSender::new(
+                ds_credential_with_key.signature_key.clone(),
+                ds_credential_with_key.credential.clone(),
+            ),
+        ])))
+        .expect("error adding external senders extension to group context extensions")
         .crypto_config(CryptoConfig::with_default_version(ciphersuite))
         .use_ratchet_tree_extension(true)
         .build();
@@ -201,10 +204,6 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
                 10,   // out_of_order_tolerance
                 2000, // maximum_forward_distance
             ))
-            .external_senders(vec![ExternalSender::new(
-                ds_credential_with_key.signature_key,
-                ds_credential_with_key.credential,
-            )])
             .crypto_config(CryptoConfig::with_default_version(ciphersuite))
             .use_ratchet_tree_extension(true)
             .build(provider, &alice_signature_keys, alice_credential.clone())


### PR DESCRIPTION
This PR removes the dedicated `required_capabilities` and `external_senders` fields (along with their getters and setters) in favor of the `group_context_extension` field. This makes processing during group creation easier.