### PR TITLE
Align storage provider naming

### DIFF
--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -417,7 +417,7 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
             .collect::<Result<Vec<_>, _>>()
     }
 
-    fn treesync<
+    fn tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         TreeSync: traits::TreeSync<CURRENT_VERSION>,
     >(

--- a/memory_storage/src/test_store.rs
+++ b/memory_storage/src/test_store.rs
@@ -175,7 +175,7 @@ impl StorageProvider<V_TEST> for MemoryStorage {
         todo!()
     }
 
-    fn treesync<GroupId: traits::GroupId<V_TEST>, TreeSync: traits::TreeSync<V_TEST>>(
+    fn tree<GroupId: traits::GroupId<V_TEST>, TreeSync: traits::TreeSync<V_TEST>>(
         &self,
         _group_id: &GroupId,
     ) -> Result<Option<TreeSync>, Self::Error> {

--- a/traits/src/public_storage.rs
+++ b/traits/src/public_storage.rs
@@ -196,7 +196,7 @@ where
         &self,
         group_id: &GroupId,
     ) -> Result<Option<TreeSync>, Self::PublicError> {
-        <Self as StorageProvider<VERSION>>::treesync(self, group_id)
+        <Self as StorageProvider<VERSION>>::tree(self, group_id)
     }
 
     fn group_context<

--- a/traits/src/storage.rs
+++ b/traits/src/storage.rs
@@ -287,7 +287,7 @@ pub trait StorageProvider<const VERSION: u16> {
     ) -> Result<Vec<(ProposalRef, QueuedProposal)>, Self::Error>;
 
     /// Returns the TreeSync tree for the group with group id `group_id`.
-    fn treesync<GroupId: traits::GroupId<VERSION>, TreeSync: traits::TreeSync<VERSION>>(
+    fn tree<GroupId: traits::GroupId<VERSION>, TreeSync: traits::TreeSync<VERSION>>(
         &self,
         group_id: &GroupId,
     ) -> Result<Option<TreeSync>, Self::Error>;


### PR DESCRIPTION
Some of the naming in the storage provider was not consistent, this PR corrects that.