### PR TITLE
Some more benchmarks

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -1,8 +1,8 @@
 name: Benchmarks
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true 
+  cancel-in-progress: true
 
 on:
   push:
@@ -32,3 +32,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Benchmarks
         run: cargo bench -p openmls --verbose
+
+      - name: Large groups
+        run: |
+          cargo run -p openmls --example large-groups --release -- --write -g 2 3
+          cargo run -p openmls --example large-groups --release -- -g 3

--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -1,5 +1,5 @@
 use openmls_traits::storage::*;
-use serde::{ser::SerializeStruct, Serialize};
+use serde::Serialize;
 use std::{collections::HashMap, sync::RwLock};
 
 /// A storage for the V_TEST version.
@@ -11,33 +11,17 @@ pub mod persistence;
 
 #[derive(Debug, Default)]
 pub struct MemoryStorage {
-    values: RwLock<HashMap<Vec<u8>, Vec<u8>>>,
+    pub values: RwLock<HashMap<Vec<u8>, Vec<u8>>>,
 }
 
-impl serde::ser::Serialize for MemoryStorage {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut store = serializer.serialize_struct("MemoryStorage", 2)?;
+// For testing we want to clone.
+#[cfg(feature = "test-utils")]
+impl Clone for MemoryStorage {
+    fn clone(&self) -> Self {
         let values = self.values.read().unwrap();
-        let values_vec: Vec<(Vec<u8>, Vec<u8>)> =
-            values.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        store.serialize_field("values", &values_vec)?;
-        store.end()
-    }
-}
-
-impl<'de> serde::de::Deserialize<'de> for MemoryStorage {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let values = Vec::<(Vec<u8>, Vec<u8>)>::deserialize(deserializer)?;
-        let values = values.into_iter().collect();
-        Ok(Self {
-            values: RwLock::new(values),
-        })
+        Self {
+            values: RwLock::new(values.clone()),
+        }
     }
 }
 

--- a/memory_storage/src/persistence.rs
+++ b/memory_storage/src/persistence.rs
@@ -23,7 +23,7 @@ impl super::MemoryStorage {
         get_file_path(&("openmls_cli_".to_owned() + user_name + "_ks.json"))
     }
 
