### PR TITLE
Add check and (basic) test for check 701: remove can't contain inde to blank leaf

### DIFF
--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -424,7 +424,7 @@ impl PublicGroup {
                 return Err(ProposalValidationError::UnknownMemberRemoval);
             }
 
-            // removed node can not be blank (check 701)
+            // valn0701: removed node can not be blank
             if self.treesync().leaf(removed).is_none() {
                 return Err(ProposalValidationError::UnknownMemberRemoval);
             }

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -423,6 +423,11 @@ impl PublicGroup {
             if !self.treesync().is_leaf_in_tree(removed) {
                 return Err(ProposalValidationError::UnknownMemberRemoval);
             }
+
+            // removed node can not be blank (check 701)
+            if self.treesync().leaf(removed).is_none() {
+                return Err(ProposalValidationError::UnknownMemberRemoval);
+            }
         }
 
         Ok(())

--- a/openmls/src/group/tests_and_kats/tests/remove_operation.rs
+++ b/openmls/src/group/tests_and_kats/tests/remove_operation.rs
@@ -83,7 +83,7 @@ fn remove_blank() {
         .into_welcome()
         .expect("expected message to be a welcome");
 
-    let mut bob_group = StagedWelcome::new_from_welcome(
+    let bob_group = StagedWelcome::new_from_welcome(
         bob_provider,
         mls_group_create_config.join_config(),
         welcome.clone(),
@@ -91,16 +91,6 @@ fn remove_blank() {
     )
     .expect("Error creating staged join from Welcome")
     .into_group(bob_provider)
-    .expect("Error creating group from staged join");
-
-    let mut charlie_group = StagedWelcome::new_from_welcome(
-        charlie_provider,
-        mls_group_create_config.join_config(),
-        welcome,
-        Some(alice_group.export_ratchet_tree().into()),
-    )
-    .expect("Error creating staged join from Welcome")
-    .into_group(charlie_provider)
     .expect("Error creating group from staged join");
 
     // === Remove operation ===


### PR DESCRIPTION
This PR adds check 701 from [the dashboard](https://validation.openmls.tech/) and a basic test. It doesn't properly test validation for incoming messages, because I wanted more checks done instead of futzing with Frankenstein messages for now.