### PR TITLE
Cleanup unused CoreGroup methods

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,6 @@ jobs:
         uses: actions-rs/grcov@v0.1
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ${{ steps.coverage.outputs.report }}

--- a/openmls/src/framing/errors.rs
+++ b/openmls/src/framing/errors.rs
@@ -31,9 +31,6 @@ pub enum MessageDecryptionError {
     /// See [`SecretTreeError`] for more details.
     #[error(transparent)]
     SecretTreeError(#[from] SecretTreeError),
-    /// See [`SenderError`] for more details.
-    #[error(transparent)]
-    SenderError(#[from] SenderError),
 }
 
 /// Message encryption error
@@ -48,23 +45,6 @@ pub(crate) enum MessageEncryptionError {
     /// See [`SecretTreeError`] for more details.
     #[error(transparent)]
     SecretTreeError(#[from] SecretTreeError),
-    /// See [`SenderError`] for more details.
-    #[error(transparent)]
-    SenderError(#[from] SenderError),
-}
-
-/// Sender error
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum SenderError {
-    /// See [`LibraryError`] for more details.
-    #[error(transparent)]
-    LibraryError(#[from] LibraryError),
-    /// The requested client is not a member of the group.
-    #[error("The requested client is not a member of the group.")]
-    NotAMember,
-    /// Unknown sender
-    #[error("Unknown sender")]
-    UnknownSender,
 }
 
 /// MlsMessage error

--- a/openmls/src/framing/private_message.rs
+++ b/openmls/src/framing/private_message.rs
@@ -129,7 +129,8 @@ impl PrivateMessage {
         )
     }
 
-    /// Internal function to encrypt content.
+    /// Internal function to encrypt content. The extra message header is only used
+    /// for tests. Otherwise, the data from the given `AuthenticatedContent` is used.
     fn encrypt_content(
         test_header: Option<MlsMessageHeader>,
         public_message: &AuthenticatedContent,

--- a/openmls/src/framing/private_message.rs
+++ b/openmls/src/framing/private_message.rs
@@ -129,8 +129,7 @@ impl PrivateMessage {
         )
     }
 
-    /// Internal function to encrypt content. The extra message header is only used
-    /// for tests. Otherwise, the data from the given `AuthenticatedContent` is used.
+    /// Internal function to encrypt content.
     fn encrypt_content(
         test_header: Option<MlsMessageHeader>,
         public_message: &AuthenticatedContent,
@@ -142,7 +141,7 @@ impl PrivateMessage {
         let sender_index = if let Some(index) = public_message.sender().as_member() {
             index
         } else {
-            return Err(MessageEncryptionError::SenderError(SenderError::NotAMember));
+            return Err(LibraryError::custom("Sender is not a member.").into());
         };
         // Take the provided header only if one is given and if this is indeed a test.
         let header = match test_header {

--- a/openmls/src/framing/private_message_in.rs
+++ b/openmls/src/framing/private_message_in.rs
@@ -170,7 +170,7 @@ impl PrivateMessageIn {
                     "  Ciphertext generation out of bounds {}\n\t{e:?}",
                     sender_data.generation
                 );
-                MessageDecryptionError::GenerationOutOfBound
+                MessageDecryptionError::SecretTreeError(e)
             })?;
         // Prepare the nonce by xoring with the reuse guard.
         let prepared_nonce = ratchet_nonce.xor_with_reuse_guard(&sender_data.reuse_guard);

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -588,10 +588,16 @@ fn unknown_sender(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
     )
     .expect("Encryption error");
 
-    let received_message = group_charlie.decrypt(&enc_message.into(), provider, configuration);
+    let received_message = group_charlie.decrypt_message(
+        provider.crypto(),
+        ProtocolMessage::from(PrivateMessageIn::from(enc_message)),
+        configuration,
+    );
     assert_eq!(
         received_message.unwrap_err(),
-        MessageDecryptionError::SenderError(SenderError::UnknownSender)
+        ValidationError::UnableToDecrypt(MessageDecryptionError::SecretTreeError(
+            SecretTreeError::IndexOutOfBounds
+        ))
     );
 }
 

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -33,7 +33,9 @@ mod test_past_secrets;
 mod test_proposals;
 
 use log::{debug, trace};
-use openmls_traits::{key_store::OpenMlsKeyStore, signatures::Signer, types::Ciphersuite};
+use openmls_traits::{
+    crypto::OpenMlsCrypto, key_store::OpenMlsKeyStore, signatures::Signer, types::Ciphersuite,
+};
 use serde::{Deserialize, Serialize};
 use tls_codec::Serialize as TlsSerializeTrait;
 
@@ -82,9 +84,6 @@ use crate::{
 use super::errors::CreateGroupContextExtProposalError;
 #[cfg(test)]
 use crate::treesync::node::leaf_node::TreePosition;
-use openmls_traits::crypto::OpenMlsCrypto;
-#[cfg(test)]
-use std::io::{Error, Read, Write};
 
 #[derive(Debug)]
 pub(crate) struct CreateCommitResult {
@@ -169,11 +168,13 @@ impl CoreGroupBuilder {
             public_group_builder,
         }
     }
+
     /// Set the [`CoreGroupConfig`] of the [`CoreGroup`].
     pub(crate) fn with_config(mut self, config: CoreGroupConfig) -> Self {
         self.config = Some(config);
         self
     }
+
     /// Set the [`Vec<PreSharedKeyId>`] of the [`CoreGroup`].
     #[cfg(test)]
     pub(crate) fn with_psk(mut self, psk_ids: Vec<PreSharedKeyId>) -> Self {
@@ -218,6 +219,7 @@ impl CoreGroupBuilder {
         self.max_past_epochs = max_past_epochs;
         self
     }
+
     /// Set the [`Lifetime`] for the own leaf in the group.
     pub fn with_lifetime(mut self, lifetime: Lifetime) -> Self {
         self.public_group_builder = self.public_group_builder.with_lifetime(lifetime);
@@ -317,7 +319,6 @@ impl CoreGroupBuilder {
     }
 }
 
-/// Public [`CoreGroup`] functions.
 impl CoreGroup {
     /// Get a builder for [`CoreGroup`].
     pub(crate) fn builder(
@@ -431,44 +432,6 @@ impl CoreGroup {
         )
     }
 
-    /// Create a `GroupContextExtensions` proposal.
-    #[cfg(test)]
-    pub(crate) fn create_group_context_ext_proposal(
-        &self,
-        framing_parameters: FramingParameters,
-        extensions: Extensions,
-        signer: &impl Signer,
-    ) -> Result<AuthenticatedContent, CreateGroupContextExtProposalError> {
-        // Ensure that the group supports all the extensions that are wanted.
-
-        let required_extension = extensions
-            .iter()
-            .find(|extension| extension.extension_type() == ExtensionType::RequiredCapabilities);
-        if let Some(required_extension) = required_extension {
-            let required_capabilities = required_extension.as_required_capabilities_extension()?;
-            // Ensure we support all the capabilities.
-            required_capabilities.check_support()?;
-            self.own_leaf_node()?
-                .capabilities()
-                .supports_required_capabilities(required_capabilities)?;
-
-            // Ensure that all other leaf nodes support all the required
-            // extensions as well.
-            self.public_group()
-                .check_extension_support(required_capabilities.extension_types())?;
-        }
-        let proposal = GroupContextExtensionProposal::new(extensions);
-        let proposal = Proposal::GroupContextExtensions(proposal);
-        AuthenticatedContent::member_proposal(
-            framing_parameters,
-            self.own_leaf_index(),
-            proposal,
-            self.context(),
-            signer,
-        )
-        .map_err(|e| e.into())
-    }
-
     // Create application message
     pub(crate) fn create_application_message(
         &mut self,
@@ -501,38 +464,6 @@ impl CoreGroup {
             provider,
             self.message_secrets_store.message_secrets_mut(),
             padding_size,
-        )
-    }
-
-    /// Decrypt an PrivateMessage into an PublicMessage
-    #[cfg(test)]
-    pub(crate) fn decrypt(
-        &mut self,
-        private_message: &PrivateMessageIn,
-        provider: &impl OpenMlsProvider,
-        sender_ratchet_configuration: &SenderRatchetConfiguration,
-    ) -> Result<VerifiableAuthenticatedContentIn, MessageDecryptionError> {
-        let ciphersuite = self.ciphersuite();
-        let message_secrets = self
-            .message_secrets_mut(private_message.epoch())
-            .map_err(|_| MessageDecryptionError::AeadError)?;
-        let sender_data =
-            private_message.sender_data(message_secrets, provider.crypto(), ciphersuite)?;
-        if self.public_group().leaf(sender_data.leaf_index).is_none() {
-            return Err(MessageDecryptionError::SenderError(
-                SenderError::UnknownSender,
-            ));
-        }
-        let message_secrets = self
-            .message_secrets_mut(private_message.epoch())
-            .map_err(|_| MessageDecryptionError::AeadError)?;
-        private_message.to_verifiable_content(
-            ciphersuite,
-            provider.crypto(),
-            message_secrets,
-            sender_data.leaf_index,
-            sender_ratchet_configuration,
-            sender_data,
         )
     }
 
@@ -616,19 +547,6 @@ impl CoreGroup {
         self.group_epoch_secrets().resumption_psk()
     }
 
-    /// Loads the state from persisted state
-    #[cfg(test)]
-    pub(crate) fn load<R: Read>(reader: R) -> Result<CoreGroup, Error> {
-        serde_json::from_reader(reader).map_err(|e| e.into())
-    }
-
-    /// Persists the state
-    #[cfg(test)]
-    pub(crate) fn save<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        let serialized_core_group = serde_json::to_string_pretty(self)?;
-        writer.write_all(&serialized_core_group.into_bytes())
-    }
-
     /// Returns a reference to the public group.
     pub(crate) fn public_group(&self) -> &PublicGroup {
         &self.public_group
@@ -654,32 +572,11 @@ impl CoreGroup {
         self.public_group.group_id()
     }
 
-    /// Get the group context extensions.
-    #[cfg(test)]
-    pub(crate) fn group_context_extensions(&self) -> &Extensions {
-        self.public_group.group_context().extensions()
-    }
-
     /// Get the required capabilities extension of this group.
     pub(crate) fn required_capabilities(&self) -> Option<&RequiredCapabilitiesExtension> {
         self.public_group.required_capabilities()
     }
 
-    /// Returns `true` if the group uses the ratchet tree extension anf `false
-    /// otherwise
-    #[cfg(test)]
-    pub(crate) fn use_ratchet_tree_extension(&self) -> bool {
-        self.use_ratchet_tree_extension
-    }
-
-    #[cfg(test)]
-    pub(crate) fn set_own_leaf_index(&mut self, own_leaf_index: LeafNodeIndex) {
-        self.own_leaf_index = own_leaf_index;
-    }
-}
-
-// Private and crate functions
-impl CoreGroup {
     /// Get the leaf index of this client.
     pub(crate) fn own_leaf_index(&self) -> LeafNodeIndex {
         self.own_leaf_index
@@ -839,11 +736,9 @@ impl CoreGroup {
             self.own_leaf_index(),
         )
         .map_err(|e| match e {
-            crate::group::errors::ProposalQueueError::LibraryError(e) => e.into(),
-            crate::group::errors::ProposalQueueError::ProposalNotFound => {
-                CreateCommitError::MissingProposal
-            }
-            crate::group::errors::ProposalQueueError::SenderError(_) => {
+            ProposalQueueError::LibraryError(e) => e.into(),
+            ProposalQueueError::ProposalNotFound => CreateCommitError::MissingProposal,
+            ProposalQueueError::UpdateFromExternalSender => {
                 CreateCommitError::WrongProposalSenderType
             }
         })?;
@@ -1112,11 +1007,89 @@ impl CoreGroup {
             group_info: group_info.filter(|_| self.use_ratchet_tree_extension),
         })
     }
+}
 
-    #[cfg(test)]
+// Test functions
+#[cfg(test)]
+impl CoreGroup {
+    pub(crate) fn create_group_context_ext_proposal(
+        &self,
+        framing_parameters: FramingParameters,
+        extensions: Extensions,
+        signer: &impl Signer,
+    ) -> Result<AuthenticatedContent, CreateGroupContextExtProposalError> {
+        // Ensure that the group supports all the extensions that are wanted.
+        let required_extension = extensions
+            .iter()
+            .find(|extension| extension.extension_type() == ExtensionType::RequiredCapabilities);
+        if let Some(required_extension) = required_extension {
+            let required_capabilities = required_extension.as_required_capabilities_extension()?;
+            // Ensure we support all the capabilities.
+            required_capabilities.check_support()?;
+            self.own_leaf_node()?
+                .capabilities()
+                .supports_required_capabilities(required_capabilities)?;
+
+            // Ensure that all other leaf nodes support all the required
+            // extensions as well.
+            self.public_group()
+                .check_extension_support(required_capabilities.extension_types())?;
+        }
+        let proposal = GroupContextExtensionProposal::new(extensions);
+        let proposal = Proposal::GroupContextExtensions(proposal);
+        AuthenticatedContent::member_proposal(
+            framing_parameters,
+            self.own_leaf_index(),
+            proposal,
+            self.context(),
+            signer,
+        )
+        .map_err(|e| e.into())
+    }
+
+    pub(crate) fn use_ratchet_tree_extension(&self) -> bool {
+        self.use_ratchet_tree_extension
+    }
+
+    pub(crate) fn set_own_leaf_index(&mut self, own_leaf_index: LeafNodeIndex) {
+        self.own_leaf_index = own_leaf_index;
+    }
+
     pub(crate) fn own_tree_position(&self) -> TreePosition {
         TreePosition::new(self.group_id().clone(), self.own_leaf_index())
     }
+
+    pub(crate) fn message_secrets_store(&self) -> &MessageSecretsStore {
+        &self.message_secrets_store
+    }
+
+    pub(crate) fn set_group_context(&mut self, group_context: GroupContext) {
+        self.public_group.set_group_context(group_context)
+    }
+}
+
+// Test and test-utils functions
+#[cfg(any(feature = "test-utils", test))]
+impl CoreGroup {
+    pub(crate) fn context_mut(&mut self) -> &mut GroupContext {
+        self.public_group.context_mut()
+    }
+
+    pub(crate) fn message_secrets_test_mut(&mut self) -> &mut MessageSecrets {
+        self.message_secrets_store.message_secrets_mut()
+    }
+
+    pub(crate) fn print_ratchet_tree(&self, message: &str) {
+        println!("{}: {}", message, self.public_group().export_ratchet_tree());
+    }
+}
+
+/// Configuration for core group.
+#[derive(Clone, Copy, Default, Debug)]
+pub(crate) struct CoreGroupConfig {
+    /// Flag whether to send the ratchet tree along with the `GroupInfo` or not.
+    /// Defaults to false.
+    pub(crate) add_ratchet_tree_extension: bool,
 }
 
 /// Composite key for key material of a client within an epoch
@@ -1133,37 +1106,4 @@ impl EpochKeypairId {
             .concat(),
         )
     }
-}
-
-#[cfg(any(feature = "test-utils", test))]
-impl CoreGroup {
-    pub(crate) fn context_mut(&mut self) -> &mut GroupContext {
-        self.public_group.context_mut()
-    }
-
-    pub(crate) fn message_secrets_test_mut(&mut self) -> &mut MessageSecrets {
-        self.message_secrets_store.message_secrets_mut()
-    }
-
-    pub(crate) fn print_ratchet_tree(&self, message: &str) {
-        println!("{}: {}", message, self.public_group().export_ratchet_tree());
-    }
-
-    #[cfg(test)]
-    pub(crate) fn message_secrets_store(&self) -> &MessageSecretsStore {
-        &self.message_secrets_store
-    }
-
-    #[cfg(test)]
-    pub(crate) fn set_group_context(&mut self, group_context: GroupContext) {
-        self.public_group.set_group_context(group_context)
-    }
-}
-
-/// Configuration for core group.
-#[derive(Clone, Copy, Default, Debug)]
-pub(crate) struct CoreGroupConfig {
-    /// Flag whether to send the ratchet tree along with the `GroupInfo` or not.
-    /// Defaults to false.
-    pub(crate) add_ratchet_tree_extension: bool,
 }

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -8,9 +8,7 @@ use crate::{
     binary_tree::array_representation::LeafNodeIndex,
     ciphersuite::hash_ref::ProposalRef,
     error::LibraryError,
-    framing::{
-        mls_auth_content::AuthenticatedContent, mls_content::FramedContentBody, Sender, SenderError,
-    },
+    framing::{mls_auth_content::AuthenticatedContent, mls_content::FramedContentBody, Sender},
     group::errors::*,
     messages::proposals::{
         AddProposal, PreSharedKeyProposal, Proposal, ProposalOrRef, ProposalOrRefType,
@@ -466,7 +464,7 @@ impl ProposalQueue {
                     // ValSem112
                     let leaf_index = match queued_proposal.sender.clone() {
                         Sender::Member(hash_ref) => hash_ref,
-                        _ => return Err(ProposalQueueError::SenderError(SenderError::NotAMember)),
+                        _ => return Err(ProposalQueueError::UpdateFromExternalSender),
                     };
                     if leaf_index != own_index {
                         members

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -49,25 +49,6 @@ pub(crate) fn setup_alice_group(
     (group, alice_credential_with_key, alice_signature_keys, pk)
 }
 
-#[apply(ciphersuites_and_providers)]
-fn test_core_group_persistence(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
-    let (alice_group, _, _, _) = setup_alice_group(ciphersuite, provider);
-
-    // we need something that implements io::Write
-    let mut file_out: Vec<u8> = vec![];
-    alice_group
-        .save(&mut file_out)
-        .expect("Could not write group state to file");
-
-    // make it into a type that implements io::Read
-    let file_in: &[u8] = &file_out;
-
-    let alice_group_deserialized =
-        CoreGroup::load(file_in).expect("Could not deserialize mls group");
-
-    assert_eq!(alice_group, alice_group_deserialized);
-}
-
 /// This function flips the last byte of the ciphertext.
 pub fn flip_last_byte(ctxt: &mut HpkeCiphertext) {
     let mut last_bits = ctxt

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -10,7 +10,7 @@ use crate::{
     ciphersuite::signable::SignatureError,
     error::LibraryError,
     extensions::errors::{ExtensionError, InvalidExtensionError},
-    framing::errors::{MessageDecryptionError, SenderError},
+    framing::errors::MessageDecryptionError,
     key_packages::errors::KeyPackageVerifyError,
     key_packages::errors::{KeyPackageExtensionSupportError, KeyPackageNewError},
     messages::{group_info::GroupInfoError, GroupSecretsError},
@@ -439,9 +439,9 @@ pub(crate) enum ProposalQueueError {
     /// Not all proposals in the Commit were found locally.
     #[error("Not all proposals in the Commit were found locally.")]
     ProposalNotFound,
-    /// See [`SenderError`] for more details.
-    #[error(transparent)]
-    SenderError(#[from] SenderError),
+    /// Update proposal from external sender.
+    #[error("Update proposal from external sender.")]
+    UpdateFromExternalSender,
 }
 
 /// Errors that can arise when creating a [`ProposalQueue`] from committed
@@ -457,25 +457,6 @@ pub(crate) enum FromCommittedProposalsError {
     /// The sender of a Commit tried to remove themselves.
     #[error("The sender of a Commit tried to remove themselves.")]
     SelfRemoval,
-}
-
-/// Creation proposal queue error
-#[derive(Error, Debug, PartialEq, Clone)]
-pub(crate) enum CreationProposalQueueError {
-    /// See [`LibraryError`] for more details.
-    #[error(transparent)]
-    LibraryError(#[from] LibraryError),
-    /// See [`SenderError`] for more details.
-    #[error(transparent)]
-    SenderError(#[from] SenderError),
-}
-
-// Apply proposals error
-#[derive(Error, Debug, PartialEq, Clone)]
-pub(crate) enum ApplyProposalsError {
-    /// See [`LibraryError`] for more details.
-    #[error(transparent)]
-    LibraryError(#[from] LibraryError),
 }
 
 // Core group build error

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -1019,7 +1019,8 @@ fn group_context_extensions_proposal(ciphersuite: Ciphersuite, provider: &impl O
     // No required capabilities, so no specifically required extensions.
     assert!(alice_group
         .group()
-        .group_context_extensions()
+        .context()
+        .extensions()
         .required_capabilities()
         .is_none());
 
@@ -1047,7 +1048,8 @@ fn group_context_extensions_proposal(ciphersuite: Ciphersuite, provider: &impl O
 
     let required_capabilities = alice_group
         .group()
-        .group_context_extensions()
+        .context()
+        .extensions()
         .required_capabilities()
         .expect("couldn't get required_capabilities");
 

--- a/openmls/src/group/tests/external_remove_proposal.rs
+++ b/openmls/src/group/tests/external_remove_proposal.rs
@@ -118,7 +118,8 @@ fn external_remove_proposal_should_remove_member(
     // DS is an allowed external sender of the group
     assert!(alice_group
          .group()
-         .group_context_extensions()
+         .context()
+         .extensions()
          .iter()
          .any(|e| matches!(e, Extension::ExternalSenders(senders) if senders.iter().any(|s| s.credential() == &ds_credential_with_key.credential_with_key.credential) )));
 

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -120,39 +120,39 @@ pub struct MessagesTestVector {
 }
 
 pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
-    let crypto = OpenMlsRustCrypto::default();
+    let provider = OpenMlsRustCrypto::default();
 
     let alice_credential_with_key_and_signer = generate_credential_with_key(
         b"Alice".to_vec(),
         SignatureScheme::from(ciphersuite),
-        &crypto,
+        &provider,
     );
 
     // Create a proposal to update the user's key package.
     let alice_key_package = generate_key_package(
         ciphersuite,
         Extensions::default(),
-        &crypto,
+        &provider,
         alice_credential_with_key_and_signer.clone(),
     );
 
     // Let's create a group
     let mut alice_group = CoreGroup::builder(
-        GroupId::random(crypto.rand()),
+        GroupId::random(provider.rand()),
         CryptoConfig::with_default_version(ciphersuite),
         alice_credential_with_key_and_signer
             .credential_with_key
             .clone(),
     )
     .with_max_past_epoch_secrets(2)
-    .build(&crypto, &alice_credential_with_key_and_signer.signer)
+    .build(&provider, &alice_credential_with_key_and_signer.signer)
     .unwrap();
 
     let alice_ratchet_tree = alice_group.public_group().export_ratchet_tree();
 
     let alice_group_info = alice_group
         .export_group_info(
-            crypto.rand(),
+            provider.rand(),
             &alice_credential_with_key_and_signer.signer,
             true,
         )
@@ -182,7 +182,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
             capabilities,
             Extensions::default(),
             TreeInfoTbs::Update(alice_group.own_tree_position()),
-            &crypto,
+            &provider,
             &alice_credential_with_key_and_signer.signer.clone(),
         )
         .unwrap()
@@ -193,11 +193,14 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     };
 
     // Bob
-    let bob_credential_with_key_and_signer =
-        generate_credential_with_key(b"Bob".to_vec(), SignatureScheme::from(ciphersuite), &crypto);
+    let bob_credential_with_key_and_signer = generate_credential_with_key(
+        b"Bob".to_vec(),
+        SignatureScheme::from(ciphersuite),
+        &provider,
+    );
 
     let bob_key_package_bundle = KeyPackageBundle::new(
-        &crypto,
+        &provider,
         &bob_credential_with_key_and_signer.signer,
         ciphersuite,
         bob_credential_with_key_and_signer.credential_with_key,
@@ -216,9 +219,12 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     let psk_proposal = {
         let psk_id = PreSharedKeyId::new(
             ciphersuite,
-            crypto.rand(),
+            provider.rand(),
             Psk::External(ExternalPsk::new(
-                crypto.rand().random_vec(ciphersuite.hash_length()).unwrap(),
+                provider
+                    .rand()
+                    .random_vec(ciphersuite.hash_length())
+                    .unwrap(),
             )),
         )
         .unwrap();
@@ -253,7 +259,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     let mut proposal_store = ProposalStore::from_queued_proposal(
         QueuedProposal::from_authenticated_content_by_ref(
             ciphersuite,
-            crypto.crypto(),
+            provider.crypto(),
             add_proposal_content.clone(),
         )
         .unwrap(),
@@ -265,13 +271,13 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     let create_commit_result = alice_group
         .create_commit(
             params,
-            &crypto,
+            &provider,
             &alice_credential_with_key_and_signer.signer,
         )
         .unwrap();
     alice_group
         .merge_staged_commit(
-            &crypto,
+            &provider,
             create_commit_result.staged_commit,
             &mut proposal_store,
         )
@@ -289,7 +295,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
         alice_welcome.clone(),
         Some(alice_group.public_group().export_ratchet_tree().into()),
         bob_key_package_bundle,
-        &crypto,
+        &provider,
         ResumptionPskStore::new(1024),
     )
     .expect("Error creating receiver group.");
@@ -300,18 +306,20 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
             b"aad",
             b"msg",
             random_u8() as usize,
-            &crypto,
+            &provider,
             &alice_credential_with_key_and_signer.signer,
         )
         .unwrap();
     // Replace the secret tree
     let verifiable_public_message_application: VerifiableAuthenticatedContentIn = receiver_group
-        .decrypt(
-            &private_message_application.into(),
-            &crypto,
+        .decrypt_message(
+            provider.crypto(),
+            ProtocolMessage::from(PrivateMessageIn::from(private_message_application)),
             &SenderRatchetConfiguration::default(),
         )
-        .unwrap();
+        .unwrap()
+        .verifiable_content()
+        .to_owned();
     let mls_content_application: AuthenticatedContent =
         AuthenticatedContentIn::from(verifiable_public_message_application).into();
 
@@ -338,7 +346,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     commit_pt.set_membership_tag_test(random_membership_tag);
 
     let private_message = alice_group
-        .encrypt(encryption_target, random_u8() as usize, &crypto)
+        .encrypt(encryption_target, random_u8() as usize, &provider)
         .unwrap();
 
     MessagesTestVector {
@@ -354,7 +362,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
 
         group_secrets: GroupSecrets::random_encoded(
             ciphersuite,
-            crypto.rand(),
+            provider.rand(),
             ProtocolVersion::default(),
         )
         .unwrap(),

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -305,9 +305,7 @@ fn test_valsem201(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
     let gce_proposal = || {
         queued(Proposal::GroupContextExtensions(
-            GroupContextExtensionProposal::new(
-                alice_group.group().group_context_extensions().clone(),
-            ),
+            GroupContextExtensionProposal::new(alice_group.group().context().extensions().clone()),
         ))
     };
 

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -246,14 +246,14 @@ fn test_valsem242(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
                 group_id: alice_group.group_id().clone(),
                 version: Default::default(),
                 ciphersuite,
-                extensions: alice_group.group().group_context_extensions().clone(),
+                extensions: alice_group.group().context().extensions().clone(),
             }))
         };
 
         let gce_proposal = {
             ProposalOrRef::Proposal(Proposal::GroupContextExtensions(
                 GroupContextExtensionProposal::new(
-                    alice_group.group().group_context_extensions().clone(),
+                    alice_group.group().context().extensions().clone(),
                 ),
             ))
         };

--- a/openmls/src/group/tests/test_group.rs
+++ b/openmls/src/group/tests/test_group.rs
@@ -396,12 +396,14 @@ fn group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         .into();
 
     let verifiable_plaintext = group_bob
-        .decrypt(
-            &mls_ciphertext_alice,
-            provider,
+        .decrypt_message(
+            provider.crypto(),
+            mls_ciphertext_alice.into(),
             &sender_ratchet_configuration,
         )
-        .expect("An unexpected error occurred.");
+        .expect("An unexpected error occurred.")
+        .verifiable_content()
+        .to_owned();
 
     let mls_plaintext_bob: AuthenticatedContentIn = verifiable_plaintext
         .verify(
@@ -726,12 +728,14 @@ fn group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
     // Alice decrypts and verifies
     let verifiable_plaintext = group_alice
-        .decrypt(
-            &mls_ciphertext_charlie.clone(),
-            provider,
+        .decrypt_message(
+            provider.crypto(),
+            mls_ciphertext_charlie.clone().into(),
             &sender_ratchet_configuration,
         )
-        .expect("An unexpected error occurred.");
+        .expect("An unexpected error occurred.")
+        .verifiable_content()
+        .to_owned();
 
     let mls_plaintext_alice: AuthenticatedContentIn = verifiable_plaintext
         .verify(
@@ -750,12 +754,14 @@ fn group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
     // Bob decrypts and verifies
     let verifiable_plaintext = group_bob
-        .decrypt(
-            &mls_ciphertext_charlie,
-            provider,
+        .decrypt_message(
+            provider.crypto(),
+            mls_ciphertext_charlie.into(),
             &sender_ratchet_configuration,
         )
-        .expect("An unexpected error occurred.");
+        .expect("An unexpected error occurred.")
+        .verifiable_content()
+        .to_owned();
 
     let mls_plaintext_bob: AuthenticatedContentIn = verifiable_plaintext
         .verify(

--- a/openmls/src/treesync/errors.rs
+++ b/openmls/src/treesync/errors.rs
@@ -100,9 +100,7 @@ pub(crate) enum TreeSyncError {
     /// See [`PathSecretError`] for more details.
     #[error(transparent)]
     DerivationError(#[from] PathSecretError),
-    /// See [`SenderError`] for more details.
-    #[error(transparent)]
-    SenderError(#[from] SenderError),
+
     /// See [`CryptoError`] for more details.
     #[error(transparent)]
     CryptoError(#[from] CryptoError),

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -64,7 +64,6 @@ use crate::{
     credentials::CredentialWithKey,
     error::LibraryError,
     extensions::Extensions,
-    framing::SenderError,
     group::{config::CryptoConfig, GroupId, Member},
     key_packages::Lifetime,
     messages::{PathSecret, PathSecretError},


### PR DESCRIPTION
Fixes #645.

This PR does the following:

 - Remove test functions from the CoreGroup that are not useful along with the corresponding tests.
 - Moves code in `core_group/mod.rs`
 - Refactor unnecessary errors
 - Minor renaming