### PR TITLE
Remove serde for PublicGroup and CoreGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0-pre.2 (2024-08-XX)
+
+### Changed
+
+- [#1637](https://github.com/openmls/openmls/pull/1637): Remove `serde` from `MlsGroup`.
+- [#1638](https://github.com/openmls/openmls/pull/1638): Remove `serde` from `PublicGroup`. `PublicGroup::load()` becomes public to load a group from the storage provider.
+
 ## 0.6.0-pre.1 (2024-07-22)
 
 ### Added
@@ -31,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1559](https://github.com/openmls/openmls/pull/1559): Remove the `PartialEq` type constraint on the error type of both the `OpenMlsRand` and `OpenMlsKeyStore` traits. Additionally, remove the `Clone` type constraint on the error type of the `OpenMlsRand` trait.
 - [#1565](https://github.com/openmls/openmls/pull/1565): Removed `OpenMlsKeyStore` and replace it with a new `StorageProvider` trait in the `openmls_traits` crate.
 - [#1606](https://github.com/openmls/openmls/pull/1606): Added additional `LeafNodeParameters` argument to `MlsGroup.self_update()` and `MlsGroup.propose_self_update()` to allow for updating the leaf node with custom parameters. `MlsGroup::join_by_external_commit()` now also takes optional parameters to set the capabilities and the extensions of the LeafNode.
-- [#1615](https://github.com/openmls/openmls/pull/1615): Changes the AAD handlling. The AAD is no longer persisted and needs to be set before every API call that generates an `MlsMessageOut`. The functions `ProccessedMessage` to accees the AAD has been renamed to `aad()`.
+- [#1615](https://github.com/openmls/openmls/pull/1615): Changes the AAD handling. The AAD is no longer persisted and needs to be set before every API call that generates an `MlsMessageOut`. The functions `ProccessedMessage` to accees the AAD has been renamed to `aad()`.
 
 ### Fixed
 

--- a/openmls/src/group/core_group/mod.rs
+++ b/openmls/src/group/core_group/mod.rs
@@ -142,7 +142,7 @@ pub(crate) struct StagedCoreWelcome {
     path_keypairs: Option<Vec<EncryptionKeyPair>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
 pub(crate) struct CoreGroup {
     public_group: PublicGroup,

--- a/openmls/src/group/public_group/mod.rs
+++ b/openmls/src/group/public_group/mod.rs
@@ -383,10 +383,8 @@ impl PublicGroup {
         Ok(())
     }
 
-    /// Loads the [`PublicGroup`] from storage. Called from [`CoreGroup::load`].
-    ///
-    /// [`CoreGroup::load`]: crate::group::core_group::CoreGroup::load
-    pub(crate) fn load<Storage: StorageProvider>(
+    /// Loads the [`PublicGroup`] corresponding to a [`GroupId`] from storage.
+    pub fn load<Storage: StorageProvider>(
         storage: &Storage,
         group_id: &GroupId,
     ) -> Result<Option<Self>, Storage::Error> {

--- a/openmls/src/group/public_group/mod.rs
+++ b/openmls/src/group/public_group/mod.rs
@@ -60,7 +60,7 @@ mod tests;
 mod validation;
 
 /// This struct holds all public values of an MLS group.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq, Clone))]
 pub struct PublicGroup {
     treesync: TreeSync,


### PR DESCRIPTION
This is a follow-up to #1637: We also remove `serde` from the `PublicGroup` to make things consistent.