### PR TITLE
Correctly Look Up Credentials and Public Keys for Members for Previous Epochs

### DIFF
--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -33,7 +33,7 @@ use tls_codec::{
 #[cfg(test)]
 mod tests;
 
-use crate::ciphersuite::SignaturePublicKey;
+use crate::{ciphersuite::SignaturePublicKey, group::Member, treesync::LeafNode};
 use errors::*;
 
 // Public
@@ -295,6 +295,24 @@ pub struct CredentialWithKey {
     pub credential: Credential,
     /// The corresponding public key as [`SignaturePublicKey`].
     pub signature_key: SignaturePublicKey,
+}
+
+impl From<&LeafNode> for CredentialWithKey {
+    fn from(leaf_node: &LeafNode) -> Self {
+        Self {
+            credential: leaf_node.credential().clone(),
+            signature_key: leaf_node.signature_key().clone(),
+        }
+    }
+}
+
+impl From<&Member> for CredentialWithKey {
+    fn from(member: &Member) -> Self {
+        Self {
+            credential: member.credential.clone(),
+            signature_key: member.signature_key.clone().into(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -33,7 +33,6 @@ use crate::{
     extensions::ExternalSendersExtension,
     group::{errors::ValidationError, mls_group::staged_commit::StagedCommit},
     tree::sender_ratchet::SenderRatchetConfiguration,
-    treesync::TreeSync,
     versions::ProtocolVersion,
 };
 
@@ -149,6 +148,11 @@ impl DecryptedMessage {
     }
 
     /// Gets the correct credential from the message depending on the sender type.
+    ///
+    /// The closure argument is used to look up the credential and signature key. If the epoch of
+    /// the message is the same as that of the group, look it up in the tree; else, look in up in
+    /// the past trees of the message secret store.
+    ///
     /// Checks the following semantic validation:
     ///  - ValSem112
     ///  - ValSem245
@@ -158,50 +162,13 @@ impl DecryptedMessage {
     /// Returns the [`Credential`] and the leaf's [`SignaturePublicKey`].
     pub(crate) fn credential(
         &self,
-        treesync: &TreeSync,
-        old_leaves: &[Member],
+        look_up_credential_with_key: impl Fn(LeafNodeIndex) -> Option<CredentialWithKey>,
         external_senders: Option<&ExternalSendersExtension>,
     ) -> Result<CredentialWithKey, ValidationError> {
         let sender = self.sender();
         match sender {
             Sender::Member(leaf_index) => {
-                match treesync.leaf(*leaf_index) {
-                    Some(sender_leaf) => {
-                        let credential = sender_leaf.credential().clone();
-                        let pk = sender_leaf.signature_key().clone();
-                        Ok(CredentialWithKey {
-                            credential,
-                            signature_key: pk,
-                        })
-                    }
-                    None => {
-                        // This might not actually be an error but the sender's
-                        // key package changed. Let's check old leaves we still
-                        // have around.
-                        // TODO: As part of #819 looking up old leaves changes.
-                        //       Just checking the index is probably not enough.
-                        //       Revisit when the transition is further along
-                        //       and we have better test cases.
-                        if let Some(Member { index, .. }) = old_leaves
-                            .iter()
-                            .find(|&old_member| *leaf_index == old_member.index)
-                        {
-                            match treesync.leaf(*index) {
-                                Some(node) => {
-                                    let credential = node.credential().clone();
-                                    let signature_key = node.signature_key().clone();
-                                    Ok(CredentialWithKey {
-                                        credential,
-                                        signature_key,
-                                    })
-                                }
-                                None => Err(ValidationError::UnknownMember),
-                            }
-                        } else {
-                            Err(ValidationError::UnknownMember)
-                        }
-                    }
-                }
+                look_up_credential_with_key(*leaf_index).ok_or(ValidationError::UnknownMember)
             }
             Sender::External(index) => {
                 let sender = external_senders

--- a/openmls/src/group/public_group/process.rs
+++ b/openmls/src/group/public_group/process.rs
@@ -17,7 +17,6 @@ use crate::{
         past_secrets::MessageSecretsStore, proposal_store::QueuedProposal,
     },
     messages::proposals::Proposal,
-    prelude::SignaturePublicKey,
 };
 
 use super::PublicGroup;
@@ -60,18 +59,12 @@ impl PublicGroup {
             if message_epoch == self.group_context().epoch() {
                 self.treesync()
                     .leaf(leaf_node_index)
-                    .map(|leaf| CredentialWithKey {
-                        credential: leaf.credential().clone(),
-                        signature_key: leaf.signature_key().clone(),
-                    })
+                    .map(CredentialWithKey::from)
             } else if let Some(store) = message_secrets_store_option {
                 store
                     .leaves_for_epoch(message_epoch)
                     .get(leaf_node_index.u32() as usize)
-                    .map(|member| CredentialWithKey {
-                        credential: member.credential.clone(),
-                        signature_key: SignaturePublicKey::from(member.signature_key.clone()),
-                    })
+                    .map(CredentialWithKey::from)
             } else {
                 None
             }

--- a/openmls/src/group/tests_and_kats/tests/group.rs
+++ b/openmls/src/group/tests_and_kats/tests/group.rs
@@ -689,8 +689,6 @@ fn decrypt_after_leaf_index_reuse() {
         _ => unreachable!(),
     };
 
-    println!("{}", group_bob.epoch());
-
     let charlie_protocol_message = charlie_msg.into_protocol_message().unwrap();
 
     let _bob_incoming_appmsg = group_bob

--- a/openmls/src/group/tests_and_kats/tests/group.rs
+++ b/openmls/src/group/tests_and_kats/tests/group.rs
@@ -569,6 +569,7 @@ fn decrypt_after_leaf_index_reuse() {
     // Alice creates a group
     let mut group_alice = MlsGroup::builder()
         .ciphersuite(ciphersuite)
+        .max_past_epochs(5)
         .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .build(
             &alice_provider,
@@ -623,6 +624,7 @@ fn decrypt_after_leaf_index_reuse() {
         &bob_provider,
         &MlsGroupJoinConfig::builder()
             .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .max_past_epochs(5)
             .build(),
         welcome.clone(),
         Some(group_alice.export_ratchet_tree().into()),
@@ -634,6 +636,7 @@ fn decrypt_after_leaf_index_reuse() {
         &charlie_provider,
         &MlsGroupJoinConfig::builder()
             .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .max_past_epochs(5)
             .build(),
         welcome,
         Some(group_alice.export_ratchet_tree().into()),
@@ -666,6 +669,8 @@ fn decrypt_after_leaf_index_reuse() {
         .stage_commit(&alice_provider)
         .unwrap();
 
+    group_alice.merge_pending_commit(&alice_provider).unwrap();
+
     let bob_incoming_commit = group_bob
         .process_message(
             &bob_provider,
@@ -684,7 +689,11 @@ fn decrypt_after_leaf_index_reuse() {
         _ => unreachable!(),
     };
 
+    println!("{}", group_bob.epoch());
+
+    let charlie_protocol_message = charlie_msg.into_protocol_message().unwrap();
+
     let _bob_incoming_appmsg = group_bob
-        .process_message(&bob_provider, charlie_msg.into_protocol_message().unwrap())
+        .process_message(&bob_provider, charlie_protocol_message)
         .unwrap();
 }

--- a/openmls/src/group/tests_and_kats/tests/group.rs
+++ b/openmls/src/group/tests_and_kats/tests/group.rs
@@ -1,5 +1,6 @@
 use crate::{framing::*, group::*, test_utils::*, *};
 use mls_group::tests_and_kats::utils::{setup_alice_bob, setup_alice_bob_group, setup_client};
+use prelude::KeyPackageBundle;
 use treesync::{node::leaf_node::Capabilities, LeafNodeParameters};
 
 #[openmls_test::openmls_test]
@@ -534,4 +535,156 @@ fn group_operations() {
     let exporter_length = exporter_length + 1;
     let alice_exporter = alice_group.export_secret(provider, "export test", &[], exporter_length);
     assert!(alice_exporter.is_err())
+}
+
+#[openmls_test::openmls_test]
+fn sender_after_epoch_change() {
+    let mut alice_provider = Provider::default();
+    let mut bob_provider = Provider::default();
+    let mut charlie_provider = Provider::default();
+    let mut dora_provider = Provider::default();
+    // Create credentials and keys
+    let (alice_credential, alice_signature_keys) = crate::credentials::test_utils::new_credential(
+        &alice_provider,
+        b"Alice",
+        ciphersuite.signature_algorithm(),
+    );
+    let (bob_credential, bob_signature_keys) = crate::credentials::test_utils::new_credential(
+        &bob_provider,
+        b"Bob",
+        ciphersuite.signature_algorithm(),
+    );
+    let (charlie_credential, charlie_signature_keys) =
+        crate::credentials::test_utils::new_credential(
+            &charlie_provider,
+            b"charlie",
+            ciphersuite.signature_algorithm(),
+        );
+    let (dora_credential, dora_signature_keys) = crate::credentials::test_utils::new_credential(
+        &dora_provider,
+        b"dora",
+        ciphersuite.signature_algorithm(),
+    );
+
+    // Alice creates a group
+    let mut group_alice = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .build(
+            &alice_provider,
+            &alice_signature_keys,
+            alice_credential.clone(),
+        )
+        .expect("Error creating group.");
+
+    // Generate KeyPackages
+    let bob_key_package_bundle = KeyPackageBundle::generate(
+        &bob_provider,
+        &bob_signature_keys,
+        ciphersuite,
+        bob_credential.clone(),
+    );
+    let bob_key_package = bob_key_package_bundle.key_package();
+
+    // Generate KeyPackages
+    let charlie_key_package_bundle = KeyPackageBundle::generate(
+        &charlie_provider,
+        &charlie_signature_keys,
+        ciphersuite,
+        charlie_credential.clone(),
+    );
+    let charlie_key_package = charlie_key_package_bundle.key_package();
+
+    // Generate KeyPackages
+    let dora_key_package_bundle = KeyPackageBundle::generate(
+        &dora_provider,
+        &dora_signature_keys,
+        ciphersuite,
+        dora_credential.clone(),
+    );
+    let dora_key_package = dora_key_package_bundle.key_package();
+
+    // Alice adds Bob
+    let (_commit, welcome, _group_info_option) = group_alice
+        .add_members(
+            &alice_provider,
+            &alice_signature_keys,
+            &[bob_key_package.clone(), charlie_key_package.clone()],
+        )
+        .expect("Could not create proposal.");
+
+    group_alice
+        .merge_pending_commit(&alice_provider)
+        .expect("error merging pending commit");
+
+    let welcome = welcome.into_welcome().unwrap();
+
+    let mut group_bob = StagedWelcome::new_from_welcome(
+        &bob_provider,
+        &MlsGroupJoinConfig::builder()
+            .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .build(),
+        welcome.clone(),
+        Some(group_alice.export_ratchet_tree().into()),
+    )
+    .and_then(|staged_join| staged_join.into_group(provider))
+    .expect("error creating bob's group from welcome");
+
+    let mut group_charlie = StagedWelcome::new_from_welcome(
+        &charlie_provider,
+        &MlsGroupJoinConfig::builder()
+            .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .build(),
+        welcome,
+        Some(group_alice.export_ratchet_tree().into()),
+    )
+    .and_then(|staged_join| staged_join.into_group(provider))
+    .expect("error creating charlie's group from welcome");
+
+    let charlie_msg = group_charlie
+        .create_message(
+            &charlie_provider,
+            &charlie_signature_keys,
+            b"this is a test message",
+        )
+        .unwrap();
+
+    // replace charlie with dora
+    let commit_bundle = group_alice
+        .commit_builder()
+        .propose_removals(Some(group_charlie.own_leaf_index()))
+        .propose_adds(Some(dora_key_package.clone()))
+        .load_psks(alice_provider.storage())
+        .unwrap()
+        .build(
+            alice_provider.rand(),
+            alice_provider.crypto(),
+            &alice_signature_keys,
+            |_| true,
+        )
+        .unwrap()
+        .stage_commit(&alice_provider)
+        .unwrap();
+
+    let bob_incoming_commit = group_bob
+        .process_message(
+            &bob_provider,
+            commit_bundle
+                .commit()
+                .clone()
+                .into_protocol_message()
+                .unwrap(),
+        )
+        .unwrap();
+
+    match bob_incoming_commit.into_content() {
+        ProcessedMessageContent::StagedCommitMessage(staged_commit) => group_bob
+            .merge_staged_commit(&bob_provider, *staged_commit)
+            .unwrap(),
+        _ => unreachable!(),
+    };
+
+    let _bob_incoming_appmsg = group_bob
+        .process_message(&bob_provider, charlie_msg.into_protocol_message().unwrap())
+        .unwrap();
 }

--- a/openmls/src/group/tests_and_kats/tests/group.rs
+++ b/openmls/src/group/tests_and_kats/tests/group.rs
@@ -538,11 +538,11 @@ fn group_operations() {
 }
 
 #[openmls_test::openmls_test]
-fn sender_after_epoch_change() {
-    let mut alice_provider = Provider::default();
-    let mut bob_provider = Provider::default();
-    let mut charlie_provider = Provider::default();
-    let mut dora_provider = Provider::default();
+fn decrypt_after_leaf_index_reuse() {
+    let alice_provider = Provider::default();
+    let bob_provider = Provider::default();
+    let charlie_provider = Provider::default();
+    let dora_provider = Provider::default();
     // Create credentials and keys
     let (alice_credential, alice_signature_keys) = crate::credentials::test_utils::new_credential(
         &alice_provider,
@@ -627,7 +627,7 @@ fn sender_after_epoch_change() {
         welcome.clone(),
         Some(group_alice.export_ratchet_tree().into()),
     )
-    .and_then(|staged_join| staged_join.into_group(provider))
+    .and_then(|staged_join| staged_join.into_group(&bob_provider))
     .expect("error creating bob's group from welcome");
 
     let mut group_charlie = StagedWelcome::new_from_welcome(
@@ -638,7 +638,7 @@ fn sender_after_epoch_change() {
         welcome,
         Some(group_alice.export_ratchet_tree().into()),
     )
-    .and_then(|staged_join| staged_join.into_group(provider))
+    .and_then(|staged_join| staged_join.into_group(&charlie_provider))
     .expect("error creating charlie's group from welcome");
 
     let charlie_msg = group_charlie


### PR DESCRIPTION
When reading through the code I found a sketchy looking bit (the removed block in framing/validation.rs). The code looks like it tries to fetch the keys and credentials for messages from old epochs, but a closer read suggest it just tries the same thing again in a convoluted way. Also, it doesn't check for the epoch, it just retries if the lookup failed. This means that it is happy with finding any leaf node, regardless of whether the message epoch matches the group epoch.

So I added a test that provokes a problem: When removing a member and adding a new member, the key material in the leaf node is replaced. If we then receive a message from the old epoch, it should load the wrong key material from the current tree, and signature verification should fail. And that's exactly what's happening.

Then I fixed the code that does the looking up. I am not sure the closure really is the best approach, but passing in the many arguments needed to handle all cases seemed bad as well. Maybe the behavior shouldn't even be attached to the `DecryptedMessage` in the first place. Anyway, this works and we can use this as a base for discussion.