### PR TITLE
Make StorageId Public

### DIFF
--- a/basic_credential/src/lib.rs
+++ b/basic_credential/src/lib.rs
@@ -109,7 +109,7 @@ impl SignatureKeyPair {
         }
     }
 
-    fn id(&self) -> StorageId {
+    pub fn id(&self) -> StorageId {
         StorageId {
             value: id(&self.public, self.signature_scheme),
         }
@@ -161,8 +161,14 @@ impl SignatureKeyPair {
 // Storage
 
 #[derive(Debug, Serialize, Deserialize)]
-struct StorageId {
+pub struct StorageId {
     value: Vec<u8>,
+}
+
+impl From<Vec<u8>> for StorageId {
+    fn from(vec: Vec<u8>) -> Self {
+        StorageId { value: vec }
+    }
 }
 
 // Implement key traits for the storage id


### PR DESCRIPTION
In order to call `StorageProvider` functions that require a `SignaturePublicKey` we need the `StorageId` to be accessible.
Also adds a from function so you can get a storage id from a public key vec

For example

```rust
let signature_keys = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm());
let public_key = StorageId::from(signature_keys.to_public_vec());
storage_provider.write_signature_key_pair::<StorageId, SignatureKeyPair>(&public_key, &signature_keys);
```