### PR TITLE
Expose the whole tls_codec crate in prelude

### DIFF
--- a/basic_credential/src/lib.rs
+++ b/basic_credential/src/lib.rs
@@ -8,8 +8,8 @@ use std::fmt::Debug;
 
 use openmls_traits::{
     key_store::{MlsEntity, MlsEntityId, OpenMlsKeyStore},
-    signatures::Signer,
-    types::{CryptoError, Error, SignatureScheme},
+    signatures::{Signer, SignerError},
+    types::{CryptoError, SignatureScheme},
 };
 
 use p256::ecdsa::{signature::Signer as P256Signer, Signature, SigningKey};
@@ -42,21 +42,21 @@ impl Debug for SignatureKeyPair {
 }
 
 impl Signer for SignatureKeyPair {
-    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, Error> {
+    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, SignerError> {
         match self.signature_scheme {
             SignatureScheme::ECDSA_SECP256R1_SHA256 => {
                 let k = SigningKey::from_bytes(self.private.as_slice().into())
-                    .map_err(|_| Error::SigningError)?;
+                    .map_err(|_| SignerError::SigningError)?;
                 let signature: Signature = k.sign(payload);
                 Ok(signature.to_der().to_bytes().into())
             }
             SignatureScheme::ED25519 => {
                 let k = ed25519_dalek::SigningKey::try_from(self.private.as_slice())
-                    .map_err(|_| Error::SigningError)?;
+                    .map_err(|_| SignerError::SigningError)?;
                 let signature = k.sign(payload);
                 Ok(signature.to_bytes().into())
             }
-            _ => Err(Error::SigningError),
+            _ => Err(SignerError::SigningError),
         }
     }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,6 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 base64 = "0.13"
 log = "0.4"
 pretty_env_logger = "0.4"
-tls_codec = { workspace = true }
 
 openmls = { path = "../openmls", features = ["test-utils"] }
 ds-lib = { path = "../delivery-service/ds-lib" }
@@ -18,11 +17,10 @@ openmls_traits = { path = "../traits" }
 openmls_rust_crypto = { path = "../openmls_rust_crypto" }
 openmls_memory_keystore = { path = "../memory_keystore" }
 openmls_basic_credential = { path = "../basic_credential" }
-serde = { version = "^1.0"}
+serde = { version = "^1.0" }
 thiserror = "1.0"
 serde_json = "1.0"
 rand_chacha = { version = "0.3.1" }
-
 
 [dependencies.termion]
 version = "1.5"

--- a/cli/src/networking.rs
+++ b/cli/src/networking.rs
@@ -1,7 +1,7 @@
 use reqwest::{self, blocking::Client, StatusCode};
 use url::Url;
 
-use tls_codec::Serialize;
+use openmls::prelude::tls_codec::Serialize;
 
 // TODO: return objects not bytes.
 

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -6,9 +6,8 @@ use std::path::PathBuf;
 use std::{cell::RefCell, collections::HashMap, str};
 
 use ds_lib::{ClientKeyPackages, GroupMessage};
-use openmls::prelude::*;
+use openmls::prelude::{tls_codec::*, *};
 use openmls_traits::OpenMlsProvider;
-use tls_codec::TlsByteVecU8;
 
 use super::{
     backend::Backend, conversation::Conversation, conversation::ConversationMessage, file_helpers,

--- a/delivery-service/ds-lib/Cargo.toml
+++ b/delivery-service/ds-lib/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 description = "Types to interact with the OpenMLS DS."
 
 [dependencies]
-tls_codec = { workspace = true }
 openmls = { path = "../../openmls", features = ["test-utils"] }
 openmls_traits = { path = "../../traits" }
 openmls_rust_crypto = { path = "../../openmls_rust_crypto" }

--- a/delivery-service/ds-lib/src/lib.rs
+++ b/delivery-service/ds-lib/src/lib.rs
@@ -7,11 +7,7 @@
 
 use std::collections::HashSet;
 
-use openmls::prelude::*;
-use tls_codec::{
-    TlsByteSliceU16, TlsByteVecU16, TlsByteVecU32, TlsByteVecU8, TlsDeserialize,
-    TlsDeserializeBytes, TlsSerialize, TlsSize, TlsVecU32, VLBytes,
-};
+use openmls::prelude::{tls_codec::*, *};
 
 /// Information about a client.
 /// To register a new client create a new `ClientInfo` and send it to

--- a/delivery-service/ds/Cargo.toml
+++ b/delivery-service/ds/Cargo.toml
@@ -14,11 +14,10 @@ futures-util = "0.3"
 serde_json = "1.0"
 log = "0.4"
 pretty_env_logger = "0.5"
-serde = {version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 clap = "4"
 base64 = "0.13"
-tls_codec = { workspace = true }
 
 openmls = { path = "../../openmls", features = ["test-utils"] }
 

--- a/fuzz/fuzz_targets/key_package_decode.rs
+++ b/fuzz/fuzz_targets/key_package_decode.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use openmls::prelude::*;
+use openmls::prelude::{tls_codec::*, *};
 
 fuzz_target!(|data: &[u8]| {
     let _ = KeyPackageIn::tls_deserialize(&mut &data[..]);

--- a/fuzz/fuzz_targets/mls_message_decode.rs
+++ b/fuzz/fuzz_targets/mls_message_decode.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use openmls::prelude::*;
+use openmls::prelude::{tls_codec::*, *};
 
 fuzz_target!(|data: &[u8]| {
     let _ = MlsMessageIn::tls_deserialize_exact(data);

--- a/fuzz/fuzz_targets/proposal_decode.rs
+++ b/fuzz/fuzz_targets/proposal_decode.rs
@@ -1,7 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-
-use openmls::prelude::*;
+use openmls::prelude::{tls_codec::*, *};
 
 fuzz_target!(|data: &[u8]| {
     let _ = ProposalIn::tls_deserialize(&mut &data[..]);

--- a/fuzz/fuzz_targets/welcome_decode.rs
+++ b/fuzz/fuzz_targets/welcome_decode.rs
@@ -1,7 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-
-use openmls::prelude::*;
+use openmls::prelude::{tls_codec::*, *};
 
 fuzz_target!(|data: &[u8]| {
     let _ = Welcome::tls_deserialize(&mut &data[..]);

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -29,7 +29,7 @@
 //! package bundle can be created as follows:
 //!
 //! ```
-//! use openmls::prelude::*;
+//! use openmls::prelude::{*, tls_codec::*};
 //! use openmls_rust_crypto::OpenMlsRustCrypto;
 //! use openmls_basic_credential::SignatureKeyPair;
 //!
@@ -65,7 +65,7 @@
 //! as follows;
 //!
 //! ```
-//! use openmls::prelude::*;
+//! use openmls::prelude::{*, tls_codec::*};
 //! use openmls::test_utils::hex_to_bytes;
 //! use openmls_rust_crypto::OpenMlsRustCrypto;
 //!

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -4,7 +4,7 @@
 //! up to parties and have them create a group.
 //!
 //! ```
-//! use openmls::prelude::{*, config::CryptoConfig};
+//! use openmls::prelude::{*, config::CryptoConfig, tls_codec::*};
 //! use openmls_rust_crypto::{OpenMlsRustCrypto};
 //! use openmls_basic_credential::SignatureKeyPair;
 //!

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -55,9 +55,7 @@ pub use crate::treesync::{
 // };
 
 // TLS codec traits
-pub use tls_codec::{
-    Deserialize as TlsDeserializeTrait, Serialize as TlsSerializeTrait, Size as TlsSizeTrait,
-};
+pub use tls_codec::{self, *};
 
 // Errors
 pub use crate::error::*;

--- a/openmls/src/treesync/tests_and_kats/tests.rs
+++ b/openmls/src/treesync/tests_and_kats/tests.rs
@@ -1,5 +1,5 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
-use tls_codec::VLBytes;
+use tls_codec::*;
 
 use crate::{
     group::{

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -1,5 +1,5 @@
 use openmls::{
-    prelude::{config::CryptoConfig, *},
+    prelude::{config::CryptoConfig, tls_codec::*, *},
     test_utils::*,
     *,
 };

--- a/openmls/tests/test_external_commit.rs
+++ b/openmls/tests/test_external_commit.rs
@@ -1,6 +1,9 @@
 use openmls::{
-    credentials::test_utils::new_credential, messages::group_info::VerifiableGroupInfo, prelude::*,
-    test_utils::*, *,
+    credentials::test_utils::new_credential,
+    messages::group_info::VerifiableGroupInfo,
+    prelude::{tls_codec::*, *},
+    test_utils::*,
+    *,
 };
 use openmls_basic_credential::SignatureKeyPair;
 

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -1,5 +1,5 @@
 use openmls::{
-    prelude::{config::CryptoConfig, test_utils::new_credential, *},
+    prelude::{config::CryptoConfig, test_utils::new_credential, tls_codec::*, *},
     test_utils::*,
     *,
 };

--- a/traits/src/signatures.rs
+++ b/traits/src/signatures.rs
@@ -1,11 +1,18 @@
-use crate::types::{Error, SignatureScheme};
+use crate::types::{CryptoError, SignatureScheme};
+/// Trait errors.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SignerError {
+    CryptoError(CryptoError),
+    InvalidSignature,
+    SigningError,
+}
 
 /// Sign the provided payload and return a signature.
 pub trait Signer {
     /// Sign the provided payload.
     ///
     /// Returns a signature on success or an Error.
-    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, Error>;
+    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, SignerError>;
 
     /// The [`SignatureScheme`] of this signer.
     fn signature_scheme(&self) -> SignatureScheme;

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -120,14 +120,6 @@ impl TryFrom<u16> for SignatureScheme {
     }
 }
 
-/// Trait errors.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum Error {
-    CryptoError(CryptoError),
-    InvalidSignature,
-    SigningError,
-}
-
 /// Crypto errors.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum CryptoError {


### PR DESCRIPTION
This PR exposes the whole `tls_crate` in the prelude (and cleans up the fallout).

Applications using OpenMLS no longer have to import `tls_codec` separately this way. For various projects depending on OpenMLS this has been painful because of the frequent version changes.