### PR TITLE
chore: fix typo in credential verification sentence

### DIFF
--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -5,7 +5,7 @@
 //! used to authenticate their messages. Each
 //! [`KeyPackage`](crate::key_packages::KeyPackage) as well as each client (leaf node)
 //! in the group (tree) contains a [`Credential`] and is authenticated.
-//! The [`Credential`] must the be checked by an authentication server and the
+//! The [`Credential`] must be checked by an authentication server and the
 //! application, which is out of scope of MLS.
 //!
 //! Clients can create a [`Credential`].


### PR DESCRIPTION
I’ve fixed a typo in the sentence about credential verification. The word “the” was mistakenly included, making the sentence grammatically incorrect. Now, it reads properly:

> The [`Credential`] must be checked by an authentication server and the application, which is out of scope of MLS.