### PR TITLE
Adds test for updating Unknown Group Context Extension

### DIFF
--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -1322,21 +1322,23 @@ fn builder_pattern(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
 
 // Test the successful update of Group Context Extension with type Extension::Unknown(0xff11)
 #[apply(ciphersuites_and_providers)]
-fn update_group_context_with_unknown_extension(ciphersuite: Ciphersuite, provider: &impl OpenMlsProvider) {
+fn update_group_context_with_unknown_extension(
+    ciphersuite: Ciphersuite,
+    provider: &impl OpenMlsProvider,
+) {
     let (alice_credential_with_key, _alice_kpb, alice_signer, _alice_pk) =
         setup_client("Alice", ciphersuite, provider);
 
     // Define the unknown group context extension and initial data
     let unknown_extension_data = vec![1, 2]; // Sample data for the extension
     let unknown_gc_extension = Extension::Unknown(0xff11, UnknownExtension(unknown_extension_data));
-    
-    let required_extension_types = &[
-        ExtensionType::Unknown(0xff11),
-    ];
 
-    let required_capabilities =
-    Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(required_extension_types, &[], &[]));
-    
+    let required_extension_types = &[ExtensionType::Unknown(0xff11)];
+
+    let required_capabilities = Extension::RequiredCapabilities(
+        RequiredCapabilitiesExtension::new(required_extension_types, &[], &[]),
+    );
+
     let capabilities = Capabilities::new(None, None, Some(required_extension_types), None, None);
 
     let test_gc_extensions = Extensions::from_vec(vec![
@@ -1344,7 +1346,6 @@ fn update_group_context_with_unknown_extension(ciphersuite: Ciphersuite, provide
         required_capabilities.clone(),
     ])
     .expect("error creating test group context extensions");
-
 
     // === Alice creates a group ===
     let mut alice_group = MlsGroup::builder()
@@ -1355,11 +1356,14 @@ fn update_group_context_with_unknown_extension(ciphersuite: Ciphersuite, provide
         .expect("error adding leaf node unknown extension to builder")
         .build(provider, &alice_signer, alice_credential_with_key)
         .expect("error creating group using builder");
-    
+
     // Create updated unknown extension
     let updated_unknown_extension_data = vec![3, 4]; // Sample data for the extension
-    let updated_unknown_gc_extension = Extension::Unknown(0xff11, UnknownExtension(updated_unknown_extension_data.clone()));
-    
+    let updated_unknown_gc_extension = Extension::Unknown(
+        0xff11,
+        UnknownExtension(updated_unknown_extension_data.clone()),
+    );
+
     let mut updated_extensions = test_gc_extensions.clone();
     updated_extensions.add_or_replace(updated_unknown_gc_extension);
 
@@ -1368,7 +1372,11 @@ fn update_group_context_with_unknown_extension(ciphersuite: Ciphersuite, provide
         .propose_group_context_extensions(provider, updated_extensions, &alice_signer)
         .expect("failed to propose group context extensions with unknown extension");
 
-    assert_eq!(alice_group.pending_proposals().count(), 1, "Expected one pending proposal");
+    assert_eq!(
+        alice_group.pending_proposals().count(),
+        1,
+        "Expected one pending proposal"
+    );
 
     // === Commit to the proposed group context extension ===
     alice_group
@@ -1381,10 +1389,7 @@ fn update_group_context_with_unknown_extension(ciphersuite: Ciphersuite, provide
         .expect("error merging pending commit");
 
     // === Verify the group context extension was updated ===
-    let group_context_extensions = alice_group
-        .group()
-        .context()
-        .extensions();
+    let group_context_extensions = alice_group.group().context().extensions();
 
     // Extract and verify the unknown extension's data
     let mut extracted_data = None;
@@ -1394,10 +1399,16 @@ fn update_group_context_with_unknown_extension(ciphersuite: Ciphersuite, provide
         }
     }
 
-    assert!(extracted_data.is_some(), "Extension::Unknown(0xff11) should be present in the group context");
-    assert_eq!(extracted_data.unwrap(), vec![3, 4], "The data of Extension::Unknown(0xff11) does not match the expected data");
+    assert!(
+        extracted_data.is_some(),
+        "Extension::Unknown(0xff11) should be present in the group context"
+    );
+    assert_eq!(
+        extracted_data.unwrap(),
+        vec![3, 4],
+        "The data of Extension::Unknown(0xff11) does not match the expected data"
+    );
 }
-
 
 // Test that unknown group context and leaf node extensions can be used in groups
 #[apply(ciphersuites_and_providers)]

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -1329,33 +1329,98 @@ fn update_group_context_with_unknown_extension(
     let (alice_credential_with_key, _alice_kpb, alice_signer, _alice_pk) =
         setup_client("Alice", ciphersuite, provider);
 
-    // Define the unknown group context extension and initial data
-    let unknown_extension_data = vec![1, 2]; // Sample data for the extension
+    // === Define the unknown group context extension and initial data ===
+    let unknown_extension_data = vec![1, 2];
     let unknown_gc_extension = Extension::Unknown(0xff11, UnknownExtension(unknown_extension_data));
-
     let required_extension_types = &[ExtensionType::Unknown(0xff11)];
-
     let required_capabilities = Extension::RequiredCapabilities(
         RequiredCapabilitiesExtension::new(required_extension_types, &[], &[]),
     );
-
     let capabilities = Capabilities::new(None, None, Some(required_extension_types), None, None);
-
     let test_gc_extensions = Extensions::from_vec(vec![
         unknown_gc_extension.clone(),
         required_capabilities.clone(),
     ])
     .expect("error creating test group context extensions");
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .with_group_context_extensions(test_gc_extensions.clone())
+        .expect("error adding unknown extension to config")
+        .capabilities(capabilities.clone())
+        .crypto_config(CryptoConfig::with_default_version(ciphersuite))
+        .build();
 
     // === Alice creates a group ===
-    let mut alice_group = MlsGroup::builder()
-        .with_group_context_extensions(test_gc_extensions.clone())
-        .expect("error adding unknown extension to builder")
-        .with_capabilities(capabilities)
-        .build(provider, &alice_signer, alice_credential_with_key)
-        .expect("error creating group using builder");
+    let mut alice_group = MlsGroup::new(
+        provider,
+        &alice_signer,
+        &mls_group_create_config,
+        alice_credential_with_key,
+    )
+    .expect("error creating group");
 
-    // Create updated unknown extension
+    // === Verify the initial group context extension data is correct ===
+    let group_context_extensions = alice_group.group().context().extensions();
+    let mut extracted_data = None;
+    for extension in group_context_extensions.iter() {
+        if let Extension::Unknown(0xff11, UnknownExtension(data)) = extension {
+            extracted_data = Some(data.clone());
+        }
+    }
+    assert_eq!(
+        extracted_data.unwrap(),
+        vec![1, 2],
+        "The data of Extension::Unknown(0xff11) does not match the expected data"
+    );
+
+    // === Alice adds Bob ===
+    let (bob_credential_with_key, _bob_kpb, bob_signer, _bob_pk) =
+        setup_client("Bob", ciphersuite, provider);
+
+    let bob_key_package = KeyPackage::builder()
+        .leaf_node_capabilities(capabilities)
+        .build(
+            CryptoConfig::with_default_version(ciphersuite),
+            provider,
+            &bob_signer,
+            bob_credential_with_key,
+        )
+        .expect("error building key package");
+
+    let (_, welcome, _) = alice_group
+        .add_members(provider, &alice_signer, &[bob_key_package.clone()])
+        .unwrap();
+    alice_group.merge_pending_commit(provider).unwrap();
+
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected message to be a welcome");
+
+    let bob_group = StagedWelcome::new_from_welcome(
+        provider,
+        &MlsGroupJoinConfig::default(),
+        welcome,
+        Some(alice_group.export_ratchet_tree().into()),
+    )
+    .expect("Error creating staged join from Welcome")
+    .into_group(provider)
+    .expect("Error creating group from staged join");
+
+    // === Verify Bob's initial group context extension data is correct ===
+    let group_context_extensions = bob_group.group().context().extensions();
+    let mut extracted_data_2 = None;
+    for extension in group_context_extensions.iter() {
+        if let Extension::Unknown(0xff11, UnknownExtension(data)) = extension {
+            extracted_data_2 = Some(data.clone());
+        }
+    }
+    assert_eq!(
+        extracted_data_2.unwrap(),
+        vec![1, 2],
+        "The data of Extension::Unknown(0xff11) does not match the expected data"
+    );
+
+    // === Propose the new group context extension ===
     let updated_unknown_extension_data = vec![3, 4]; // Sample data for the extension
     let updated_unknown_gc_extension = Extension::Unknown(
         0xff11,
@@ -1364,8 +1429,6 @@ fn update_group_context_with_unknown_extension(
 
     let mut updated_extensions = test_gc_extensions.clone();
     updated_extensions.add_or_replace(updated_unknown_gc_extension);
-
-    // === Propose the new group context extension ===
     alice_group
         .propose_group_context_extensions(provider, updated_extensions, &alice_signer)
         .expect("failed to propose group context extensions with unknown extension");
@@ -1381,28 +1444,40 @@ fn update_group_context_with_unknown_extension(
         .commit_to_pending_proposals(provider, &alice_signer)
         .expect("failed to commit to pending group context extensions");
 
-    // Merge the pending commit to apply the new group context extensions
     alice_group
         .merge_pending_commit(provider)
         .expect("error merging pending commit");
 
+    alice_group
+        .save(provider.key_store())
+        .expect("error saving group");
+
     // === Verify the group context extension was updated ===
     let group_context_extensions = alice_group.group().context().extensions();
-
-    // Extract and verify the unknown extension's data
-    let mut extracted_data = None;
+    let mut extracted_data_updated = None;
     for extension in group_context_extensions.iter() {
         if let Extension::Unknown(0xff11, UnknownExtension(data)) = extension {
-            extracted_data = Some(data.clone());
+            extracted_data_updated = Some(data.clone());
         }
     }
-
-    assert!(
-        extracted_data.is_some(),
-        "Extension::Unknown(0xff11) should be present in the group context"
-    );
     assert_eq!(
-        extracted_data.unwrap(),
+        extracted_data_updated.unwrap(),
+        vec![3, 4],
+        "The data of Extension::Unknown(0xff11) does not match the expected data"
+    );
+
+    // === Verify Bob sees the group context extension updated ===
+    let bob_group_loaded = MlsGroup::load(bob_group.group().group_id(), provider.key_store())
+        .expect("error loading group");
+    let group_context_extensions_2 = bob_group_loaded.export_group_context().extensions();
+    let mut extracted_data_2 = None;
+    for extension in group_context_extensions_2.iter() {
+        if let Extension::Unknown(0xff11, UnknownExtension(data)) = extension {
+            extracted_data_2 = Some(data.clone());
+        }
+    }
+    assert_eq!(
+        extracted_data_2.unwrap(),
         vec![3, 4],
         "The data of Extension::Unknown(0xff11) does not match the expected data"
     );

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -1352,8 +1352,6 @@ fn update_group_context_with_unknown_extension(
         .with_group_context_extensions(test_gc_extensions.clone())
         .expect("error adding unknown extension to builder")
         .with_capabilities(capabilities)
-        .with_leaf_node_extensions(Extensions::single(unknown_gc_extension))
-        .expect("error adding leaf node unknown extension to builder")
         .build(provider, &alice_signer, alice_credential_with_key)
         .expect("error creating group using builder");
 


### PR DESCRIPTION
Related to https://github.com/openmls/openmls/issues/1549

 The idea of the test is basically to show that we can  save and update data to Group Context Extensions that all group members can read via Unknown Group Context Extension and Group Context Extension proposals.