### PR TITLE
Remove unnecessary cloning of proposals

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,6 @@ jobs:
         uses: actions-rs/grcov@v0.1
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ${{ steps.coverage.outputs.report }}

--- a/openmls/src/framing/mls_auth_content.rs
+++ b/openmls/src/framing/mls_auth_content.rs
@@ -266,6 +266,11 @@ impl AuthenticatedContent {
     pub fn sender(&self) -> &Sender {
         &self.content.sender
     }
+
+    /// Decompose into body and sender.
+    pub(crate) fn into_body_and_sender(self) -> (FramedContentBody, Sender) {
+        (self.content.body, self.content.sender)
+    }
 }
 
 #[cfg(test)]

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -115,15 +115,17 @@ impl QueuedProposal {
             ProposalRef::from_authenticated_content_by_ref(crypto, ciphersuite, &public_message)
                 .map_err(|_| LibraryError::custom("Could not calculate `ProposalRef`."))?;
 
-        let proposal = match public_message.content() {
-            FramedContentBody::Proposal(p) => p.to_owned(),
+        let (body, sender) = public_message.into_body_and_sender();
+
+        let proposal = match body {
+            FramedContentBody::Proposal(p) => p,
             _ => return Err(LibraryError::custom("Wrong content type")),
         };
 
         Ok(Self {
             proposal,
             proposal_reference,
-            sender: public_message.sender().to_owned(),
+            sender,
             proposal_or_ref_type,
         })
     }

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -111,18 +111,19 @@ impl QueuedProposal {
         public_message: AuthenticatedContent,
         proposal_or_ref_type: ProposalOrRefType,
     ) -> Result<Self, LibraryError> {
-        let proposal = match public_message.content() {
-            FramedContentBody::Proposal(p) => p,
-            _ => return Err(LibraryError::custom("Wrong content type")),
-        };
         let proposal_reference =
             ProposalRef::from_authenticated_content_by_ref(crypto, ciphersuite, &public_message)
                 .map_err(|_| LibraryError::custom("Could not calculate `ProposalRef`."))?;
 
+        let proposal = match public_message.content() {
+            FramedContentBody::Proposal(p) => p.to_owned(),
+            _ => return Err(LibraryError::custom("Wrong content type")),
+        };
+
         Ok(Self {
-            proposal: proposal.clone(), // FIXME
+            proposal,
             proposal_reference,
-            sender: public_message.sender().clone(),
+            sender: public_message.sender().to_owned(),
             proposal_or_ref_type,
         })
     }


### PR DESCRIPTION
Fixes #347.

The context is explained [here](https://github.com/openmls/openmls/issues/347#issuecomment-1937815975), this PR just gets rid of an unnecessary `.clone()`.