### PR TITLE
`StagedWelcome::new_from_welcome_body` for processing `Welcome` messages

### DIFF
--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -72,6 +72,15 @@ impl MlsGroup {
         self.flag_state_change();
     }
 
+    /// Clears or empties the internal [ProposalStore]
+    pub fn clear_pending_proposals(&mut self) {
+        // Empty the internal ProposalStore
+        self.proposal_store.empty();
+
+        // Since the state of the group might be changed, arm the state flag
+        self.flag_state_change();
+    }
+
     /// Creates a Commit message that covers the pending proposals that are
     /// currently stored in the group's [ProposalStore]. The Commit message is
     /// created even if there are no valid pending proposals.

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -72,15 +72,6 @@ impl MlsGroup {
         self.flag_state_change();
     }
 
-    /// Clears or empties the internal [ProposalStore]
-    pub fn clear_pending_proposals(&mut self) {
-        // Empty the internal ProposalStore
-        self.proposal_store.empty();
-
-        // Since the state of the group might be changed, arm the state flag
-        self.flag_state_change();
-    }
-
     /// Creates a Commit message that covers the pending proposals that are
     /// currently stored in the group's [ProposalStore]. The Commit message is
     /// created even if there are no valid pending proposals.


### PR DESCRIPTION
Closes #1519 

This PR provides an additional method within `StagedWelcome` for creating a new group from a `Welcome` message.  This is in addition to the current API, which provides `StagedWelcome::new_from_welcome` for creating a new group from a `MlsMessageIn`.