### PR TITLE
Proposal storage update

### DIFF
--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -795,16 +795,25 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         self.delete::<CURRENT_VERSION>(EPOCH_KEY_PAIRS_LABEL, &key)
     }
 
-    fn clear_proposal_queue<GroupId: traits::GroupId<CURRENT_VERSION>>(
+    fn clear_proposal_queue<
+        GroupId: traits::GroupId<CURRENT_VERSION>,
+        ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
+    >(
         &self,
         group_id: &GroupId,
     ) -> Result<(), Self::Error> {
+        // Get all proposal refs for this group.
+        let proposal_refs: Vec<ProposalRef> =
+            self.read_list(PROPOSAL_QUEUE_REFS_LABEL, &serde_json::to_vec(group_id)?)?;
         let mut values = self.values.write().unwrap();
+        for proposal_ref in proposal_refs {
+            // Delete all proposals.
+            let key = serde_json::to_vec(&(group_id, proposal_ref))?;
+            values.remove(&key);
+        }
 
-        let key = build_key::<CURRENT_VERSION, &GroupId>(QUEUED_PROPOSAL_LABEL, group_id);
-
-        // XXX #1566: also remove the proposal refs. can't be done now because they are stored in a
-        // non-recoverable way
+        // Delete the proposal refs from the store.
+        let key = build_key::<CURRENT_VERSION, &GroupId>(PROPOSAL_QUEUE_REFS_LABEL, group_id);
         values.remove(&key);
 
         Ok(())

--- a/memory_storage/src/test_store.rs
+++ b/memory_storage/src/test_store.rs
@@ -438,7 +438,10 @@ impl StorageProvider<V_TEST> for MemoryStorage {
         todo!()
     }
 
-    fn clear_proposal_queue<GroupId: traits::GroupId<V_TEST>>(
+    fn clear_proposal_queue<
+        GroupId: traits::GroupId<V_TEST>,
+        ProposalRef: traits::ProposalRef<V_TEST>,
+    >(
         &self,
         _group_id: &GroupId,
     ) -> Result<(), Self::Error> {

--- a/memory_storage/tests/proposals.rs
+++ b/memory_storage/tests/proposals.rs
@@ -1,0 +1,81 @@
+use openmls_memory_storage::MemoryStorage;
+use openmls_traits::storage::{
+    traits::{self},
+    Entity, Key, StorageProvider, CURRENT_VERSION,
+};
+use serde::{Deserialize, Serialize};
+
+// Test types
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestGroupId(Vec<u8>);
+impl traits::GroupId<CURRENT_VERSION> for TestGroupId {}
+impl Key<CURRENT_VERSION> for TestGroupId {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
+struct ProposalRef(usize);
+impl traits::ProposalRef<CURRENT_VERSION> for ProposalRef {}
+impl Key<CURRENT_VERSION> for ProposalRef {}
+impl Entity<CURRENT_VERSION> for ProposalRef {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct Proposal(Vec<u8>);
+impl traits::QueuedProposal<CURRENT_VERSION> for Proposal {}
+impl Entity<CURRENT_VERSION> for Proposal {}
+
+/// Write and read some proposals
+#[test]
+fn read_write_delete() {
+    let group_id = TestGroupId(b"TestGroupId".to_vec());
+    let proposals = (0..10)
+        .map(|i| Proposal(format!("TestProposal{i}").as_bytes().to_vec()))
+        .collect::<Vec<_>>();
+    let storage = MemoryStorage::default();
+
+    // Store proposals
+    for (i, proposal) in proposals.iter().enumerate() {
+        storage
+            .queue_proposal(&group_id, &ProposalRef(i), proposal)
+            .unwrap();
+    }
+
+    // Read proposal refs
+    let proposal_refs_read: Vec<ProposalRef> = storage.queued_proposal_refs(&group_id).unwrap();
+    assert_eq!(
+        (0..10).map(|i| ProposalRef(i)).collect::<Vec<_>>(),
+        proposal_refs_read
+    );
+
+    // Read proposals
+    let proposals_read: Vec<(ProposalRef, Proposal)> = storage.queued_proposals(&group_id).unwrap();
+    let proposals_expected: Vec<(ProposalRef, Proposal)> = (0..10)
+        .map(|i| ProposalRef(i))
+        .zip(proposals.clone().into_iter())
+        .collect();
+    assert_eq!(proposals_expected, proposals_read);
+
+    // Remove proposal 5
+    storage.remove_proposal(&group_id, &ProposalRef(5)).unwrap();
+
+    let proposal_refs_read: Vec<ProposalRef> = storage.queued_proposal_refs(&group_id).unwrap();
+    let mut expected = (0..10).map(|i| ProposalRef(i)).collect::<Vec<_>>();
+    expected.remove(5);
+    assert_eq!(expected, proposal_refs_read);
+
+    let proposals_read: Vec<(ProposalRef, Proposal)> = storage.queued_proposals(&group_id).unwrap();
+    let mut proposals_expected: Vec<(ProposalRef, Proposal)> = (0..10)
+        .map(|i| ProposalRef(i))
+        .zip(proposals.clone().into_iter())
+        .collect();
+    proposals_expected.remove(5);
+    assert_eq!(proposals_expected, proposals_read);
+
+    // Clear all proposals
+    storage
+        .clear_proposal_queue::<TestGroupId, ProposalRef>(&group_id)
+        .unwrap();
+    let proposal_refs_read: Vec<ProposalRef> = storage.queued_proposal_refs(&group_id).unwrap();
+    assert!(proposal_refs_read.is_empty());
+
+    let proposals_read: Vec<(ProposalRef, Proposal)> = storage.queued_proposals(&group_id).unwrap();
+    assert!(proposals_read.is_empty());
+}

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -312,7 +312,7 @@ impl MlsGroup {
             self.proposal_store.empty();
 
             // Clear proposals in storage
-            storage.clear_proposal_queue(self.group_id())?;
+            storage.clear_proposal_queue::<GroupId, ProposalRef>(self.group_id())?;
         }
 
         Ok(())
@@ -371,7 +371,7 @@ impl MlsGroup {
     ) -> Result<(), StorageProvider::Error> {
         self.group.delete(storage)?;
         storage.delete_group_config(self.group_id())?;
-        storage.clear_proposal_queue(self.group_id())?;
+        storage.clear_proposal_queue::<GroupId, ProposalRef>(self.group_id())?;
         storage.delete_own_leaf_nodes(self.group_id())?;
         storage.delete_aad(self.group_id())?;
         storage.delete_group_state(self.group_id())?;

--- a/traits/src/storage.rs
+++ b/traits/src/storage.rs
@@ -531,7 +531,10 @@ pub trait StorageProvider<const VERSION: u16> {
     ) -> Result<(), Self::Error>;
 
     /// Clear the proposal queue for the grou pwith the given id.
-    fn clear_proposal_queue<GroupId: traits::GroupId<VERSION>>(
+    fn clear_proposal_queue<
+        GroupId: traits::GroupId<VERSION>,
+        ProposalRef: traits::ProposalRef<VERSION>,
+    >(
         &self,
         group_id: &GroupId,
     ) -> Result<(), Self::Error>;


### PR DESCRIPTION
The memory storage clear proposal function is working now. This required a small change to the storage API such that we know the ProposalRef type.
There's also a test for the proposals in the storage crate now.