### PR TITLE
Improve BasicCredential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1478](https://github.com/openmls/openmls/pull/1478): Remove explicit functions to set `RequiredCapabilitiesExtension` and `ExternalSendersExtension` when building an MlsGroup(Config) in favor of the more general function to set group context extensions
 - [#1479](https://github.com/openmls/openmls/pull/1479): Allow the use of extensions with `ExtensionType::Unknown` in group context, key packages and leaf nodes
 - [#1488](https://github.com/openmls/openmls/pull/1488): Allow unknown credentials. Credentials other than the basic credential or X.509 may be used now as long as they are encoded as variable-sized vectors.
+ - [#1527](https://github.com/openmls/openmls/pull/1527): CredentialType::Unknown is now called CredentialType::Other.
 
 ### Fixed
 

--- a/cli/src/identity.rs
+++ b/cli/src/identity.rs
@@ -23,10 +23,10 @@ impl Identity {
         crypto: &OpenMlsRustPersistentCrypto,
         id: &[u8],
     ) -> Self {
-        let credential = BasicCredential::new_credential(id.to_vec());
+        let credential = BasicCredential::new(id.to_vec()).unwrap();
         let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
         let credential_with_key = CredentialWithKey {
-            credential,
+            credential: credential.into(),
             signature_key: signature_keys.to_public_vec().into(),
         };
         signature_keys.store(crypto.key_store()).unwrap();

--- a/delivery-service/ds-lib/tests/test_codec.rs
+++ b/delivery-service/ds-lib/tests/test_codec.rs
@@ -11,10 +11,10 @@ fn test_client_info() {
     let client_name = "Client1";
     let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
-    let credential = BasicCredential::new_credential(client_name.as_bytes().to_vec());
+    let credential = BasicCredential::new(client_name.as_bytes().to_vec()).unwrap();
     let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
     let credential_with_key = CredentialWithKey {
-        credential,
+        credential: credential.into(),
         signature_key: signature_keys.to_public_vec().into(),
     };
     signature_keys.store(crypto.key_store()).unwrap();

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -11,10 +11,10 @@ fn generate_credential(
     identity: Vec<u8>,
     signature_scheme: SignatureScheme,
 ) -> (CredentialWithKey, SignatureKeyPair) {
-    let credential = BasicCredential::new_credential(identity);
+    let credential = BasicCredential::new(identity).unwrap();
     let signature_keys = SignatureKeyPair::new(signature_scheme).unwrap();
     let credential_with_key = CredentialWithKey {
-        credential,
+        credential: credential.into(),
         signature_key: signature_keys.to_public_vec().into(),
     };
 

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -222,7 +222,7 @@ impl MlsClient for MlsClientImpl {
         let provider = OpenMlsRustCrypto::default();
 
         let ciphersuite = Ciphersuite::try_from(request.cipher_suite as u16).unwrap();
-        let credential = BasicCredential::new_credential(request.identity.clone());
+        let credential = BasicCredential::new(request.identity.clone()).unwrap();
         let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
         signature_keys.store(provider.key_store()).unwrap();
 
@@ -244,7 +244,7 @@ impl MlsClient for MlsClientImpl {
             &mls_group_config,
             GroupId::from_slice(&request.group_id),
             CredentialWithKey {
-                credential,
+                credential: credential.into(),
                 signature_key: signature_keys.public().into(),
             },
         )
@@ -287,7 +287,7 @@ impl MlsClient for MlsClientImpl {
             "Creating key package."
         );
 
-        let credential = BasicCredential::new_credential(identity);
+        let credential = BasicCredential::new(identity).unwrap();
         let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
         let key_package = KeyPackage::builder()
@@ -310,7 +310,7 @@ impl MlsClient for MlsClientImpl {
                 &crypto_provider,
                 &signature_keys,
                 CredentialWithKey {
-                    credential: credential.clone(),
+                    credential: credential.clone().into(),
                     signature_key: signature_keys.public().into(),
                 },
             )
@@ -350,7 +350,7 @@ impl MlsClient for MlsClientImpl {
                 key_package,
                 private_key,
                 encryption_key_pair,
-                credential,
+                credential.into(),
                 signature_keys,
                 crypto_provider,
             ),
@@ -499,7 +499,7 @@ impl MlsClient for MlsClientImpl {
             let ciphersuite = verifiable_group_info.ciphersuite();
 
             let (credential_with_key, signer) = {
-                let credential = BasicCredential::new_credential(request.identity.to_vec());
+                let credential = BasicCredential::new(request.identity.to_vec()).unwrap();
 
                 let signature_keypair =
                     SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
@@ -507,7 +507,7 @@ impl MlsClient for MlsClientImpl {
                 signature_keypair.store(provider.key_store()).unwrap();
 
                 let credential_with_key = CredentialWithKey {
-                    credential,
+                    credential: credential.into(),
                     signature_key: signature_keypair.public().into(),
                 };
 
@@ -880,7 +880,7 @@ impl MlsClient for MlsClientImpl {
         let request = request.get_ref();
         info!(?request, "Request");
 
-        let removed_credential = BasicCredential::new_credential(request.removed_id.clone());
+        let removed_credential = BasicCredential::new(request.removed_id.clone()).unwrap();
         trace!("   for credential: {removed_credential:x?}");
 
         let mut groups = self.groups.lock().unwrap();
@@ -906,7 +906,7 @@ impl MlsClient for MlsClientImpl {
             .propose_remove_member_by_credential(
                 &interop_group.crypto_provider,
                 &interop_group.signature_keys,
-                &removed_credential,
+                &removed_credential.into(),
             )
             .map_err(into_status)?;
 
@@ -1008,13 +1008,13 @@ impl MlsClient for MlsClientImpl {
                 }
                 "remove" => {
                     let removed_credential =
-                        BasicCredential::new_credential(proposal.removed_id.clone());
+                        BasicCredential::new(proposal.removed_id.clone()).unwrap();
 
                     group
                         .propose_remove_member_by_credential_by_value(
                             &interop_group.crypto_provider,
                             &interop_group.signature_keys,
-                            &removed_credential,
+                            &removed_credential.into(),
                         )
                         .map_err(|_| Status::internal("Unable to generate proposal by value"))?
                 }

--- a/openmls-wasm/src/lib.rs
+++ b/openmls-wasm/src/lib.rs
@@ -73,13 +73,13 @@ impl Identity {
     pub fn new(provider: &Provider, name: &str) -> Result<Identity, JsError> {
         let signature_scheme = SignatureScheme::ED25519;
         let identity = name.bytes().collect();
-        let credential = BasicCredential::new_credential(identity);
+        let credential = BasicCredential::new(identity)?;
         let keypair = SignatureKeyPair::new(signature_scheme)?;
 
         keypair.store(provider.0.key_store())?;
 
         let credential_with_key = CredentialWithKey {
-            credential,
+            credential: credential.into(),
             signature_key: keypair.public().into(),
         };
 

--- a/openmls/benches/benchmark.rs
+++ b/openmls/benches/benchmark.rs
@@ -16,11 +16,11 @@ fn criterion_kp_bundle(c: &mut Criterion, provider: &impl OpenMlsProvider) {
             move |b| {
                 b.iter_with_setup(
                     || {
-                        let credential = BasicCredential::new_credential(vec![1, 2, 3]);
+                        let credential = BasicCredential::new(vec![1, 2, 3]).unwrap();
                         let signer =
                             SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
                         let credential_with_key = CredentialWithKey {
-                            credential,
+                            credential: credential.into(),
                             signature_key: signer.to_public_vec().into(),
                         };
 

--- a/openmls/src/credentials/errors.rs
+++ b/openmls/src/credentials/errors.rs
@@ -18,3 +18,14 @@ pub enum CredentialError {
     #[error("Invalid signature.")]
     InvalidSignature,
 }
+
+/// An error that occurs in methods of a [`super::Credential`].
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum BasicCredentialError {
+    /// TLS codec error
+    #[error(transparent)]
+    TlsCodecError(#[from] tls_codec::Error),
+    /// Wrong credential type
+    #[error("Wrong credential type.")]
+    WrongCredentialType,
+}

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -27,13 +27,14 @@ use std::io::{Read, Write};
 use serde::{Deserialize, Serialize};
 use tls_codec::{
     Deserialize as TlsDeserializeTrait, DeserializeBytes, Error, Serialize as TlsSerializeTrait,
-    Size, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes,
+    Size, VLBytes,
 };
 
 #[cfg(test)]
 mod tests;
 
 use crate::ciphersuite::SignaturePublicKey;
+use errors::*;
 
 // Public
 pub mod errors;
@@ -77,8 +78,8 @@ pub enum CredentialType {
     Basic = 1,
     /// An X.509 [`Certificate`]
     X509 = 2,
-    /// A currently unknown credential.
-    Unknown(u16),
+    /// Another type of credential that is not in the MLS protocol spec.
+    Other(u16),
 }
 
 impl Size for CredentialType {
@@ -124,7 +125,7 @@ impl From<u16> for CredentialType {
         match value {
             1 => CredentialType::Basic,
             2 => CredentialType::X509,
-            unknown => CredentialType::Unknown(unknown),
+            other => CredentialType::Other(other),
         }
     }
 }
@@ -134,7 +135,7 @@ impl From<CredentialType> for u16 {
         match value {
             CredentialType::Basic => 1,
             CredentialType::X509 => 2,
-            CredentialType::Unknown(unknown) => unknown,
+            CredentialType::Other(other) => other,
         }
     }
 }
@@ -251,13 +252,11 @@ impl Credential {
     }
 
     /// Creates and returns a new [`Credential`] of the given
-    /// the serialized credential.
-    ///
-    /// Returns an error if the given [`CredentialType`] is not supported.
-    pub fn new(serialized_credential: Vec<u8>) -> Self {
+    /// [`CredentialType`].
+    pub fn new(credential_type: CredentialType, serialized_credential: Vec<u8>) -> Self {
         Self {
+            credential_type,
             serialized_credential_content: serialized_credential.into(),
-            credential_type: CredentialType::Basic,
         }
     }
 
@@ -287,48 +286,53 @@ impl Credential {
 ///
 /// OpenMLS provides an implementation of signature keys for convenience in the
 /// `openmls_basic_credential` crate.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    TlsSerialize,
-    TlsDeserialize,
-    TlsDeserializeBytes,
-    TlsSize,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BasicCredential {
-    credential: Credential,
-}
-
-/// An internal type for (de)serialization of a basic credential as [`Credential`].
-#[derive(TlsSerialize, TlsSize)]
-struct MlsBasicCredential {
-    identity: VLBytes,
+    header: Vec<u8>,
+    identity: Vec<u8>,
 }
 
 impl BasicCredential {
-    /// Create a new basic credential as a [`Credential`].
-    pub fn new_credential(identity: Vec<u8>) -> Credential {
-        let cred = MlsBasicCredential {
-            identity: identity.into(),
-        };
+    /// Create a new basic credential.
+    ///
+    /// Errors
+    ///
+    /// Returns a [`BasicCredentialError`] if the length of the identity is too
+    /// large to be encoded as a variable-length vector.
+    pub fn new(identity: Vec<u8>) -> Result<Self, BasicCredentialError> {
+        let mut header = Vec::new();
+        tls_codec::vlen::write_length(&mut header, identity.len())?;
+        Ok(Self { header, identity })
+    }
+
+    /// Get the identity of this basic credential as byte slice.
+    pub fn identity(&self) -> &[u8] {
+        &self.identity
+    }
+}
+
+impl From<BasicCredential> for Credential {
+    fn from(mut credential: BasicCredential) -> Self {
+        let mut serialized_credential_content = credential.header;
+        serialized_credential_content.append(&mut credential.identity);
         Credential {
-            // This can't error, because we know the struct above will always serialize
-            serialized_credential_content: cred.tls_serialize_detached().unwrap().into(),
+            serialized_credential_content: serialized_credential_content.into(),
             credential_type: CredentialType::Basic,
         }
     }
+}
 
-    /// Get the identity of this basic credential as byte vector.
-    pub fn identity(&self) -> Vec<u8> {
-        // The unwrap here is safe because when we were able to build this
-        // basic credential, the value in the select statement must have been
-        // a variable-length byte vector.
-        let id: VLBytes = self.credential.deserialized().unwrap();
-        id.into()
+impl TryFrom<&Credential> for BasicCredential {
+    type Error = BasicCredentialError;
+
+    fn try_from(credential: &Credential) -> Result<Self, Self::Error> {
+        match credential.credential_type() {
+            CredentialType::Basic => {
+                let identity: VLBytes = credential.deserialized().unwrap();
+                Ok(BasicCredential::new(identity.into())?)
+            }
+            _ => Err(errors::BasicCredentialError::WrongCredentialType),
+        }
     }
 }
 
@@ -370,13 +374,13 @@ pub mod test_utils {
         identity: &[u8],
         signature_scheme: SignatureScheme,
     ) -> (CredentialWithKey, SignatureKeyPair) {
-        let credential = BasicCredential::new_credential(identity.into());
+        let credential = BasicCredential::new(identity.into()).unwrap();
         let signature_keys = SignatureKeyPair::new(signature_scheme).unwrap();
         signature_keys.store(provider.key_store()).unwrap();
 
         (
             CredentialWithKey {
-                credential,
+                credential: credential.into(),
                 signature_key: signature_keys.public().into(),
             },
             signature_keys,
@@ -386,25 +390,33 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod unit_tests {
-    use tls_codec::{DeserializeBytes, Serialize, VLBytes};
+    use tls_codec::{DeserializeBytes, Serialize};
 
     use super::{BasicCredential, Credential};
 
     #[test]
-    fn basic_credential_encoding() {
-        let credential = BasicCredential::new_credential("identity".into());
-        eprintln!("{credential:#?}");
-        let serialized = credential.tls_serialize_detached().unwrap();
-        eprintln!("{:#?}", VLBytes::from(serialized.clone()));
-        let (deserialized, remainder) = Credential::tls_deserialize_bytes(&serialized).unwrap();
-        eprintln!("remainder: {remainder:x?}");
+    fn basic_credential_identity_and_codec() {
+        const IDENTITY: &str = "identity";
+        // Test the identity getter.
+        let basic_credential = BasicCredential::new(IDENTITY.into()).unwrap();
+        assert_eq!(basic_credential.identity(), IDENTITY.as_bytes());
 
+        // Test the encoding and decoding.
+        let credential = Credential::from(basic_credential.clone());
+        let serialized = credential.tls_serialize_detached().unwrap();
+
+        let deserialized = Credential::tls_deserialize_exact_bytes(&serialized).unwrap();
         assert_eq!(credential.credential_type(), deserialized.credential_type());
         assert_eq!(
             credential.serialized_content(),
             deserialized.serialized_content()
         );
-        let identity: VLBytes = credential.deserialized().unwrap();
-        assert_eq!(identity.as_slice(), b"identity");
+
+        let deserialized_basic_credential = BasicCredential::try_from(&deserialized).unwrap();
+        assert_eq!(
+            deserialized_basic_credential.identity(),
+            IDENTITY.as_bytes()
+        );
+        assert_eq!(basic_credential, deserialized_basic_credential);
     }
 }

--- a/openmls/src/credentials/tests.rs
+++ b/openmls/src/credentials/tests.rs
@@ -37,7 +37,7 @@ fn that_unknown_credential_types_are_de_serialized_correctly() {
         let got = CredentialType::tls_deserialize_exact(&test).unwrap();
 
         match got {
-            CredentialType::Unknown(got_proposal_type) => {
+            CredentialType::Other(got_proposal_type) => {
                 assert_eq!(credential_type, got_proposal_type);
             }
             other => panic!("Expected `CredentialType::Unknown`, got `{:?}`.", other),

--- a/openmls/src/extensions/external_sender_extension.rs
+++ b/openmls/src/extensions/external_sender_extension.rs
@@ -97,13 +97,13 @@ mod test {
             let mut external_sender_extensions = Vec::new();
 
             for _ in 0..8 {
-                let credential = BasicCredential::new_credential(b"Alice".to_vec());
+                let credential = BasicCredential::new(b"Alice".to_vec()).unwrap();
                 let signature_keys =
                     SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
                 external_sender_extensions.push(ExternalSender {
                     signature_key: signature_keys.to_public_vec().into(),
-                    credential,
+                    credential: credential.into(),
                 });
             }
 

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -365,7 +365,7 @@ fn last_resort_extension(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvid
     let last_resort = Extension::LastResort(LastResortExtension::default());
 
     // Build a KeyPackage with a last resort extension
-    let credential = BasicCredential::new_credential(b"Bob".to_vec());
+    let credential = BasicCredential::new(b"Bob".to_vec()).unwrap();
     let signer =
         openmls_basic_credential::SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
@@ -387,7 +387,7 @@ fn last_resort_extension(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvid
             provider,
             &signer,
             CredentialWithKey {
-                credential: credential.clone(),
+                credential: credential.clone().into(),
                 signature_key: signer.to_public_vec().into(),
             },
         )

--- a/openmls/src/group/tests/external_remove_proposal.rs
+++ b/openmls/src/group/tests/external_remove_proposal.rs
@@ -1,7 +1,7 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use rstest::*;
 use rstest_reuse::{self, *};
-use tls_codec::{Deserialize, Serialize};
+use tls_codec::Deserialize;
 
 use crate::{
     credentials::BasicCredential,
@@ -129,8 +129,7 @@ fn external_remove_proposal_should_remove_member(
     let bob_index = alice_group
         .members()
         .find(|member| {
-            let serialized = member.credential.tls_serialize_detached().unwrap();
-            let credential = BasicCredential::tls_deserialize_exact(serialized).unwrap();
+            let credential = BasicCredential::try_from(&member.credential).unwrap();
             let identity = credential.identity();
             identity == b"Bob"
         })

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -355,7 +355,7 @@ fn test_valsem101a(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
             provider,
             &charlie_credential_with_key.signer,
             CredentialWithKey {
-                credential: BasicCredential::new_credential(b"Dave".to_vec()),
+                credential: BasicCredential::new(b"Dave".to_vec()).unwrap().into(),
                 signature_key: charlie_credential_with_key
                     .credential_with_key
                     .signature_key,
@@ -599,7 +599,7 @@ fn test_valsem101b(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
             }
             .map(|(name, keypair)| CredentialWithKeyAndSigner {
                 credential_with_key: CredentialWithKey {
-                    credential: BasicCredential::new_credential(name.into()),
+                    credential: BasicCredential::new(name.into()).unwrap().into(),
                     signature_key: keypair.to_public_vec().into(),
                 },
                 signer: keypair,

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -335,7 +335,7 @@ pub(crate) fn generate_credential_with_key(
     provider: &impl OpenMlsProvider,
 ) -> CredentialWithKeyAndSigner {
     let (credential, signer) = {
-        let credential = BasicCredential::new_credential(identity);
+        let credential = BasicCredential::new(identity).unwrap();
         let signature_keys = SignatureKeyPair::new(signature_scheme).unwrap();
         signature_keys.store(provider.key_store()).unwrap();
 
@@ -346,7 +346,7 @@ pub(crate) fn generate_credential_with_key(
 
     CredentialWithKeyAndSigner {
         credential_with_key: CredentialWithKey {
-            credential,
+            credential: credential.into(),
             signature_key: signature_key.into(),
         },
         signer,

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -36,12 +36,13 @@
 //! let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 //! let provider = OpenMlsRustCrypto::default();
 //!
-//! let credential = BasicCredential::new_credential("identity".into());
+//! let credential = BasicCredential::new("identity".into())
+//!     .expect("Error creating a credential.");
 //! let signer =
 //!     SignatureKeyPair::new(ciphersuite.signature_algorithm())
 //!         .expect("Error generating a signature key pair.");
 //! let credential_with_key = CredentialWithKey {
-//!     credential,
+//!     credential: credential.into(),
 //!     signature_key: signer.public().into(),
 //! };
 //! let key_package = KeyPackage::builder()

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -10,7 +10,7 @@ pub(crate) fn key_package(
     ciphersuite: Ciphersuite,
     provider: &impl OpenMlsProvider,
 ) -> (KeyPackage, Credential, SignatureKeyPair) {
-    let credential = BasicCredential::new_credential(b"Sasha".to_vec());
+    let credential = BasicCredential::new(b"Sasha".to_vec()).unwrap();
     let signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
     // Generate a valid KeyPackage.
@@ -23,13 +23,13 @@ pub(crate) fn key_package(
             provider,
             &signer,
             CredentialWithKey {
-                credential: credential.clone(),
+                credential: credential.clone().into(),
                 signature_key: signer.to_public_vec().into(),
             },
         )
         .expect("An unexpected error occurred.");
 
-    (key_package, credential, signer)
+    (key_package, credential.into(), signer)
 }
 
 #[apply(ciphersuites_and_providers)]
@@ -59,7 +59,7 @@ fn serialization(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
 #[apply(ciphersuites_and_providers)]
 fn application_id_extension(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
-    let credential = BasicCredential::new_credential(b"Sasha".to_vec());
+    let credential = BasicCredential::new(b"Sasha".to_vec()).unwrap();
     let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
     // Generate a valid KeyPackage.
@@ -77,7 +77,7 @@ fn application_id_extension(ciphersuite: Ciphersuite, provider: &impl OpenMlsPro
             &signature_keys,
             CredentialWithKey {
                 signature_key: signature_keys.to_public_vec().into(),
-                credential,
+                credential: credential.into(),
             },
         )
         .expect("An unexpected error occurred.");

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -22,7 +22,8 @@
 //!     signature_algorithm: SignatureScheme,
 //!     provider: &impl OpenMlsProvider,
 //! ) -> (CredentialWithKey, SignatureKeyPair) {
-//!     let credential = BasicCredential::new_credential(identity);
+//!     let credential = BasicCredential::new(identity)
+//!         .expect("Error creating a credential.");
 //!     let signature_keys =
 //!         SignatureKeyPair::new(signature_algorithm)
 //!             .expect("Error generating a signature key pair.");
@@ -35,7 +36,7 @@
 //!     
 //!     (
 //!         CredentialWithKey {
-//!             credential,
+//!             credential: credential.into(),
 //!             signature_key: signature_keys.public().into(),
 //!         },
 //!         signature_keys,

--- a/openmls/src/test_utils/mod.rs
+++ b/openmls/src/test_utils/mod.rs
@@ -114,7 +114,7 @@ pub(crate) fn generate_group_candidate(
     use crate::credentials::BasicCredential;
 
     let credential_with_key_and_signer = {
-        let credential = BasicCredential::new_credential(identity.to_vec());
+        let credential = BasicCredential::new(identity.to_vec()).unwrap();
 
         let signature_keypair = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
@@ -131,7 +131,7 @@ pub(crate) fn generate_group_candidate(
 
         CredentialWithKeyAndSigner {
             credential_with_key: CredentialWithKey {
-                credential,
+                credential: credential.into(),
                 signature_key: signature_pkey.into(),
             },
             signer: signature_keypair,

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -346,9 +346,7 @@ impl Client {
         let group = groups.get(group_id).unwrap();
         let leaf = group.own_leaf();
         leaf.map(|l| {
-            let credential = l.credential();
-            let credential =
-                BasicCredential::tls_deserialize_exact(credential.serialized_content()).unwrap();
+            let credential = BasicCredential::try_from(l.credential()).unwrap();
             credential.identity().to_vec()
         })
     }

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -150,7 +150,7 @@ impl MlsGroupTestSetup {
             let crypto = OpenMlsRustCrypto::default();
             let mut credentials = HashMap::new();
             for ciphersuite in crypto.crypto().supported_ciphersuites().iter() {
-                let credential = BasicCredential::new_credential(identity.clone());
+                let credential = BasicCredential::new(identity.clone()).unwrap();
                 let signature_keys =
                     SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
                 signature_keys.store(crypto.key_store()).unwrap();
@@ -163,7 +163,7 @@ impl MlsGroupTestSetup {
                 credentials.insert(
                     *ciphersuite,
                     CredentialWithKey {
-                        credential,
+                        credential: credential.into(),
                         signature_key: signature_key.into(),
                     },
                 );

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -142,13 +142,13 @@ fn generate_credential(
     signature_algorithm: SignatureScheme,
     provider: &impl OpenMlsProvider,
 ) -> (CredentialWithKey, SignatureKeyPair) {
-    let credential = BasicCredential::new_credential(identity);
+    let credential = BasicCredential::new(identity).unwrap();
     let signature_keys = SignatureKeyPair::new(signature_algorithm).unwrap();
     signature_keys.store(provider.key_store()).unwrap();
 
     (
         CredentialWithKey {
-            credential,
+            credential: credential.into(),
             signature_key: signature_keys.to_public_vec().into(),
         },
         signature_keys,

--- a/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
@@ -110,13 +110,13 @@ fn generate_credential(
     signature_algorithm: SignatureScheme,
     provider: &impl OpenMlsProvider,
 ) -> (CredentialWithKey, SignatureKeyPair) {
-    let credential = BasicCredential::new_credential(identity);
+    let credential = BasicCredential::new(identity).unwrap();
     let signature_keys = SignatureKeyPair::new(signature_algorithm).unwrap();
     signature_keys.store(provider.key_store()).unwrap();
 
     (
         CredentialWithKey {
-            credential,
+            credential: credential.into(),
             signature_key: signature_keys.to_public_vec().into(),
         },
         signature_keys,
@@ -239,7 +239,7 @@ pub fn run_test_vector(
         );
 
         // Set up the group, unfortunately we can't do without.
-        let credential = BasicCredential::new_credential(b"This is not needed".to_vec());
+        let credential = BasicCredential::new(b"This is not needed".to_vec()).unwrap();
         let signature_private_key = hex_to_bytes(&test.signature_priv);
         let random_own_signature_key =
             SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
@@ -254,21 +254,21 @@ pub fn run_test_vector(
             group_context.group_id().clone(),
             CryptoConfig::with_default_version(ciphersuite),
             CredentialWithKey {
-                credential,
+                credential: credential.into(),
                 signature_key: random_own_signature_key.into(),
             },
         )
         .build(provider, &signer)
         .unwrap();
 
-        let credential = BasicCredential::new_credential("Fake user".into());
+        let credential = BasicCredential::new("Fake user".into()).unwrap();
         let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
         let bob_key_package_bundle = KeyPackageBundle::new(
             provider,
             &signature_keys,
             ciphersuite,
             CredentialWithKey {
-                credential,
+                credential: credential.into(),
                 signature_key: hex_to_bytes(&test.signature_pub).into(),
             },
         );

--- a/openmls/src/treesync/node/leaf_node/capabilities.rs
+++ b/openmls/src/treesync/node/leaf_node/capabilities.rs
@@ -281,9 +281,9 @@ mod tests {
         let credentials = vec![
             CredentialType::Basic,
             CredentialType::X509,
-            CredentialType::Unknown(0x0000),
-            CredentialType::Unknown(0x7A7A),
-            CredentialType::Unknown(0xFFFF),
+            CredentialType::Other(0x0000),
+            CredentialType::Other(0x7A7A),
+            CredentialType::Other(0xFFFF),
         ];
 
         let expected = Capabilities {

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -26,7 +26,7 @@ fn generate_credential(
     provider: &impl OpenMlsProvider,
 ) -> (CredentialWithKey, SignatureKeyPair) {
     // ANCHOR: create_basic_credential
-    let credential = BasicCredential::new_credential(identity);
+    let credential = BasicCredential::new(identity).unwrap();
     // ANCHOR_END: create_basic_credential
     // ANCHOR: create_credential_keys
     let signature_keys = SignatureKeyPair::new(signature_algorithm).unwrap();
@@ -35,7 +35,7 @@ fn generate_credential(
 
     (
         CredentialWithKey {
-            credential,
+            credential: credential.into(),
             signature_key: signature_keys.to_public_vec().into(),
         },
         signature_keys,

--- a/openmls/tests/key_store.rs
+++ b/openmls/tests/key_store.rs
@@ -6,7 +6,7 @@ use openmls_basic_credential::SignatureKeyPair;
 fn test_store_key_package(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
     // ANCHOR: key_store_store
     // First we generate a credential and key package for our user.
-    let credential = BasicCredential::new_credential(b"User ID".to_vec());
+    let credential = BasicCredential::new(b"User ID".to_vec()).unwrap();
     let signature_keys = SignatureKeyPair::new(ciphersuite.into()).unwrap();
 
     let key_package = KeyPackage::builder()
@@ -15,7 +15,7 @@ fn test_store_key_package(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvi
             provider,
             &signature_keys,
             CredentialWithKey {
-                credential,
+                credential: credential.into(),
                 signature_key: signature_keys.to_public_vec().into(),
             },
         )


### PR DESCRIPTION
Fixes #1526 

This PR makes `BasicCredential` more ergonomic, because it can now be converted from a `Credential` without having to serialize and deserialize the content of the credential. It also checks the input size of the indentity.