### PR TITLE
Return an empty vector in storage.aad when it's not found

### DIFF
--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -870,7 +870,12 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         group_id: &GroupId,
     ) -> Result<Vec<u8>, Self::Error> {
         let key = serde_json::to_vec(group_id)?;
-        self.read_list(AAD_LABEL, &key)
+        self.read::<CURRENT_VERSION, Vec<u8>>(AAD_LABEL, &key)
+            .map(|v| {
+                // When we didn't find the value, we return an empty vector as
+                // required by the trait.
+                v.unwrap_or_default()
+            })
     }
 
     fn write_aad<GroupId: traits::GroupId<CURRENT_VERSION>>(

--- a/traits/src/storage.rs
+++ b/traits/src/storage.rs
@@ -645,3 +645,5 @@ pub mod traits {
     pub trait ProposalRef<const VERSION: u16>: Entity<VERSION> + Key<VERSION> {}
 }
 // ANCHOR_END: traits
+
+impl<const VERSION: u16> Entity<VERSION> for Vec<u8> {}


### PR DESCRIPTION
Using `read_list` has the same effect here, but it's the wrong function really.