### PR TITLE
Fix typo in documentation

### DIFF
--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -90,7 +90,7 @@ impl From<PendingCommitState> for StagedCommit {
 ///
 /// * [`MlsGroupState::PendingCommit`]: This state is split into two possible
 /// sub-states, one for each Commit type:
-/// [`PendingCommitState::Member`] and [`PendingCommitState::Member`]:
+/// [`PendingCommitState::Member`] and [`PendingCommitState::External`]:
 ///
 ///   * If the client creates a commit for this group, the `PendingCommit` state
 ///   is entered with [`PendingCommitState::Member`] and with the [`StagedCommit`] as


### PR DESCRIPTION
Fix typo in documentation: Member -> External