### PR TITLE
Introduce InitKey type for KeyPackages

### DIFF
--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -429,7 +429,7 @@ fn test_valsem102(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
                     Extensions::empty(),
                     Capabilities::default(),
                     Extensions::empty(),
-                    charlie_key_package.hpke_init_key().as_slice().to_vec(),
+                    charlie_key_package.hpke_init_key().to_owned(),
                 )
                 .unwrap();
             }
@@ -829,11 +829,13 @@ fn test_valsem103_valsem104(ciphersuite: Ciphersuite, provider: &impl OpenMlsPro
                     .into_with_init_key(
                         CryptoConfig::with_default_version(ciphersuite),
                         &bob_credential_with_key.signer,
-                        bob_key_package
-                            .leaf_node()
-                            .encryption_key()
-                            .as_slice()
-                            .to_vec(),
+                        InitKey::from(
+                            bob_key_package
+                                .leaf_node()
+                                .encryption_key()
+                                .as_slice()
+                                .to_vec(),
+                        ),
                     )
                     .unwrap();
             }

--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -15,7 +15,7 @@ use tls_codec::{
 };
 
 use super::{
-    errors::KeyPackageVerifyError, KeyPackage, KeyPackageTbs, SIGNATURE_KEY_PACKAGE_LABEL,
+    errors::KeyPackageVerifyError, InitKey, KeyPackage, KeyPackageTbs, SIGNATURE_KEY_PACKAGE_LABEL,
 };
 
 /// Intermediary struct for deserialization of a [`KeyPackageIn`].
@@ -86,7 +86,7 @@ impl VerifiedStruct for KeyPackage {}
 struct KeyPackageTbsIn {
     protocol_version: ProtocolVersion,
     ciphersuite: Ciphersuite,
-    init_key: HpkePublicKey,
+    init_key: InitKey,
     leaf_node: LeafNodeIn,
     extensions: Extensions,
 }
@@ -155,7 +155,7 @@ impl KeyPackageIn {
         }
 
         // Verify that the encryption key and the init key are different
-        if leaf_node.encryption_key().key() == &self.payload.init_key {
+        if leaf_node.encryption_key().key() == self.payload.init_key.key() {
             return Err(KeyPackageVerifyError::InitKeyEqualsEncryptionKey);
         }
 

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -123,7 +123,9 @@ use openmls_traits::{
     OpenMlsProvider,
 };
 use serde::{Deserialize, Serialize};
-use tls_codec::{Serialize as TlsSerializeTrait, TlsSerialize, TlsSize};
+use tls_codec::{
+    Serialize as TlsSerializeTrait, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+};
 
 // Private
 use errors::*;
@@ -159,7 +161,7 @@ pub use lifetime::Lifetime;
 struct KeyPackageTbs {
     protocol_version: ProtocolVersion,
     ciphersuite: Ciphersuite,
-    init_key: HpkePublicKey,
+    init_key: InitKey,
     leaf_node: LeafNode,
     extensions: Extensions,
 }
@@ -216,6 +218,48 @@ pub(crate) struct KeyPackageCreationResult {
     pub init_private_key: HpkePrivateKey,
 }
 
+/// Init key for HPKE.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    TlsSize,
+    TlsSerialize,
+    Serialize,
+    Deserialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+)]
+pub struct InitKey {
+    key: HpkePublicKey,
+}
+
+impl InitKey {
+    /// Return the internal [`HpkePublicKey`].
+    pub fn key(&self) -> &HpkePublicKey {
+        &self.key
+    }
+
+    /// Return the internal [`HpkePublicKey`] as a slice.
+    pub fn as_slice(&self) -> &[u8] {
+        self.key.as_slice()
+    }
+}
+
+impl From<HpkePublicKey> for InitKey {
+    fn from(key: HpkePublicKey) -> Self {
+        Self { key }
+    }
+}
+
+impl From<Vec<u8>> for InitKey {
+    fn from(key: Vec<u8>) -> Self {
+        Self {
+            key: HpkePublicKey::from(key),
+        }
+    }
+}
+
 // Public `KeyPackage` functions.
 impl KeyPackage {
     /// Create a key package builder.
@@ -256,7 +300,7 @@ impl KeyPackage {
             extensions,
             leaf_node_capabilities,
             leaf_node_extensions,
-            init_key.public,
+            init_key.public.into(),
         )?;
 
         Ok(KeyPackageCreationResult {
@@ -285,7 +329,7 @@ impl KeyPackage {
         extensions: Extensions,
         capabilities: Capabilities,
         leaf_node_extensions: Extensions,
-        init_key: Vec<u8>,
+        init_key: InitKey,
     ) -> Result<(Self, EncryptionKeyPair), KeyPackageNewError<KeyStore::Error>> {
         // We don't need the private key here. It's stored in the key store for
         // use later when creating a group with this key package.
@@ -305,7 +349,7 @@ impl KeyPackage {
         let key_package_tbs = KeyPackageTbs {
             protocol_version: config.version,
             ciphersuite: config.ciphersuite,
-            init_key: init_key.into(),
+            init_key,
             leaf_node,
             extensions,
         };
@@ -373,7 +417,7 @@ impl KeyPackage {
     }
 
     /// Get the public HPKE init key of this key package.
-    pub fn hpke_init_key(&self) -> &HpkePublicKey {
+    pub fn hpke_init_key(&self) -> &InitKey {
         &self.payload.init_key
     }
 
@@ -404,7 +448,7 @@ impl KeyPackage {
         extensions: Extensions,
         leaf_node_capabilities: Capabilities,
         leaf_node_extensions: Extensions,
-        init_key: Vec<u8>,
+        init_key: InitKey,
     ) -> Result<Self, KeyPackageNewError<KeyStore::Error>> {
         let (key_package, encryption_key_pair) = Self::new_from_keys(
             config,
@@ -503,12 +547,12 @@ impl KeyPackage {
         self,
         config: CryptoConfig,
         signer: &impl Signer,
-        init_key: Vec<u8>,
+        init_key: InitKey,
     ) -> Result<Self, SignatureError> {
         let key_package_tbs = KeyPackageTbs {
             protocol_version: config.version,
             ciphersuite: config.ciphersuite,
-            init_key: init_key.into(),
+            init_key,
             leaf_node: self.leaf_node().clone(),
             extensions: self.extensions().clone(),
         };
@@ -533,8 +577,8 @@ impl KeyPackage {
     }
 
     /// Replace the public key in the KeyPackage.
-    pub fn set_init_key(&mut self, public_key: HpkePublicKey) {
-        self.payload.init_key = public_key
+    pub fn set_init_key(&mut self, init_key: InitKey) {
+        self.payload.init_key = init_key
     }
 
     /// Replace the version in the KeyPackage.

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -130,7 +130,14 @@ fn key_package_validation(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvi
     let mut key_package = key_package_orig;
 
     // Set an invalid init key
-    key_package.set_init_key(key_package.leaf_node().encryption_key().key().clone());
+    key_package.set_init_key(InitKey::from(
+        key_package
+            .leaf_node()
+            .encryption_key()
+            .key()
+            .as_slice()
+            .to_vec(),
+    ));
 
     let encoded = key_package
         .tls_serialize_detached()


### PR DESCRIPTION
Fixes #1264.

This PR introduces as distinct `InitKey` type for KeyPackages. This change makes it less likely to confuse the init key with other HPKE public keys.