### PR TITLE
Make backtrace an optional feature

### DIFF
--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -25,52 +25,51 @@ serde_json = { version = "1.0", optional = true }
 itertools = { version = "0.10", optional = true }
 openmls_rust_crypto = { version = "0.2.0", path = "../openmls_rust_crypto", optional = true }
 openmls_basic_credential = { version = "0.2.0", path = "../basic_credential", optional = true, features = [
-    "clonable",
-    "test-utils",
+  "clonable",
+  "test-utils",
 ] }
 wasm-bindgen-test = { version = "0.3.40", optional = true }
 getrandom = { version = "0.2.12", optional = true, features = ["js"] }
 fluvio-wasm-timer = { version = "0.2.5", optional = true }
 openmls_memory_storage = { path = "../memory_storage", features = [
-    "test-utils",
+  "test-utils",
 ], optional = true }
 openmls_test = { path = "../openmls_test", optional = true }
 openmls_libcrux_crypto = { path = "../libcrux_crypto", optional = true }
 once_cell = { version = "1.19.0", optional = true }
 
 [features]
-default = ["backtrace"]
 crypto-subtle = [] # Enable subtle crypto APIs that have to be used with care.
 test-utils = [
-    "dep:serde_json",
-    "dep:itertools",
-    "dep:openmls_rust_crypto",
-    "dep:rand",
-    "dep:wasm-bindgen-test",
-    "dep:openmls_basic_credential",
-    "dep:openmls_memory_storage",
-    "dep:openmls_test",
-    "dep:once_cell",
+  "dep:serde_json",
+  "dep:itertools",
+  "dep:openmls_rust_crypto",
+  "dep:rand",
+  "dep:wasm-bindgen-test",
+  "dep:openmls_basic_credential",
+  "dep:openmls_memory_storage",
+  "dep:openmls_test",
+  "dep:once_cell",
+  "dep:backtrace",
 ]
 libcrux-provider = [
-    "dep:openmls_libcrux_crypto",
-    "openmls_test?/libcrux-provider",
+  "dep:openmls_libcrux_crypto",
+  "openmls_test?/libcrux-provider",
 ]
 crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
 js = [
-    "dep:getrandom",
-    "dep:fluvio-wasm-timer",
+  "dep:getrandom",
+  "dep:fluvio-wasm-timer",
 ] # enable js randomness source for provider
 
 [dev-dependencies]
-backtrace = "0.3"
 criterion = { version = "^0.5", default-features = false } # need to disable default features for wasm
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.10"
 lazy_static = "1.4"
 openmls_traits = { version = "0.2.0", path = "../traits", features = [
-    "test-utils",
+  "test-utils",
 ] }
 pretty_env_logger = "0.5"
 tempfile = "3"

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -50,8 +50,9 @@ test-utils = [
   "dep:openmls_memory_storage",
   "dep:openmls_test",
   "dep:once_cell",
-  "dep:backtrace",
+  "backtrace",
 ]
+backtrace = ["dep:backtrace"]
 libcrux-provider = [
   "dep:openmls_libcrux_crypto",
   "openmls_test?/libcrux-provider",


### PR DESCRIPTION
This PR makes backtrace an optional feature in order to make the library faster in non-debug builds.

fixes #1598