### PR TITLE
Make StagedWelcome consume Welcome instead of MlsMessageIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#1506](https://github.com/openmls/openmls/pull/1506): Add `StagedWelcome` and `StagedCoreWelcome` to make joining a group staged in order to inspect the `Welcome` message
+- [#1506](https://github.com/openmls/openmls/pull/1506): Add `StagedWelcome` and `StagedCoreWelcome` to make joining a group staged in order to inspect the `Welcome` message. This was followed up with PR [#1533](https://github.com/openmls/openmls/pull/1533) to adjust the API.
 - [#1516](https://github.com/openmls/openmls/pull/1516): Add `MlsGroup::clear_pending_proposals` to the public API; this allows users to clear a group's internal `ProposalStore`
 
 ### Changed
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1479](https://github.com/openmls/openmls/pull/1479): Allow the use of extensions with `ExtensionType::Unknown` in group context, key packages and leaf nodes
 - [#1488](https://github.com/openmls/openmls/pull/1488): Allow unknown credentials. Credentials other than the basic credential or X.509 may be used now as long as they are encoded as variable-sized vectors.
 - [#1527](https://github.com/openmls/openmls/pull/1527): CredentialType::Unknown is now called CredentialType::Other.
-- [#1533](https://github.com/openmls/openmls/pull/1533): Make `MlsGroup::new_from_welcome` consume a `Welcome` instead of an `MlsMessageIn`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#1506](https://github.com/openmls/openmls/pull/1506): Add `StagedWelcome` and `StagedCoreWelcome` to make joining a group staged in order to inspect the `Welcome` message
 - [#1516](https://github.com/openmls/openmls/pull/1516): Add `MlsGroup::clear_pending_proposals` to the public API; this allows users to clear a group's internal `ProposalStore`
 
 ### Changed
@@ -20,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1478](https://github.com/openmls/openmls/pull/1478): Remove explicit functions to set `RequiredCapabilitiesExtension` and `ExternalSendersExtension` when building an MlsGroup(Config) in favor of the more general function to set group context extensions
 - [#1479](https://github.com/openmls/openmls/pull/1479): Allow the use of extensions with `ExtensionType::Unknown` in group context, key packages and leaf nodes
 - [#1488](https://github.com/openmls/openmls/pull/1488): Allow unknown credentials. Credentials other than the basic credential or X.509 may be used now as long as they are encoded as variable-sized vectors.
- - [#1527](https://github.com/openmls/openmls/pull/1527): CredentialType::Unknown is now called CredentialType::Other.
+- [#1527](https://github.com/openmls/openmls/pull/1527): CredentialType::Unknown is now called CredentialType::Other.
+- [#1533](https://github.com/openmls/openmls/pull/1533): Make `MlsGroup::new_from_welcome` consume a `Welcome` instead of an `MlsMessageIn`
 
 ### Fixed
 

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -680,15 +680,11 @@ impl User {
         let group_config = MlsGroupJoinConfig::builder()
             .use_ratchet_tree_extension(true)
             .build();
-        let mut mls_group = StagedWelcome::new_from_welcome(
-            &self.crypto,
-            &group_config,
-            MlsMessageOut::from_welcome(welcome, ProtocolVersion::default()).into(),
-            None,
-        )
-        .expect("Failed to create staged join")
-        .into_group(&self.crypto)
-        .expect("Failed to create MlsGroup");
+        let mut mls_group =
+            StagedWelcome::new_from_welcome(&self.crypto, &group_config, welcome, None)
+                .expect("Failed to create staged join")
+                .into_group(&self.crypto)
+                .expect("Failed to create MlsGroup");
 
         let group_id = mls_group.group_id().to_vec();
         // XXX: Use Welcome's encrypted_group_info field to store group_name.

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -322,10 +322,15 @@ async fn test_group() {
     assert_eq!(welcome_msg, welcome_message.into());
     assert!(messages.is_empty());
 
+    let welcome = match welcome_msg.body() {
+        MlsMessageBodyOut::Welcome(welcome) => welcome,
+        other => panic!("expected a welcome message, got {:?}", other),
+    };
+
     let mut group_on_client2 = StagedWelcome::new_from_welcome(
         crypto,
         mls_group_create_config.join_config(),
-        welcome_msg.into(),
+        welcome.clone(),
         Some(group.export_ratchet_tree().into()), // delivered out of band
     )
     .expect("Error creating staged join from Welcome")

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -427,7 +427,9 @@ impl MlsClient for MlsClientImpl {
             .map_err(into_status)?;
 
         let welcome = MlsMessageIn::tls_deserialize(&mut request.welcome.as_slice())
-            .map_err(|_| Status::aborted("failed to deserialize MlsMessage with a Welcome"))?;
+            .map_err(|_| Status::aborted("failed to deserialize MlsMessage with a Welcome"))?
+            .into_welcome()
+            .expect("expected a welcome");
 
         let ratchet_tree = ratchet_tree_from_config(request.ratchet_tree.clone());
 

--- a/openmls-wasm/src/lib.rs
+++ b/openmls-wasm/src/lib.rs
@@ -162,6 +162,11 @@ impl Group {
         ratchet_tree: RatchetTree,
     ) -> Result<Group, JsError> {
         let welcome = MlsMessageIn::tls_deserialize(&mut welcome)?;
+        let welcome = welcome
+            .into_welcome()
+            .ok_or(openmls::error::ErrorString::from(
+                "expected a message of type welcome",
+            ))?;
         let config = MlsGroupJoinConfig::builder().build();
         let mls_group =
             StagedWelcome::new_from_welcome(&provider.0, &config, welcome, Some(ratchet_tree.0))?
@@ -289,7 +294,10 @@ impl Group {
     }
 
     fn native_join(provider: &Provider, mut welcome: &[u8], ratchet_tree: RatchetTree) -> Group {
-        let welcome = MlsMessageIn::tls_deserialize(&mut welcome).unwrap();
+        let welcome = MlsMessageIn::tls_deserialize(&mut welcome)
+            .unwrap()
+            .into_welcome()
+            .expect("expected a message of type welcome");
         let config = MlsGroupJoinConfig::builder().build();
         let mls_group = StagedWelcome::new_from_welcome(
             provider.as_ref(),

--- a/openmls-wasm/src/lib.rs
+++ b/openmls-wasm/src/lib.rs
@@ -3,7 +3,7 @@ mod utils;
 use js_sys::Uint8Array;
 use openmls::{
     credentials::{BasicCredential, CredentialWithKey},
-    framing::{MlsMessageIn, MlsMessageOut},
+    framing::{MlsMessageBodyIn, MlsMessageIn, MlsMessageOut},
     group::{config::CryptoConfig, GroupId, MlsGroup, MlsGroupJoinConfig, StagedWelcome},
     key_packages::KeyPackage as OpenMlsKeyPackage,
     prelude::SignatureScheme,
@@ -161,12 +161,12 @@ impl Group {
         mut welcome: &[u8],
         ratchet_tree: RatchetTree,
     ) -> Result<Group, JsError> {
-        let welcome = MlsMessageIn::tls_deserialize(&mut welcome)?;
-        let welcome = welcome
-            .into_welcome()
-            .ok_or(openmls::error::ErrorString::from(
-                "expected a message of type welcome",
-            ))?;
+        let welcome = match MlsMessageIn::tls_deserialize(&mut welcome)?.extract() {
+            MlsMessageBodyIn::Welcome(welcome) => Ok(welcome),
+            other => Err(openmls::error::ErrorString::from(format!(
+                "expected a message of type welcome, got {other:?}",
+            ))),
+        }?;
         let config = MlsGroupJoinConfig::builder().build();
         let mls_group =
             StagedWelcome::new_from_welcome(&provider.0, &config, welcome, Some(ratchet_tree.0))?

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -436,10 +436,13 @@ fn last_resort_extension(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvid
 
     alice_group.merge_pending_commit(provider).unwrap();
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome.into_welcome().expect("expected a welcome");
+
     let _bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("An unexpected error occurred.")

--- a/openmls/src/group/core_group/kat_passive_client.rs
+++ b/openmls/src/group/core_group/kat_passive_client.rs
@@ -293,10 +293,14 @@ impl PassiveClient {
         mls_message_welcome: MlsMessageIn,
         ratchet_tree: Option<RatchetTreeIn>,
     ) {
+        let welcome = mls_message_welcome
+            .into_welcome()
+            .expect("expected a welcome");
+
         let group = StagedWelcome::new_from_welcome(
             &self.provider,
             &self.group_config,
-            mls_message_welcome,
+            welcome,
             ratchet_tree,
         )
         .unwrap()

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -8,7 +8,10 @@ use crate::{
         core_group::create_commit_params::CreateCommitParams,
         errors::{ExternalCommitError, WelcomeError},
     },
-    messages::group_info::{GroupInfo, VerifiableGroupInfo},
+    messages::{
+        group_info::{GroupInfo, VerifiableGroupInfo},
+        Welcome,
+    },
     schedule::psk::store::ResumptionPskStore,
     treesync::RatchetTreeIn,
 };
@@ -134,14 +137,9 @@ impl StagedWelcome {
     pub fn new_from_welcome<KeyStore: OpenMlsKeyStore>(
         provider: &impl OpenMlsProvider<KeyStoreProvider = KeyStore>,
         mls_group_config: &MlsGroupJoinConfig,
-        welcome: MlsMessageIn,
+        welcome: Welcome,
         ratchet_tree: Option<RatchetTreeIn>,
     ) -> Result<Self, WelcomeError<KeyStore::Error>> {
-        let welcome = match welcome.body {
-            MlsMessageBodyIn::Welcome(welcome) => welcome,
-            _ => return Err(WelcomeError::NotAWelcomeMessage),
-        };
-
         let resumption_psk_store =
             ResumptionPskStore::new(mls_group_config.number_of_resumption_psks);
         let (key_package, _) = welcome

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -98,10 +98,13 @@ fn remover(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         .merge_pending_commit(provider)
         .expect("error merging pending commit");
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome.into_welcome().expect("expected a welcome");
+
     let mut bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("Error creating staged join from Welcome")
@@ -135,10 +138,13 @@ fn remover(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         .merge_pending_commit(provider)
         .expect("error merging pending commit");
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome.into_welcome().expect("expected a welcome");
+
     let mut charlie_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(bob_group.export_ratchet_tree().into()),
     )
     .expect("Error creating group from Welcome")
@@ -278,10 +284,13 @@ fn staged_join(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
     let join_config = mls_group_create_config.join_config();
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome.into_welcome().expect("expected a welcome");
+
     let staged_bob_group = StagedWelcome::new_from_welcome(
         provider,
         join_config,
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("error creating staged mls group");
@@ -476,10 +485,15 @@ fn test_verify_staged_commit_credentials(
     assert!(alice_group.pending_commit().is_none());
     assert!(alice_group.pending_proposals().next().is_none());
 
+    let welcome: MlsMessageIn = welcome_option.expect("expected a welcome").into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     let mut bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_config.join_config(),
-        welcome_option.expect("no welcome after commit").into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("error creating group from welcome")
@@ -642,10 +656,15 @@ fn test_commit_with_update_path_leaf_node(
     assert!(alice_group.pending_commit().is_none());
     assert!(alice_group.pending_proposals().next().is_none());
 
+    let welcome: MlsMessageIn = welcome_option.expect("expected a welcome").into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     let mut bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome_option.expect("no welcome after commit").into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("error creating group from welcome")
@@ -883,10 +902,15 @@ fn test_pending_commit_logic(ciphersuite: Ciphersuite, provider: &impl OpenMlsPr
         .expect("error merging pending commit");
     assert!(alice_group.pending_commit().is_none());
 
+    let welcome: MlsMessageIn = welcome_option.expect("expected a welcome").into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     let mut bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome_option.expect("no welcome after commit").into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("error creating group from welcome")
@@ -962,11 +986,16 @@ fn key_package_deletion(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
 
     alice_group.merge_pending_commit(provider).unwrap();
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     // === Bob joins the group ===
     let _bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("Error creating staged join from Welcome")
@@ -1028,10 +1057,16 @@ fn remove_prosposal_by_ref(ciphersuite: Ciphersuite, provider: &impl OpenMlsProv
         .add_members(provider, &alice_signer, &[bob_key_package])
         .unwrap();
     alice_group.merge_pending_commit(provider).unwrap();
+
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     let mut bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .unwrap()
@@ -1355,10 +1390,16 @@ fn unknown_extensions(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider)
         .add_members(provider, &alice_signer, &[bob_key_package.clone()])
         .unwrap();
     alice_group.merge_pending_commit(provider).unwrap();
+
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     let _bob_group = StagedWelcome::new_from_welcome(
         provider,
         &MlsGroupJoinConfig::default(),
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("Error creating staged join from Welcome")
@@ -1416,10 +1457,16 @@ fn join_multiple_groups_last_resort_extension(
         .merge_pending_commit(provider)
         .expect("error merging commit for alice's group");
     // charlie calls new_from_welcome(...) with alice's Welcome message; SHOULD SUCCEED
+
+    let alice_welcome: MlsMessageIn = alice_welcome.into();
+    let alice_welcome = alice_welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     StagedWelcome::new_from_welcome(
         provider,
         &MlsGroupJoinConfig::default(),
-        alice_welcome.into(),
+        alice_welcome,
         None,
     )
     .expect("error creating staged join from welcome")
@@ -1434,6 +1481,10 @@ fn join_multiple_groups_last_resort_extension(
         .merge_pending_commit(provider)
         .expect("error merging commit for bob's group");
     // charlie calls new_from_welcome(...) with bob's Welcome message; SHOULD SUCCEED
+    let bob_welcome: MlsMessageIn = bob_welcome.into();
+    let bob_welcome = bob_welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
     StagedWelcome::new_from_welcome(
         provider,
         &MlsGroupJoinConfig::default(),

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -1485,14 +1485,9 @@ fn join_multiple_groups_last_resort_extension(
     let bob_welcome = bob_welcome
         .into_welcome()
         .expect("expected message to be a welcome");
-    StagedWelcome::new_from_welcome(
-        provider,
-        &MlsGroupJoinConfig::default(),
-        bob_welcome.into(),
-        None,
-    )
-    .expect("error creating staged join from welcome")
-    .into_group(provider)
-    .expect("error creating group from staged join");
+    StagedWelcome::new_from_welcome(provider, &MlsGroupJoinConfig::default(), bob_welcome, None)
+        .expect("error creating staged join from welcome")
+        .into_group(provider)
+        .expect("error creating group from staged join");
     // done :-)
 }

--- a/openmls/src/group/public_group/tests.rs
+++ b/openmls/src/group/public_group/tests.rs
@@ -6,7 +6,7 @@ use rstest_reuse::{self, *};
 use crate::{
     binary_tree::LeafNodeIndex,
     framing::{
-        public_message_in::PublicMessageIn, MlsMessageOut, ProcessedMessage,
+        public_message_in::PublicMessageIn, MlsMessageIn, MlsMessageOut, ProcessedMessage,
         ProcessedMessageContent, ProtocolMessage, Sender,
     },
     group::{
@@ -91,12 +91,17 @@ fn public_group(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         }
     };
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     // In the future, we'll use helper functions to skip the extraction steps above.
 
     let mut bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("Error creating staged join from Welcome")
@@ -139,10 +144,15 @@ fn public_group(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         .merge_pending_commit(provider)
         .expect("error merging pending commit");
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     let mut charlie_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(bob_group.export_ratchet_tree().into()),
     )
     .expect("Error creating group from Welcome")

--- a/openmls/src/group/tests/external_add_proposal.rs
+++ b/openmls/src/group/tests/external_add_proposal.rs
@@ -87,10 +87,15 @@ fn validation_test_setup(
         .wire_format_policy(wire_format_policy)
         .build();
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     let bob_group = StagedWelcome::new_from_welcome(
         provider,
         &mls_group_config,
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("error creating group from welcome")
@@ -194,6 +199,11 @@ fn external_add_proposal_should_succeed(ciphersuite: Ciphersuite, provider: &imp
         }
         assert_eq!(bob_group.members().count(), 3);
 
+        let welcome: MlsMessageIn = welcome.expect("expected a welcome").into();
+        let welcome = welcome
+            .into_welcome()
+            .expect("expected message to be a welcome");
+
         // Finally, Charlie can join with the Welcome
         let mls_group_config = MlsGroupJoinConfig::builder()
             .wire_format_policy(policy)
@@ -201,7 +211,7 @@ fn external_add_proposal_should_succeed(ciphersuite: Ciphersuite, provider: &imp
         let charlie_group = StagedWelcome::new_from_welcome(
             provider,
             &mls_group_config,
-            welcome.unwrap().into(),
+            welcome,
             Some(alice_group.export_ratchet_tree().into()),
         )
         .unwrap()

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -91,10 +91,15 @@ fn validation_test_setup(
         .merge_pending_commit(provider)
         .expect("error merging pending commit");
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     let bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.clone().into(),
+        welcome.clone(),
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("error creating staged join from welcome")
@@ -104,7 +109,7 @@ fn validation_test_setup(
     let charlie_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("error creating staged join from welcome")

--- a/openmls/src/group/tests/test_framing_validation.rs
+++ b/openmls/src/group/tests/test_framing_validation.rs
@@ -88,10 +88,15 @@ fn validation_test_setup(
         .merge_pending_commit(provider)
         .expect("error merging pending commit");
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     let bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("error creating bob's group from welcome")

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -8,7 +8,7 @@ use rstest_reuse::{self, *};
 
 use super::utils::{generate_credential_with_key, generate_key_package};
 use crate::{
-    framing::{MessageDecryptionError, ProcessedMessageContent},
+    framing::{MessageDecryptionError, MlsMessageIn, ProcessedMessageContent},
     group::{config::CryptoConfig, *},
 };
 
@@ -68,10 +68,15 @@ fn test_past_secrets_in_group(ciphersuite: Ciphersuite, provider: &impl OpenMlsP
             .merge_pending_commit(provider)
             .expect("error merging pending commit");
 
+        let welcome: MlsMessageIn = welcome.into();
+        let welcome = welcome
+            .into_welcome()
+            .expect("expected message to be a welcome");
+
         let mut bob_group = StagedWelcome::new_from_welcome(
             provider,
             mls_group_create_config.join_config(),
-            welcome.into(),
+            welcome,
             Some(alice_group.export_ratchet_tree().into()),
         )
         .expect("Error creating staged join from Welcome")

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -159,10 +159,15 @@ fn validation_test_setup(
         .wire_format_policy(wire_format_policy)
         .build();
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
     let bob_group = StagedWelcome::new_from_welcome(
         provider,
         &mls_group_config,
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .unwrap()

--- a/openmls/src/group/tests/test_remove_operation.rs
+++ b/openmls/src/group/tests/test_remove_operation.rs
@@ -91,10 +91,15 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, provider: &impl Open
             .merge_pending_commit(&alice_provider)
             .expect("error merging pending commit");
 
+        let welcome: MlsMessageIn = welcome.into();
+        let welcome = welcome
+            .into_welcome()
+            .expect("expected message to be a welcome");
+
         let mut bob_group = StagedWelcome::new_from_welcome(
             &bob_provider,
             mls_group_create_config.join_config(),
-            welcome.clone().into(),
+            welcome.clone(),
             Some(alice_group.export_ratchet_tree().into()),
         )
         .expect("Error creating staged join from Welcome")
@@ -104,7 +109,7 @@ fn test_remove_operation_variants(ciphersuite: Ciphersuite, provider: &impl Open
         let mut charlie_group = StagedWelcome::new_from_welcome(
             &charlie_provider,
             mls_group_create_config.join_config(),
-            welcome.into(),
+            welcome,
             Some(alice_group.export_ratchet_tree().into()),
         )
         .expect("Error creating staged join from Welcome")

--- a/openmls/src/group/tests/test_wire_format_policy.rs
+++ b/openmls/src/group/tests/test_wire_format_policy.rs
@@ -78,11 +78,15 @@ fn receive_message(
         .wire_format_policy(alice_group.configuration().wire_format_policy())
         .build();
 
-    let mut bob_group =
-        StagedWelcome::new_from_welcome(provider, &mls_group_config, welcome.into(), None)
-            .expect("error creating bob's staged join from welcome")
-            .into_group(provider)
-            .expect("error creating bob's group from staged join");
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
+    let mut bob_group = StagedWelcome::new_from_welcome(provider, &mls_group_config, welcome, None)
+        .expect("error creating bob's staged join from welcome")
+        .into_group(provider)
+        .expect("error creating bob's group from staged join");
 
     let (message, _welcome, _group_info) = bob_group
         .self_update(provider, &bob_credential_with_key_and_signer.signer)

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -112,8 +112,15 @@
 //!    .expect("Error serializing welcome");
 //!
 //! // Maxim can now de-serialize the message as an [`MlsMessageIn`] ...
-//! let welcome = MlsMessageIn::tls_deserialize(&mut serialized_welcome.as_slice())
+//! let mls_message_in = MlsMessageIn::tls_deserialize(&mut serialized_welcome.as_slice())
 //!    .expect("An unexpected error occurred.");
+//!
+//! // ... and inspect the message.
+//! let welcome = match mls_message_in.extract() {
+//!    MlsMessageBodyIn::Welcome(welcome) => welcome,
+//!    // We know it's a welcome message, so we ignore all other cases.
+//!    _ => unreachable!("Unexpected message type."),
+//! };
 //!
 //! // Now Maxim can build a staged join for the group in order to inspect the welcome
 //! let maxim_staged_join = StagedWelcome::new_from_welcome(

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -13,7 +13,6 @@ use crate::{
         hash_ref::KeyPackageRef, hpke, signable::Signable, AeadKey, AeadNonce, Mac, Secret,
     },
     extensions::Extensions,
-    framing::MlsMessageOut,
     group::{
         config::CryptoConfig, errors::WelcomeError, GroupContext, GroupId, MlsGroup,
         MlsGroupCreateConfig, StagedWelcome,
@@ -165,7 +164,7 @@ fn test_welcome_context_mismatch(ciphersuite: Ciphersuite, provider: &impl OpenM
     let err = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        MlsMessageOut::from_welcome(welcome, ProtocolVersion::default()).into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect_err("Created a staged join from an invalid Welcome.");
@@ -198,7 +197,7 @@ fn test_welcome_context_mismatch(ciphersuite: Ciphersuite, provider: &impl OpenM
     let _group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        MlsMessageOut::from_welcome(original_welcome, ProtocolVersion::default()).into(),
+        original_welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("Error creating staged join from a valid Welcome.")

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -122,7 +122,6 @@ impl Client {
         welcome: Welcome,
         ratchet_tree: Option<RatchetTreeIn>,
     ) -> Result<(), ClientError> {
-        let welcome = MlsMessageOut::from_welcome(welcome, ProtocolVersion::default()).into();
         let staged_join = StagedWelcome::new_from_welcome(
             &self.crypto,
             &mls_group_config,

--- a/openmls/src/treesync/tests_and_kats/tests.rs
+++ b/openmls/src/treesync/tests_and_kats/tests.rs
@@ -104,6 +104,10 @@ fn that_commit_secret_is_derived_from_end_of_update_path_not_root(
             &[bob.key_package, charlie.key_package, dave.key_package],
         )
         .expect("Adding members failed.");
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
 
     alice_group.merge_pending_commit(&alice.provider).unwrap();
     alice_group.print_ratchet_tree("Alice (after add_members)");
@@ -115,7 +119,7 @@ fn that_commit_secret_is_derived_from_end_of_update_path_not_root(
         StagedWelcome::new_from_welcome(
             &charlie.provider,
             mls_group_create_config.join_config(),
-            welcome.into(),
+            welcome,
             None,
         )
         .expect("Staging the join failed.")

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -271,10 +271,14 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         .build();
     // ANCHOR_END: mls_group_config_example
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected the message to be a welcome message");
+
     // ANCHOR: bob_joins_with_welcome
-    let staged_join =
-        StagedWelcome::new_from_welcome(provider, &mls_group_config, welcome.into(), None)
-            .expect("Error constructing staged join");
+    let staged_join = StagedWelcome::new_from_welcome(provider, &mls_group_config, welcome, None)
+        .expect("Error constructing staged join");
     let mut bob_group = staged_join
         .into_group(provider)
         .expect("Error joining group from StagedWelcome");
@@ -533,10 +537,15 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         unreachable!("Expected a StagedCommit.");
     }
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected the message to be a welcome message");
+
     let mut charlie_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(bob_group.export_ratchet_tree().into()),
     )
     .expect("Error building StagedWelcome")
@@ -994,11 +1003,16 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
     assert_eq!(credential0.as_slice(), b"Alice");
     assert_eq!(credential1.as_slice(), b"Bob");
 
+    let welcome: MlsMessageIn = welcome_option.expect("Welcome was not returned").into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected the message to be a welcome message");
+
     // Bob creates a new group
     let mut bob_group = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome_option.expect("Welcome was not returned").into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("Error creating StagedWelcome")
@@ -1234,10 +1248,15 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
                 .expect("Could not merge commit");
             assert_eq!(alice_group.members().count(), 2);
 
+            let welcome: MlsMessageIn = welcome.expect("Welcome was not returned").into();
+            let welcome = welcome
+                .into_welcome()
+                .expect("expected the message to be a welcome message");
+
             let bob_group = StagedWelcome::new_from_welcome(
                 provider,
                 mls_group_create_config.join_config(),
-                welcome.unwrap().into(),
+                welcome,
                 None,
             )
             .expect("Bob could not stage the the group join")
@@ -1320,10 +1339,15 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         .merge_pending_commit(provider)
         .expect("error merging pending commit");
 
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected the message to be a welcome message");
+
     let bob_staged_welcome = StagedWelcome::new_from_welcome(
         provider,
         mls_group_create_config.join_config(),
-        welcome.into(),
+        welcome,
         Some(alice_group.export_ratchet_tree().into()),
     )
     .expect("Could not create StagedWelcome from Welcome");

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -124,10 +124,15 @@ fn mls_group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
         assert_eq!(credential0.as_slice(), b"Alice");
         assert_eq!(credential1.as_slice(), b"Bob");
 
+        let welcome: MlsMessageIn = welcome.into();
+        let welcome = welcome
+            .into_welcome()
+            .expect("expected the message to be a welcome message");
+
         let mut bob_group = StagedWelcome::new_from_welcome(
             provider,
             mls_group_create_config.join_config(),
-            welcome.into(),
+            welcome,
             Some(alice_group.export_ratchet_tree().into()),
         )
         .expect("Error creating StagedWelcome from Welcome")
@@ -342,10 +347,15 @@ fn mls_group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
             unreachable!("Expected a StagedCommit.");
         }
 
+        let welcome: MlsMessageIn = welcome.into();
+        let welcome = welcome
+            .into_welcome()
+            .expect("expected the message to be a welcome message");
+
         let mut charlie_group = StagedWelcome::new_from_welcome(
             provider,
             mls_group_create_config.join_config(),
-            welcome.into(),
+            welcome,
             Some(bob_group.export_ratchet_tree().into()),
         )
         .expect("Error creating staged join from Welcome")
@@ -708,11 +718,16 @@ fn mls_group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
         assert_eq!(credential0.as_slice(), b"Alice");
         assert_eq!(credential1.as_slice(), b"Bob");
 
+        let welcome: MlsMessageIn = welcome_option.expect("Welcome was not returned").into();
+        let welcome = welcome
+            .into_welcome()
+            .expect("expected the message to be a welcome message");
+
         // Bob creates a new group
         let mut bob_group = StagedWelcome::new_from_welcome(
             provider,
             mls_group_create_config.join_config(),
-            welcome_option.expect("Welcome was not returned").into(),
+            welcome,
             Some(alice_group.export_ratchet_tree().into()),
         )
         .expect("Error creating staged join from Welcome")
@@ -910,10 +925,15 @@ fn mls_group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
             .merge_pending_commit(provider)
             .expect("error merging pending commit");
 
+        let welcome: MlsMessageIn = welcome.into();
+        let welcome = welcome
+            .into_welcome()
+            .expect("expected the message to be a welcome message");
+
         let mut bob_group = StagedWelcome::new_from_welcome(
             provider,
             mls_group_create_config.join_config(),
-            welcome.into(),
+            welcome,
             Some(alice_group.export_ratchet_tree().into()),
         )
         .expect("Could not create staged join from Welcome")
@@ -1131,11 +1151,16 @@ fn mls_group_ratchet_tree_extension(ciphersuite: Ciphersuite, provider: &impl Op
             .add_members(provider, &alice_signer, &[bob_key_package.clone()])
             .unwrap();
 
+        let welcome: MlsMessageIn = welcome.into();
+        let welcome = welcome
+            .into_welcome()
+            .expect("expected the message to be a welcome message");
+
         // === Bob joins using the ratchet tree extension ===
         let _bob_group = StagedWelcome::new_from_welcome(
             provider,
             mls_group_create_config.join_config(),
-            welcome.into(),
+            welcome,
             None,
         )
         .expect("Error creating staged join from Welcome")
@@ -1177,11 +1202,16 @@ fn mls_group_ratchet_tree_extension(ciphersuite: Ciphersuite, provider: &impl Op
             .add_members(provider, &alice_signer, &[bob_key_package])
             .unwrap();
 
+        let welcome: MlsMessageIn = welcome.into();
+        let welcome = welcome
+            .into_welcome()
+            .expect("expected the message to be a welcome message");
+
         // === Bob tries to join without the ratchet tree extension ===
         let error = StagedWelcome::new_from_welcome(
             provider,
             mls_group_create_config.join_config(),
-            welcome.into(),
+            welcome,
             None,
         )
         .expect_err("Could join a group without a ratchet tree");


### PR DESCRIPTION
In #1506 we not only added the StagedWelcome types, but also made the methods to create them consume an MlsMessageIn instead of a Welcome. This was done at the time because there was the open issue #1326 that asked to do this, and we didn't check whether that really was a good idea.

It wasn't.

This PR keeps StagedWelcome, but makes the method that create these structs a Welcome instead of a MlsMessageIn.

Fixes #1519.