### PR TITLE
Fix validation bug

### DIFF
--- a/openmls/src/extensions/required_capabilities.rs
+++ b/openmls/src/extensions/required_capabilities.rs
@@ -79,8 +79,8 @@ impl RequiredCapabilitiesExtension {
         self.credential_types.as_slice()
     }
 
-    /// Checks whether the provided extension type is supported.
-    pub(crate) fn supports_extension_type(&self, ext_type: ExtensionType) -> bool {
+    /// Checks whether support for the provided extension type is required.
+    pub(crate) fn requires_extension_type_support(&self, ext_type: ExtensionType) -> bool {
         self.extension_types.contains(&ext_type) || default_extensions().contains(&ext_type)
     }
 

--- a/openmls/src/extensions/required_capabilities.rs
+++ b/openmls/src/extensions/required_capabilities.rs
@@ -1,6 +1,9 @@
 use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 
-use crate::{credentials::CredentialType, messages::proposals::ProposalType};
+use crate::{
+    credentials::CredentialType, messages::proposals::ProposalType,
+    treesync::node::leaf_node::default_extensions,
+};
 
 use super::{Deserialize, ExtensionError, ExtensionType, Serialize};
 
@@ -74,6 +77,11 @@ impl RequiredCapabilitiesExtension {
     #[allow(unused)]
     pub(crate) fn credential_types(&self) -> &[CredentialType] {
         self.credential_types.as_slice()
+    }
+
+    /// Checks whether the provided extension type is supported.
+    pub(crate) fn supports_extension_type(&self, ext_type: ExtensionType) -> bool {
+        self.extension_types.contains(&ext_type) || default_extensions().contains(&ext_type)
     }
 
     /// Check if all extension and proposal types are supported.

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -542,12 +542,21 @@ pub enum GroupContextExtensionsProposalValidationError {
     /// Commit has more than one GroupContextExtensions proposal.
     #[error("Commit has more than one GroupContextExtensions proposal.")]
     TooManyGCEProposals,
+
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
-    /// The new extensions set contails extensions that are not supported by all group members.
+
+    /// The new extension types in required capabilties contails extensions that are not supported by all group members.
     #[error(
-        "The new extensions set contails extensions that are not supported by all group members."
+        "The new required capabilties contain extension types that are not supported by all group members."
     )]
-    ExtensionNotSupportedByAllMembers,
+    RequiredExtensionNotSupportedByAllMembers,
+
+    /// An extension in the group context extensions is not listed in the required capabilties'
+    /// extension types.
+    #[error(
+        "An extension in the group context extensions is not listed in the required capabilties' extension types."
+    )]
+    ExtensionNotInRequiredCapabilities,
 }

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -524,7 +524,7 @@ impl PublicGroup {
         let iter = proposal_queue.filtered_by_type(ProposalType::GroupContextExtensions);
 
         for (i, queued_proposal) in iter.enumerate() {
-            // There may only be one group context extionsion proposal. Return an error if there are more
+            // There must at most be one group context extionsion proposal. Return an error if there are more
             if i > 0 {
                 return Err(GroupContextExtensionsProposalValidationError::TooManyGCEProposals);
             }

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -536,12 +536,11 @@ impl PublicGroup {
                         Some(required_capabilities_new) => {
                             // a required capabilities extension in the group context extensions is
                             // only valid if all member support it.
-                            self.check_extension_support(&required_capabilities_new.extension_types()).map_err(|_| GroupContextExtensionsProposalValidationError::RequiredExtensionNotSupportedByAllMembers)?;
+                            self.check_extension_support(required_capabilities_new.extension_types()).map_err(|_| GroupContextExtensionsProposalValidationError::RequiredExtensionNotSupportedByAllMembers)?;
                             required_capabilities_new
                         }
                         None => self
                             .required_capabilities()
-                            .map(|required_capabilities| required_capabilities)
                             .unwrap_or(&default_required_capabilities),
                     };
 

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -576,13 +576,6 @@ impl PublicGroup {
         }
 
         Ok(())
-
-        // There may only be one group context extionsion proposal. Return an error if there are
-        // more
-        // match iter.next() {
-        //     Some(_) => Err(GroupContextExtensionsProposalValidationError::TooManyGCEProposals),
-        //     None => Ok(()),
-        //}
     }
 
     /// Returns a [`LeafNodeValidationError`] if an [`ExtensionType`]

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -544,15 +544,15 @@ impl PublicGroup {
                     let required_capabilities = match required_capabilities_in_proposal {
                         Some(required_capabilities_new) => {
                             // If a group context extensions proposal updates the required capabilities, we
-                            // need to chec that these are satisfied for all existing members of the group.
+                            // need to check that these are satisfied for all existing members of the group.
                             self.check_extension_support(required_capabilities_new.extension_types()).map_err(|_| GroupContextExtensionsProposalValidationError::RequiredExtensionNotSupportedByAllMembers)?;
                             required_capabilities_new
                         }
                         None => &default_required_capabilities,
                     };
 
-                    // Make sure that all other extensions are know to be supported, by checking
-                    // that they are required to be supported by the required capabilities.
+                    // Make sure that all other extensions are known to be supported, by checking
+                    // that they are included in the required capabilities.
                     let all_extensions_are_in_required_capabilities: bool = extensions
                         .extensions()
                         .iter()

--- a/openmls/src/treesync/node/leaf_node/capabilities.rs
+++ b/openmls/src/treesync/node/leaf_node/capabilities.rs
@@ -215,7 +215,7 @@ pub(super) fn default_ciphersuites() -> Vec<Ciphersuite> {
 }
 
 /// All extensions defined in the MLS spec are considered "default" by the spec.
-pub(super) fn default_extensions() -> Vec<ExtensionType> {
+pub(crate) fn default_extensions() -> Vec<ExtensionType> {
     vec![
         ExtensionType::ApplicationId,
         ExtensionType::RatchetTree,


### PR DESCRIPTION
This PR addresses issue #1487. The problem is that currently the list of extensions in a `GroupContextExtensions` proposal is compared against the capabilities of the current members. Instead, it needs to

1. check that the `RequiredCapabilities` of the group are satisfied by all members of the group
2. check that the types of all extensions in the proposal are in the `RequiredCapabilities`.

This PR also adds a method on the `RequiredCapabilitiesExtension` for checking whether an extension type is supported. This is needed because the extension types defined in the RFC are supported implicitly, so we also have to compare against the defaults. The defaults are defined close to the `Capabilities` struct and used to be private to these modules. I made the one for extension types `pub(crate)` so I can check against it.

Finally, I haven't written tests for this, yet. It seems this behaviour was barely tested before, as [the tests](https://github.com/openmls/openmls/blob/5052cbef2731214911ba69ea5a12e7a64481f45c/openmls/src/group/core_group/test_proposals.rs#L524-L540) seem to be commented out already. This is already tracked in #1130.

How do you all feel about merging this as-is and fixing the tests later (and opening an issue for it, of course)?

Fixes #1487 