### PR TITLE
Add test for incorrect max_past_epochs value

### DIFF
--- a/openmls/src/group/mls_group/past_secrets.rs
+++ b/openmls/src/group/mls_group/past_secrets.rs
@@ -21,7 +21,7 @@ struct EpochTree {
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
 pub(crate) struct MessageSecretsStore {
     // Maximum size of the `past_epoch_trees` list.
-    max_epochs: usize,
+    pub(crate) max_epochs: usize,
     // Past message secrets.
     past_epoch_trees: VecDeque<EpochTree>,
     // The message secrets of the current epoch.

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -1156,6 +1156,34 @@ fn remove_prosposal_by_ref(
     }
 }
 
+#[openmls_test]
+fn max_past_epochs_join_config(
+    ciphersuite: Ciphersuite,
+    provider: &impl crate::storage::OpenMlsProvider,
+) {
+    let max_past_epochs = 10;
+
+    let create_config = MlsGroupCreateConfig::builder()
+        .max_past_epochs(max_past_epochs)
+        .build();
+
+    let (alice_credential_with_key, _alice_kpb, alice_signer, _alice_pk) =
+        setup_client("Alice", ciphersuite, provider);
+
+    let alice_group = MlsGroup::new(
+        provider,
+        &alice_signer,
+        &create_config,
+        alice_credential_with_key,
+    )
+    .expect("failed to create group");
+
+    assert_eq!(
+        alice_group.message_secrets_store.max_epochs,
+        max_past_epochs
+    );
+}
+
 // Test that the builder pattern accurately configures the new group.
 #[openmls_test]
 fn builder_pattern() {


### PR DESCRIPTION
We noticed that there was an issue with the `max_past_epochs` flag being respected in the `MlsGroupCreateConfig`. Members of the group joining from a Welcome would see the specified value, but the group creator would always have a `max_past_epochs` set to 0.

This is because when the `MlsGroupBuilder::build` method is run, it uses the `max_past_epochs` flag from the builder instead of the `MlsGroupCreateConfig`

[This is how we fixed it](https://github.com/xmtp/openmls/pull/38/commits/043b347cb18d528647df36f500725ab57c41c7db) in our fork, but you may want to handle differently. Is the `max_past_epochs` flag on the `MlsGroupBuilder` even necessary with the group create config. From my cursory look, it seems to be always `None`.