-    fn save_to_file(&self, output_file: &File) -> Result<(), String> {
+    pub fn save_to_file(&self, output_file: &File) -> Result<(), String> {
         let writer = BufWriter::new(output_file);
 
         let mut ser_ks = SerializableKeyStore::default();
@@ -48,7 +48,7 @@ impl super::MemoryStorage {
         }
     }
 
-    fn load_from_file(&mut self, input_file: &File) -> Result<(), String> {
+    pub fn load_from_file(&mut self, input_file: &File) -> Result<(), String> {
         // Prepare file reader.
         let reader = BufReader::new(input_file);
 

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -77,6 +77,7 @@ wasm-bindgen-test = "0.3.40"
 clap = { version = "4", features = ["derive"] }
 base64 = "0.22.1"
 flate2 = "1.0"
+indicatif = "0.17.8"
 
 # Disable for wasm32 and Win32
 [target.'cfg(not(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows"))))'.dev-dependencies]

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -76,6 +76,7 @@ wasm-bindgen = "0.2.90"
 wasm-bindgen-test = "0.3.40"
 clap = { version = "4", features = ["derive"] }
 base64 = "0.22.1"
+flate2 = "1.0"
 
 # Disable for wasm32 and Win32
 [target.'cfg(not(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows"))))'.dev-dependencies]

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -74,6 +74,7 @@ pretty_env_logger = "0.5"
 tempfile = "3"
 wasm-bindgen = "0.2.90"
 wasm-bindgen-test = "0.3.40"
+clap = { version = "4", features = ["derive"] }
 
 # Disable for wasm32 and Win32
 [target.'cfg(not(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows"))))'.dev-dependencies]
@@ -83,4 +84,8 @@ openmls = { path = ".", features = ["test-utils"] }
 
 [[bench]]
 name = "benchmark"
+harness = false
+
+[[bench]]
+name = "large-balanced-group"
 harness = false

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -43,7 +43,7 @@ crypto-subtle = [] # Enable subtle crypto APIs that have to be used with care.
 test-utils = [
     "dep:serde_json",
     "dep:itertools",
-    "dep:openmls_rust_crypto",
+    "openmls_rust_crypto/test-utils",
     "dep:rand",
     "dep:wasm-bindgen-test",
     "dep:openmls_basic_credential",
@@ -75,6 +75,7 @@ tempfile = "3"
 wasm-bindgen = "0.2.90"
 wasm-bindgen-test = "0.3.40"
 clap = { version = "4", features = ["derive"] }
+base64 = "0.22.1"
 
 # Disable for wasm32 and Win32
 [target.'cfg(not(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows"))))'.dev-dependencies]
@@ -84,8 +85,4 @@ openmls = { path = ".", features = ["test-utils"] }
 
 [[bench]]
 name = "benchmark"
-harness = false
-
-[[bench]]
-name = "large-balanced-group"
 harness = false

--- a/openmls/benches/large-balanced-group.rs
+++ b/openmls/benches/large-balanced-group.rs
@@ -1,0 +1,462 @@
+//! This benchmarks tests the performance of group operations in a large group
+//! when the tree is fully populated.
+//!
+//! In particular do we assume that each member commits after joining the group.
+//!
+//! ## Measurements
+//!
+//! | Operation    | Time (2 Members) | Time (5 Members) | Time (10 Members) | Time (25 Members) |
+//! | ------------ | ---------------- | ---------------- | ----------------- | ----------------- |
+//! | Add          |                  |                  |                   |                   |
+//! | Remove       |                  |                  |                   |                   |
+//! | Update       |                  |                  |                   |                   |
+
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter},
+    time::{Duration, Instant},
+};
+
+use clap::{arg, command, Parser};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use openmls::{
+    credentials::{BasicCredential, CredentialWithKey},
+    framing::{MlsMessageIn, MlsMessageOut, ProcessedMessageContent},
+    group::{MlsGroup, MlsGroupCreateConfig, StagedWelcome, PURE_PLAINTEXT_WIRE_FORMAT_POLICY},
+    prelude::LeafNodeIndex,
+    prelude_test::*,
+};
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use openmls_traits::types::Ciphersuite;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[allow(dead_code)]
+struct Member {
+    provider: OpenMlsRustCrypto,
+    credential_with_key: CredentialWithKey,
+    signer: SignatureKeyPair,
+}
+
+#[inline(always)]
+fn process_commit(
+    group: &mut MlsGroup,
+    provider: &OpenMlsRustCrypto,
+    commit: openmls::prelude::MlsMessageOut,
+) {
+    let processed_message = group
+        .process_message(provider, commit.into_protocol_message().unwrap())
+        .unwrap();
+
+    if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+        processed_message.into_content()
+    {
+        group.merge_staged_commit(provider, *staged_commit).unwrap();
+    } else {
+        unreachable!("Expected a StagedCommit.");
+    }
+}
+
+#[inline(always)]
+fn self_update(
+    group: &mut MlsGroup,
+    provider: &OpenMlsRustCrypto,
+    signer: &SignatureKeyPair,
+) -> MlsMessageOut {
+    let (commit, _, _group_info) = group.self_update(provider, signer).unwrap();
+
+    group.merge_pending_commit(provider).unwrap();
+
+    commit
+}
+
+/// Remove member 1
+#[inline(always)]
+fn remove_member(
+    group: &mut MlsGroup,
+    provider: &OpenMlsRustCrypto,
+    signer: &SignatureKeyPair,
+) -> MlsMessageOut {
+    let (commit, _, _group_info) = group
+        .remove_members(provider, signer, &[LeafNodeIndex::new(1)])
+        .unwrap();
+
+    group.merge_pending_commit(provider).unwrap();
+
+    commit
+}
+
+/// Create a new member
+fn new_member(
+    name: &str,
+) -> (
+    OpenMlsRustCrypto,
+    SignatureKeyPair,
+    CredentialWithKey,
+    openmls::prelude::KeyPackageBundle,
+) {
+    let member_provider = OpenMlsRustCrypto::default();
+    let credential = BasicCredential::new(name.into());
+    let signer = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm()).unwrap();
+    let credential_with_key = CredentialWithKey {
+        credential: credential.into(),
+        signature_key: signer.to_public_vec().into(),
+    };
+    let key_package = KeyPackage::builder()
+        .build(
+            CIPHERSUITE,
+            &member_provider,
+            &signer,
+            credential_with_key.clone(),
+        )
+        .expect("An unexpected error occurred.");
+    (member_provider, signer, credential_with_key, key_package)
+}
+
+#[inline(always)]
+fn add_member(
+    group: &mut MlsGroup,
+    provider: &OpenMlsRustCrypto,
+    signer: &SignatureKeyPair,
+    key_package: KeyPackage,
+) -> MlsMessageOut {
+    let (commit, _welcome, _) = group.add_members(provider, signer, &[key_package]).unwrap();
+
+    group.merge_pending_commit(provider).unwrap();
+
+    commit
+}
+
+// const GROUP_SIZES: &[usize] = &[2, 3, 4, 5, 10, 25, 50, 100, 200, 500];
+const GROUP_SIZES: &[usize] = &[3, 10];
+// const GROUP_SIZES: &[usize] = &[100, 200];
+const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519;
+
+/// Create a group of `num` clients.
+/// All of them committed after joining.
+fn setup(num: usize) -> Vec<(MlsGroup, Member)> {
+    let creator_provider = OpenMlsRustCrypto::default();
+    let creator_credential = BasicCredential::new(format!("Creator").into());
+    let creator_signer = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm()).unwrap();
+    let creator_credential_with_key = CredentialWithKey {
+        credential: creator_credential.into(),
+        signature_key: creator_signer.to_public_vec().into(),
+    };
+
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(CIPHERSUITE)
+        .build();
+
+    // Create the group
+    let creator_group = MlsGroup::new(
+        &creator_provider,
+        &creator_signer,
+        &mls_group_create_config,
+        creator_credential_with_key.clone(),
+    )
+    .expect("An unexpected error occurred.");
+
+    let mut members: Vec<(MlsGroup, Member)> = vec![(
+        creator_group,
+        Member {
+            provider: creator_provider,
+            credential_with_key: creator_credential_with_key,
+            signer: creator_signer,
+        },
+    )];
+
+    for member_i in 0..num - 1 {
+        let (member_provider, signer, credential_with_key, key_package) =
+            new_member(&format!("Member {member_i}"));
+
+        let creator = &mut members[0];
+        let creator_group = &mut creator.0;
+        let creator_provider = &creator.1.provider;
+        let creator_signer = &creator.1.signer;
+        let (commit, welcome, _) = creator_group
+            .add_members(
+                creator_provider,
+                creator_signer,
+                &[key_package.key_package().clone()],
+            )
+            .unwrap();
+
+        creator_group
+            .merge_pending_commit(creator_provider)
+            .expect("error merging pending commit");
+
+        let welcome: MlsMessageIn = welcome.into();
+        let welcome = welcome
+            .into_welcome()
+            .expect("expected the message to be a welcome message");
+        let mut member_i_group = StagedWelcome::new_from_welcome(
+            &member_provider,
+            mls_group_create_config.join_config(),
+            welcome,
+            Some(creator_group.export_ratchet_tree().into()),
+        )
+        .unwrap()
+        .into_group(&member_provider)
+        .unwrap();
+
+        // Merge commit on all other members
+        for (group, member) in members.iter_mut().skip(1) {
+            process_commit(group, &member.provider, commit.clone());
+        }
+
+        // The new member commits and everyone else processes it.
+        let update_commit = self_update(&mut member_i_group, &member_provider, &signer);
+        for (group, member) in members.iter_mut() {
+            process_commit(group, &member.provider, update_commit.clone());
+        }
+
+        // Add new member to list
+        members.push((
+            member_i_group,
+            Member {
+                provider: member_provider,
+                credential_with_key,
+                signer,
+            },
+        ));
+    }
+
+    members
+}
+
+fn add(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Add");
+
+    for group_size in GROUP_SIZES.iter() {
+        group.bench_with_input(
+            BenchmarkId::new("Adder", group_size),
+            group_size,
+            |b, group_size| {
+                b.iter_batched(
+                    || {
+                        let groups = setup(*group_size);
+
+                        let (_member_provider, _signer, _credential_with_key, key_package) =
+                            new_member(&format!("New Member"));
+                        (groups, key_package.key_package().clone())
+                    },
+                    |(mut groups, key_package)| {
+                        add_bench(groups, key_package);
+                    },
+                    BatchSize::LargeInput,
+                )
+            },
+        );
+    }
+}
+
+/// Benchmarking the time for member 1 in the list of `groups` to add a new
+/// member.
+fn add_bench(mut groups: Vec<(MlsGroup, Member)>, key_package: KeyPackage) {
+    // Let group 1 add a member and merge the commit.
+    let (updater_group, updater) = &mut groups[1];
+    let provider = &updater.provider;
+    let signer = &updater.signer;
+    let _ = add_member(updater_group, provider, signer, key_package);
+}
+
+fn remove(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Remove");
+
+    for group_size in GROUP_SIZES.iter() {
+        group.bench_with_input(
+            BenchmarkId::new("Remover", group_size),
+            group_size,
+            |b, group_size| {
+                b.iter_batched(
+                    || {
+                        let groups = setup(*group_size);
+                        groups
+                    },
+                    |mut groups| {
+                        // Let group 1 update and merge the commit.
+                        let (updater_group, updater) = &mut groups[0];
+                        let provider = &updater.provider;
+                        let signer = &updater.signer;
+                        let _ = remove_member(updater_group, provider, signer);
+                    },
+                    BatchSize::LargeInput,
+                )
+            },
+        );
+    }
+}
+
+fn update(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Update");
+
+    for group_size in GROUP_SIZES.iter() {
+        group.bench_with_input(
+            BenchmarkId::new("Updater", group_size),
+            group_size,
+            |b, group_size| {
+                b.iter_batched(
+                    || {
+                        let groups = setup(*group_size);
+                        groups
+                    },
+                    |mut groups| {
+                        // Let group 1 update and merge the commit.
+                        let (updater_group, updater) = &mut groups[1];
+                        let provider = &updater.provider;
+                        let signer = &updater.signer;
+                        let _ = self_update(updater_group, provider, signer);
+                    },
+                    BatchSize::LargeInput,
+                )
+            },
+        );
+    }
+
+    for group_size in GROUP_SIZES.iter() {
+        group.bench_with_input(
+            BenchmarkId::new("Member", group_size),
+            group_size,
+            |b, group_size| {
+                b.iter_batched(
+                    || {
+                        let mut groups = setup(*group_size);
+
+                        // Let group 1 update and merge the commit.
+                        let (updater_group, updater) = &mut groups[1];
+                        let provider = &updater.provider;
+                        let signer = &updater.signer;
+                        let commit = self_update(updater_group, provider, signer);
+
+                        (groups, commit)
+                    },
+                    |(mut groups, commit)| {
+                        // Apply the commit at member 0
+                        let (member_group, member) = &mut groups[0];
+                        let provider = &member.provider;
+
+                        process_commit(member_group, provider, commit);
+                    },
+                    BatchSize::LargeInput,
+                )
+            },
+        );
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    add(c);
+    // remove(c);
+    // update(c);
+}
+
+// Criterion is super slow. So we're doing manual benchmarks here as well
+// criterion_group!(benches, criterion_benchmark);
+// criterion_main!(benches);
+
+const ITERATIONS: usize = 10;
+const WARMUP_ITERATIONS: usize = 1;
+
+fn duration(d: Duration) -> f64 {
+    ((d.as_secs() as f64) + (d.subsec_nanos() as f64 * 1e-9)) * 1000000f64
+}
+
+fn bench<I, O, S, R>(mut setup: S, mut routine: R) -> f64
+where
+    S: FnMut() -> I,
+    R: FnMut(I) -> O,
+{
+    let mut time = 0f64;
+
+    // Warmup
+    for _ in 0..WARMUP_ITERATIONS {
+        let input = setup();
+        routine(input);
+    }
+
+    // Benchmark
+    for _ in 0..ITERATIONS {
+        let input = setup();
+
+        let start = Instant::now();
+        core::hint::black_box(routine(input));
+        let end = Instant::now();
+
+        time += duration(end.duration_since(start));
+    }
+
+    time
+}
+
+// #[derive(Parser, Debug)]
+// #[command(version, about, long_about = None)]
+// struct Args {
+//     /// Write groups out.
+//     #[arg(short, long, num_args = 0)]
+//     write: Option<bool>,
+// }
+
+fn main() {
+    // let args = Args::parse();
+
+    let mut groups = vec![];
+
+    if false {
+        println!("Writing groups for benchmarks ...");
+        for num in GROUP_SIZES {
+            println!("Generating group of size {num} ...");
+            // Generate and write out groups.
+            let new_groups = setup(*num);
+            // let (groups, members): (Vec<MlsGroup>, Vec<Member>) = new_groups.into_iter().unzip();
+            // eprintln!("{:?}", serde_json::to_vec(&new_groups));
+            groups.push(new_groups);
+        }
+        let file = File::create("large-balanced-group.json").unwrap();
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer(&mut writer, &groups).unwrap();
+
+        println!("Wrote new test groups to file.");
+        return;
+    }
+
+    let file = File::open("large-balanced-group.json").unwrap();
+    let mut reader = BufReader::new(file);
+    let groups: Vec<Vec<(MlsGroup, Member)>> = serde_json::from_reader(&mut reader).unwrap();
+
+    // for num in GROUP_SIZES {
+    //     println!("{num} Members");
+
+    //     // Add
+    //     let time = bench(
+    //         || {
+    //             let groups = setup(*num);
+    //             let (_member_provider, _signer, _credential_with_key, key_package) =
+    //                 new_member(&format!("New Member"));
+    //             let key_package = key_package.key_package().clone();
+
+    //             (groups, key_package)
+    //         },
+    //         |(groups, key_package)| add_bench(groups, key_package),
+    //     );
+    //     println!("  Adder: {}μs", time / (ITERATIONS as f64));
+
+    //     // Update
+    //     let time = bench(
+    //         || setup(*num),
+    //         |groups| {
+    //             bench_update(groups);
+    //         },
+    //     );
+    //     println!("  Updater: {}μs", time / (ITERATIONS as f64));
+    // }
+}
+
+fn bench_update(mut groups: Vec<(MlsGroup, Member)>) {
+    // Let group 1 update and merge the commit.
+    let (updater_group, updater) = &mut groups[1];
+    let provider = &updater.provider;
+    let signer = &updater.signer;
+    let _ = self_update(updater_group, provider, signer);
+}

--- a/openmls/examples/large-groups.rs
+++ b/openmls/examples/large-groups.rs
@@ -5,11 +5,12 @@
 //!
 //! ## Measurements
 //!
-//! | Operation    | Time (2 Members) | Time (5 Members) | Time (10 Members) | Time (25 Members) |
-//! | ------------ | ---------------- | ---------------- | ----------------- | ----------------- |
-//! | Add          |                  |                  |                   |                   |
-//! | Remove       |                  |                  |                   |                   |
-//! | Update       |                  |                  |                   |                   |
+//! |                | 2      | 3      | 4      | 5      | 10     | 25      | 50      | 100      | 200      | 500       |
+//! | -------------- | ------ | ------ | ------ | ------ | ------ | ------- | ------- | -------- | -------- | --------- |
+//! | Adder          | 613 μs | 935 μs | 680 μs | 711 μs | 901 μs | 1.40 ms | 3.18 ms | 9.97 ms  | 39.80 ms | 260.49 ms |
+//! | Updater        | 308 μs | 510 μs | 496 μs | 595 μs | 748 μs | 1.32 ms | 3.01 ms | 10.47 ms | 39.99 ms | 249.49 ms |
+//! | Remover        | 193 μs | 305 μs | 320 μs | 474 μs | 698 μs | 1.23 ms | 3.10 ms | 10.07 ms | 38.10 ms | 257.24 ms |
+//! | Process update | 303 μs | 433 μs | 429 μs | 529 μs | 698 μs | 1.16 ms | 2.86 ms | 9.61 ms  | 35.27 ms | 249.96 ms |
 
 use std::{
     collections::HashMap,
@@ -422,9 +423,6 @@ fn main() {
 
     let all_groups = read();
     for groups in all_groups {
-        if groups.len() > 25 {
-            break;
-        }
         println!("{} Members", groups.len());
 
         // Add

--- a/openmls/examples/large-groups.rs
+++ b/openmls/examples/large-groups.rs
@@ -379,24 +379,38 @@ macro_rules! bench {
     }};
 }
 
+/// The different group setups for the benchmarks.
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]
 enum SetupVariants {
+    /// No messages are sent after the setup.
     Bare,
+
+    /// Every member sends a commit directly after joining the group.
     CommitAfterJoin,
+
+    /// Every member sends a commit after everyone was added to the group.
     CommitToFullGroup,
 }
 
+/// A tool to benchmark openmls (large) groups.
+///
+/// The benchmarks need to write a setup first that is then read to run the benchmarks.
 #[derive(Parser)]
 struct Args {
+    /// Write out the setup (groups and states)
     #[clap(short, long, action)]
     write: bool,
 
+    /// The file to read or write.
     #[clap(short, long)]
     data: Option<String>,
 
+    /// The group sizes to run or generate.
+    /// This has to be a list of values, separated by spaces, e.g. 2 3 5 10
     #[clap(short, long, value_delimiter = ' ', num_args = 1..)]
     groups: Option<Vec<usize>>,
 
+    /// The group setup to use.
     #[clap(short, long)]
     setup: Option<SetupVariants>,
 }

--- a/openmls/examples/large-groups.rs
+++ b/openmls/examples/large-groups.rs
@@ -2,15 +2,6 @@
 //! when the tree is fully populated.
 //!
 //! In particular do we assume that each member commits after joining the group.
-//!
-//! ## Measurements
-//!
-//! |                | 2      | 3      | 4      | 5      | 10     | 25      | 50      | 100      | 200      | 500       |
-//! | -------------- | ------ | ------ | ------ | ------ | ------ | ------- | ------- | -------- | -------- | --------- |
-//! | Adder          | 613 μs | 935 μs | 680 μs | 711 μs | 901 μs | 1.40 ms | 3.18 ms | 9.97 ms  | 39.80 ms | 260.49 ms |
-//! | Updater        | 308 μs | 510 μs | 496 μs | 595 μs | 748 μs | 1.32 ms | 3.01 ms | 10.47 ms | 39.99 ms | 249.49 ms |
-//! | Remover        | 193 μs | 305 μs | 320 μs | 474 μs | 698 μs | 1.23 ms | 3.10 ms | 10.07 ms | 38.10 ms | 257.24 ms |
-//! | Process update | 303 μs | 433 μs | 429 μs | 529 μs | 698 μs | 1.16 ms | 2.86 ms | 9.61 ms  | 35.27 ms | 249.96 ms |
 
 use std::{
     collections::HashMap,
@@ -18,6 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use base64::prelude::*;
 use clap::Parser;
 use openmls::{
     credentials::{BasicCredential, CredentialWithKey},
@@ -52,7 +44,7 @@ impl Member {
         for (key, value) in &*storage.values.read().unwrap() {
             serializable_storage
                 .values
-                .insert(base64::encode(key), base64::encode(value));
+                .insert(BASE64_STANDARD.encode(key), BASE64_STANDARD.encode(value));
         }
 
         (
@@ -70,7 +62,10 @@ impl Member {
         let provider = OpenMlsRustCrypto::default();
         let mut ks_map = provider.storage().values.write().unwrap();
         for (key, value) in serializable_storage.values {
-            ks_map.insert(base64::decode(key).unwrap(), base64::decode(value).unwrap());
+            ks_map.insert(
+                BASE64_STANDARD.decode(key).unwrap(),
+                BASE64_STANDARD.decode(value).unwrap(),
+            );
         }
         drop(ks_map);
 

--- a/openmls/src/binary_tree/array_representation/diff.rs
+++ b/openmls/src/binary_tree/array_representation/diff.rs
@@ -42,6 +42,7 @@ use super::{
 /// was created from. However, the lack of the internal reference means that its
 /// lifetime is not tied to that of the original tree.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub(crate) struct StagedAbDiff<L: Clone + Debug + Default, P: Clone + Debug + Default> {
     leaf_diff: BTreeMap<LeafNodeIndex, L>,
     parent_diff: BTreeMap<ParentNodeIndex, P>,

--- a/openmls/src/binary_tree/array_representation/tree.rs
+++ b/openmls/src/binary_tree/array_representation/tree.rs
@@ -27,7 +27,7 @@ where
     Parent(P),
 }
 
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 /// A representation of a full, left-balanced binary tree that uses a simple
 /// vector to store nodes. Each tree has to consist of at least one node.

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -159,7 +159,8 @@ pub(crate) struct StagedCoreWelcome {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub(crate) struct CoreGroup {
     public_group: PublicGroup,
     group_epoch_secrets: GroupEpochSecrets,

--- a/openmls/src/group/core_group/past_secrets.rs
+++ b/openmls/src/group/core_group/past_secrets.rs
@@ -6,7 +6,8 @@ use super::*;
 
 // Internal helper struct
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
 struct EpochTree {
     epoch: u64,
@@ -17,7 +18,8 @@ struct EpochTree {
 /// Can store message secrets for up to `max_epochs`. The trees are added with [`self::add()`] and can be queried
 /// with [`Self::get_epoch()`].
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
 pub(crate) struct MessageSecretsStore {
     // Maximum size of the `past_epoch_trees` list.

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -20,7 +20,7 @@ use crate::{
 /// A [ProposalStore] can store the standalone proposals that are received from
 /// the DS in between two commit messages.
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
-#[cfg_attr(test, derive(Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub struct ProposalStore {
     queued_proposals: Vec<QueuedProposal>,
 }
@@ -204,6 +204,7 @@ impl OrderedProposalRefs {
 /// accessed efficiently. To enable iteration over the queue in order, the
 /// `ProposalQueue` also contains a vector of `ProposalRef`s.
 #[derive(Default, Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub(crate) struct ProposalQueue {
     /// `proposal_references` holds references to the proposals in the queue and
     /// determines the order of the queue.

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -424,6 +424,7 @@ impl CoreGroup {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub(crate) enum StagedCommitState {
     PublicState(Box<PublicStagedCommitState>),
     GroupMember(Box<MemberStagedCommitState>),
@@ -431,6 +432,7 @@ pub(crate) enum StagedCommitState {
 
 /// Contains the changes from a commit to the group state.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub struct StagedCommit {
     staged_proposal_queue: ProposalQueue,
     state: StagedCommitState,
@@ -563,6 +565,7 @@ impl StagedCommit {
 
 /// This struct is used internally by [StagedCommit] to encapsulate all the modified group state.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub(crate) struct MemberStagedCommitState {
     group_epoch_secrets: GroupEpochSecrets,
     message_secrets: MessageSecrets,

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -42,6 +42,7 @@ mod test_mls_group;
 /// Pending Commit state. Differentiates between Commits issued by group members
 /// and External Commits.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub enum PendingCommitState {
     /// Commit from a group member
     Member(StagedCommit),
@@ -114,6 +115,7 @@ impl From<PendingCommitState> for StagedCommit {
 ///   external commit process, see [`MlsGroup::join_by_external_commit()`] or
 ///   Section 11.2.1 of the MLS specification.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub enum MlsGroupState {
     /// There is currently a pending Commit that hasn't been merged yet.
     PendingCommit(Box<PendingCommitState>),
@@ -148,6 +150,7 @@ pub enum MlsGroupState {
 /// inactive, as well as if it has a pending commit. See [`MlsGroupState`] for
 /// more information.
 #[derive(Debug)]
+#[cfg_attr(feature = "test-utils", derive(Clone))]
 pub struct MlsGroup {
     // The group configuration. See [`MlsGroupJoinConfig`] for more information.
     mls_group_config: MlsGroupJoinConfig,

--- a/openmls/src/group/public_group/diff.rs
+++ b/openmls/src/group/public_group/diff.rs
@@ -238,6 +238,7 @@ impl<'a> PublicGroupDiff<'a> {
 /// The staged version of a [`PublicGroupDiff`], which means it can no longer be
 /// modified. Its only use is to merge it into the original [`PublicGroup`].
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub(crate) struct StagedPublicGroupDiff {
     pub(super) staged_diff: StagedTreeSyncDiff,
     pub(super) group_context: GroupContext,

--- a/openmls/src/group/public_group/mod.rs
+++ b/openmls/src/group/public_group/mod.rs
@@ -61,7 +61,7 @@ mod validation;
 
 /// This struct holds all public values of an MLS group.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq, Clone))]
 pub struct PublicGroup {
     treesync: TreeSync,
     proposal_store: ProposalStore,

--- a/openmls/src/group/public_group/staged_commit.rs
+++ b/openmls/src/group/public_group/staged_commit.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub struct PublicStagedCommitState {
     pub(super) staged_diff: StagedPublicGroupDiff,
     pub(super) update_path_leaf_node: Option<LeafNode>,

--- a/openmls/src/schedule/message_secrets.rs
+++ b/openmls/src/schedule/message_secrets.rs
@@ -4,7 +4,7 @@ use super::*;
 
 /// Combined message secrets that need to be stored for later decryption/verification
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(test, derive(Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
 pub(crate) struct MessageSecrets {
     sender_data_secret: SenderDataSecret,

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -190,7 +190,7 @@ impl ResumptionPskSecret {
 /// A secret that can be used among members to make sure everyone has the same
 /// group state.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(Eq, PartialEq, Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Eq, PartialEq, Clone))]
 pub struct EpochAuthenticator {
     secret: Secret,
 }
@@ -255,7 +255,7 @@ impl CommitSecret {
 
 /// The `InitSecret` is used to connect the next epoch to the current one.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq, Clone))]
 pub(crate) struct InitSecret {
     secret: Secret,
 }
@@ -711,7 +711,7 @@ impl EncryptionSecret {
 
 /// A secret that we can derive secrets from, that are used outside of OpenMLS.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq, Clone))]
 pub(crate) struct ExporterSecret {
     secret: Secret,
 }
@@ -757,7 +757,7 @@ impl ExporterSecret {
 
 /// A secret used when joining a group with an external Commit.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq, Clone))]
 pub(crate) struct ExternalSecret {
     secret: Secret,
 }
@@ -792,7 +792,7 @@ impl ExternalSecret {
 
 /// The confirmation key is used to calculate the `ConfirmationTag`.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq, Clone))]
 pub(crate) struct ConfirmationKey {
     secret: Secret,
 }
@@ -864,7 +864,7 @@ impl ConfirmationKey {
 
 /// The membership key is used to calculate the `MembershipTag`.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq, Clone))]
 pub(crate) struct MembershipKey {
     secret: Secret,
 }
@@ -1225,7 +1225,7 @@ impl EpochSecrets {
 }
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(test, derive(Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub(crate) struct GroupEpochSecrets {
     init_secret: InitSecret,
     exporter_secret: ExporterSecret,

--- a/openmls/src/schedule/psk.rs
+++ b/openmls/src/schedule/psk.rs
@@ -490,7 +490,8 @@ pub mod store {
     ///
     /// This is where the resumption PSKs are kept in a rollover list.
     #[derive(Debug, Serialize, Deserialize)]
-    #[cfg_attr(test, derive(PartialEq, Clone))]
+    #[cfg_attr(test, derive(PartialEq))]
+    #[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
     pub(crate) struct ResumptionPskStore {
         max_number_of_secrets: usize,
         resumption_psk: Vec<(GroupEpoch, ResumptionPskSecret)>,

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -59,6 +59,7 @@ pub(crate) type UpdatePathResult = (
 /// The [`StagedTreeSyncDiff`] can be created from a [`TreeSyncDiff`], examined
 /// and later merged into a [`TreeSync`] instance.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub(crate) struct StagedTreeSyncDiff {
     diff: StagedMlsBinaryTreeDiff<TreeSyncLeafNode, TreeSyncParentNode>,
     new_tree_hash: Vec<u8>,

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -354,7 +354,7 @@ impl fmt::Display for RatchetTree {
 /// creating a new instance from an imported set of nodes, as well as when
 /// merging a diff.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq, Clone))]
 pub(crate) struct TreeSync {
     tree: MlsBinaryTree<TreeSyncLeafNode, TreeSyncParentNode>,
     tree_hash: Vec<u8>,

--- a/openmls/src/treesync/treesync_node.rs
+++ b/openmls/src/treesync/treesync_node.rs
@@ -57,7 +57,7 @@ impl From<TreeSyncNode> for TreeNode<TreeSyncLeafNode, TreeSyncParentNode> {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq))]
 /// This intermediate struct on top of `Option<Node>` allows us to cache tree
 /// hash values. Blank nodes are represented by [`TreeSyncNode`] instances where
 /// `node = None`.
@@ -109,7 +109,7 @@ impl From<TreeSyncLeafNode> for Option<Node> {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq))]
 /// This intermediate struct on top of `Option<Node>` allows us to cache tree
 /// hash values. Blank nodes are represented by [`TreeSyncNode`] instances where
 /// `node = None`.

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -31,3 +31,6 @@ hpke-rs-rust-crypto = { version = "0.2.0" }
 tls_codec = { workspace = true }
 thiserror = "1.0"
 serde = { version = "^1.0", features = ["derive"] }
+
+[features]
+test-utils = []

--- a/openmls_rust_crypto/src/lib.rs
+++ b/openmls_rust_crypto/src/lib.rs
@@ -15,6 +15,27 @@ pub struct OpenMlsRustCrypto {
     key_store: MemoryStorage,
 }
 
+impl serde::ser::Serialize for OpenMlsRustCrypto {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.key_store.serialize(serializer)
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OpenMlsRustCrypto {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let key_store = MemoryStorage::deserialize(deserializer)?;
+        let crypto = RustCrypto::default();
+
+        Ok(Self { crypto, key_store })
+    }
+}
+
 impl OpenMlsProvider for OpenMlsRustCrypto {
     type CryptoProvider = RustCrypto;
     type RandProvider = RustCrypto;

--- a/openmls_rust_crypto/src/lib.rs
+++ b/openmls_rust_crypto/src/lib.rs
@@ -10,30 +10,10 @@ mod provider;
 pub use provider::*;
 
 #[derive(Default, Debug)]
+#[cfg_attr(feature = "test-utils", derive(Clone))]
 pub struct OpenMlsRustCrypto {
     crypto: RustCrypto,
     key_store: MemoryStorage,
-}
-
-impl serde::ser::Serialize for OpenMlsRustCrypto {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.key_store.serialize(serializer)
-    }
-}
-
-impl<'de> serde::de::Deserialize<'de> for OpenMlsRustCrypto {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let key_store = MemoryStorage::deserialize(deserializer)?;
-        let crypto = RustCrypto::default();
-
-        Ok(Self { crypto, key_store })
-    }
 }
 
 impl OpenMlsProvider for OpenMlsRustCrypto {

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -31,6 +31,15 @@ pub struct RustCrypto {
     rng: RwLock<rand_chacha::ChaCha20Rng>,
 }
 
+// For testing we want to clone.
+// But really we just create a new Rng.
+#[cfg(feature = "test-utils")]
+impl Clone for RustCrypto {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
 impl Default for RustCrypto {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
This PR adds facilities to run benchmarks on larger groups.

Design
- not criterion based
- ability read/write group state into files for testing larger groups
- different group setups
- cli interface to quickly test different scenarios

This required a few small changes to OpenMLS library code to derive some more `Clone`s for testing (benchmarking). Also, the memory key store can be written to files now.

Closes #1596 