### PR TITLE
fix: verify epoch equality on proposals

### DIFF
--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -276,6 +276,13 @@ impl MlsGroup {
                         ))
                     }
                     FramedContentBody::Proposal(_) => {
+                        // On receiving a FramedContent containing a Proposal, a client MUST verify that the
+                        // epoch field of the enclosing FramedContent is equal to the epoch field of the current
+                        // GroupContext object.
+                        if epoch != self.epoch() {
+                            return Err(ValidationError::WrongEpoch.into());
+                        }
+
                         let proposal = Box::new(QueuedProposal::from_authenticated_content_by_ref(
                             self.ciphersuite(),
                             provider.crypto(),


### PR DESCRIPTION
RFC9420 states the following in the [proposals section](https://datatracker.ietf.org/doc/html/rfc9420#section-12.1):

> On receiving a FramedContent containing a Proposal, a client MUST verify the signature inside FramedContentAuthData and that the epoch field of the enclosing FramedContent is equal to the epoch field of the current GroupContext object.

From what I can see, the signature is already verified correctly, but the epoch field is not checked for equality with the current GroupContext, so I added a corresponding check.
