### PR TITLE
Change error in MemoryStorage and result handling in OpenMLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1672](https://github.com/openmls/openmls/pull/1672): Add `epoch()` getter method to `VerifiableGroupInfo`.
 - [#1673](https://github.com/openmls/openmls/pull/1673): Return more specific error when attemtping to decrypt own messages: `ProcessMessageError::ValidationError(ValidationError::CannotDecryptOwnMessage)`.
 
+### Changed
+
+- [#1700](https://github.com/openmls/openmls/pull/1700): During commit processing, OpenMLS will now return a `StorageError` if the storage provider fails while fetching `encryption_epoch_key_pairs`. Previously, it would ignore any error returned by the storage provider and just assume that no keys could be found (which typically lead to an error later during commit processing).
+
 ## 0.6.0 (2024-09-04)
 
 ### Added

--- a/memory_storage/CHANGELOG.md
+++ b/memory_storage/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- [#1700](https://github.com/openmls/openmls/pull/1700): Have `encryption_epoch_key_pairs` return an empty vector instead of an error if no value is found
+
+## 0.3.3 (2024-09-04)
+
+### Changed
 - [#909](https://github.com/openmls/openmls/pull/909): Use thiserror crate for errors
 
 ## 0.1.0 (2022-02-28)

--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -246,8 +246,6 @@ pub enum MemoryStorageError {
     UnsupportedMethod,
     #[error("Error serializing value.")]
     SerializationError,
-    #[error("Value does not exist.")]
-    None,
 }
 
 const KEY_PACKAGE_LABEL: &[u8] = b"KeyPackage";
@@ -826,7 +824,7 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
             return Ok(serde_json::from_slice(value).unwrap());
         }
 
-        Err(MemoryStorageError::None)
+        Ok(vec![])
     }
 
     fn delete_encryption_epoch_key_pairs<

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -679,19 +679,16 @@ impl MlsGroup {
     /// Read the [`EncryptionKeyPair`]s of this group and its current
     /// [`GroupEpoch`] from the `provider`'s storage.
     ///
-    /// Returns an empty vector if access to the store fails or it can't find
-    /// any keys.
+    /// Returns an error if the lookup in the [`StorageProvider`] fails.
     pub(super) fn read_epoch_keypairs<Storage: StorageProvider>(
         &self,
         store: &Storage,
-    ) -> Vec<EncryptionKeyPair> {
-        store
-            .encryption_epoch_key_pairs(
-                self.group_id(),
-                &self.context().epoch(),
-                self.own_leaf_index().u32(),
-            )
-            .unwrap_or_default()
+    ) -> Result<Vec<EncryptionKeyPair>, Storage::Error> {
+        store.encryption_epoch_key_pairs(
+            self.group_id(),
+            &self.context().epoch(),
+            self.own_leaf_index().u32(),
+        )
     }
 
     /// Delete the [`EncryptionKeyPair`]s from the previous [`GroupEpoch`] from

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -204,7 +204,10 @@ impl MlsGroup {
         own_leaf_nodes: &[LeafNode],
     ) -> Result<(Vec<EncryptionKeyPair>, Vec<EncryptionKeyPair>), StageCommitError> {
         // All keys from the previous epoch are potential decryption keypairs.
-        let old_epoch_keypairs = self.read_epoch_keypairs(provider.storage());
+        let old_epoch_keypairs = self.read_epoch_keypairs(provider.storage()).map_err(|e| {
+            log::error!("Error reading epoch keypairs: {:?}", e);
+            StageCommitError::MissingDecryptionKey
+        })?;
 
         // If we are processing an update proposal that originally came from
         // us, the keypair corresponding to the leaf in the update is also a

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -334,7 +334,9 @@ impl MlsGroup {
     ) -> Result<(), MergeCommitError<Provider::StorageError>> {
         // Get all keypairs from the old epoch, so we can later store the ones
         // that are still relevant in the new epoch.
-        let old_epoch_keypairs = self.read_epoch_keypairs(provider.storage());
+        let old_epoch_keypairs = self
+            .read_epoch_keypairs(provider.storage())
+            .map_err(MergeCommitError::StorageError)?;
         match staged_commit.state {
             StagedCommitState::PublicState(staged_state) => {
                 self.public_group

--- a/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
@@ -1848,6 +1848,7 @@ fn test_valsem110() {
     // process the commit.
     let leaf_keypair = alice_group
         .read_epoch_keypairs(provider.storage())
+        .unwrap()
         .into_iter()
         .find(|keypair| keypair.public_key() == &alice_encryption_key)
         .unwrap();


### PR DESCRIPTION
This PR fixes two related problems:

- MemoryStorage returned an error if no epoch key pairs could be found. This is a little inconsistent with the other implementations of reader-type functions. Other storage provider implementations are not likely to implement the same semantics, which means it's probably better placed within OpenMLS. This PR thus changes MemoryStorage's return to be an `Ok(vec![])` if no values can be found.
- OpenMLS didn't actually care about any error returned by the storage provider when looking up epoch key pairs, using `unwrap_or_default` instead, which means fix 1 doesn't really have any impact. That's not great, though, so this PR also adds some error handling behaviour s.t. OpenMLS actually detects if something went wrong at the provider.