### PR TITLE
Fix docs link

### DIFF
--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "openmls"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["OpenMLS Authors"]
 edition = "2021"
 description = "A Rust implementation of the Messaging Layer Security (MLS) protocol, as defined in RFC 9420."
 license = "MIT"
-documentation = "https://openmls.github.io/openmls/"
+documentation = "https://docs.rs/openmls"
 repository = "https://github.com/openmls/openmls/"
 readme = "../README.md"
 keywords = ["MLS", "IETF", "RFC9420", "Encryption", "E2EE"]


### PR DESCRIPTION
The docs link of the openmls pointed at github. That's broken now. But it should really link to docs.rs.