### PR TITLE
Remove OpenMlsProvider dependency of PublicGroup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1637](https://github.com/openmls/openmls/pull/1637): Remove `serde` from `MlsGroup`.
 - [#1638](https://github.com/openmls/openmls/pull/1638): Remove `serde` from `PublicGroup`. `PublicGroup::load()` becomes public to load a group from the storage provider.
 - [#1640](https://github.com/openmls/openmls/pull/1640): The storage provider function `treesync()` was renamed to `tree()` so that it is consistent with other treesync functions.
+- [#1642](https://github.com/openmls/openmls/pull/1642): `OpenMlsProvider` is no longer required for the `PublicGroup` API. The `PublicGroup` API now uses the `PublicStorageProvider` trait directly.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1637](https://github.com/openmls/openmls/pull/1637): Remove `serde` from `MlsGroup`.
 - [#1638](https://github.com/openmls/openmls/pull/1638): Remove `serde` from `PublicGroup`. `PublicGroup::load()` becomes public to load a group from the storage provider.
 - [#1640](https://github.com/openmls/openmls/pull/1640): The storage provider function `treesync()` was renamed to `tree()` so that it is consistent with other treesync functions.
-- [#1642](https://github.com/openmls/openmls/pull/1642): `OpenMlsProvider` is no longer required for the `PublicGroup` API. The `PublicGroup` API now uses the `PublicStorageProvider` trait directly.
+- [#1642](https://github.com/openmls/openmls/pull/1642): `OpenMlsProvider` is no longer required for the `PublicGroup` API. The `PublicGroup` API now uses the `PublicStorageProvider` trait directly. `ProcessMessageError::InvalidSignature` was removed and replaced with `ValidationError::InvalidSignature`.
 
 ### Fixed
 

--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -48,7 +48,8 @@ impl CoreGroup {
             };
 
         let (public_group, group_info) = PublicGroup::from_external(
-            provider,
+            provider.crypto(),
+            provider.storage(),
             ratchet_tree,
             verifiable_group_info,
             // Existing proposals are discarded when joining by external commit.

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -119,7 +119,8 @@ pub(in crate::group) fn build_staged_welcome<Provider: OpenMlsProvider>(
     // Since there is currently only the external pub extension, there is no
     // group info extension of interest here.
     let (public_group, _group_info_extensions) = PublicGroup::from_external(
-        provider,
+        provider.crypto(),
+        provider.storage(),
         ratchet_tree,
         verifiable_group_info.clone(),
         ProposalStore::new(),

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -45,12 +45,12 @@ impl CoreGroup {
         unverified_message: UnverifiedMessage,
         old_epoch_keypairs: Vec<EncryptionKeyPair>,
         leaf_node_keypairs: Vec<EncryptionKeyPair>,
-    ) -> Result<ProcessedMessage, ProcessMessageError<Provider::StorageError>> {
+    ) -> Result<ProcessedMessage, ProcessMessageError> {
         // Checks the following semantic validation:
         //  - ValSem010
         //  - ValSem246 (as part of ValSem010)
         let (content, credential) =
-            unverified_message.verify(self.ciphersuite(), provider, self.version())?;
+            unverified_message.verify(self.ciphersuite(), provider.crypto(), self.version())?;
 
         match content.sender() {
             Sender::Member(_) | Sender::NewMemberCommit | Sender::NewMemberProposal => {
@@ -173,7 +173,7 @@ impl CoreGroup {
         message: impl Into<ProtocolMessage>,
         sender_ratchet_configuration: &SenderRatchetConfiguration,
         own_leaf_nodes: &[LeafNode],
-    ) -> Result<ProcessedMessage, ProcessMessageError<Provider::StorageError>> {
+    ) -> Result<ProcessedMessage, ProcessMessageError> {
         let message: ProtocolMessage = message.into();
 
         // Checks the following semantic validation:

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -517,7 +517,7 @@ pub enum CreateGroupContextExtProposalError<StorageError> {
     LeafNodeValidation(#[from] LeafNodeValidationError),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    MlsGroupStateError(#[from] MlsGroupStateError<StorageError>),
+    MlsGroupStateError(#[from] MlsGroupStateError),
     /// See [`CreateCommitError`] for more details.
     #[error(transparent)]
     CreateCommitError(#[from] CreateCommitError<StorageError>),

--- a/openmls/src/group/mls_group/application.rs
+++ b/openmls/src/group/mls_group/application.rs
@@ -18,7 +18,7 @@ impl MlsGroup {
         provider: &Provider,
         signer: &impl Signer,
         message: &[u8],
-    ) -> Result<MlsMessageOut, CreateMessageError<Provider::StorageError>> {
+    ) -> Result<MlsMessageOut, CreateMessageError> {
         if !self.is_active() {
             return Err(CreateMessageError::GroupStateError(
                 MlsGroupStateError::UseAfterEviction,

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -60,7 +60,7 @@ pub enum EmptyInputError {
 
 /// Group state error
 #[derive(Error, Debug, PartialEq, Clone)]
-pub enum MlsGroupStateError<StorageError> {
+pub enum MlsGroupStateError {
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
@@ -79,9 +79,6 @@ pub enum MlsGroupStateError<StorageError> {
     /// Requested pending proposal hasn't been found in local pending proposals
     #[error("Requested pending proposal hasn't been found in local pending proposals.")]
     PendingProposalNotFound,
-    /// An error ocurred while writing to storage
-    #[error("An error ocurred while writing to storage")]
-    StorageError(StorageError),
 }
 
 /// Error merging pending commit
@@ -89,7 +86,7 @@ pub enum MlsGroupStateError<StorageError> {
 pub enum MergePendingCommitError<StorageError> {
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    MlsGroupStateError(#[from] MlsGroupStateError<StorageError>),
+    MlsGroupStateError(#[from] MlsGroupStateError),
     /// See [`MergeCommitError`] for more details.
     #[error(transparent)]
     MergeCommitError(#[from] MergeCommitError<StorageError>),
@@ -97,7 +94,7 @@ pub enum MergePendingCommitError<StorageError> {
 
 /// Process message error
 #[derive(Error, Debug, PartialEq, Clone)]
-pub enum ProcessMessageError<StorageError> {
+pub enum ProcessMessageError {
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
@@ -109,7 +106,7 @@ pub enum ProcessMessageError<StorageError> {
     ValidationError(#[from] ValidationError),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
     /// The message's signature is invalid.
     #[error("The message's signature is invalid.")]
     InvalidSignature,
@@ -126,13 +123,13 @@ pub enum ProcessMessageError<StorageError> {
 
 /// Create message error
 #[derive(Error, Debug, PartialEq, Clone)]
-pub enum CreateMessageError<StorageError> {
+pub enum CreateMessageError {
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
 }
 
 /// Add members error
@@ -149,7 +146,7 @@ pub enum AddMembersError<StorageError> {
     CreateCommitError(#[from] CreateCommitError<StorageError>),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
     /// Error writing to storage.
     #[error("Error writing to storage")]
     StorageError(StorageError),
@@ -166,7 +163,7 @@ pub enum ProposeAddMemberError<StorageError> {
     UnsupportedExtensions,
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
     /// See [`LeafNodeValidationError`] for more details.
     #[error(transparent)]
     LeafNodeValidation(#[from] LeafNodeValidationError),
@@ -183,7 +180,7 @@ pub enum ProposeRemoveMemberError<StorageError> {
     LibraryError(#[from] LibraryError),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
     /// The member that should be removed can not be found.
     #[error("The member that should be removed can not be found.")]
     UnknownMember,
@@ -206,7 +203,7 @@ pub enum RemoveMembersError<StorageError> {
     CreateCommitError(#[from] CreateCommitError<StorageError>),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
     /// The member that should be removed can not be found.
     #[error("The member that should be removed can not be found.")]
     UnknownMember,
@@ -223,7 +220,10 @@ pub enum LeaveGroupError<StorageError> {
     LibraryError(#[from] LibraryError),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
+    /// An error ocurred while writing to storage
+    #[error("An error ocurred while writing to storage")]
+    StorageError(StorageError),
 }
 
 /// Self update error
@@ -237,7 +237,7 @@ pub enum SelfUpdateError<StorageError> {
     CreateCommitError(#[from] CreateCommitError<StorageError>),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
     /// Error accessing the storage.
     #[error("Error accessing the storage.")]
     StorageError(StorageError),
@@ -252,7 +252,7 @@ pub enum ProposeSelfUpdateError<StorageError> {
 
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
     /// Error accessing storage.
     #[error("Error accessing storage.")]
     StorageError(StorageError),
@@ -275,7 +275,7 @@ pub enum CommitToPendingProposalsError<StorageError> {
     CreateCommitError(#[from] CreateCommitError<StorageError>),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
     /// Error writing to storage
     #[error("Error writing to storage: {0}")]
     StorageError(StorageError),
@@ -283,18 +283,18 @@ pub enum CommitToPendingProposalsError<StorageError> {
 
 /// Errors that can happen when exporting a group info object.
 #[derive(Error, Debug, PartialEq, Clone)]
-pub enum ExportGroupInfoError<StorageError> {
+pub enum ExportGroupInfoError {
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
 }
 
 /// Export secret error
 #[derive(Error, Debug, PartialEq, Clone)]
-pub enum ExportSecretError<StorageError> {
+pub enum ExportSecretError {
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
@@ -303,24 +303,24 @@ pub enum ExportSecretError<StorageError> {
     KeyLengthTooLong,
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
 }
 
 /// Propose PSK error
 #[derive(Error, Debug, PartialEq, Clone)]
-pub enum ProposePskError<StorageError> {
+pub enum ProposePskError {
     /// See [`PskError`] for more details.
     #[error(transparent)]
     Psk(#[from] PskError),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
 }
 
-/// Export secret error
+/// Proposal error
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum ProposalError<StorageError> {
     /// See [`LibraryError`] for more details.
@@ -340,7 +340,7 @@ pub enum ProposalError<StorageError> {
     ProposeRemoveMemberError(#[from] ProposeRemoveMemberError<StorageError>),
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
-    GroupStateError(#[from] MlsGroupStateError<StorageError>),
+    GroupStateError(#[from] MlsGroupStateError),
     /// See [`ValidationError`] for more details.
     #[error(transparent)]
     ValidationError(#[from] ValidationError),
@@ -350,4 +350,15 @@ pub enum ProposalError<StorageError> {
     /// Error writing proposal to storage.
     #[error("error writing proposal to storage")]
     StorageError(StorageError),
+}
+
+/// Remove proposal error
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum RemoveProposalError<StorageError> {
+    /// Couldn't find the proposal for the given `ProposalRef`.
+    #[error("Couldn't find the proposal for the given `ProposalRef`")]
+    ProposalNotFound,
+    /// Error erasing proposal from storage.
+    #[error("error writing proposal to storage")]
+    Storage(StorageError),
 }

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -107,9 +107,6 @@ pub enum ProcessMessageError {
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
     GroupStateError(#[from] MlsGroupStateError),
-    /// The message's signature is invalid.
-    #[error("The message's signature is invalid.")]
-    InvalidSignature,
     /// See [`StageCommitError`] for more details.
     #[error(transparent)]
     InvalidCommit(#[from] StageCommitError),

--- a/openmls/src/group/mls_group/exporting.rs
+++ b/openmls/src/group/mls_group/exporting.rs
@@ -18,7 +18,7 @@ impl MlsGroup {
         label: &str,
         context: &[u8],
         key_length: usize,
-    ) -> Result<Vec<u8>, ExportSecretError<Provider::StorageError>> {
+    ) -> Result<Vec<u8>, ExportSecretError> {
         let crypto = provider.crypto();
 
         if self.is_active() {
@@ -58,7 +58,7 @@ impl MlsGroup {
         provider: &Provider,
         signer: &impl Signer,
         with_ratchet_tree: bool,
-    ) -> Result<MlsMessageOut, ExportGroupInfoError<Provider::StorageError>> {
+    ) -> Result<MlsMessageOut, ExportGroupInfoError> {
         Ok(self
             .group
             .export_group_info(provider.crypto(), signer, with_ratchet_tree)?

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -254,7 +254,7 @@ impl MlsGroup {
                 &queued_remove_proposal.proposal_reference(),
                 &queued_remove_proposal,
             )
-            .map_err(MlsGroupStateError::StorageError)?;
+            .map_err(LeaveGroupError::StorageError)?;
 
         self.proposal_store_mut().add(queued_remove_proposal);
 

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -225,9 +225,7 @@ impl MlsGroup {
 
     /// Returns own credential. If the group is inactive, it returns a
     /// `UseAfterEviction` error.
-    pub fn credential<Provider: OpenMlsProvider>(
-        &self,
-    ) -> Result<&Credential, MlsGroupStateError<Provider::StorageError>> {
+    pub fn credential(&self) -> Result<&Credential, MlsGroupStateError> {
         if !self.is_active() {
             return Err(MlsGroupStateError::UseAfterEviction);
         }
@@ -439,7 +437,7 @@ impl MlsGroup {
 
     /// Check if the group is operational. Throws an error if the group is
     /// inactive or if there is a pending commit.
-    fn is_operational<StorageError>(&self) -> Result<(), MlsGroupStateError<StorageError>> {
+    fn is_operational(&self) -> Result<(), MlsGroupStateError> {
         match self.group_state {
             MlsGroupState::PendingCommit(_) => Err(MlsGroupStateError::PendingCommit),
             MlsGroupState::Inactive => Err(MlsGroupStateError::UseAfterEviction),

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -28,7 +28,7 @@ impl MlsGroup {
         &mut self,
         provider: &Provider,
         message: impl Into<ProtocolMessage>,
-    ) -> Result<ProcessedMessage, ProcessMessageError<Provider::StorageError>> {
+    ) -> Result<ProcessedMessage, ProcessMessageError> {
         // Make sure we are still a member of the group
         if !self.is_active() {
             return Err(ProcessMessageError::GroupStateError(

--- a/openmls/src/group/mls_group/proposal.rs
+++ b/openmls/src/group/mls_group/proposal.rs
@@ -4,7 +4,7 @@ use super::{
     core_group::create_commit_params::CreateCommitParams,
     errors::{ProposalError, ProposeAddMemberError, ProposeRemoveMemberError},
     CreateGroupContextExtProposalError, CustomProposal, GroupContextExtensionProposal, MlsGroup,
-    MlsGroupState, MlsGroupStateError, PendingCommitState, Proposal,
+    MlsGroupState, PendingCommitState, Proposal, RemoveProposalError,
 };
 use crate::{
     binary_tree::LeafNodeIndex,
@@ -450,12 +450,12 @@ impl MlsGroup {
         &mut self,
         storage: &Storage,
         proposal_ref: &ProposalRef,
-    ) -> Result<(), MlsGroupStateError<Storage::Error>> {
+    ) -> Result<(), RemoveProposalError<Storage::Error>> {
         storage
             .remove_proposal(self.group_id(), proposal_ref)
-            .map_err(MlsGroupStateError::StorageError)?;
+            .map_err(RemoveProposalError::Storage)?;
         self.proposal_store_mut()
             .remove(proposal_ref)
-            .ok_or(MlsGroupStateError::PendingProposalNotFound)
+            .ok_or(RemoveProposalError::ProposalNotFound)
     }
 }

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -1113,7 +1113,7 @@ fn remove_prosposal_by_ref(
     let err = alice_group
         .remove_pending_proposal(provider.storage(), &reference)
         .unwrap_err();
-    assert!(matches!(err, MlsGroupStateError::PendingProposalNotFound));
+    assert!(matches!(err, RemoveProposalError::ProposalNotFound));
 
     // the commit should have no proposal
     let (commit, _, _) = alice_group

--- a/openmls/src/group/public_group/tests.rs
+++ b/openmls/src/group/public_group/tests.rs
@@ -73,7 +73,7 @@ fn public_group<Provider: OpenMlsProvider>(ciphersuite: Ciphersuite, provider: &
         ProtocolMessage::PublicMessage(public_message) => public_message,
     };
     let processed_message = public_group
-        .process_message(provider, public_message)
+        .process_message(provider.crypto(), public_message)
         .unwrap();
 
     // Further inspection of the message can take place here ...
@@ -135,7 +135,7 @@ fn public_group<Provider: OpenMlsProvider>(ciphersuite: Ciphersuite, provider: &
 
     // The public group processes
     let ppm = public_group
-        .process_message(provider, into_public_message(queued_messages))
+        .process_message(provider.crypto(), into_public_message(queued_messages))
         .unwrap();
     public_group
         .merge_commit(provider.storage(), extract_staged_commit(ppm))
@@ -179,7 +179,7 @@ fn public_group<Provider: OpenMlsProvider>(ciphersuite: Ciphersuite, provider: &
 
     // The public group processes
     let ppm = public_group
-        .process_message(provider, into_public_message(queued_messages))
+        .process_message(provider.crypto(), into_public_message(queued_messages))
         .unwrap();
     // We have to add the proposal to the public group's proposal store.
     match ppm.into_content() {
@@ -226,7 +226,10 @@ fn public_group<Provider: OpenMlsProvider>(ciphersuite: Ciphersuite, provider: &
 
     // The public group processes
     let ppm = public_group
-        .process_message(provider, into_public_message(queued_messages.clone()))
+        .process_message(
+            provider.crypto(),
+            into_public_message(queued_messages.clone()),
+        )
         .unwrap();
     public_group
         .merge_commit(provider.storage(), extract_staged_commit(ppm))

--- a/openmls/src/group/public_group/tests.rs
+++ b/openmls/src/group/public_group/tests.rs
@@ -51,7 +51,8 @@ fn public_group<Provider: OpenMlsProvider>(ciphersuite: Ciphersuite, provider: &
         .unwrap();
     let ratchet_tree = alice_group.export_ratchet_tree();
     let (mut public_group, _extensions) = PublicGroup::from_external(
-        provider,
+        provider.crypto(),
+        provider.storage(),
         ratchet_tree.into(),
         verifiable_group_info,
         ProposalStore::new(),

--- a/openmls/src/group/tests_and_kats/tests/external_add_proposal.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_add_proposal.rs
@@ -269,7 +269,7 @@ fn external_add_proposal_should_be_signed_by_key_package_it_references<
         alice_group
             .process_message(provider, invalid_proposal.into_protocol_message().unwrap())
             .unwrap_err(),
-        ProcessMessageError::InvalidSignature
+        ProcessMessageError::ValidationError(ValidationError::InvalidSignature)
     ));
 }
 

--- a/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
@@ -509,7 +509,10 @@ fn test_valsem246() {
 
     // This shows that signature verification fails if the signature is not done
     // using the credential in the path.
-    assert!(matches!(err, ProcessMessageError::InvalidSignature));
+    assert!(matches!(
+        err,
+        ProcessMessageError::ValidationError(ValidationError::InvalidSignature)
+    ));
 
     // This shows that the credential in the original path key package is actually bob's credential.
     let commit = if let FramedContentBody::Commit(commit) = public_message_commit.content() {

--- a/openmls/src/group/tests_and_kats/tests/external_remove_proposal.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_remove_proposal.rs
@@ -316,7 +316,10 @@ fn external_remove_proposal_should_fail_when_invalid_signature() {
                 .unwrap(),
         )
         .unwrap_err();
-    assert!(matches!(error, ProcessMessageError::InvalidSignature));
+    assert!(matches!(
+        error,
+        ProcessMessageError::ValidationError(ValidationError::InvalidSignature)
+    ));
 }
 
 #[openmls_test]

--- a/openmls/src/group/tests_and_kats/tests/framing_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/framing_validation.rs
@@ -647,7 +647,10 @@ fn test_valsem010() {
         .process_message(provider, message_in)
         .expect_err("Could process message despite wrong signature.");
 
-    assert!(matches!(err, ProcessMessageError::InvalidSignature));
+    assert!(matches!(
+        err,
+        ProcessMessageError::ValidationError(ValidationError::InvalidSignature)
+    ));
 
     // Positive case
     bob_group

--- a/openmls/src/group/tests_and_kats/tests/group_context_extensions.rs
+++ b/openmls/src/group/tests_and_kats/tests/group_context_extensions.rs
@@ -235,10 +235,7 @@ impl<Provider: crate::storage::OpenMlsProvider> MemberState<Provider> {
     }
 
     /// This wrapper that expects [`MlsGroup::process_message`] to return an error.
-    fn fail_processing(
-        &mut self,
-        msg: MlsMessageIn,
-    ) -> ProcessMessageError<Provider::StorageError> {
+    fn fail_processing(&mut self, msg: MlsMessageIn) -> ProcessMessageError {
         let msg = msg.into_protocol_message().unwrap();
         let err_msg = format!(
             "expected an error when processing message at {}",

--- a/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
@@ -1263,11 +1263,9 @@ fn test_valsem105() {
                 KeyPackageTestVersion::ValidTestCase => {
                     assert!(matches!(
                         err,
-                        ProcessMessageError::<<Provider as OpenMlsProvider>::StorageError>::InvalidCommit(
-                            StageCommitError::UpdatePathError(
-                                ApplyUpdatePathError::PathLengthMismatch,
-                            ),
-                        )
+                        ProcessMessageError::InvalidCommit(StageCommitError::UpdatePathError(
+                            ApplyUpdatePathError::PathLengthMismatch,
+                        ),)
                     ));
                 }
                 KeyPackageTestVersion::WrongCiphersuite => {
@@ -1279,21 +1277,21 @@ fn test_valsem105() {
                     assert!(
                         matches!(
                             err,
-                            ProcessMessageError::<<Provider as OpenMlsProvider>::StorageError>::InvalidCommit(
+                            ProcessMessageError::InvalidCommit(
                                 StageCommitError::ProposalValidationError(
                                     ProposalValidationError::InvalidAddProposalCiphersuiteOrVersion,
                                 ),
                             )
                         ) || matches!(
                             err,
-                            ProcessMessageError::<<Provider as OpenMlsProvider>::StorageError>::ValidationError(
+                            ProcessMessageError::ValidationError(
                                 ValidationError::KeyPackageVerifyError(
                                     KeyPackageVerifyError::InvalidLeafNodeSignature,
                                 ),
                             )
                         ) || matches!(
                             err,
-                            ProcessMessageError::<<Provider as OpenMlsProvider>::StorageError>::ValidationError(
+                            ProcessMessageError::ValidationError(
                                 ValidationError::InvalidAddProposalCiphersuite,
                             )
                         )
@@ -1306,14 +1304,14 @@ fn test_valsem105() {
                     assert!(
                         matches!(
                             err,
-                            ProcessMessageError::<<Provider as OpenMlsProvider>::StorageError>::InvalidCommit(
+                            ProcessMessageError::InvalidCommit(
                                 StageCommitError::ProposalValidationError(
                                     ProposalValidationError::InvalidAddProposalCiphersuiteOrVersion,
                                 ),
                             )
                         ) || matches!(
                             err,
-                            ProcessMessageError::<<Provider as OpenMlsProvider>::StorageError>::ValidationError(
+                            ProcessMessageError::ValidationError(
                                 ValidationError::KeyPackageVerifyError(
                                     KeyPackageVerifyError::InvalidProtocolVersion,
                                 ),
@@ -1325,14 +1323,14 @@ fn test_valsem105() {
                     assert!(
                         matches!(
                             err,
-                            ProcessMessageError::<<Provider as OpenMlsProvider>::StorageError>::ValidationError(
+                            ProcessMessageError::ValidationError(
                                 ValidationError::KeyPackageVerifyError(
                                     KeyPackageVerifyError::InvalidProtocolVersion,
                                 ),
                             )
                         ) || matches!(
                             err,
-                            ProcessMessageError::<<Provider as OpenMlsProvider>::StorageError>::InvalidCommit(
+                            ProcessMessageError::InvalidCommit(
                                 StageCommitError::ProposalValidationError(
                                     ProposalValidationError::InsufficientCapabilities,
                                 ),
@@ -1343,7 +1341,7 @@ fn test_valsem105() {
                 KeyPackageTestVersion::UnsupportedCiphersuite => {
                     assert!(matches!(
                         err,
-                        ProcessMessageError::<<Provider as OpenMlsProvider>::StorageError>::InvalidCommit(
+                        ProcessMessageError::InvalidCommit(
                             StageCommitError::ProposalValidationError(
                                 ProposalValidationError::InsufficientCapabilities,
                             ),
@@ -2275,10 +2273,7 @@ fn test_valsem401_valsem402() {
     let bob_provider = Provider::default();
 
     // TODO(#1354): This is currently not tested because we can't easily create invalid commits.
-    let bad_psks: [(
-        Vec<PreSharedKeyId>,
-        ProcessMessageError<<Provider as OpenMlsProvider>::StorageError>,
-    ); 0] = [
+    let bad_psks: [(Vec<PreSharedKeyId>, ProcessMessageError); 0] = [
         // // ValSem401
         // (
         //     vec![PreSharedKeyId::external(

--- a/openmls/src/test_utils/test_framework/client.rs
+++ b/openmls/src/test_utils/test_framework/client.rs
@@ -157,7 +157,9 @@ impl<Provider: OpenMlsProvider> Client<Provider> {
                 group_state.clear_pending_commit(self.provider.storage())?;
             }
             // Process the message.
-            let processed_message = group_state.process_message(&self.provider, message.clone())?;
+            let processed_message = group_state
+                .process_message(&self.provider, message.clone())
+                .map_err(ClientError::ProcessMessageError)?;
 
             match processed_message.into_content() {
                 ProcessedMessageContent::ApplicationMessage(_) => {}

--- a/openmls/src/test_utils/test_framework/errors.rs
+++ b/openmls/src/test_utils/test_framework/errors.rs
@@ -23,7 +23,7 @@ pub enum SetupError<StorageError> {
     ClientError(#[from] ClientError<StorageError>),
     /// See [`ExportSecretError`] for more details.
     #[error(transparent)]
-    ExportSecretError(#[from] ExportSecretError<StorageError>),
+    ExportSecretError(#[from] ExportSecretError),
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
@@ -56,11 +56,8 @@ pub enum ClientError<StorageError> {
     #[error(transparent)]
     TlsCodecError(tls_codec::Error),
     /// See [`ProcessMessageError`] for more details.
-    #[error(transparent)]
-    ProcessMessageError(#[from] ProcessMessageError<StorageError>),
-    /// See [`MlsGroupStateError`] for more details.
-    #[error(transparent)]
-    MlsGroupStateError(#[from] MlsGroupStateError<StorageError>),
+    #[error("See ProcessMessageError for more details.")]
+    ProcessMessageError(ProcessMessageError),
     /// See [`AddMembersError`] for more details.
     #[error(transparent)]
     AddMembersError(#[from] AddMembersError<StorageError>),
@@ -74,8 +71,8 @@ pub enum ClientError<StorageError> {
     #[error(transparent)]
     ProposeRemoveMemberError(#[from] ProposeRemoveMemberError<StorageError>),
     /// See [`ExportSecretError`] for more details.
-    #[error(transparent)]
-    ExportSecretError(#[from] ExportSecretError<StorageError>),
+    #[error("Error exporting secret")]
+    ExportSecretError(ExportSecretError),
     /// See [`NewGroupError`] for more details.
     #[error(transparent)]
     NewGroupError(#[from] NewGroupError<StorageError>),

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -354,7 +354,9 @@ impl<Provider: OpenMlsProvider + Default> MlsGroupTestSetup<Provider> {
             )
             .collect();
         group.public_tree = sender_group.export_ratchet_tree();
-        group.exporter_secret = sender_group.export_secret(&sender.provider, "test", &[], 32)?;
+        group.exporter_secret = sender_group
+            .export_secret(&sender.provider, "test", &[], 32)
+            .map_err(ClientError::ExportSecretError)?;
         Ok(())
     }
 

--- a/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
@@ -364,7 +364,7 @@ pub fn run_test_vector(
                 .parse_message(decrypted_message, group.group().message_secrets_store())
                 .unwrap();
             let processed_message: AuthenticatedContent = processed_unverified_message
-                .verify(ciphersuite, provider, ProtocolVersion::Mls10)
+                .verify(ciphersuite, provider.crypto(), ProtocolVersion::Mls10)
                 .unwrap()
                 .0;
             match processed_message.content().to_owned() {

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -1117,9 +1117,7 @@ fn book_operations() {
         assert_eq!(sender_cred_from_msg, sender_cred_from_group);
         assert_eq!(
             &sender_cred_from_msg,
-            alice_group
-                .credential::<Provider>()
-                .expect("Expected a credential.")
+            alice_group.credential().expect("Expected a credential.")
         );
     } else {
         unreachable!("Expected an ApplicationMessage.");

--- a/openmls/tests/mls_group.rs
+++ b/openmls/tests/mls_group.rs
@@ -176,7 +176,7 @@ fn mls_group_operations() {
             assert_eq!(
                 &sender,
                 alice_group
-                    .credential::<Provider>()
+                    .credential()
                     .expect("An unexpected error occurred.")
             );
         } else {
@@ -805,9 +805,7 @@ fn mls_group_operations() {
             // Check that Alice sent the message
             assert_eq!(
                 &sender,
-                alice_group
-                    .credential::<Provider>()
-                    .expect("Expected a credential")
+                alice_group.credential().expect("Expected a credential")
             );
         } else {
             unreachable!("Expected an ApplicationMessage.");


### PR DESCRIPTION
It was impossible to instantiate a `PublicGroup` without implementing a full `StorageProvider` (via `OpenMlsProvider`), this PR removes that requirement.