### PR TITLE
fixup build after #1548

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,3 +67,18 @@ jobs:
       - name: Build
         if: ${{ matrix.arch != 'wasm32-unknown-unknown'  }} 
         run: cargo build $TEST_MODE --verbose --target ${{ matrix.arch }} -p openmls
+
+  # Check feature powerset
+  check:
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Cargo hack
+        run: cargo hack check --feature-powerset --no-dev-deps --verbose -p openmls

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -31,9 +31,9 @@ openmls_basic_credential = { version = "0.2.0", path = "../basic_credential", op
 ] }
 rstest = { version = "^0.16", optional = true }
 rstest_reuse = { version = "0.4", optional = true }
-wasm-bindgen-test = {version = "0.3.40", optional = true}
-getrandom = {version = "0.2.12", optional = true, features = [ "js" ]}
-fluvio-wasm-timer = {version = "0.2.5", optional = true}
+wasm-bindgen-test = { version = "0.3.40", optional = true }
+getrandom = { version = "0.2.12", optional = true, features = ["js"] }
+fluvio-wasm-timer = { version = "0.2.5", optional = true }
 
 [features]
 default = ["backtrace"]
@@ -48,14 +48,17 @@ test-utils = [
     "dep:wasm-bindgen-test",
     "dep:openmls_basic_credential",
 ]
-libcrux-provider = ["dep:openmls_libcrux_crypto",]
+libcrux-provider = ["dep:openmls_libcrux_crypto"]
 crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
-js = ["dep:getrandom", "dep:fluvio-wasm-timer"] # enable js randomness source for provider
+js = [
+    "dep:getrandom",
+    "dep:fluvio-wasm-timer",
+] # enable js randomness source for provider
 
 [dev-dependencies]
 backtrace = "0.3"
-criterion = {version = "^0.5", default-features = false} # need to disable default features for wasm
+criterion = { version = "^0.5", default-features = false } # need to disable default features for wasm
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.10"
 lazy_static = "1.4"

--- a/openmls/src/binary_tree/array_representation/treemath.rs
+++ b/openmls/src/binary_tree/array_representation/treemath.rs
@@ -151,7 +151,7 @@ impl TreeNodeIndex {
     }
 
     /// Re-exported for testing.
-    #[cfg(any(feature = "test-utils", test))]
+    #[cfg(any(feature = "test-utils", feature = "crypto-debug", test))]
     pub(crate) fn test_u32(&self) -> u32 {
         self.u32()
     }

--- a/openmls/src/ciphersuite/secret.rs
+++ b/openmls/src/ciphersuite/secret.rs
@@ -20,7 +20,7 @@ impl Debug for Secret {
         let mut ds = f.debug_struct("Secret");
 
         #[cfg(feature = "crypto-debug")]
-        ds.field("value", &self.value);
+        return ds.field("value", &self.value).finish();
         #[cfg(not(feature = "crypto-debug"))]
         ds.field("value", &"***").finish()
     }
@@ -156,10 +156,9 @@ impl Secret {
     ) -> Result<Secret, CryptoError> {
         log_crypto!(
             trace,
-            "derive secret from {:x?} with label {} and {:?}",
+            "derive secret from {:x?} with label {}",
             self.value,
-            label,
-            self.ciphersuite
+            label
         );
         self.kdf_expand_label(crypto, ciphersuite, label, &[], ciphersuite.hash_length())
     }

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -940,7 +940,10 @@ fn ciphertext_sample(ciphersuite: Ciphersuite, ciphertext: &[u8]) -> &[u8] {
 /// A key that can be used to derive an `AeadKey` and an `AeadNonce`.
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
-#[cfg_attr(any(feature = "test-utils", test), derive(Debug, Clone))]
+#[cfg_attr(
+    any(feature = "test-utils", feature = "crypto-debug", test),
+    derive(Debug, Clone)
+)]
 pub(crate) struct SenderDataSecret {
     secret: Secret,
 }

--- a/openmls/src/schedule/psk.rs
+++ b/openmls/src/schedule/psk.rs
@@ -458,7 +458,7 @@ impl PskSecret {
         &self.secret
     }
 
-    #[cfg(any(feature = "test-utils", test))]
+    #[cfg(any(feature = "test-utils", feature = "crypto-debug", test))]
     pub(crate) fn as_slice(&self) -> &[u8] {
         self.secret.as_slice()
     }


### PR DESCRIPTION
This fixes the build issues introduced in #1548.

It also adds a `cargo hack check` command to ensure all features are built on ci.