### PR TITLE
Fix x25519-dalek crate link in README

### DIFF
--- a/openmls_rust_crypto/README.md
+++ b/openmls_rust_crypto/README.md
@@ -1,12 +1,13 @@
 # Rust Crypto Backend
 
-This crate implements the [OpenMLS traits](../traits/README.md) using the following rust crates: [hkdf], [sha2], [p256], [p384], [x25519-dalek-ng], [ed25519-dalek] [chacha20poly1305], [aes-gcm].
+This crate implements the [OpenMLS traits](../traits/README.md) using the following rust crates: [hkdf], [hpke-rs], [sha2], [p256], [p384], [x25519-dalek], [ed25519-dalek] [chacha20poly1305], [aes-gcm].
 
 [hkdf]: https://docs.rs/hkdf
+[hpke-rs]: https://docs.rs/hpke-rs
 [sha2]: https://docs.rs/sha2
 [p256]: https://docs.rs/p256
 [p384]: https://docs.rs/p384
-[x25519-dalek-ng]: https://docs.rs/x25519-dalek-ng
+[x25519-dalek]: https://docs.rs/x25519-dalek
 [ed25519-dalek]: https://docs.rs/ed25519-dalek
 [chacha20poly1305]: https://docs.rs/chacha20poly1305
 [aes-gcm]: https://docs.rs/aes-gcm


### PR DESCRIPTION
It's not `-ng` anymore. Also mention hpke-rs.