### PR TITLE
docs(openmls): typo in rustdoc for MlsGroupJoinConfig

### DIFF
--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -48,7 +48,7 @@ pub struct MlsGroupJoinConfig {
     /// Maximum number of past epochs for which application messages
     /// can be decrypted. The default is 0.
     pub(crate) max_past_epochs: usize,
-    /// Number of resumtion secrets to keep
+    /// Number of resumption secrets to keep
     pub(crate) number_of_resumption_psks: usize,
     /// Flag to indicate the Ratchet Tree Extension should be used
     pub(crate) use_ratchet_tree_extension: bool,


### PR DESCRIPTION
This PR addresses a single word typo in the rustdoc for the `number_of_resumption_psks` field in the `MlsGroupJoinConfig` struct.
Feel free to dismiss this PR if it is useless.