### PR TITLE
Fix Missing Persisting of Message Secrets

### DIFF
--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -3,7 +3,7 @@ use core_group::proposals::QueuedProposal;
 use crate::{
     framing::mls_content::FramedContentBody,
     group::{
-        errors::{MergeCommitError, StageCommitError, ValidationError},
+        errors::{StageCommitError, ValidationError},
         mls_group::errors::ProcessMessageError,
     },
 };

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -284,27 +284,4 @@ impl CoreGroup {
 
         Ok((old_epoch_keypairs, leaf_node_keypairs))
     }
-
-    /// Merge a [StagedCommit] into the group after inspection
-    pub(crate) fn merge_staged_commit<Provider: OpenMlsProvider>(
-        &mut self,
-        provider: &Provider,
-        staged_commit: StagedCommit,
-    ) -> Result<(), MergeCommitError<Provider::StorageError>> {
-        // Save the past epoch
-        let past_epoch = self.context().epoch();
-        // Get all the full leaves
-        let leaves = self.public_group().members().collect();
-        // Merge the staged commit into the group state and store the secret tree from the
-        // previous epoch in the message secrets store.
-        if let Some(message_secrets) = self.merge_commit(provider, staged_commit)? {
-            self.message_secrets_store
-                .add(past_epoch, message_secrets, leaves);
-        }
-        provider
-            .storage()
-            .write_message_secrets(self.group_id(), &self.message_secrets_store)
-            .map_err(MergeCommitError::StorageError)?;
-        Ok(())
-    }
 }

--- a/openmls/src/group/core_group/process.rs
+++ b/openmls/src/group/core_group/process.rs
@@ -301,6 +301,10 @@ impl CoreGroup {
             self.message_secrets_store
                 .add(past_epoch, message_secrets, leaves);
         }
+        provider
+            .storage()
+            .write_message_secrets(self.group_id(), &self.message_secrets_store)
+            .map_err(MergeCommitError::StorageError)?;
         Ok(())
     }
 }

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -142,7 +142,7 @@ impl MlsGroup {
             .map_err(MergeCommitError::StorageError)?;
 
         // Merge staged commit
-        self.group.merge_staged_commit(provider, staged_commit)?;
+        self.group.merge_commit(provider, staged_commit)?;
 
         // Extract and store the resumption psk for the current epoch
         let resumption_psk = self.group.group_epoch_secrets().resumption_psk();


### PR DESCRIPTION
In `CoreGroup::merge_staged_commit` we forgot persisting the new message secrets. This PR addresses this. As part of testing this, I also updated the test to use separate providers for different group members.