### PR TITLE
Upstream some changes from XMTP

### DIFF
--- a/openmls/src/ciphersuite/hpke.rs
+++ b/openmls/src/ciphersuite/hpke.rs
@@ -68,6 +68,7 @@ impl From<CryptoError> for Error {
     }
 }
 
+/// Context for HPKE encryption
 #[derive(Debug, Clone, TlsSerialize, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
 pub struct EncryptContext {
     label: VLBytes,

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -601,7 +601,7 @@ mod test {
 
     #[test]
     fn that_unknown_extensions_are_de_serialized_correctly() {
-        let extension_types = [0x0000u16, 0x0A0A, 0x7A7A, 0xF000, 0xFFFF];
+        let extension_types = [0x0000u16, 0x0A0A, 0x7A7A, 0xF100, 0xFFFF];
         let extension_datas = [vec![], vec![0], vec![1, 2, 3]];
 
         for extension_type in extension_types.into_iter() {

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -27,7 +27,6 @@ use super::{past_secrets::MessageSecretsStore, MlsGroup, MlsGroupState};
 pub struct MlsGroupBuilder {
     group_id: Option<GroupId>,
     mls_group_create_config_builder: MlsGroupCreateConfigBuilder,
-    max_past_epochs: Option<usize>,
     psk_ids: Vec<PreSharedKeyId>,
 }
 
@@ -136,7 +135,7 @@ impl MlsGroupBuilder {
             .map_err(LibraryError::unexpected_crypto_error)?;
 
         let message_secrets_store = MessageSecretsStore::new_with_secret(
-            self.max_past_epochs.unwrap_or_default(),
+            mls_group_create_config.max_past_epochs(),
             message_secrets,
         );
 

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -136,8 +136,7 @@ impl MlsGroupBuilder {
             .map_err(LibraryError::unexpected_crypto_error)?;
 
         let message_secrets_store = MessageSecretsStore::new_with_secret(
-            self.max_past_epochs
-                .unwrap_or(mls_group_create_config.max_past_epochs()),
+            self.max_past_epochs.unwrap_or_default(),
             message_secrets,
         );
 

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -136,7 +136,8 @@ impl MlsGroupBuilder {
             .map_err(LibraryError::unexpected_crypto_error)?;
 
         let message_secrets_store = MessageSecretsStore::new_with_secret(
-            self.max_past_epochs.unwrap_or_default(),
+            self.max_past_epochs
+                .unwrap_or(mls_group_create_config.max_past_epochs()),
             message_secrets,
         );
 

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -275,6 +275,22 @@ impl MlsGroup {
             .leaf(leaf_index)
             .map(|leaf| leaf.credential())
     }
+
+    /// Returns the [`Member`] corresponding to the given
+    /// leaf index. Returns `None` if the member can not be found in this group.
+    pub fn member_at(&self, leaf_index: LeafNodeIndex) -> Option<Member> {
+        self.public_group()
+            // This will return an error if the member can't be found.
+            .leaf(leaf_index)
+            .map(|leaf_node| {
+                Member::new(
+                    leaf_index,
+                    leaf_node.encryption_key().as_slice().to_vec(),
+                    leaf_node.signature_key().as_slice().to_vec(),
+                    leaf_node.credential().clone(),
+                )
+            })
+    }
 }
 
 /// Helper `enum` that classifies the kind of remove operation. This can be used to

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -280,7 +280,7 @@ impl MlsGroup {
     /// leaf index. Returns `None` if the member can not be found in this group.
     pub fn member_at(&self, leaf_index: LeafNodeIndex) -> Option<Member> {
         self.public_group()
-            // This will return an error if the member can't be found.
+            // This will return None if the member can't be found.
             .leaf(leaf_index)
             .map(|leaf_node| {
                 Member::new(

--- a/openmls/src/key_packages/lifetime.rs
+++ b/openmls/src/key_packages/lifetime.rs
@@ -74,7 +74,7 @@ impl Lifetime {
     }
 
     /// Returns true if this lifetime is valid.
-    pub(crate) fn is_valid(&self) -> bool {
+    pub fn is_valid(&self) -> bool {
         match SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|duration| duration.as_secs())
@@ -92,6 +92,16 @@ impl Lifetime {
     /// and reject any LeafNode where the total lifetime is longer than this duration.
     pub fn has_acceptable_range(&self) -> bool {
         self.not_after.saturating_sub(self.not_before) <= MAX_LEAF_NODE_LIFETIME_RANGE_SECONDS
+    }
+
+    /// Returns the "not before" timestamp of the KeyPackage.
+    pub fn not_before(&self) -> u64 {
+        self.not_before
+    }
+
+    /// Returns the "not after" timestamp of the KeyPackage.
+    pub fn not_after(&self) -> u64 {
+        self.not_after
     }
 }
 

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -401,6 +401,11 @@ impl KeyPackage {
     pub fn last_resort(&self) -> bool {
         self.payload.extensions.contains(ExtensionType::LastResort)
     }
+
+    /// Get the lifetime of the KeyPackage
+    pub fn life_time(&self) -> &Lifetime {
+        self.payload.leaf_node.life_time().unwrap()
+    }
 }
 
 /// Crate visible `KeyPackage` functions.

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -404,6 +404,9 @@ impl KeyPackage {
 
     /// Get the lifetime of the KeyPackage
     pub fn life_time(&self) -> &Lifetime {
+        // Leaf nodes contain a lifetime if an only if they are inside a KeyPackage. Since we are
+        // in a KeyPackage, this can never be None and unwrap is safe.
+        // TODO: get rid of the unwrap, see https://github.com/openmls/openmls/issues/1663.
         self.payload.leaf_node.life_time().unwrap()
     }
 }

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -494,7 +494,7 @@ impl GroupContextExtensionProposal {
     }
 
     /// Get the extensions of the proposal
-    pub(crate) fn extensions(&self) -> &Extensions {
+    pub fn extensions(&self) -> &Extensions {
         &self.extensions
     }
 }


### PR DESCRIPTION
XMTP has been maintaining their own fork of OpenMLS. Here we take some of their changes and bring them back into this tree. We are also looking at making it easier to build commits with multiple kinds of proposals, but would prefer a different API.

This PR also incorporates XMTP's fix for the test submitted in #1660.