### PR TITLE
Expose getter for ext_sender_index function

### DIFF
--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -308,6 +308,14 @@ impl MlsGroup {
         self.group.public_group().group_context().extensions()
     }
 
+    /// Returns the index of the sender of a staged, external commit.
+    pub fn ext_commit_sender_index(
+        &self,
+        commit: &StagedCommit,
+    ) -> Result<LeafNodeIndex, LibraryError> {
+        self.group.public_group().ext_commit_sender_index(commit)
+    }
+
     // === Load & save ===
 
     /// Loads the state from persisted state.


### PR DESCRIPTION
`PublicGroup` already has a function that allows the caller to get the (future) index of an external sender. This PR makes that function accessible via the `MlsGroup` API.