### PR TITLE
Further improve credentials

### DIFF
--- a/cli/src/identity.rs
+++ b/cli/src/identity.rs
@@ -23,7 +23,7 @@ impl Identity {
         crypto: &OpenMlsRustPersistentCrypto,
         id: &[u8],
     ) -> Self {
-        let credential = BasicCredential::new(id.to_vec()).unwrap();
+        let credential = BasicCredential::new(id.to_vec());
         let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
         let credential_with_key = CredentialWithKey {
             credential: credential.into(),

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -195,7 +195,7 @@ impl User {
             credential,
         } in mls_group.members()
         {
-            let credential = BasicCredential::try_from(&credential).unwrap();
+            let credential = BasicCredential::try_from(credential).unwrap();
             if credential.identity() == name.as_bytes() {
                 return Ok(index);
             }
@@ -237,7 +237,7 @@ impl User {
                 .as_slice()
                 != signature_key.as_slice()
             {
-                let credential = BasicCredential::try_from(&credential).unwrap();
+                let credential = BasicCredential::try_from(credential).unwrap();
                 log::debug!(
                     "Searching for contact {:?}",
                     str::from_utf8(credential.identity()).unwrap()
@@ -401,7 +401,7 @@ impl User {
             match processed_message.into_content() {
                 ProcessedMessageContent::ApplicationMessage(application_message) => {
                     let processed_message_credential =
-                        BasicCredential::try_from(&processed_message_credential).unwrap();
+                        BasicCredential::try_from(processed_message_credential).unwrap();
 
                     let sender_name = match self
                         .contacts
@@ -412,7 +412,7 @@ impl User {
                             // Contact list is not updated right now, get the identity from the
                             // mls_group member
                             let user_id = mls_group.members().find_map(|m| {
-                                let m_credential = BasicCredential::try_from(&m.credential).unwrap();
+                                let m_credential = BasicCredential::try_from(m.credential).unwrap();
                                 if m_credential.identity()
                                     == processed_message_credential.identity()
                                     && (self

--- a/delivery-service/ds-lib/src/lib.rs
+++ b/delivery-service/ds-lib/src/lib.rs
@@ -46,10 +46,7 @@ impl ClientInfo {
     /// key packages with corresponding hashes.
     pub fn new(client_name: String, mut key_packages: Vec<(Vec<u8>, KeyPackageIn)>) -> Self {
         let key_package: KeyPackage = KeyPackage::from(key_packages[0].1.clone());
-        let id = VLBytes::tls_deserialize_exact(
-            key_package.leaf_node().credential().serialized_content(),
-        )
-        .unwrap();
+        let id = key_package.leaf_node().credential().serialized_content();
         Self {
             client_name,
             id: id.into(),

--- a/delivery-service/ds-lib/tests/test_codec.rs
+++ b/delivery-service/ds-lib/tests/test_codec.rs
@@ -11,7 +11,7 @@ fn test_client_info() {
     let client_name = "Client1";
     let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
-    let credential = BasicCredential::new(client_name.as_bytes().to_vec()).unwrap();
+    let credential = BasicCredential::new(client_name.as_bytes().to_vec());
     let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
     let credential_with_key = CredentialWithKey {
         credential: credential.into(),

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -5,13 +5,13 @@ use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::types::SignatureScheme;
 use openmls_traits::OpenMlsProvider;
-use tls_codec::{TlsByteVecU8, TlsVecU16, VLBytes};
+use tls_codec::{TlsByteVecU8, TlsVecU16};
 
 fn generate_credential(
     identity: Vec<u8>,
     signature_scheme: SignatureScheme,
 ) -> (CredentialWithKey, SignatureKeyPair) {
-    let credential = BasicCredential::new(identity).unwrap();
+    let credential = BasicCredential::new(identity);
     let signature_keys = SignatureKeyPair::new(signature_scheme).unwrap();
     let credential_with_key = CredentialWithKey {
         credential: credential.into(),
@@ -79,10 +79,8 @@ async fn test_list_clients() {
     let crypto = &OpenMlsRustCrypto::default();
     let (credential_with_key, signer) =
         generate_credential(client_name.into(), SignatureScheme::from(ciphersuite));
-    let identity =
-        VLBytes::tls_deserialize_exact(credential_with_key.credential.serialized_content())
-            .unwrap();
-    let client_id = identity.as_slice().to_vec();
+    let identity = credential_with_key.credential.serialized_content();
+    let client_id = identity.to_vec();
     let client_key_package = generate_key_package(
         ciphersuite,
         credential_with_key.clone(),
@@ -199,10 +197,8 @@ async fn test_group() {
         );
         key_packages.push(client_key_package);
 
-        let id =
-            VLBytes::tls_deserialize_exact(credential_with_key.credential.serialized_content())
-                .unwrap();
-        client_ids.push(id.as_slice().to_vec());
+        let id = credential_with_key.credential.serialized_content();
+        client_ids.push(id.to_vec());
         credentials_with_key.push(credential_with_key);
         signers.push(signer);
         let req = test::TestRequest::post()

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -222,7 +222,7 @@ impl MlsClient for MlsClientImpl {
         let provider = OpenMlsRustCrypto::default();
 
         let ciphersuite = Ciphersuite::try_from(request.cipher_suite as u16).unwrap();
-        let credential = BasicCredential::new(request.identity.clone()).unwrap();
+        let credential = BasicCredential::new(request.identity.clone());
         let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
         signature_keys.store(provider.key_store()).unwrap();
 
@@ -287,7 +287,7 @@ impl MlsClient for MlsClientImpl {
             "Creating key package."
         );
 
-        let credential = BasicCredential::new(identity).unwrap();
+        let credential = BasicCredential::new(identity);
         let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
         let key_package = KeyPackage::builder()
@@ -501,7 +501,7 @@ impl MlsClient for MlsClientImpl {
             let ciphersuite = verifiable_group_info.ciphersuite();
 
             let (credential_with_key, signer) = {
-                let credential = BasicCredential::new(request.identity.to_vec()).unwrap();
+                let credential = BasicCredential::new(request.identity.to_vec());
 
                 let signature_keypair =
                     SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
@@ -882,7 +882,7 @@ impl MlsClient for MlsClientImpl {
         let request = request.get_ref();
         info!(?request, "Request");
 
-        let removed_credential = BasicCredential::new(request.removed_id.clone()).unwrap();
+        let removed_credential = BasicCredential::new(request.removed_id.clone());
         trace!("   for credential: {removed_credential:x?}");
 
         let mut groups = self.groups.lock().unwrap();
@@ -1009,8 +1009,7 @@ impl MlsClient for MlsClientImpl {
                         .map_err(|_| Status::internal("Unable to generate proposal by value"))?
                 }
                 "remove" => {
-                    let removed_credential =
-                        BasicCredential::new(proposal.removed_id.clone()).unwrap();
+                    let removed_credential = BasicCredential::new(proposal.removed_id.clone());
 
                     group
                         .propose_remove_member_by_credential_by_value(

--- a/openmls-wasm/src/lib.rs
+++ b/openmls-wasm/src/lib.rs
@@ -73,7 +73,7 @@ impl Identity {
     pub fn new(provider: &Provider, name: &str) -> Result<Identity, JsError> {
         let signature_scheme = SignatureScheme::ED25519;
         let identity = name.bytes().collect();
-        let credential = BasicCredential::new(identity)?;
+        let credential = BasicCredential::new(identity);
         let keypair = SignatureKeyPair::new(signature_scheme)?;
 
         keypair.store(provider.0.key_store())?;

--- a/openmls/benches/benchmark.rs
+++ b/openmls/benches/benchmark.rs
@@ -16,7 +16,7 @@ fn criterion_kp_bundle(c: &mut Criterion, provider: &impl OpenMlsProvider) {
             move |b| {
                 b.iter_with_setup(
                     || {
-                        let credential = BasicCredential::new(vec![1, 2, 3]).unwrap();
+                        let credential = BasicCredential::new(vec![1, 2, 3]);
                         let signer =
                             SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
                         let credential_with_key = CredentialWithKey {

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -279,9 +279,9 @@ impl TryFrom<Credential> for BasicCredential {
     type Error = BasicCredentialError;
 
     fn try_from(credential: Credential) -> Result<Self, Self::Error> {
-        match credential.credential_type() {
+        match credential.credential_type {
             CredentialType::Basic => Ok(BasicCredential::new(
-                credential.serialized_credential_content.clone().into(),
+                credential.serialized_credential_content.into(),
             )),
             _ => Err(errors::BasicCredentialError::WrongCredentialType),
         }
@@ -344,7 +344,6 @@ pub mod test_utils {
 mod unit_tests {
     use tls_codec::{
         DeserializeBytes, Serialize, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
-        VLBytes,
     };
 
     use super::{BasicCredential, Credential, CredentialType};
@@ -382,12 +381,15 @@ mod unit_tests {
             Debug, Clone, PartialEq, Eq, TlsSize, TlsSerialize, TlsDeserialize, TlsDeserializeBytes,
         )]
         struct CustomCredential {
-            inner: VLBytes,
+            custom_field1: u32,
+            custom_field2: Vec<u8>,
+            custom_field3: Option<u8>,
         }
 
-        const IDENTITY: &str = "custom identity";
         let custom_credential = CustomCredential {
-            inner: IDENTITY.as_bytes().to_vec().into(),
+            custom_field1: 42,
+            custom_field2: vec![1, 2, 3],
+            custom_field3: Some(2),
         };
 
         let credential = Credential::new(

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -27,7 +27,7 @@ use std::io::{Read, Write};
 use serde::{Deserialize, Serialize};
 use tls_codec::{
     Deserialize as TlsDeserializeTrait, DeserializeBytes, Error, Serialize as TlsSerializeTrait,
-    Size, VLBytes,
+    Size, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes,
 };
 
 #[cfg(test)]
@@ -184,65 +184,21 @@ pub struct Certificate {
 ///     };
 /// } Credential;
 /// ```
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Serialize,
+    Deserialize,
+    TlsSize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+)]
 pub struct Credential {
     credential_type: CredentialType,
     serialized_credential_content: VLBytes,
-}
-
-impl tls_codec::Size for Credential {
-    fn tls_serialized_len(&self) -> usize {
-        CredentialType::tls_serialized_len(&CredentialType::Basic)
-            + self.serialized_credential_content.as_ref().len()
-    }
-}
-
-impl tls_codec::Serialize for Credential {
-    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
-        self.credential_type.tls_serialize(writer)?;
-        writer.write_all(self.serialized_credential_content.as_slice())?;
-        Ok(self.tls_serialized_len())
-    }
-}
-
-impl tls_codec::Deserialize for Credential {
-    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
-        // We can not deserialize arbitrary credentials because we don't know
-        // their structure. While we don't care, we still need to parse it
-        // in order to move the reader forward and read the values in the struct
-        // after this credential.
-
-        // The credential type is important, so we read that.
-        let credential_type = CredentialType::tls_deserialize(bytes)?;
-
-        // Now we don't know what we get unfortunately.
-        // We assume that it is a variable-sized vector. This works for the
-        // currently specified credentials and any other credential MUST be
-        // encoded in a vector as well. Otherwise OpenMLS may fail later on
-        // or exhibit unexpected behaviour.
-        let (length, _) = tls_codec::vlen::read_length(bytes)?;
-        let mut actual_credential_content = vec![0u8; length];
-        bytes.read_exact(&mut actual_credential_content)?;
-
-        // Rebuild the credential again.
-        let mut serialized_credential = Vec::new();
-        tls_codec::vlen::write_length(&mut serialized_credential, length)?;
-        serialized_credential.append(&mut actual_credential_content);
-
-        Ok(Self {
-            serialized_credential_content: serialized_credential.into(),
-            credential_type,
-        })
-    }
-}
-
-impl tls_codec::DeserializeBytes for Credential {
-    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let mut bytes_ref = bytes;
-        let secret = Self::tls_deserialize(&mut bytes_ref)?;
-        let remainder = &bytes[secret.tls_serialized_len()..];
-        Ok((secret, remainder))
-    }
 }
 
 impl Credential {
@@ -288,8 +244,7 @@ impl Credential {
 /// `openmls_basic_credential` crate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BasicCredential {
-    header: Vec<u8>,
-    identity: Vec<u8>,
+    identity: VLBytes,
 }
 
 impl BasicCredential {
@@ -299,38 +254,35 @@ impl BasicCredential {
     ///
     /// Returns a [`BasicCredentialError`] if the length of the identity is too
     /// large to be encoded as a variable-length vector.
-    pub fn new(identity: Vec<u8>) -> Result<Self, BasicCredentialError> {
-        let mut header = Vec::new();
-        tls_codec::vlen::write_length(&mut header, identity.len())?;
-        Ok(Self { header, identity })
+    pub fn new(identity: Vec<u8>) -> Self {
+        Self {
+            identity: identity.into(),
+        }
     }
 
     /// Get the identity of this basic credential as byte slice.
     pub fn identity(&self) -> &[u8] {
-        &self.identity
+        &self.identity.as_slice()
     }
 }
 
 impl From<BasicCredential> for Credential {
-    fn from(mut credential: BasicCredential) -> Self {
-        let mut serialized_credential_content = credential.header;
-        serialized_credential_content.append(&mut credential.identity);
+    fn from(credential: BasicCredential) -> Self {
         Credential {
-            serialized_credential_content: serialized_credential_content.into(),
             credential_type: CredentialType::Basic,
+            serialized_credential_content: credential.identity,
         }
     }
 }
 
-impl TryFrom<&Credential> for BasicCredential {
+impl TryFrom<Credential> for BasicCredential {
     type Error = BasicCredentialError;
 
-    fn try_from(credential: &Credential) -> Result<Self, Self::Error> {
+    fn try_from(credential: Credential) -> Result<Self, Self::Error> {
         match credential.credential_type() {
-            CredentialType::Basic => {
-                let identity: VLBytes = credential.deserialized().unwrap();
-                Ok(BasicCredential::new(identity.into())?)
-            }
+            CredentialType::Basic => Ok(BasicCredential::new(
+                credential.serialized_credential_content.clone().into(),
+            )),
             _ => Err(errors::BasicCredentialError::WrongCredentialType),
         }
     }
@@ -374,7 +326,7 @@ pub mod test_utils {
         identity: &[u8],
         signature_scheme: SignatureScheme,
     ) -> (CredentialWithKey, SignatureKeyPair) {
-        let credential = BasicCredential::new(identity.into()).unwrap();
+        let credential = BasicCredential::new(identity.into());
         let signature_keys = SignatureKeyPair::new(signature_scheme).unwrap();
         signature_keys.store(provider.key_store()).unwrap();
 
@@ -390,15 +342,18 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod unit_tests {
-    use tls_codec::{DeserializeBytes, Serialize};
+    use tls_codec::{
+        DeserializeBytes, Serialize, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+        VLBytes,
+    };
 
-    use super::{BasicCredential, Credential};
+    use super::{BasicCredential, Credential, CredentialType};
 
     #[test]
     fn basic_credential_identity_and_codec() {
         const IDENTITY: &str = "identity";
         // Test the identity getter.
-        let basic_credential = BasicCredential::new(IDENTITY.into()).unwrap();
+        let basic_credential = BasicCredential::new(IDENTITY.into());
         assert_eq!(basic_credential.identity(), IDENTITY.as_bytes());
 
         // Test the encoding and decoding.
@@ -412,11 +367,42 @@ mod unit_tests {
             deserialized.serialized_content()
         );
 
-        let deserialized_basic_credential = BasicCredential::try_from(&deserialized).unwrap();
+        let deserialized_basic_credential = BasicCredential::try_from(deserialized).unwrap();
         assert_eq!(
             deserialized_basic_credential.identity(),
             IDENTITY.as_bytes()
         );
         assert_eq!(basic_credential, deserialized_basic_credential);
+    }
+
+    /// Test the [`Credential`] with a custom credential.
+    #[test]
+    fn custom_credential() {
+        #[derive(
+            Debug, Clone, PartialEq, Eq, TlsSize, TlsSerialize, TlsDeserialize, TlsDeserializeBytes,
+        )]
+        struct CustomCredential {
+            inner: VLBytes,
+        }
+
+        const IDENTITY: &str = "custom identity";
+        let custom_credential = CustomCredential {
+            inner: IDENTITY.as_bytes().to_vec().into(),
+        };
+
+        let credential = Credential::new(
+            CredentialType::Other(1234),
+            custom_credential.tls_serialize_detached().unwrap(),
+        );
+
+        let serialized = credential.tls_serialize_detached().unwrap();
+        let deserialized = Credential::tls_deserialize_exact_bytes(&serialized).unwrap();
+        assert_eq!(credential, deserialized);
+
+        let deserialized_custom_credential =
+            CustomCredential::tls_deserialize_exact_bytes(&deserialized.serialized_content())
+                .unwrap();
+
+        assert_eq!(custom_credential, deserialized_custom_credential);
     }
 }

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -262,7 +262,7 @@ impl BasicCredential {
 
     /// Get the identity of this basic credential as byte slice.
     pub fn identity(&self) -> &[u8] {
-        &self.identity.as_slice()
+        self.identity.as_slice()
     }
 }
 
@@ -400,7 +400,7 @@ mod unit_tests {
         assert_eq!(credential, deserialized);
 
         let deserialized_custom_credential =
-            CustomCredential::tls_deserialize_exact_bytes(&deserialized.serialized_content())
+            CustomCredential::tls_deserialize_exact_bytes(deserialized.serialized_content())
                 .unwrap();
 
         assert_eq!(custom_credential, deserialized_custom_credential);

--- a/openmls/src/extensions/external_sender_extension.rs
+++ b/openmls/src/extensions/external_sender_extension.rs
@@ -97,7 +97,7 @@ mod test {
             let mut external_sender_extensions = Vec::new();
 
             for _ in 0..8 {
-                let credential = BasicCredential::new(b"Alice".to_vec()).unwrap();
+                let credential = BasicCredential::new(b"Alice".to_vec());
                 let signature_keys =
                     SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -365,7 +365,7 @@ fn last_resort_extension(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvid
     let last_resort = Extension::LastResort(LastResortExtension::default());
 
     // Build a KeyPackage with a last resort extension
-    let credential = BasicCredential::new(b"Bob".to_vec()).unwrap();
+    let credential = BasicCredential::new(b"Bob".to_vec());
     let signer =
         openmls_basic_credential::SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 

--- a/openmls/src/framing/mls_content.rs
+++ b/openmls/src/framing/mls_content.rs
@@ -227,7 +227,8 @@ pub(crate) fn framed_content_tbs_serialized<'context, W: Write>(
     // NewMemberCommit.
     written += match serialized_context.into() {
         Some(context) if matches!(sender, Sender::Member(_) | Sender::NewMemberCommit) => {
-            writer.write(context)?
+            writer.write_all(context)?;
+            context.len()
         }
         _ => 0,
     };

--- a/openmls/src/group/core_group/kat_passive_client.rs
+++ b/openmls/src/group/core_group/kat_passive_client.rs
@@ -556,10 +556,7 @@ fn propose_remove(
 ) -> TestProposal {
     let remove = group
         .members()
-        .find(|Member { credential, .. }| {
-            let identity = VLBytes::tls_deserialize_exact(credential.serialized_content()).unwrap();
-            identity.as_slice() == remove_identity
-        })
+        .find(|Member { credential, .. }| credential.serialized_content() == remove_identity)
         .unwrap()
         .index;
 

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -1,7 +1,7 @@
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::{crypto::OpenMlsCrypto, types::HpkeCiphertext, OpenMlsProvider};
-use tls_codec::{Deserialize, Serialize};
+use tls_codec::Serialize;
 
 use crate::{
     binary_tree::*,
@@ -647,11 +647,7 @@ fn test_proposal_application_after_self_was_removed(
                  index: _,
                  credential,
                  ..
-             }| {
-                let identity =
-                    VLBytes::tls_deserialize_exact(credential.serialized_content()).unwrap();
-                identity.as_slice() == b"Bob"
-            },
+             }| { credential.serialized_content() == b"Bob" },
         )
         .expect("Couldn't find Bob in tree.")
         .index;
@@ -740,28 +736,23 @@ fn test_proposal_application_after_self_was_removed(
         // didn't get updated.
         assert_eq!(alice_member.index, bob_member.index);
 
-        let alice_id =
-            VLBytes::tls_deserialize_exact(alice_member.credential.serialized_content()).unwrap();
-        let bob_id =
-            VLBytes::tls_deserialize_exact(bob_member.credential.serialized_content()).unwrap();
-        let charlie_id =
-            VLBytes::tls_deserialize_exact(charlie_member.credential.serialized_content()).unwrap();
-        assert_eq!(alice_id.as_slice(), bob_id.as_slice());
+        let alice_id = alice_member.credential.serialized_content();
+        let bob_id = bob_member.credential.serialized_content();
+        let charlie_id = charlie_member.credential.serialized_content();
+        assert_eq!(alice_id, bob_id);
         assert_eq!(alice_member.signature_key, bob_member.signature_key);
         assert_eq!(charlie_member.index, bob_member.index);
-        assert_eq!(charlie_id.as_slice(), bob_id.as_slice());
+        assert_eq!(charlie_id, bob_id);
         assert_eq!(charlie_member.signature_key, bob_member.signature_key);
         assert_eq!(charlie_member.encryption_key, alice_member.encryption_key);
     }
 
     let mut bob_members = bob_group.public_group().members();
 
-    let bob_next_id =
-        VLBytes::tls_deserialize_exact(bob_members.next().unwrap().credential.serialized_content())
-            .unwrap();
-    assert_eq!(bob_next_id.as_slice(), b"Alice");
-    let bob_next_id =
-        VLBytes::tls_deserialize_exact(bob_members.next().unwrap().credential.serialized_content())
-            .unwrap();
-    assert_eq!(bob_next_id.as_slice(), b"Charlie");
+    let member = bob_members.next().unwrap();
+    let bob_next_id = member.credential.serialized_content();
+    assert_eq!(bob_next_id, b"Alice");
+    let member = bob_members.next().unwrap();
+    let bob_next_id = member.credential.serialized_content();
+    assert_eq!(bob_next_id, b"Charlie");
 }

--- a/openmls/src/group/tests/external_remove_proposal.rs
+++ b/openmls/src/group/tests/external_remove_proposal.rs
@@ -1,7 +1,6 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use rstest::*;
 use rstest_reuse::{self, *};
-use tls_codec::Deserialize;
 
 use crate::{
     credentials::BasicCredential,
@@ -129,7 +128,7 @@ fn external_remove_proposal_should_remove_member(
     let bob_index = alice_group
         .members()
         .find(|member| {
-            let credential = BasicCredential::try_from(&member.credential).unwrap();
+            let credential = BasicCredential::try_from(member.credential.clone()).unwrap();
             let identity = credential.identity();
             identity == b"Bob"
         })
@@ -236,11 +235,7 @@ fn external_remove_proposal_should_fail_when_invalid_external_senders_index(
     // get Bob's index
     let bob_index = alice_group
         .members()
-        .find(|member| {
-            let identity =
-                VLBytes::tls_deserialize_exact(member.credential.serialized_content()).unwrap();
-            identity.as_slice() == b"Bob"
-        })
+        .find(|member| member.credential.serialized_content() == b"Bob")
         .map(|member| member.index)
         .unwrap();
     // Now Delivery Service wants to (already) remove Bob with invalid sender index
@@ -303,11 +298,7 @@ fn external_remove_proposal_should_fail_when_invalid_signature(
     // get Bob's index
     let bob_index = alice_group
         .members()
-        .find(|member| {
-            let identity =
-                VLBytes::tls_deserialize_exact(member.credential.serialized_content()).unwrap();
-            identity.as_slice() == b"Bob"
-        })
+        .find(|member| member.credential.serialized_content() == b"Bob")
         .map(|member| member.index)
         .unwrap();
     // Now Delivery Service wants to (already) remove Bob with invalid sender index
@@ -354,11 +345,7 @@ fn external_remove_proposal_should_fail_when_no_external_senders(
     // get Bob's index
     let bob_index = alice_group
         .members()
-        .find(|member| {
-            let identity =
-                VLBytes::tls_deserialize_exact(member.credential.serialized_content()).unwrap();
-            identity.as_slice() == b"Bob"
-        })
+        .find(|member| member.credential.serialized_content() == b"Bob")
         .map(|member| member.index)
         .unwrap();
     // Now Delivery Service wants to remove Bob with invalid sender index but there's no extension

--- a/openmls/src/group/tests/test_commit_validation.rs
+++ b/openmls/src/group/tests/test_commit_validation.rs
@@ -784,11 +784,7 @@ fn test_partial_proposal_commit(ciphersuite: Ciphersuite, provider: &impl OpenMl
 
     let charlie_index = alice_group
         .members()
-        .find(|m| {
-            let identity =
-                VLBytes::tls_deserialize_exact(m.credential.serialized_content()).unwrap();
-            identity.as_slice() == b"Charlie"
-        })
+        .find(|m| m.credential.serialized_content() == b"Charlie")
         .unwrap()
         .index;
 

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -360,7 +360,7 @@ fn test_valsem101a(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
             provider,
             &charlie_credential_with_key.signer,
             CredentialWithKey {
-                credential: BasicCredential::new(b"Dave".to_vec()).unwrap().into(),
+                credential: BasicCredential::new(b"Dave".to_vec()).into(),
                 signature_key: charlie_credential_with_key
                     .credential_with_key
                     .signature_key,
@@ -604,7 +604,7 @@ fn test_valsem101b(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
             }
             .map(|(name, keypair)| CredentialWithKeyAndSigner {
                 credential_with_key: CredentialWithKey {
-                    credential: BasicCredential::new(name.into()).unwrap().into(),
+                    credential: BasicCredential::new(name.into()).into(),
                     signature_key: keypair.to_public_vec().into(),
                 },
                 signer: keypair,
@@ -672,10 +672,7 @@ fn test_valsem101b(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
                 let bob_index = alice_group
                     .members()
                     .find_map(|member| {
-                        let identity =
-                            VLBytes::tls_deserialize_exact(member.credential.serialized_content())
-                                .unwrap();
-                        if identity.as_slice() == b"Bob" {
+                        if member.credential.serialized_content() == b"Bob" {
                             Some(member.index)
                         } else {
                             None

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -335,7 +335,7 @@ pub(crate) fn generate_credential_with_key(
     provider: &impl OpenMlsProvider,
 ) -> CredentialWithKeyAndSigner {
     let (credential, signer) = {
-        let credential = BasicCredential::new(identity).unwrap();
+        let credential = BasicCredential::new(identity);
         let signature_keys = SignatureKeyPair::new(signature_scheme).unwrap();
         signature_keys.store(provider.key_store()).unwrap();
 

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -36,8 +36,7 @@
 //! let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 //! let provider = OpenMlsRustCrypto::default();
 //!
-//! let credential = BasicCredential::new("identity".into())
-//!     .expect("Error creating a credential.");
+//! let credential = BasicCredential::new("identity".into());
 //! let signer =
 //!     SignatureKeyPair::new(ciphersuite.signature_algorithm())
 //!         .expect("Error generating a signature key pair.");

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -10,7 +10,7 @@ pub(crate) fn key_package(
     ciphersuite: Ciphersuite,
     provider: &impl OpenMlsProvider,
 ) -> (KeyPackage, Credential, SignatureKeyPair) {
-    let credential = BasicCredential::new(b"Sasha".to_vec()).unwrap();
+    let credential = BasicCredential::new(b"Sasha".to_vec());
     let signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
     // Generate a valid KeyPackage.
@@ -59,7 +59,7 @@ fn serialization(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
 #[apply(ciphersuites_and_providers)]
 fn application_id_extension(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
-    let credential = BasicCredential::new(b"Sasha".to_vec()).unwrap();
+    let credential = BasicCredential::new(b"Sasha".to_vec());
     let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
     // Generate a valid KeyPackage.
@@ -155,7 +155,7 @@ fn key_package_validation(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvi
 /// the last resort flag is set during the build process.
 #[apply(ciphersuites_and_providers)]
 fn last_resort_key_package(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
-    let credential = Credential::from(BasicCredential::new(b"Sasha".to_vec()).unwrap());
+    let credential = Credential::from(BasicCredential::new(b"Sasha".to_vec()));
     let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 
     // build without any other extensions

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -22,8 +22,7 @@
 //!     signature_algorithm: SignatureScheme,
 //!     provider: &impl OpenMlsProvider,
 //! ) -> (CredentialWithKey, SignatureKeyPair) {
-//!     let credential = BasicCredential::new(identity)
-//!         .expect("Error creating a credential.");
+//!     let credential = BasicCredential::new(identity);
 //!     let signature_keys =
 //!         SignatureKeyPair::new(signature_algorithm)
 //!             .expect("Error generating a signature key pair.");

--- a/openmls/src/test_utils/mod.rs
+++ b/openmls/src/test_utils/mod.rs
@@ -114,7 +114,7 @@ pub(crate) fn generate_group_candidate(
     use crate::credentials::BasicCredential;
 
     let credential_with_key_and_signer = {
-        let credential = BasicCredential::new(identity.to_vec()).unwrap();
+        let credential = BasicCredential::new(identity.to_vec());
 
         let signature_keypair = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
 

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -345,7 +345,7 @@ impl Client {
         let group = groups.get(group_id).unwrap();
         let leaf = group.own_leaf();
         leaf.map(|l| {
-            let credential = BasicCredential::try_from(l.credential()).unwrap();
+            let credential = BasicCredential::try_from(l.credential().clone()).unwrap();
             credential.identity().to_vec()
         })
     }

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -150,7 +150,7 @@ impl MlsGroupTestSetup {
             let crypto = OpenMlsRustCrypto::default();
             let mut credentials = HashMap::new();
             for ciphersuite in crypto.crypto().supported_ciphersuites().iter() {
-                let credential = BasicCredential::new(identity.clone()).unwrap();
+                let credential = BasicCredential::new(identity.clone());
                 let signature_keys =
                     SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
                 signature_keys.store(crypto.key_store()).unwrap();
@@ -346,11 +346,7 @@ impl MlsGroupTestSetup {
             .map(
                 |Member {
                      index, credential, ..
-                 }| {
-                    let identity =
-                        VLBytes::tls_deserialize_exact(credential.serialized_content()).unwrap();
-                    (index.usize(), identity.as_slice().to_vec())
-                },
+                 }| { (index.usize(), credential.serialized_content().to_vec()) },
             )
             .collect();
         group.public_tree = sender_group.export_ratchet_tree();

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -142,7 +142,7 @@ fn generate_credential(
     signature_algorithm: SignatureScheme,
     provider: &impl OpenMlsProvider,
 ) -> (CredentialWithKey, SignatureKeyPair) {
-    let credential = BasicCredential::new(identity).unwrap();
+    let credential = BasicCredential::new(identity);
     let signature_keys = SignatureKeyPair::new(signature_algorithm).unwrap();
     signature_keys.store(provider.key_store()).unwrap();
 

--- a/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
@@ -110,7 +110,7 @@ fn generate_credential(
     signature_algorithm: SignatureScheme,
     provider: &impl OpenMlsProvider,
 ) -> (CredentialWithKey, SignatureKeyPair) {
-    let credential = BasicCredential::new(identity).unwrap();
+    let credential = BasicCredential::new(identity);
     let signature_keys = SignatureKeyPair::new(signature_algorithm).unwrap();
     signature_keys.store(provider.key_store()).unwrap();
 
@@ -239,7 +239,7 @@ pub fn run_test_vector(
         );
 
         // Set up the group, unfortunately we can't do without.
-        let credential = BasicCredential::new(b"This is not needed".to_vec()).unwrap();
+        let credential = BasicCredential::new(b"This is not needed".to_vec());
         let signature_private_key = hex_to_bytes(&test.signature_priv);
         let random_own_signature_key =
             SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
@@ -261,7 +261,7 @@ pub fn run_test_vector(
         .build(provider, &signer)
         .unwrap();
 
-        let credential = BasicCredential::new("Fake user".into()).unwrap();
+        let credential = BasicCredential::new("Fake user".into());
         let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
         let bob_key_package_bundle = KeyPackageBundle::new(
             provider,

--- a/openmls/src/treesync/tests_and_kats/tests.rs
+++ b/openmls/src/treesync/tests_and_kats/tests.rs
@@ -1,5 +1,4 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
-use tls_codec::*;
 
 use crate::{
     group::{
@@ -68,9 +67,7 @@ fn that_commit_secret_is_derived_from_end_of_update_path_not_root(
         group
             .members()
             .find_map(|member| {
-                let identity =
-                    VLBytes::tls_deserialize_exact(member.credential.serialized_content()).unwrap();
-                if identity.as_slice() == target_id {
+                if member.credential.serialized_content() == target_id {
                     Some(member.index)
                 } else {
                     None

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -6,7 +6,6 @@ use openmls::{
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::{signatures::Signer, types::SignatureScheme, OpenMlsProvider};
-use tls_codec::VLBytes;
 
 #[test]
 fn create_provider_rust_crypto() {
@@ -26,7 +25,7 @@ fn generate_credential(
     provider: &impl OpenMlsProvider,
 ) -> (CredentialWithKey, SignatureKeyPair) {
     // ANCHOR: create_basic_credential
-    let credential = BasicCredential::new(identity).unwrap();
+    let credential = BasicCredential::new(identity);
     // ANCHOR_END: create_basic_credential
     // ANCHOR: create_credential_keys
     let signature_keys = SignatureKeyPair::new(signature_algorithm).unwrap();
@@ -255,10 +254,10 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
     // Check that Alice & Bob are the members of the group
     let members = alice_group.members().collect::<Vec<Member>>();
-    let id0 = VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-    let id1 = VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-    assert_eq!(id0.as_slice(), b"Alice");
-    assert_eq!(id1.as_slice(), b"Bob");
+    let id0 = members[0].credential.serialized_content();
+    let id1 = members[1].credential.serialized_content();
+    assert_eq!(id0, b"Alice");
+    assert_eq!(id1, b"Bob");
 
     // ANCHOR: mls_group_config_example
     let mls_group_config = MlsGroupJoinConfig::builder()
@@ -564,15 +563,12 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
     // Check that Alice, Bob & Charlie are the members of the group
     let members = alice_group.members().collect::<Vec<Member>>();
-    let credential0 =
-        VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-    let credential1 =
-        VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-    let credential2 =
-        VLBytes::tls_deserialize_exact(members[2].credential.serialized_content()).unwrap();
-    assert_eq!(credential0.as_slice(), b"Alice");
-    assert_eq!(credential1.as_slice(), b"Bob");
-    assert_eq!(credential2.as_slice(), b"Charlie");
+    let credential0 = members[0].credential.serialized_content();
+    let credential1 = members[1].credential.serialized_content();
+    let credential2 = members[2].credential.serialized_content();
+    assert_eq!(credential0, b"Alice");
+    assert_eq!(credential1, b"Bob");
+    assert_eq!(credential2, b"Charlie");
     assert_eq!(members.len(), 3);
 
     // === Charlie sends a message to the group ===
@@ -681,26 +677,18 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
                  index: _,
                  credential,
                  ..
-             }| {
-                let credential =
-                    VLBytes::tls_deserialize_exact(credential.serialized_content()).unwrap();
-                credential.as_slice() == b"Bob"
-            },
+             }| { credential.serialized_content() == b"Bob" },
         )
         .expect("Couldn't find Bob in the list of group members.");
 
     // Make sure that this is Bob's actual KP reference.
-    let bob_cred =
-        VLBytes::tls_deserialize_exact(bob_member.credential.serialized_content()).unwrap();
-    let bob_group_cred = VLBytes::tls_deserialize_exact(
-        bob_group
-            .own_leaf()
-            .unwrap()
-            .credential()
-            .serialized_content(),
-    )
-    .unwrap();
-    assert_eq!(bob_cred.as_slice(), bob_group_cred.as_slice());
+    let bob_cred = bob_member.credential.serialized_content();
+    let bob_group_cred = bob_group
+        .own_leaf()
+        .unwrap()
+        .credential()
+        .serialized_content();
+    assert_eq!(bob_cred, bob_group_cred);
 
     // === Charlie removes Bob ===
     // ANCHOR: charlie_removes_bob
@@ -821,12 +809,10 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
     assert!(!bob_group.is_active());
     let members = bob_group.members().collect::<Vec<Member>>();
     assert_eq!(members.len(), 2);
-    let credential0 =
-        VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-    let credential1 =
-        VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-    assert_eq!(credential0.as_slice(), b"Alice");
-    assert_eq!(credential1.as_slice(), b"Charlie");
+    let credential0 = members[0].credential.serialized_content();
+    let credential1 = members[1].credential.serialized_content();
+    assert_eq!(credential0, b"Alice");
+    assert_eq!(credential1, b"Charlie");
     // ANCHOR_END: getting_removed
 
     // Make sure that all groups have the same public tree
@@ -840,12 +826,10 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
     // Check that Alice & Charlie are the members of the group
     let members = alice_group.members().collect::<Vec<Member>>();
-    let credential0 =
-        VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-    let credential1 =
-        VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-    assert_eq!(credential0.as_slice(), b"Alice");
-    assert_eq!(credential1.as_slice(), b"Charlie");
+    let credential0 = members[0].credential.serialized_content();
+    let credential1 = members[1].credential.serialized_content();
+    assert_eq!(credential0, b"Alice");
+    assert_eq!(credential1, b"Charlie");
 
     // Check that Bob can no longer send messages
     assert!(bob_group
@@ -996,12 +980,10 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
     // Check that Alice & Bob are the members of the group
     let members = alice_group.members().collect::<Vec<Member>>();
 
-    let credential0 =
-        VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-    let credential1 =
-        VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-    assert_eq!(credential0.as_slice(), b"Alice");
-    assert_eq!(credential1.as_slice(), b"Bob");
+    let credential0 = members[0].credential.serialized_content();
+    let credential1 = members[1].credential.serialized_content();
+    assert_eq!(credential0, b"Alice");
+    assert_eq!(credential1, b"Bob");
 
     let welcome: MlsMessageIn = welcome_option.expect("Welcome was not returned").into();
     let welcome = welcome
@@ -1024,24 +1006,20 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
     // Check that Alice & Bob are the members of the group
     let members = alice_group.members().collect::<Vec<Member>>();
-    let credential0 =
-        VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-    let credential1 =
-        VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-    assert_eq!(credential0.as_slice(), b"Alice");
-    assert_eq!(credential1.as_slice(), b"Bob");
+    let credential0 = members[0].credential.serialized_content();
+    let credential1 = members[1].credential.serialized_content();
+    assert_eq!(credential0, b"Alice");
+    assert_eq!(credential1, b"Bob");
 
     // Make sure the group contains two members
     assert_eq!(bob_group.members().count(), 2);
 
     // Check that Alice & Bob are the members of the group
     let members = bob_group.members().collect::<Vec<Member>>();
-    let credential0 =
-        VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-    let credential1 =
-        VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-    assert_eq!(credential0.as_slice(), b"Alice");
-    assert_eq!(credential1.as_slice(), b"Bob");
+    let credential0 = members[0].credential.serialized_content();
+    let credential1 = members[1].credential.serialized_content();
+    assert_eq!(credential0, b"Alice");
+    assert_eq!(credential1, b"Bob");
 
     // === Alice sends a message to the group ===
     let message_alice = b"Hi, I'm Alice!";
@@ -1202,9 +1180,8 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
     // Check that Alice is the only member of the group
     let members = alice_group.members().collect::<Vec<Member>>();
-    let credential0 =
-        VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-    assert_eq!(credential0.as_slice(), b"Alice");
+    let credential0 = members[0].credential.serialized_content();
+    assert_eq!(credential0, b"Alice");
 
     // === Re-Add Bob with external Add proposal ===
 
@@ -1272,9 +1249,8 @@ fn book_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
     let bob_index = alice_group
         .members()
         .find_map(|member| {
-            let credential =
-                VLBytes::tls_deserialize_exact(member.credential.serialized_content()).unwrap();
-            if credential.as_slice() == b"Bob" {
+            let credential = member.credential.serialized_content();
+            if credential == b"Bob" {
                 Some(member.index)
             } else {
                 None

--- a/openmls/tests/key_store.rs
+++ b/openmls/tests/key_store.rs
@@ -6,7 +6,7 @@ use openmls_basic_credential::SignatureKeyPair;
 fn test_store_key_package(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
     // ANCHOR: key_store_store
     // First we generate a credential and key package for our user.
-    let credential = BasicCredential::new(b"User ID".to_vec()).unwrap();
+    let credential = BasicCredential::new(b"User ID".to_vec());
     let signature_keys = SignatureKeyPair::new(ciphersuite.into()).unwrap();
 
     let key_package = KeyPackage::builder()

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -1,11 +1,10 @@
 use openmls::{
-    prelude::{config::CryptoConfig, test_utils::new_credential, tls_codec::*, *},
+    prelude::{config::CryptoConfig, test_utils::new_credential, *},
     test_utils::*,
     *,
 };
 
 use openmls_traits::{key_store::OpenMlsKeyStore, signatures::Signer, OpenMlsProvider};
-use tls_codec::VLBytes;
 
 fn generate_key_package<KeyStore: OpenMlsKeyStore>(
     ciphersuite: Ciphersuite,
@@ -117,12 +116,10 @@ fn mls_group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
 
         // Check that Alice & Bob are the members of the group
         let members = alice_group.members().collect::<Vec<Member>>();
-        let credential0 =
-            VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-        let credential1 =
-            VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-        assert_eq!(credential0.as_slice(), b"Alice");
-        assert_eq!(credential1.as_slice(), b"Bob");
+        let credential0 = members[0].credential.serialized_content();
+        let credential1 = members[1].credential.serialized_content();
+        assert_eq!(credential0, b"Alice");
+        assert_eq!(credential1, b"Bob");
 
         let welcome: MlsMessageIn = welcome.into();
         let welcome = welcome
@@ -374,15 +371,12 @@ fn mls_group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
 
         // Check that Alice, Bob & Charlie are the members of the group
         let members = alice_group.members().collect::<Vec<Member>>();
-        let credential0 =
-            VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-        let credential1 =
-            VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-        let credential2 =
-            VLBytes::tls_deserialize_exact(members[2].credential.serialized_content()).unwrap();
-        assert_eq!(credential0.as_slice(), b"Alice");
-        assert_eq!(credential1.as_slice(), b"Bob");
-        assert_eq!(credential2.as_slice(), b"Charlie");
+        let credential0 = members[0].credential.serialized_content();
+        let credential1 = members[1].credential.serialized_content();
+        let credential2 = members[2].credential.serialized_content();
+        assert_eq!(credential0, b"Alice");
+        assert_eq!(credential1, b"Bob");
+        assert_eq!(credential2, b"Charlie");
 
         // === Charlie sends a message to the group ===
         let message_charlie = b"Hi, I'm Charlie!";
@@ -575,12 +569,10 @@ fn mls_group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
 
         // Check that Alice & Charlie are the members of the group
         let members = alice_group.members().collect::<Vec<Member>>();
-        let credential0 =
-            VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-        let credential1 =
-            VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-        assert_eq!(credential0.as_slice(), b"Alice");
-        assert_eq!(credential1.as_slice(), b"Charlie");
+        let credential0 = members[0].credential.serialized_content();
+        let credential1 = members[1].credential.serialized_content();
+        assert_eq!(credential0, b"Alice");
+        assert_eq!(credential1, b"Charlie");
 
         // Check that Bob can no longer send messages
         assert!(bob_group
@@ -711,12 +703,10 @@ fn mls_group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
 
         // Check that Alice & Bob are the members of the group
         let members = alice_group.members().collect::<Vec<Member>>();
-        let credential0 =
-            VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-        let credential1 =
-            VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-        assert_eq!(credential0.as_slice(), b"Alice");
-        assert_eq!(credential1.as_slice(), b"Bob");
+        let credential0 = members[0].credential.serialized_content();
+        let credential1 = members[1].credential.serialized_content();
+        assert_eq!(credential0, b"Alice");
+        assert_eq!(credential1, b"Bob");
 
         let welcome: MlsMessageIn = welcome_option.expect("Welcome was not returned").into();
         let welcome = welcome
@@ -739,24 +729,20 @@ fn mls_group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
 
         // Check that Alice & Bob are the members of the group
         let members = alice_group.members().collect::<Vec<Member>>();
-        let credential0 =
-            VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-        let credential1 =
-            VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-        assert_eq!(credential0.as_slice(), b"Alice");
-        assert_eq!(credential1.as_slice(), b"Bob");
+        let credential0 = members[0].credential.serialized_content();
+        let credential1 = members[1].credential.serialized_content();
+        assert_eq!(credential0, b"Alice");
+        assert_eq!(credential1, b"Bob");
 
         // Make sure the group contains two members
         assert_eq!(bob_group.members().count(), 2);
 
         // Check that Alice & Bob are the members of the group
         let members = bob_group.members().collect::<Vec<Member>>();
-        let credential0 =
-            VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-        let credential1 =
-            VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-        assert_eq!(credential0.as_slice(), b"Alice");
-        assert_eq!(credential1.as_slice(), b"Bob");
+        let credential0 = members[0].credential.serialized_content();
+        let credential1 = members[1].credential.serialized_content();
+        assert_eq!(credential0, b"Alice");
+        assert_eq!(credential1, b"Bob");
 
         // === Alice sends a message to the group ===
         let message_alice = b"Hi, I'm Alice!";
@@ -892,9 +878,8 @@ fn mls_group_operations(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvide
 
         // Check that Alice is the only member of the group
         let members = alice_group.members().collect::<Vec<Member>>();
-        let credential0 =
-            VLBytes::tls_deserialize_exact(members[0].credential.serialized_content()).unwrap();
-        assert_eq!(credential0.as_slice(), b"Alice");
+        let credential0 = members[0].credential.serialized_content();
+        assert_eq!(credential0, b"Alice");
 
         // === Save the group state ===
 
@@ -1058,13 +1043,11 @@ fn addition_order(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
         // in the original API call. After merging, bob should be at index 1 and
         // charlie at index 2.
         let members = alice_group.members().collect::<Vec<Member>>();
-        let credential1 =
-            VLBytes::tls_deserialize_exact(members[1].credential.serialized_content()).unwrap();
-        let credential2 =
-            VLBytes::tls_deserialize_exact(members[2].credential.serialized_content()).unwrap();
-        assert_eq!(credential1.as_slice(), b"Bob");
+        let credential1 = members[1].credential.serialized_content();
+        let credential2 = members[2].credential.serialized_content();
+        assert_eq!(credential1, b"Bob");
         assert_eq!(members[1].index, LeafNodeIndex::new(1));
-        assert_eq!(credential2.as_slice(), b"Charlie");
+        assert_eq!(credential2, b"Charlie");
         assert_eq!(members[2].index, LeafNodeIndex::new(2));
     }
 }


### PR DESCRIPTION
This PR further improves credential handling. Since [we assume](https://github.com/openmls/openmls/blob/main/openmls/src/credentials/mod.rs#L219) that all credentials are variable-size vectors we might as well simplify things.
This way handling basic credentials and custom credentials alike becomes easier.