### PR TITLE
Disable MLS++ interop on CI

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -38,6 +38,7 @@ jobs:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg"
           vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
           vcpkgJsonGlob: "mlspp/vcpkg.json"
+          doNotUpdateVcpkg: false
           runVcpkgInstall: true
 
       - name: MLS++ | Install dependencies | 2/2
@@ -46,6 +47,7 @@ jobs:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg"
           vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
           vcpkgJsonGlob: "mlspp/cmd/interop/vcpkg.json"
+          doNotUpdateVcpkg: false
           runVcpkgInstall: true
 
       - name: MLS++ | Build | 1/2

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -36,18 +36,16 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg"
-          vcpkgGitCommitId: "eb33d2f"
+          vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
           vcpkgJsonGlob: "mlspp/vcpkg.json"
-          doNotUpdateVcpkg: false
           runVcpkgInstall: true
 
       - name: MLS++ | Install dependencies | 2/2
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg"
-          vcpkgGitCommitId: "eb33d2f"
+          vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
           vcpkgJsonGlob: "mlspp/cmd/interop/vcpkg.json"
-          doNotUpdateVcpkg: false
           runVcpkgInstall: true
 
       - name: MLS++ | Build | 1/2

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -26,39 +26,39 @@ jobs:
 
       # ---------------------------------------------------------------------------------------
 
-      - name: MLS++ | Checkout
-        run: |
-          git clone https://github.com/cisco/mlspp.git
-          cd mlspp
-          git checkout 623acd0839d1117e8665b6bd52eecad1ce05438d
+      #- name: MLS++ | Checkout
+      #  run: |
+      #    git clone https://github.com/cisco/mlspp.git
+      #    cd mlspp
+      #    git checkout 623acd0839d1117e8665b6bd52eecad1ce05438d
 
-      - name: MLS++ | Install dependencies | 1/2
-        uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgDirectory: "${{ github.workspace }}/vcpkg"
-          vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
-          vcpkgJsonGlob: "mlspp/vcpkg.json"
-          runVcpkgInstall: true
+      #- name: MLS++ | Install dependencies | 1/2
+      #  uses: lukka/run-vcpkg@v11
+      #  with:
+      #    vcpkgDirectory: "${{ github.workspace }}/vcpkg"
+      #    vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
+      #    vcpkgJsonGlob: "mlspp/vcpkg.json"
+      #    runVcpkgInstall: true
 
-      - name: MLS++ | Install dependencies | 2/2
-        uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgDirectory: "${{ github.workspace }}/vcpkg"
-          vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
-          vcpkgJsonGlob: "mlspp/cmd/interop/vcpkg.json"
-          runVcpkgInstall: true
+      #- name: MLS++ | Install dependencies | 2/2
+      #  uses: lukka/run-vcpkg@v11
+      #  with:
+      #    vcpkgDirectory: "${{ github.workspace }}/vcpkg"
+      #    vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
+      #    vcpkgJsonGlob: "mlspp/cmd/interop/vcpkg.json"
+      #    runVcpkgInstall: true
 
-      - name: MLS++ | Build | 1/2
-        working-directory: mlspp
-        run: |
-          cmake . -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
-          make
+      #- name: MLS++ | Build | 1/2
+      #  working-directory: mlspp
+      #  run: |
+      #    cmake . -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      #    make
 
-      - name: MLS++ | Build | 2/2
-        working-directory: mlspp/cmd/interop
-        run: |
-          cmake . -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
-          make
+      #- name: MLS++ | Build | 2/2
+      #  working-directory: mlspp/cmd/interop
+      #  run: |
+      #    cmake . -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      #    make
 
       # ---------------------------------------------------------------------------------------
 
@@ -89,10 +89,32 @@ jobs:
 
       # ---------------------------------------------------------------------------------------
 
-      - name: Test interoperability
+#      - name: Test interoperability
+#        run: |
+#          ./target/debug/interop_client&
+#          ./mlspp/cmd/interop/mlspp_client -live 12345&
+#
+#          cd mls-implementations/interop
+#          # TODO(#1238):
+#          # * Add `commit.json` as soon as group context extensions proposals are supported.
+#          # Note: It's also possible to remove GCE proposals by hand from `commit.json`.
+#          #       But let's not do this in CI for now and hope that it isn't needed anymore soon.
+#          for scenario in {welcome_join.json,external_join.json,application.json};
+#          do
+#            echo Running configs/$scenario
+#            errors=$(./test-runner/test-runner -fail-fast -client localhost:50051 -client localhost:12345 -config=configs/$scenario | grep error | wc -l)
+#            if [ "$errors" = "0" ];
+#            then
+#              echo "Success";
+#            else
+#              echo "Failed";
+#              exit 1;
+#            fi
+#          done
+
+      - name: Test interoperability (OpenMLS only)
         run: |
           ./target/debug/interop_client&
-          ./mlspp/cmd/interop/mlspp_client -live 12345&
 
           cd mls-implementations/interop
           # TODO(#1238):
@@ -102,7 +124,7 @@ jobs:
           for scenario in {welcome_join.json,external_join.json,application.json};
           do
             echo Running configs/$scenario
-            errors=$(./test-runner/test-runner -fail-fast -client localhost:50051 -client localhost:12345 -config=configs/$scenario | grep error | wc -l)
+            errors=$(./test-runner/test-runner -fail-fast -client localhost:50051 -config=configs/$scenario | grep error | wc -l)
             if [ "$errors" = "0" ];
             then
               echo "Success";

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -133,3 +133,4 @@ jobs:
               exit 1;
             fi
           done
+          

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -36,7 +36,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg"
-          vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
+          vcpkgGitCommitId: "eb33d2f"
           vcpkgJsonGlob: "mlspp/vcpkg.json"
           doNotUpdateVcpkg: false
           runVcpkgInstall: true
@@ -45,7 +45,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg"
-          vcpkgGitCommitId: "70992f64912b9ab0e60e915ab7421faa197524b7"
+          vcpkgGitCommitId: "eb33d2f"
           vcpkgJsonGlob: "mlspp/cmd/interop/vcpkg.json"
           doNotUpdateVcpkg: false
           runVcpkgInstall: true


### PR DESCRIPTION
Due to a recent [`vcpkg`](https://github.com/microsoft/vcpkg/pull/38017) failure (in turn due to a bug in [CMake](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9390)), this PR disables interop testing with MLS++ on CI.