### PR TITLE
Test duplicate signature key detection is not bypassed

### DIFF
--- a/openmls/tests/mls_group.rs
+++ b/openmls/tests/mls_group.rs
@@ -308,11 +308,9 @@ fn mls_duplicate_signature_key_detection_different_key_package() {
 
         // === Alice creates three proposals: Remove Bob, Add Bob, and Add Bob ===
         let bob_leaf_node_index = bob_group.own_leaf_index();
-        if let Err(e) =
-            alice_group.propose_remove_member(alice_provider, &alice_signer, bob_leaf_node_index)
-        {
-            panic!("Could not add member from group: {e:?}");
-        };
+        alice_group
+            .propose_remove_member(alice_provider, &alice_signer, bob_leaf_node_index)
+            .expect("Could not add member from group: {e:?}");
 
         // Add Bob twice, with different key packages
         for _ in 0..2 {

--- a/openmls/tests/mls_group.rs
+++ b/openmls/tests/mls_group.rs
@@ -173,7 +173,7 @@ fn mls_duplicate_signature_key_detection_same_key_package() {
 
         // Ensure that the pending commit contains the correct number of proposals
         // TODO: Determine whether the duplicate proposals should have been filtered out at this
-        // stage. See issue
+        // stage. See issue #1718
         assert_eq!(pending_commit.queued_proposals().count(), 2);
 
         // ... and merge commit


### PR DESCRIPTION
This PR addresses issue #1243 by adding tests for scenarios in which we create a commit with the proposals [Remove(a), Add(a), Add(a)].
* The test `mls_duplicate_signature_key_detection_different_key_package`: Ensure that duplicate signature key detection is not bypassed when a different key package is used for each Add proposal. This test ensures that the correct error is returned by `MlsGroup::commit_to_pending_proposals()`.
* The test `mls_duplicate_signature_key_detection_same_key_package`: Ensure that duplicate signature key detection is not bypassed when the same key package is used for each Add proposal. This test currently ensures that only one of the Add proposals is kept when creating the commit, and the other one is filtered out.

Fixes #1243