### PR TITLE
Add config type for joining from an external commit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc -p openmls --message-format json
+      - run: cargo doc -p openmls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1506](https://github.com/openmls/openmls/pull/1506): Add `StagedWelcome` and `StagedCoreWelcome` to make joining a group staged in order to inspect the `Welcome` message. This was followed up with PR [#1533](https://github.com/openmls/openmls/pull/1533) to adjust the API.
 - [#1516](https://github.com/openmls/openmls/pull/1516): Add `MlsGroup::clear_pending_proposals` to the public API; this allows users to clear a group's internal `ProposalStore`
 - [#1565](https://github.com/openmls/openmls/pull/1565): Add new `StorageProvider` trait to the `openmls_traits` crate.
+- [#1614](https://github.com/openmls/openmls/pull/1614): Add new `MlsGroupExternalJoinConfig` to make joining via external commits easier.
 
 ### Changed
 

--- a/book/src/user_manual/group_config.md
+++ b/book/src/user_manual/group_config.md
@@ -1,8 +1,8 @@
 # Group configuration
 
-Two very similar structs can help configure groups upon their creation: `MlsGroupJoinConfig` and `MlsGroupCreateConfig`.
+Three very similar structs can help configure groups upon their creation: `MlsGroupJoinConfig`, `MlsGroupExternalJoinConfig` and `MlsGroupCreateConfig`.
 
-`MlsGroupJoinConfig` contains the following runtime-relevant configuration options for an `MlsGroup` and can be set on a per-client basis when a group is joined.
+`MlsGroupJoinConfig` contains the following runtime-relevant configuration options for an `MlsGroup` and can be set on a per-client basis when a group is joined using a welcome message.
 
 | Name                           | Type                            | Explanation                                                                                      |
 | ------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------ |
@@ -13,6 +13,20 @@ Two very similar structs can help configure groups upon their creation: `MlsGrou
 | `use_ratchet_tree_extension`   | `bool`                          | Flag indicating the Ratchet Tree Extension should be used. The default is `false`.               |
 | `sender_ratchet_configuration` | `SenderRatchetConfiguration`    | Sender ratchet configuration.                                                                    |
 
+`MlsGroupJoinConfig` contains the following runtime-relevant configuration options for an `MlsGroup` and can be set on a per-client basis when a group is joined using an external commit.
+
+| Name                           | Type                            | Explanation                                                                                      |
+| ------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `wire_format_policy`           | `WireFormatPolicy`              | Defines the wire format policy for outgoing and incoming handshake messages.                     |
+| `padding_size`                 | `usize`                         | Size of padding in bytes. The default is 0.                                                      |
+| `max_past_epochs`              | `usize`                         | Maximum number of past epochs for which application messages can be decrypted. The default is 0. |
+| `number_of_resumption_psks`    | `usize`                         | Number of resumption psks to keep. The default is 0.                                             |
+| `use_ratchet_tree_extension`   | `bool`                          | Flag indicating the Ratchet Tree Extension should be used. The default is `false`.               |
+| `sender_ratchet_configuration` | `SenderRatchetConfiguration`    | Sender ratchet configuration.                                                                    |
+| `extensions`                   | `Option<Extensions>`            | Extensions set on the leaf node of the newly joined member.                                      |
+| `capabilities`                 | `Option<Capabilities>`          | Capabiltiies set in the leaf node of the newly joined member.                                    |
+| `aad`                          | `&[u8]`                         | The AAD used in the generation of the external commit message.                                   |
+
 `MlsGroupCreateConfig` contains an `MlsGroupJoinConfig`, as well as a few additional parameters that are part of the group state that is agreed-upon by all group members. It can be set at the time of a group's creation and contains the following additional configuration options.
 
 | Name                           | Type                            | Explanation                                                                                      |
@@ -21,12 +35,18 @@ Two very similar structs can help configure groups upon their creation: `MlsGrou
 | `capabilities` .               | `Capabilities`                  | Lists the capabilities of the group's creator.                                                   |
 | `leaf_extensions` .            | `Extensions`                    | Extensions to be included in the group creator's leaf                                            |
 
-Both ways of group configurations can be specified by using the struct's builder pattern, or choosing their default values. The default value contains safe values for all parameters and is suitable for scenarios without particular requirements.
+All three ways of group configurations can be specified by using the struct's builder pattern, or choosing their default values. The default value contains safe values for all parameters and is suitable for scenarios without particular requirements.
 
 Example join configuration:
 
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code.rs:mls_group_config_example}}
+```
+
+Example external join configuration:
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code.rs:mls_group_external_join_config_example}}
 ```
 
 Example create configuration:

--- a/book/src/user_manual/join_from_external_commit.md
+++ b/book/src/user_manual/join_from_external_commit.md
@@ -16,7 +16,7 @@ Or from a call to a function that results in a staged commit:
 {{#include ../../../openmls/tests/book_code.rs:alice_exports_group_info}}
 ```
 
-Calling `join_by_external_commit` requires an `MlsGroupJoinConfig` (see [Group configuration](./group_config.md) for more details). The function creates an `MlsGroup` and leave it with a commit pending to be merged.
+Calling `join_by_external_commit` requires an `MlsGroupExternalJoinConfig` (see [Group configuration](./group_config.md) for more details). The function creates an `MlsGroup` and leave it with a commit pending to be merged.
 
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code.rs:charlie_joins_external_commit}}

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -17,8 +17,9 @@ use openmls::{
     credentials::{BasicCredential, Credential, CredentialType, CredentialWithKey},
     framing::{MlsMessageBodyIn, MlsMessageIn, MlsMessageOut, ProcessedMessageContent},
     group::{
-        GroupEpoch, GroupId, MlsGroup, MlsGroupCreateConfig, MlsGroupJoinConfig, StagedWelcome,
-        WireFormatPolicy, PURE_CIPHERTEXT_WIRE_FORMAT_POLICY, PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+        GroupEpoch, GroupId, MlsGroup, MlsGroupCreateConfig, MlsGroupExternalJoinConfig,
+        MlsGroupJoinConfig, StagedWelcome, WireFormatPolicy, PURE_CIPHERTEXT_WIRE_FORMAT_POLICY,
+        PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
     },
     key_packages::{KeyPackage, KeyPackageBundle},
     prelude::{Capabilities, ExtensionType, SenderRatchetConfiguration},
@@ -480,7 +481,7 @@ impl MlsClient for MlsClientImpl {
             let mls_group_config = {
                 let wire_format_policy = wire_format_policy(request.encrypt_handshake);
 
-                MlsGroupJoinConfig::builder()
+                MlsGroupExternalJoinConfig::builder(b"")
                     .max_past_epochs(32)
                     .number_of_resumption_psks(32)
                     .sender_ratchet_configuration(SenderRatchetConfiguration::default())
@@ -495,9 +496,6 @@ impl MlsClient for MlsClientImpl {
                 ratchet_tree,
                 verifiable_group_info,
                 &mls_group_config,
-                None,
-                None,
-                b"",
                 credential_with_key,
             )
             .unwrap();

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -124,32 +124,18 @@ impl<'a> MlsGroupExternalJoinConfig<'a> {
 }
 
 impl<'a> MlsGroupExternalJoinConfig<'a> {
+    /// Creates a [`MlsGroupExternalJoinConfigBuilder`] that can be used to create an [`MlsGroupExternalJoinConfig`].
     pub fn builder(aad: &'a [u8]) -> MlsGroupExternalJoinConfigBuilder<'a> {
         MlsGroupExternalJoinConfigBuilder::new(aad)
     }
 
-    pub fn into_mls_group_join_config(self) -> MlsGroupJoinConfig {
-        let Self {
-            wire_format_policy,
-            padding_size,
-            max_past_epochs,
-            number_of_resumption_psks,
-            use_ratchet_tree_extension,
-            sender_ratchet_configuration,
-            ..
-        } = self;
-
-        MlsGroupJoinConfig {
-            wire_format_policy,
-            padding_size,
-            max_past_epochs,
-            number_of_resumption_psks,
-            use_ratchet_tree_extension,
-            sender_ratchet_configuration,
-        }
-    }
-
-    pub fn from_parts(
+    /// Creates an [`MlsGroupExternalJoinConfig`] from a [`MlsGroupJoinConfig`] as well as the
+    /// fields of the external join config that are not part of the [`MlsGroupJoinConfig`]:
+    /// - capabilities: the capabilities that should be set on the leaf node (optional)
+    /// - extension: the extensions that should be set on the leaf node (optional)
+    /// - aad: the associated data that should be used for the external commit (not in the
+    ///   resulting [`MlsGroup`]!)
+    pub(crate) fn from_parts(
         mls_group_join_config: MlsGroupJoinConfig,
         capabilities: Option<Capabilities>,
         extensions: Option<Extensions>,
@@ -177,7 +163,12 @@ impl<'a> MlsGroupExternalJoinConfig<'a> {
         }
     }
 
-    pub fn into_parts(
+    /// Converts the [`MlsGroupExternalJoinConfig`] into an [`MlsGroupJoinConfig`] as well as the
+    /// fields of the external join config that are not part of the [`MlsGroupJoinConfig`]:
+    /// - the capabilities that should be set on the leaf node (optional)
+    /// - the extensions that should be set on the leaf node (optional)
+    /// - the associated data that should be used for the external commit
+    pub(crate) fn into_parts(
         self,
     ) -> (
         MlsGroupJoinConfig,
@@ -300,6 +291,8 @@ impl MlsGroupJoinConfigBuilder {
     }
 }
 
+/// Builder struct for an [`MlsGroupExternalJoinConfig`].
+#[derive(Default)]
 pub struct MlsGroupExternalJoinConfigBuilder<'a> {
     join_config: MlsGroupExternalJoinConfig<'a>,
 }

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -78,7 +78,7 @@ impl MlsGroupJoinConfig {
     }
 }
 
-/// The [`MlsGroupJoinExternalConfig`] contains all configuration parameters that are
+/// The [`MlsGroupExternalJoinConfig`] contains all configuration parameters that are
 /// relevant to group operation at runtime. It is used to configure the group's
 /// behaviour when joining an existing group. To configure a newly created
 /// group, use [`MlsGroupCreateConfig`].

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -13,10 +13,7 @@ use crate::{
     },
     schedule::psk::{store::ResumptionPskStore, PreSharedKeyId},
     storage::OpenMlsProvider,
-    treesync::{
-        node::leaf_node::{Capabilities, LeafNodeParameters},
-        RatchetTreeIn,
-    },
+    treesync::{node::leaf_node::LeafNodeParameters, RatchetTreeIn},
 };
 
 impl MlsGroup {
@@ -86,13 +83,13 @@ impl MlsGroup {
         signer: &impl Signer,
         ratchet_tree: Option<RatchetTreeIn>,
         verifiable_group_info: VerifiableGroupInfo,
-        mls_group_config: &MlsGroupJoinConfig,
-        capabilities: Option<Capabilities>,
-        extensions: Option<Extensions>,
-        aad: &[u8],
+        mls_group_config: &MlsGroupExternalJoinConfig,
         credential_with_key: CredentialWithKey,
     ) -> Result<(Self, MlsMessageOut, Option<GroupInfo>), ExternalCommitError<Provider::StorageError>>
     {
+        let (mls_group_config, capabilities, extensions, aad) =
+            mls_group_config.clone().into_parts();
+
         // Prepare the commit parameters
         let framing_parameters = FramingParameters::new(aad, WireFormat::PublicMessage);
 
@@ -115,7 +112,7 @@ impl MlsGroup {
         group.set_max_past_epochs(mls_group_config.max_past_epochs);
 
         let mls_group = MlsGroup {
-            mls_group_config: mls_group_config.clone(),
+            mls_group_config,
             group,
             own_leaf_nodes: vec![],
             aad: vec![],

--- a/openmls/src/group/tests/test_external_commit.rs
+++ b/openmls/src/group/tests/test_external_commit.rs
@@ -5,7 +5,7 @@ use crate::{
     framing::{MlsMessageIn, Sender},
     group::{
         tests::utils::generate_credential_with_key, MlsGroup, MlsGroupCreateConfig,
-        PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+        MlsGroupExternalJoinConfig, PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
     },
     prelude::ProcessedMessageContent,
 };
@@ -45,6 +45,13 @@ fn test_external_commit() {
 
     // Bob wants to commit externally.
 
+    let external_join_config = MlsGroupExternalJoinConfig::from_parts(
+        alice_group.configuration().clone(),
+        None,
+        None,
+        &[],
+    );
+
     let verifiable_group_info = alice_group
         .export_group_info(provider, &alice_credential.signer, false)
         .unwrap()
@@ -57,10 +64,7 @@ fn test_external_commit() {
         &bob_credential.signer,
         Some(tree_option.into()),
         verifiable_group_info,
-        alice_group.configuration(),
-        None,
-        None,
-        &[],
+        &external_join_config,
         bob_credential.credential_with_key.clone(),
     )
     .unwrap();
@@ -110,6 +114,13 @@ fn test_external_commit() {
 
     // Charlie wants to commit externally.
 
+    let external_join_config = MlsGroupExternalJoinConfig::from_parts(
+        alice_group.configuration().clone(),
+        None,
+        None,
+        &[],
+    );
+
     let verifiable_group_info = alice_group
         .export_group_info(provider, &alice_credential.signer, false)
         .unwrap()
@@ -122,10 +133,7 @@ fn test_external_commit() {
         &charlie_credential.signer,
         Some(tree_option.into()),
         verifiable_group_info,
-        alice_group.configuration(),
-        None,
-        None,
-        &[],
+        &external_join_config,
         charlie_credential.credential_with_key.clone(),
     )
     .unwrap();
@@ -191,15 +199,15 @@ fn test_external_commit() {
         .unwrap();
     let tree_option = bob_group.export_ratchet_tree();
 
+    let external_join_config =
+        MlsGroupExternalJoinConfig::from_parts(bob_group.configuration().clone(), None, None, &[]);
+
     let (mut alice_group, public_message_commit, _) = MlsGroup::join_by_external_commit(
         provider,
         &alice_credential.signer,
         Some(tree_option.into()),
         verifiable_group_info,
-        bob_group.configuration(),
-        None,
-        None,
-        &[],
+        &external_join_config,
         alice_credential.credential_with_key.clone(),
     )
     .unwrap();

--- a/openmls/src/group/tests/test_external_commit_validation.rs
+++ b/openmls/src/group/tests/test_external_commit_validation.rs
@@ -19,8 +19,8 @@ use crate::{
         tests::utils::{
             generate_credential_with_key, generate_key_package, resign_external_commit,
         },
-        Extensions, MlsGroup, OpenMlsSignaturePublicKey, PURE_CIPHERTEXT_WIRE_FORMAT_POLICY,
-        PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+        Extensions, MlsGroup, MlsGroupExternalJoinConfig, OpenMlsSignaturePublicKey,
+        PURE_CIPHERTEXT_WIRE_FORMAT_POLICY, PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
     },
     messages::proposals::{
         AddProposal, ExternalInitProposal, GroupContextExtensionProposal, Proposal, ProposalOrRef,
@@ -197,15 +197,19 @@ fn test_valsem242() {
         .into_verifiable_group_info()
         .unwrap();
 
+    let external_join_config = MlsGroupExternalJoinConfig::from_parts(
+        alice_group.configuration().clone(),
+        None,
+        None,
+        &[],
+    );
+
     let (_, public_message_commit, _) = MlsGroup::join_by_external_commit(
         provider,
         &bob_credential.signer,
         None,
         verifiable_group_info,
-        alice_group.configuration(),
-        None,
-        None,
-        &[],
+        &external_join_config,
         bob_credential.credential_with_key.clone(),
     )
     .unwrap();
@@ -580,15 +584,19 @@ fn test_pure_ciphertest() {
         .into_verifiable_group_info()
         .unwrap();
 
+    let external_join_config = MlsGroupExternalJoinConfig::from_parts(
+        alice_group.configuration().clone(),
+        None,
+        None,
+        &[],
+    );
+
     let (_bob_group, message, _) = MlsGroup::join_by_external_commit(
         provider,
         &bob_credential.signer,
         None,
         verifiable_group_info,
-        alice_group.configuration(),
-        None,
-        None,
-        &[],
+        &external_join_config,
         bob_credential.credential_with_key.clone(),
     )
     .expect("Error initializing group externally.");
@@ -613,7 +621,7 @@ mod utils {
         framing::{MlsMessageIn, PublicMessage, Sender},
         group::{
             tests::utils::{generate_credential_with_key, CredentialWithKeyAndSigner},
-            MlsGroup, MlsGroupCreateConfig, WireFormatPolicy,
+            MlsGroup, MlsGroupCreateConfig, MlsGroupExternalJoinConfig, WireFormatPolicy,
         },
     };
 
@@ -667,15 +675,19 @@ mod utils {
             .unwrap();
         let tree_option = alice_group.export_ratchet_tree();
 
+        let external_join_config = MlsGroupExternalJoinConfig::from_parts(
+            alice_group.configuration().clone(),
+            None,
+            None,
+            &[],
+        );
+
         let (_, public_message_commit, _) = MlsGroup::join_by_external_commit(
             provider,
             &bob_credential.signer,
             Some(tree_option.into()),
             verifiable_group_info,
-            alice_group.configuration(),
-            None,
-            None,
-            &[],
+            &external_join_config,
             bob_credential.credential_with_key.clone(),
         )
         .unwrap();

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -268,6 +268,17 @@ fn book_operations() {
         .build();
     // ANCHOR_END: mls_group_config_example
 
+    // ANCHOR: mls_group_external_join_config_example
+    let mls_group_external_join_config = MlsGroupExternalJoinConfig::builder(b"")
+        .padding_size(100)
+        .sender_ratchet_configuration(SenderRatchetConfiguration::new(
+            10,   // out_of_order_tolerance
+            2000, // maximum_forward_distance
+        ))
+        .use_ratchet_tree_extension(true)
+        .build();
+    // ANCHOR_END: mls_group_external_join_config_example
+
     let welcome: MlsMessageIn = welcome.into();
     let welcome = welcome
         .into_welcome()
@@ -295,10 +306,7 @@ fn book_operations() {
         &dave_signature_keys,
         None, // No ratchtet tree extension
         verifiable_group_info,
-        &mls_group_config,
-        None, // No special capabilities
-        None, // No special extensions
-        &[],
+        &mls_group_external_join_config,
         dave_credential,
     )
     .expect("Error joining from external commit");

--- a/openmls/tests/test_external_commit.rs
+++ b/openmls/tests/test_external_commit.rs
@@ -83,10 +83,7 @@ fn test_external_commit() {
             &bob_signature_keys,
             None,
             verifiable_group_info,
-            &MlsGroupJoinConfig::default(),
-            None,
-            None,
-            b"",
+            &MlsGroupExternalJoinConfig::default(),
             bob_credential,
         )
         .unwrap();
@@ -102,10 +99,7 @@ fn test_external_commit() {
             &bob_signature_keys,
             None,
             verifiable_group_info_broken,
-            &MlsGroupJoinConfig::default(),
-            None,
-            None,
-            b"",
+            &MlsGroupExternalJoinConfig::default(),
             bob_credential,
         )
         .unwrap_err();
@@ -144,10 +138,7 @@ fn test_group_info() {
         &bob_signature_keys,
         None,
         verifiable_group_info,
-        &MlsGroupJoinConfig::default(),
-        None,
-        None,
-        b"",
+        &MlsGroupExternalJoinConfig::default(),
         bob_credential,
     )
     .map(|(group, msg, group_info)| (group, MlsMessageIn::from(msg), group_info))
@@ -195,10 +186,7 @@ fn test_group_info() {
         &bob_signature_keys,
         None,
         verifiable_group_info,
-        &MlsGroupJoinConfig::default(),
-        None,
-        None,
-        b"",
+        &MlsGroupExternalJoinConfig::default(),
         bob_credential,
     )
     .unwrap();


### PR DESCRIPTION
This PR adds a new sort of join config to make joining using external commits easier. I believe it's mostly pretty obvious, so just a few things:

- The types have a generic lifetime parameter, because `aad` has been a reference in the past and I wanted to avoid needless copying.
- I am not quite sure about which of the arguments belong into the config and which should be arguments. The ones I included are more on the "small data" side, whereas things like group info and ratchet tree are more on the "large protocol objects" side. I wasn't sure what to do with the credential_with_key. Feedback on this is very welcome.

Fixes #1607 