### PR TITLE
Add book examples and tests for discarded Commits

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -19,6 +19,7 @@
   - [Committing to pending proposals](user_manual/commit_to_proposals.md)
   - [Processing incoming messages](user_manual/processing.md)
   - [Persistence of group state](user_manual/persistence.md)
+  - [Discarding commits](user_manual/discarding_commits.md)
   - [Credential validation](user_manual/credential_validation.md)
   - [WebAssembly](user_manual/wasm.md)
 - [Traits & External Types](./traits/README.md)

--- a/book/src/user_manual/discarding_commits.md
+++ b/book/src/user_manual/discarding_commits.md
@@ -10,12 +10,6 @@ Generally, if a commit is discarded (e.g. due to being rejected by the Delivery 
 
 In general, the application only needs to complete the cleanup above in order to fully restore the local state to the way it was before the commit was staged. However, in several other cases, additional cleanup may need to be done.
 
-### Update
-If a staged commit containing an Update proposal must be discarded, the new signature keypair, if already stored in the `StorageProvider`, may also be removed by the application.
-```rust,no_run,noplayground
-{{#include ../../../openmls/tests/book_code_discard_commit.rs:discard_commit_update}}
-```
-
 ### ExternalJoin
 If a staged commit containing an external join proposal must be discarded, the entire `MlsGroup` instance should be discarded by the application.
 ```rust,no_run,noplayground

--- a/book/src/user_manual/discarding_commits.md
+++ b/book/src/user_manual/discarding_commits.md
@@ -8,7 +8,9 @@ Generally, if a commit is discarded (e.g. due to being rejected by the Delivery 
 {{#include ../../../openmls/tests/book_code_discard_commit.rs:discard_commit_example}}
 ```
 
-In general, the application only needs to complete the cleanup above in order to fully restore the local state to the way it was before the commit was staged. However, in several other cases, additional cleanup may need to be done.
+In general, the application only needs to complete the cleanup above in order to fully restore the local state to the way it was before the commit was staged.
+
+In several other cases, additional cleanup may need to be done.
 
 ### ExternalJoin
 If a staged commit containing an external join proposal must be discarded, the entire `MlsGroup` instance should be discarded by the application.
@@ -20,3 +22,6 @@ In addition to clearing the staged commit, the application may also clear the pr
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code_discard_commit.rs:discard_commit_psk}}
 ```
+
+### Self Update
+The storage provider may also be used by the application to store signature keypairs. For self updates that update a signature keypair, if the application has stored a new keypair in the storage provider at this point, it can be deleted from the storage provider here.

--- a/book/src/user_manual/discarding_commits.md
+++ b/book/src/user_manual/discarding_commits.md
@@ -24,4 +24,4 @@ In addition to clearing the staged commit, the application may also clear the pr
 ```
 
 ### Self Update
-The storage provider may also be used by the application to store signature keypairs. For self updates that update a signature keypair, if the application has stored a new keypair in the storage provider at this point, it can be deleted from the storage provider here.
+The storage provider may also be used by the application to store signature keypairs. For self updates that update a signature keypair for the client, if the application has stored a new keypair in the storage provider at this point, it can be deleted from the storage provider here.

--- a/book/src/user_manual/discarding_commits.md
+++ b/book/src/user_manual/discarding_commits.md
@@ -1,0 +1,28 @@
+# Discarding commits
+
+The delivery service may reject a commit sent by a client. In this case, the application needs to ensure that the local state remains the same as it was before the commit was staged.
+
+## Cleaning up local state after discarded commits
+Generally, if a commit is discarded (e.g. due to being rejected by the Delivery Service), it can be cleaned up by the application in the following way:
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code_discard_commit.rs:discard_commit_add}}
+```
+
+In general, the application only needs to complete the cleanup above in order to fully restore the local state to the way it was before the commit was staged. However, in several other cases, additional cleanup may need to be done.
+
+### Update
+If a staged commit containing an Update proposal must be discarded, the new signature keypair, if already stored in the `StorageProvider`, may also be removed by the application.
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code_discard_commit.rs:discard_commit_update}}
+```
+
+### ExternalJoin
+If a staged commit containing an external join proposal must be discarded, the entire `MlsGroup` instance should be discarded by the application.
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code_discard_commit.rs:discard_commit_external_join}}
+```
+### PreSharedKey
+In addition to clearing the staged commit, the application may also clear the pre-shared key from storage.
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code_discard_commit.rs:discard_commit_psk}}
+```

--- a/book/src/user_manual/discarding_commits.md
+++ b/book/src/user_manual/discarding_commits.md
@@ -5,7 +5,7 @@ The delivery service may reject a commit sent by a client. In this case, the app
 ## Cleaning up local state after discarded commits
 Generally, if a commit is discarded (e.g. due to being rejected by the Delivery Service), it can be cleaned up by the application in the following way:
 ```rust,no_run,noplayground
-{{#include ../../../openmls/tests/book_code_discard_commit.rs:discard_commit_add}}
+{{#include ../../../openmls/tests/book_code_discard_commit.rs:discard_commit_example}}
 ```
 
 In general, the application only needs to complete the cleanup above in order to fully restore the local state to the way it was before the commit was staged. However, in several other cases, additional cleanup may need to be done.

--- a/openmls/src/test_utils/mod.rs
+++ b/openmls/src/test_utils/mod.rs
@@ -28,6 +28,7 @@ use crate::{
 };
 
 pub mod frankenstein;
+pub mod storage_state;
 pub mod test_framework;
 
 pub(crate) fn write(file_name: &str, obj: impl Serialize) {

--- a/openmls/src/test_utils/single_group_test_framework/assertions.rs
+++ b/openmls/src/test_utils/single_group_test_framework/assertions.rs
@@ -1,5 +1,15 @@
 use super::*;
 
+impl<Provider: OpenMlsProvider> MemberState<'_, Provider> {
+    pub fn assert_group_storage_state_matches(&self, to_compare: GroupStorageState) {
+        let state_now = self.group_storage_state();
+        assert!(to_compare == state_now);
+    }
+    pub fn assert_non_proposal_group_storage_state_matches(&self, to_compare: GroupStorageState) {
+        let state_now = self.group_storage_state();
+        assert!(to_compare.non_proposal_state() == state_now.non_proposal_state());
+    }
+}
 impl<Provider: OpenMlsProvider> GroupState<'_, Provider> {
     pub fn assert_membership(&self) {
         let mut names = self

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -389,6 +389,11 @@ impl<'a, Provider: OpenMlsProvider> GroupState<'a, Provider> {
 
         Ok(())
     }
+
+    /// Returns a copy of the GroupId
+    pub fn group_id(&self) -> GroupId {
+        self.group_id.clone()
+    }
 }
 
 impl MlsGroupCreateConfig {

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -13,6 +13,8 @@ use crate::{
     prelude::{commit_builder::*, *},
 };
 
+use crate::test_utils::storage_state::GroupStorageState;
+
 mod assertions;
 
 mod errors;
@@ -113,6 +115,13 @@ pub struct MemberState<'a, Provider> {
 }
 
 impl<Provider: OpenMlsProvider> MemberState<'_, Provider> {
+    /// Get the `GroupStorageState` for this group
+    pub fn group_storage_state(&self) -> GroupStorageState {
+        let storage_provider = self.party.core_state.provider.storage();
+        let group_id = self.group.group_id();
+
+        GroupStorageState::from_storage(storage_provider, group_id)
+    }
     /// Deliver_and_apply a message to this member's `MlsGroup`
     pub fn deliver_and_apply(&mut self, message: MlsMessageIn) -> Result<(), GroupError<Provider>> {
         let message = message.try_into_protocol_message()?;

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -81,7 +81,6 @@ pub struct PreGroupPartyState<'a, Provider> {
     pub key_package_bundle: KeyPackageBundle,
     pub signer: SignatureKeyPair,
     pub core_state: &'a CorePartyState<Provider>,
-    pub ciphersuite: Ciphersuite,
 }
 
 impl<Provider: OpenMlsProvider> CorePartyState<Provider> {
@@ -106,7 +105,6 @@ impl<Provider: OpenMlsProvider> CorePartyState<Provider> {
             key_package_bundle,
             signer,
             core_state: self,
-            ciphersuite,
         }
     }
 }
@@ -120,7 +118,12 @@ pub struct MemberState<'a, Provider> {
 impl<Provider: OpenMlsProvider> MemberState<'_, Provider> {
     /// Get member's `SignatureKeyPair` if available
     pub fn get_storage_signature_key_pair(&self) -> Option<SignatureKeyPair> {
-        let ciphersuite = self.party.ciphersuite.into();
+        let ciphersuite = self
+            .party
+            .key_package_bundle
+            .key_package()
+            .ciphersuite()
+            .into();
 
         SignatureKeyPair::read(
             self.party.core_state.provider.storage(),

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -193,12 +193,14 @@ impl<'a, Provider: OpenMlsProvider> MemberState<'a, Provider> {
     pub fn create_from_pre_group(
         party: PreGroupPartyState<'a, Provider>,
         mls_group_create_config: MlsGroupCreateConfig,
+        group_id: GroupId,
     ) -> Result<Self, GroupError<Provider>> {
         // initialize MlsGroup
-        let group = MlsGroup::new(
+        let group = MlsGroup::new_with_group_id(
             &party.core_state.provider,
             &party.signer,
             &mls_group_create_config,
+            group_id,
             party.credential_with_key.clone(),
         )?;
 
@@ -241,8 +243,11 @@ impl<'a, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         let mut members = HashMap::new();
 
         let name = pre_group_state.core_state.name;
-        let member_state =
-            MemberState::create_from_pre_group(pre_group_state, mls_group_create_config)?;
+        let member_state = MemberState::create_from_pre_group(
+            pre_group_state,
+            mls_group_create_config,
+            group_id.clone(),
+        )?;
 
         members.insert(name, member_state);
 

--- a/openmls/src/test_utils/storage_state.rs
+++ b/openmls/src/test_utils/storage_state.rs
@@ -6,10 +6,8 @@ use crate::treesync::TreeSync;
 
 use openmls_traits::storage::{traits::GroupId, StorageProvider};
 
-/// All state associated only with a GroupId
 #[derive(PartialEq)]
-pub struct GroupStorageState {
-    queued_proposals: Vec<(ProposalRef, QueuedProposal)>,
+pub struct NonProposalState {
     own_leaf_nodes: Vec<LeafNode>,
     group_config: Option<MlsGroupJoinConfig>,
     tree: Option<TreeSync>,
@@ -21,6 +19,12 @@ pub struct GroupStorageState {
     resumption_psk_secrets: Option<ResumptionPskStore>,
     own_leaf_index: Option<LeafNodeIndex>,
     group_epoch_secrets: Option<GroupEpochSecrets>,
+}
+/// All state associated only with a GroupId
+#[derive(PartialEq)]
+pub struct GroupStorageState {
+    pub queued_proposals: Vec<(ProposalRef, QueuedProposal)>,
+    pub non_proposal_state: NonProposalState,
 }
 
 impl GroupStorageState {
@@ -55,17 +59,19 @@ impl GroupStorageState {
 
         GroupStorageState {
             queued_proposals,
-            own_leaf_nodes,
-            group_config,
-            tree,
-            confirmation_tag,
-            group_state,
-            context,
-            interim_transcript_hash,
-            message_secrets,
-            resumption_psk_secrets,
-            own_leaf_index,
-            group_epoch_secrets,
+            non_proposal_state: NonProposalState {
+                own_leaf_nodes,
+                group_config,
+                tree,
+                confirmation_tag,
+                group_state,
+                context,
+                interim_transcript_hash,
+                message_secrets,
+                resumption_psk_secrets,
+                own_leaf_index,
+                group_epoch_secrets,
+            },
         }
     }
 }

--- a/openmls/src/test_utils/storage_state.rs
+++ b/openmls/src/test_utils/storage_state.rs
@@ -4,8 +4,9 @@ use crate::schedule::psk::store::ResumptionPskStore;
 use crate::schedule::GroupEpochSecrets;
 use crate::treesync::TreeSync;
 
-use openmls_traits::storage::{traits::GroupId, StorageProvider};
+use openmls_traits::storage::{traits::GroupId, StorageProvider, CURRENT_VERSION};
 
+/// All state associated only with a GroupId
 #[derive(PartialEq)]
 pub struct NonProposalGroupStorageState {
     own_leaf_nodes: Vec<LeafNode>,
@@ -20,9 +21,11 @@ pub struct NonProposalGroupStorageState {
     own_leaf_index: Option<LeafNodeIndex>,
     group_epoch_secrets: Option<GroupEpochSecrets>,
 }
-
 impl NonProposalGroupStorageState {
-    pub fn from_storage(store: &impl StorageProvider<1>, group_id: &impl GroupId<1>) -> Self {
+    pub fn from_storage(
+        store: &impl StorageProvider<CURRENT_VERSION>,
+        group_id: &impl GroupId<CURRENT_VERSION>,
+    ) -> NonProposalGroupStorageState {
         let own_leaf_nodes = store.own_leaf_nodes(group_id).unwrap();
 
         let group_config = store.mls_group_join_config(group_id).unwrap();
@@ -60,18 +63,22 @@ impl NonProposalGroupStorageState {
         }
     }
 }
-
 /// All state associated only with a GroupId
 #[derive(PartialEq)]
 pub struct GroupStorageState {
-    pub queued_proposals: Vec<(ProposalRef, QueuedProposal)>,
-    pub non_proposal_state: NonProposalGroupStorageState,
+    queued_proposals: Vec<(ProposalRef, QueuedProposal)>,
+    non_proposal_state: NonProposalGroupStorageState,
 }
 
 impl GroupStorageState {
-    pub fn from_storage(store: &impl StorageProvider<1>, group_id: &impl GroupId<1>) -> Self {
+    pub fn non_proposal_state(&self) -> &NonProposalGroupStorageState {
+        &self.non_proposal_state
+    }
+    pub fn from_storage(
+        store: &impl StorageProvider<CURRENT_VERSION>,
+        group_id: &impl GroupId<CURRENT_VERSION>,
+    ) -> GroupStorageState {
         let queued_proposals = store.queued_proposals(group_id).unwrap();
-
         let non_proposal_state = NonProposalGroupStorageState::from_storage(store, group_id);
 
         GroupStorageState {

--- a/openmls/src/test_utils/storage_state.rs
+++ b/openmls/src/test_utils/storage_state.rs
@@ -1,0 +1,71 @@
+use crate::prelude::{hash_ref::ProposalRef, past_secrets::MessageSecretsStore, *};
+
+use crate::schedule::psk::store::ResumptionPskStore;
+use crate::schedule::GroupEpochSecrets;
+use crate::treesync::TreeSync;
+
+use openmls_traits::storage::{traits::GroupId, StorageProvider};
+
+/// All state associated only with a GroupId
+#[derive(PartialEq)]
+pub struct GroupStorageState {
+    queued_proposals: Vec<(ProposalRef, QueuedProposal)>,
+    own_leaf_nodes: Vec<LeafNode>,
+    group_config: Option<MlsGroupJoinConfig>,
+    tree: Option<TreeSync>,
+    confirmation_tag: Option<ConfirmationTag>,
+    group_state: Option<MlsGroupState>,
+    context: Option<GroupContext>,
+    interim_transcript_hash: Option<Vec<u8>>,
+    message_secrets: Option<MessageSecretsStore>,
+    resumption_psk_secrets: Option<ResumptionPskStore>,
+    own_leaf_index: Option<LeafNodeIndex>,
+    group_epoch_secrets: Option<GroupEpochSecrets>,
+}
+
+impl GroupStorageState {
+    pub fn from_storage(
+        store: &impl StorageProvider<1>,
+        group_id: &impl GroupId<1>,
+    ) -> GroupStorageState {
+        let queued_proposals = store.queued_proposals(group_id).unwrap();
+
+        let own_leaf_nodes = store.own_leaf_nodes(group_id).unwrap();
+
+        let group_config = store.mls_group_join_config(group_id).unwrap();
+
+        let tree = store.tree(group_id).unwrap();
+        let confirmation_tag = store.confirmation_tag(group_id).unwrap();
+
+        let group_state = store.group_state(group_id).unwrap();
+
+        let context = store.group_context(group_id).unwrap();
+
+        let interim_transcript_hash = store
+            .interim_transcript_hash(group_id)
+            .unwrap()
+            .map(|hash: InterimTranscriptHash| hash.0);
+
+        let message_secrets = store.message_secrets(group_id).unwrap();
+
+        let resumption_psk_secrets = store.resumption_psk_store(group_id).unwrap();
+        let own_leaf_index = store.own_leaf_index(group_id).unwrap();
+
+        let group_epoch_secrets = store.group_epoch_secrets(group_id).unwrap();
+
+        GroupStorageState {
+            queued_proposals,
+            own_leaf_nodes,
+            group_config,
+            tree,
+            confirmation_tag,
+            group_state,
+            context,
+            interim_transcript_hash,
+            message_secrets,
+            resumption_psk_secrets,
+            own_leaf_index,
+            group_epoch_secrets,
+        }
+    }
+}

--- a/openmls/src/test_utils/storage_state.rs
+++ b/openmls/src/test_utils/storage_state.rs
@@ -7,7 +7,7 @@ use crate::treesync::TreeSync;
 use openmls_traits::storage::{traits::GroupId, StorageProvider};
 
 #[derive(PartialEq)]
-pub struct NonProposalState {
+pub struct NonProposalGroupStorageState {
     own_leaf_nodes: Vec<LeafNode>,
     group_config: Option<MlsGroupJoinConfig>,
     tree: Option<TreeSync>,
@@ -24,7 +24,7 @@ pub struct NonProposalState {
 #[derive(PartialEq)]
 pub struct GroupStorageState {
     pub queued_proposals: Vec<(ProposalRef, QueuedProposal)>,
-    pub non_proposal_state: NonProposalState,
+    pub non_proposal_state: NonProposalGroupStorageState,
 }
 
 impl GroupStorageState {
@@ -59,7 +59,7 @@ impl GroupStorageState {
 
         GroupStorageState {
             queued_proposals,
-            non_proposal_state: NonProposalState {
+            non_proposal_state: NonProposalGroupStorageState {
                 own_leaf_nodes,
                 group_config,
                 tree,

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -244,7 +244,14 @@ fn discard_commit_update_with_new_signer() {
     //ANCHOR_END: discard_commit_update
 
     // check that alice signer still stored
-    assert!(alice.get_storage_signature_key_pair().is_some());
+    let alice_stored_signer = alice
+        .get_storage_signature_key_pair()
+        .expect("should still be stored");
+
+    // check that the stored signer's public key is the old signer's public key
+    assert_eq!(alice_stored_signer.public(), old_signer.public());
+    // check that the stored signer's public key is not the old signer's public key
+    assert_ne!(alice_stored_signer.public(), new_signer.public());
 
     // assert that the new signer is not in the StorageProvider (does not need to be cleaned up)
     assert!(SignatureKeyPair::read(

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -487,7 +487,7 @@ fn discard_commit_self_remove() {
     let mls_group_create_config = MlsGroupCreateConfig::builder()
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
-        .use_ratchet_tree_extension(true) // NOTE: important
+        .use_ratchet_tree_extension(true) // This is necessary in order for bob to be able to join from the welcome only.
         .build();
     let mut group_state = alice_bob_group(
         &alice_party,

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -416,7 +416,6 @@ fn discard_commit_psk() {
     // save the storage state
     let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
 
-    // TODO: create these values the correct way
     let psk_bytes = vec![1; 32];
     let psk = Psk::External(ExternalPsk::new(psk_bytes.clone()));
     let psk_id = PreSharedKeyId::new(ciphersuite, alice_provider.rand(), psk.clone()).unwrap();
@@ -581,7 +580,6 @@ fn discard_commit_external_join() {
     // save the storage state
     let bob_state_before = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
 
-    // TODO: get correctly
     let aad = vec![0; 32];
 
     let (mut bob_group, _message, _group_info) = MlsGroup::join_by_external_commit(

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -41,25 +41,228 @@ fn generate_key_package(
         .unwrap()
     // ANCHOR_END: create_key_package
 }
+
+use std::collections::HashMap;
+type Identity = &'static str;
+
+// This is a sketch of additional test suite functionality
+// TODO: move to separate file or combine with existing test framework
+pub(crate) struct TestingGroups<Provider: OpenMlsProvider + Default> {
+    // data for all groups
+    group_id: GroupId,
+    create_config: MlsGroupCreateConfig, // TODO: revisit
+    // map credentials to (StorageProvider, MlsGroup)
+    // store separately for borrowing reasons
+    groups: HashMap<Identity, MlsGroup>,
+    providers: HashMap<Identity, Provider>,
+    signers: HashMap<Identity, SignatureKeyPair>,
+    state: TestingGroupsState,
+}
+
+#[derive(Debug)]
+enum TestingGroupsState {
+    Ready,
+    PendingWelcomeFor {
+        identity: Identity,
+        sender: Identity,
+        welcome: MlsMessageOut,
+        commit: MlsMessageOut,
+    },
+    ReadyToApplyCommit {
+        commit: MlsMessageOut,
+        sender: Identity,
+        welcome_receiver: Option<Identity>,
+    },
+}
+
+impl<Provider: OpenMlsProvider + Default> TestingGroups<Provider> {
+    pub(crate) fn add_member(&mut self, adder: Identity, to_add: Identity) {
+        self.stage_commit_add_member(adder, to_add);
+        self.apply_welcome(None);
+        self.apply_sent_commit();
+    }
+    pub(crate) fn stage_commit_add_member(
+        &mut self,
+        adder: Identity,
+        to_add: Identity,
+        //TODO: more config, e.g. Option<KeyPackage>
+    ) {
+        let ciphersuite = self.create_config.ciphersuite();
+        let to_add_provider = Provider::default();
+
+        // Generate credentials with keys
+        let (credential, to_add_signer) = generate_credential(
+            to_add.into(),
+            ciphersuite.signature_algorithm(),
+            &to_add_provider,
+        );
+
+        // Generate KeyPackages
+        let key_package = generate_key_package(
+            ciphersuite,
+            credential.clone(),
+            Extensions::default(),
+            &to_add_provider,
+            &to_add_signer,
+        );
+
+        let adder_group = self.groups.get_mut(&adder).unwrap();
+        let adder_provider = self.providers.get_mut(&adder).unwrap();
+        let adder_signer = self.signers.get_mut(&adder).unwrap();
+
+        let (commit, welcome, _group_info) = adder_group
+            .add_members(
+                adder_provider,
+                adder_signer,
+                &[key_package.key_package().clone()],
+            )
+            .expect("Could not add members.");
+
+        // keep track of new member info
+        self.providers.insert(to_add, to_add_provider);
+        self.signers.insert(to_add, to_add_signer);
+
+        self.state = TestingGroupsState::PendingWelcomeFor {
+            identity: to_add,
+            sender: adder,
+            welcome,
+            commit: commit.clone(),
+        };
+    }
+    pub(crate) fn apply_welcome(&mut self, join_config: Option<MlsGroupJoinConfig>) {
+        if let TestingGroupsState::PendingWelcomeFor {
+            identity,
+            sender,
+            welcome,
+            commit,
+        } = &self.state
+        {
+            assert!(self.signers.contains_key(identity));
+            assert!(!self.groups.contains_key(identity));
+
+            let provider = self.providers.get(identity).unwrap();
+
+            let welcome: MlsMessageIn = welcome.clone().into();
+            let welcome = welcome
+                .into_welcome()
+                .expect("expected the message to be a welcome message");
+
+            let staged_join = StagedWelcome::new_from_welcome(
+                provider,
+                &join_config.unwrap_or_default(),
+                welcome,
+                None,
+            )
+            .expect("Error constructing staged join");
+            let group = staged_join
+                .into_group(provider)
+                .expect("Error joining group from StagedWelcome");
+
+            self.groups.insert(identity, group);
+
+            // update state
+            self.state = TestingGroupsState::ReadyToApplyCommit {
+                sender,
+                welcome_receiver: Some(identity),
+                commit: commit.clone(),
+            };
+        } else {
+            panic!("Cannot apply Welcome: no Welcome sent");
+        }
+    }
+    pub(crate) fn apply_sent_commit(&mut self) {
+        if let TestingGroupsState::ReadyToApplyCommit {
+            sender,
+            welcome_receiver,
+            commit,
+        } = &self.state
+        {
+            for (member_identity, group) in self.groups.iter_mut() {
+                match (welcome_receiver, member_identity) {
+                    (Some(identity), member_identity) if identity == member_identity => {}
+                    (_, member_identity) if member_identity == sender => {
+                        let provider = self.providers.get(member_identity).unwrap();
+                        group.merge_pending_commit(provider).unwrap();
+                    }
+                    (_, member_identity) => {
+                        //apply the commit
+                        let provider = self.providers.get(member_identity).unwrap();
+
+                        let processed_message = group
+                            .process_message(
+                                provider,
+                                commit.clone().into_protocol_message().unwrap(),
+                            )
+                            .unwrap();
+
+                        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+                            processed_message.into_content()
+                        {
+                            group.merge_staged_commit(provider, *staged_commit).unwrap();
+                        } else {
+                            panic!("Message is incorrect");
+                        }
+                    }
+                }
+            }
+        } else {
+            panic!("No commit sent");
+        }
+
+        self.state = TestingGroupsState::Ready;
+    }
+    pub(crate) fn single_from_identity(
+        group_id: GroupId,
+        identity: Identity,
+        create_config: MlsGroupCreateConfig,
+    ) -> Self {
+        let mut groups = HashMap::new();
+        let mut providers = HashMap::new();
+        let mut signers = HashMap::new();
+
+        let provider = Provider::default();
+
+        let ciphersuite = create_config.ciphersuite();
+
+        // Generate credentials with keys
+        let (credential, signer) = generate_credential(
+            identity.into(),
+            ciphersuite.signature_algorithm(),
+            &provider,
+        );
+
+        let group = MlsGroup::new_with_group_id(
+            &provider,
+            &signer,
+            &create_config,
+            group_id.clone(),
+            credential.clone(),
+        )
+        .expect("An unexpected error occurred.");
+
+        groups.insert(identity, group);
+        providers.insert(identity, provider);
+        signers.insert(identity, signer);
+
+        Self {
+            group_id,
+            groups,
+            providers,
+            signers,
+            create_config,
+            state: TestingGroupsState::Ready,
+        }
+    }
+    pub(crate) fn get_group_storage_state(&self, identity: Identity) -> GroupStorageState {
+        let provider = self.providers.get(&identity).unwrap();
+
+        GroupStorageState::from_storage(provider.storage(), &self.group_id)
+    }
+}
+
 #[openmls_test]
 fn discard_commit_add() {
     let group_id = GroupId::from_slice(b"Test Group");
-
-    let alice_provider = &Provider::default();
-    let bob_provider = &Provider::default();
-
-    // Generate credentials with keys
-    let (alice_credential, alice_signature_keys) = generate_credential(
-        "Alice".into(),
-        ciphersuite.signature_algorithm(),
-        alice_provider,
-    );
-
-    let (bob_credential, bob_signature_keys) = generate_credential(
-        "Bob".into(),
-        ciphersuite.signature_algorithm(),
-        bob_provider,
-    );
 
     // Define the MlsGroup configuration
     let mls_group_create_config = MlsGroupCreateConfig::builder()
@@ -67,15 +270,22 @@ fn discard_commit_add() {
         .use_ratchet_tree_extension(true) // NOTE: important
         .build();
 
-    // === Alice creates a group ===
-    let mut alice_group = MlsGroup::new_with_group_id(
-        alice_provider,
-        &alice_signature_keys,
-        &mls_group_create_config,
-        group_id.clone(),
-        alice_credential,
-    )
-    .expect("An unexpected error occurred.");
+    let mut testing_groups =
+        TestingGroups::single_from_identity(group_id.clone(), "Alice", mls_group_create_config);
+
+    let state_before = testing_groups.get_group_storage_state("Alice");
+
+    let alice_group = testing_groups.groups.get_mut("Alice").unwrap();
+    let alice_provider: &Provider = testing_groups.providers.get("Alice").unwrap();
+    let alice_signature_keys = testing_groups.signers.get("Alice").unwrap();
+
+    let bob_provider = &Provider::default();
+
+    let (bob_credential, bob_signature_keys) = generate_credential(
+        "Bob".into(),
+        ciphersuite.signature_algorithm(),
+        bob_provider,
+    );
 
     // Generate KeyPackages
     let bob_key_package = generate_key_package(
@@ -86,14 +296,12 @@ fn discard_commit_add() {
         &bob_signature_keys,
     );
 
-    let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
-
     // === Alice adds Bob ===
     //ANCHOR: discard_commit_add_setup
     let (_mls_message_out, _welcome, _group_info) = alice_group
         .add_members(
             alice_provider,
-            &alice_signature_keys,
+            alice_signature_keys,
             &[bob_key_package.key_package().clone()],
         )
         .expect("Could not add members.");
@@ -282,77 +490,24 @@ fn discard_commit_update() {
 
 #[openmls_test]
 fn discard_commit_remove() {
-    let alice_provider = &Provider::default();
-    let bob_provider = &Provider::default();
-
-    let group_id = GroupId::from_slice(b"Test Group");
-    // Generate credentials with keys
-    let (alice_credential, alice_signer) = generate_credential(
-        "Alice".into(),
-        ciphersuite.signature_algorithm(),
-        alice_provider,
-    );
-    let (bob_credential, bob_signer) = generate_credential(
-        "Bob".into(),
-        ciphersuite.signature_algorithm(),
-        bob_provider,
-    );
-    // Create a new KeyPackageBundle for Bob
-    let bob_key_package = generate_key_package(
-        ciphersuite,
-        bob_credential,
-        Extensions::default(),
-        bob_provider,
-        &bob_signer,
-    );
-
     // Define the MlsGroup configuration
     let mls_group_create_config = MlsGroupCreateConfig::builder()
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true) // NOTE: important
         .build();
+    let group_id = GroupId::from_slice(b"Test Group");
 
-    // === Alice creates a group ===
-    let mut alice_group = MlsGroup::new_with_group_id(
-        alice_provider,
-        &alice_signer,
-        &mls_group_create_config,
-        group_id.clone(),
-        alice_credential.clone(),
-    )
-    .expect("An unexpected error occurred.");
-
-    // === Alice adds Bob ===
-    let (_mls_message_out, welcome, _group_info) = alice_group
-        .add_members(
-            alice_provider,
-            &alice_signer,
-            &[bob_key_package.key_package().clone()],
-        )
-        .expect("Could not add members.");
-
-    alice_group
-        .merge_pending_commit(alice_provider)
-        .expect("error merging pending commit");
-
-    let welcome: MlsMessageIn = welcome.into();
-    let welcome = welcome
-        .into_welcome()
-        .expect("expected the message to be a welcome message");
-
-    let staged_join = StagedWelcome::new_from_welcome(
-        bob_provider,
-        &MlsGroupJoinConfig::default(),
-        welcome,
-        None,
-    )
-    .expect("Error constructing staged join");
-    let mut bob_group = staged_join
-        .into_group(bob_provider)
-        .expect("Error joining group from StagedWelcome");
+    // set up group with two members
+    let mut groups =
+        TestingGroups::single_from_identity(group_id, "Alice", mls_group_create_config);
+    groups.add_member("Alice", "Bob");
 
     // save the storage state
-    let state_before = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
+    let state_before = groups.get_group_storage_state("Bob");
+
+    let bob_group = groups.groups.get_mut("Bob").unwrap();
+    let bob_provider: &Provider = groups.providers.get("Bob").unwrap();
+    let bob_signer: &SignatureKeyPair = groups.signers.get("Bob").unwrap();
 
     // Bob removes Alice
 
@@ -369,7 +524,7 @@ fn discard_commit_remove() {
 
     let alice_leaf_node_index = alice_member.index;
     let (_mls_message_out, _welcome, _group_info) = bob_group
-        .remove_members(bob_provider, &bob_signer, &[alice_leaf_node_index])
+        .remove_members(bob_provider, bob_signer, &[alice_leaf_node_index])
         .expect("Could not remove Alice");
 
     // === Delivery service rejected the commit ===
@@ -381,45 +536,33 @@ fn discard_commit_remove() {
         .expect("Could not clear pending commit");
     //ANCHOR_END: discard_commit_remove
 
-    let state_after = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
+    let state_after = groups.get_group_storage_state("Bob");
     assert!(state_before == state_after);
 }
 
 #[openmls_test]
 fn discard_commit_psk() {
-    let alice_provider = &Provider::default();
-
-    let group_id = GroupId::from_slice(b"Test Group");
-    // Generate credentials with keys
-    let (alice_credential, alice_signer) = generate_credential(
-        "Alice".into(),
-        ciphersuite.signature_algorithm(),
-        alice_provider,
-    );
-
     // Define the MlsGroup configuration
     let mls_group_create_config = MlsGroupCreateConfig::builder()
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true) // NOTE: important
         .build();
+    let group_id = GroupId::from_slice(b"Test Group");
 
-    // === Alice creates a group ===
-    let mut alice_group = MlsGroup::new_with_group_id(
-        alice_provider,
-        &alice_signer,
-        &mls_group_create_config,
-        group_id.clone(),
-        alice_credential.clone(),
-    )
-    .expect("An unexpected error occurred.");
+    // set up group with two members
+    let mut testing_groups =
+        TestingGroups::single_from_identity(group_id, "Alice", mls_group_create_config);
 
-    // save the storage state
-    let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+    let alice_provider: &Provider = testing_groups.providers.get("Alice").unwrap();
+    let alice_signer = testing_groups.signers.get("Alice").unwrap();
+
+    let state_before = testing_groups.get_group_storage_state("Alice");
 
     let psk_bytes = vec![1; 32];
     let psk = Psk::External(ExternalPsk::new(psk_bytes.clone()));
     let psk_id = PreSharedKeyId::new(ciphersuite, alice_provider.rand(), psk.clone()).unwrap();
 
+    let alice_group = testing_groups.groups.get_mut("Alice").unwrap();
     // store
     // TODO: is this correct?
     psk_id
@@ -430,13 +573,13 @@ fn discard_commit_psk() {
 
     // Create commit including propose external psk
     let (_message_out, _proposal_ref) = alice_group
-        .propose_external_psk(alice_provider, &alice_signer, psk_id)
+        .propose_external_psk(alice_provider, alice_signer, psk_id)
         .expect("Could not propose adding an external psk");
 
     assert_eq!(alice_group.pending_proposals().count(), 1);
 
     let (_commit, _welcome, _group_info) = alice_group
-        .commit_to_pending_proposals(alice_provider, &alice_signer)
+        .commit_to_pending_proposals(alice_provider, alice_signer)
         .unwrap();
 
     // === Delivery service rejected the commit ===
@@ -454,7 +597,7 @@ fn discard_commit_psk() {
         .expect("Could not clear pending commit");
     //ANCHOR_END: discard_commit_psk
 
-    let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+    let state_after = testing_groups.get_group_storage_state("Alice");
     assert!(state_before.non_proposal_state == state_after.non_proposal_state);
 }
 

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -38,11 +38,11 @@ fn clear_pending_commit_and_assert_storage_state<Provider: OpenMlsProvider>(
     member_state.assert_non_proposal_group_storage_state_matches(state_before);
 }
 
-fn alice_group<'a, Provider: OpenMlsProvider>(
-    alice_party: &'a CorePartyState<Provider>,
+fn alice_group<Provider: OpenMlsProvider>(
+    alice_party: &CorePartyState<Provider>,
     ciphersuite: Ciphersuite,
     create_config: MlsGroupCreateConfig,
-) -> GroupState<'a, Provider> {
+) -> GroupState<'_, Provider> {
     let group_id = GroupId::from_slice(b"Test Group");
 
     let group_state = GroupState::new_from_party(
@@ -61,7 +61,7 @@ fn alice_bob_group<'a, Provider: OpenMlsProvider>(
     create_config: MlsGroupCreateConfig,
 ) -> GroupState<'a, Provider> {
     let join_config = create_config.join_config().clone();
-    let mut group_state = alice_group(&alice_party, ciphersuite, create_config);
+    let mut group_state = alice_group(alice_party, ciphersuite, create_config);
 
     group_state
         .add_member(AddMemberConfig {

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -25,6 +25,18 @@ fn generate_credential(
     )
 }
 
+// Utility function for checking commit
+fn clear_pending_commit_and_assert_storage_state<Provider: OpenMlsProvider>(
+    member_state: &mut MemberState<'_, Provider>,
+    state_before: GroupStorageState,
+) {
+    member_state
+        .group
+        .clear_pending_commit(member_state.party.core_state.provider.storage())
+        .expect("Could not clear pending commit");
+
+    member_state.assert_non_proposal_group_storage_state_matches(state_before);
+}
 #[openmls_test]
 fn discard_commit_add() {
     let alice_party = CorePartyState::<Provider>::new("alice");
@@ -267,12 +279,7 @@ fn discard_commit_remove() {
 
     // === Delivery service rejected the commit ===
 
-    // Discard the commit
-    bob_group
-        .clear_pending_commit(bob_provider.storage())
-        .expect("Could not clear pending commit");
-
-    bob.assert_non_proposal_group_storage_state_matches(state_before);
+    clear_pending_commit_and_assert_storage_state(bob, state_before);
 }
 
 #[openmls_test]
@@ -530,12 +537,7 @@ fn discard_commit_group_context_extensions() {
 
     // === Delivery service rejected the commit ===
 
-    // Discard the commit
-    alice_group
-        .clear_pending_commit(alice_provider.storage())
-        .expect("Could not clear pending commit");
-
-    alice.assert_non_proposal_group_storage_state_matches(state_before);
+    clear_pending_commit_and_assert_storage_state(alice, state_before);
 }
 
 #[openmls_test]
@@ -582,11 +584,7 @@ fn discard_commit_self_remove() {
     // === Delivery service rejected the commit ===
 
     // Discard the commit
-    bob_group
-        .clear_pending_commit(bob_provider.storage())
-        .expect("Could not clear pending commit");
-
-    bob.assert_non_proposal_group_storage_state_matches(state_before);
+    clear_pending_commit_and_assert_storage_state(bob, state_before);
 }
 
 /*

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -173,8 +173,6 @@ fn discard_commit_update() {
         .own_leaf_nodes(&group_id)
         .expect("could not get leaf nodes");
 
-    // NOTE: the list of own leaf nodes in the storage provider is empty.
-    // TODO: is this correct?
     assert_eq!(own_leaf_nodes_before.len(), 0);
 
     // save the storage state
@@ -583,7 +581,7 @@ fn discard_commit_external_join() {
     // save the storage state
     let bob_state_before = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
 
-    // XXX: get correctly
+    // TODO: get correctly
     let aad = vec![0; 32];
 
     let (mut bob_group, _message, _group_info) = MlsGroup::join_by_external_commit(
@@ -652,7 +650,6 @@ fn discard_commit_group_context_extensions() {
     // save the storage state
     let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
 
-    // FIXME: need a valid `Extensions` here
     let extensions = Extensions::from_vec(vec![
         Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
             &[ExtensionType::Unknown(unknown_extension_type)],
@@ -766,7 +763,6 @@ fn discard_commit_self_remove() {
 
     // Bob removes self
 
-    // TODO: ensure this is possible with current wire format
     let _mls_message_out = bob_group
         .leave_group_via_self_remove(bob_provider, &bob_signer)
         .expect("Error leaving group via self remove");
@@ -787,11 +783,13 @@ fn discard_commit_self_remove() {
     assert!(state_before == state_after);
 }
 
+/*
 #[openmls_test]
 fn discard_commit_app_ack() {
 
     // TODO: AppAck proposal not supported yet
 }
+*/
 
 #[openmls_test]
 fn discard_commit_custom_proposal() {

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -473,43 +473,6 @@ fn discard_commit_group_context_extensions() {
 }
 
 #[openmls_test]
-fn discard_commit_self_remove() {
-    let alice_party = CorePartyState::<Provider>::new("alice");
-    let bob_party = CorePartyState::<Provider>::new("bob");
-
-    // Define the MlsGroup configuration
-    let mls_group_create_config = MlsGroupCreateConfig::builder()
-        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-        .ciphersuite(ciphersuite)
-        .use_ratchet_tree_extension(true) // This is necessary in order for bob to be able to join from the welcome only.
-        .build();
-    let mut group_state = alice_bob_group(
-        &alice_party,
-        &bob_party,
-        ciphersuite,
-        mls_group_create_config,
-    );
-
-    let [bob] = group_state.members_mut(&["bob"]);
-    // save the storage state
-    let state_before = bob.group_storage_state();
-    let bob_group = &mut bob.group;
-    let bob_provider = &bob_party.provider;
-    let bob_signer = &bob.party.signer;
-
-    // Bob removes self
-
-    let _mls_message_out = bob_group
-        .leave_group_via_self_remove(bob_provider, bob_signer)
-        .expect("Error leaving group via self remove");
-
-    // === Delivery service rejected the commit ===
-
-    // Discard the commit
-    clear_pending_commit_and_assert_storage_state(bob, state_before);
-}
-
-#[openmls_test]
 fn discard_commit_custom_proposal() {
     let alice_provider = &Provider::default();
 

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -223,25 +223,12 @@ fn discard_commit_update_with_new_signer() {
     )
     .is_none());
 
-    // store for documentation purposes
-    new_signer.store(alice_provider.storage()).unwrap();
-
     // === Commit rejected by delivery service ===
-    //ANCHOR: discard_commit_update
-    // delete the unused signature key pair from the storage provider,
-    // if it was stored there earlier
-    SignatureKeyPair::delete(
-        alice_provider.storage(),
-        new_signer.public(),
-        ciphersuite.signature_algorithm(),
-    )
-    .expect("Could not delete unused signature key pair");
 
     // clear pending commit and reset state
     alice_group
         .clear_pending_commit(alice_provider.storage())
         .unwrap();
-    //ANCHOR_END: discard_commit_update
 
     // check that alice signer still stored
     let alice_stored_signer = alice

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -454,13 +454,8 @@ fn discard_commit_psk() {
         .expect("Could not clear pending commit");
     //ANCHOR_END: discard_commit_psk
 
-    // also delete the proposals so the state can be compared to the previous state
-    alice_group
-        .clear_pending_proposals(alice_provider.storage())
-        .expect("Could not clear pending proposals");
-
     let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
-    assert!(state_before == state_after);
+    assert!(state_before.non_proposal_state == state_after.non_proposal_state);
 }
 
 /*
@@ -519,13 +514,8 @@ fn discard_commit_reinit() {
         .expect("Could not clear pending commit");
     //ANCHOR_END: discard_commit_reinit
 
-    // also delete the proposals so the state can be compared to the previous state
-    alice_group
-        .clear_pending_proposals(alice_provider.storage())
-        .expect("Could not clear pending proposals");
-
     let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
-    assert!(state_before == state_after);
+    assert!(state_before.non_proposal_state == state_after.non_proposal_state);
 }
 */
 
@@ -675,13 +665,8 @@ fn discard_commit_group_context_extensions() {
         .expect("Could not clear pending commit");
     //ANCHOR_END: discard_commit_group_context_extensions
 
-    // also delete the proposals so the state can be compared to the previous state
-    alice_group
-        .clear_pending_proposals(alice_provider.storage())
-        .expect("Could not clear pending proposals");
-
     let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
-    assert!(state_before == state_after);
+    assert!(state_before.non_proposal_state == state_after.non_proposal_state);
 }
 
 #[openmls_test]
@@ -772,13 +757,8 @@ fn discard_commit_self_remove() {
         .clear_pending_commit(bob_provider.storage())
         .expect("Could not clear pending commit");
 
-    // also delete the proposals so the state can be compared to the previous state
-    bob_group
-        .clear_pending_proposals(bob_provider.storage())
-        .expect("Could not clear pending proposals");
-
     let state_after = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
-    assert!(state_before == state_after);
+    assert!(state_before.non_proposal_state == state_after.non_proposal_state);
 }
 
 /*

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -515,14 +515,6 @@ fn discard_commit_self_remove() {
     clear_pending_commit_and_assert_storage_state(bob, state_before);
 }
 
-/*
-#[openmls_test]
-fn discard_commit_app_ack() {
-
-    // TODO: AppAck proposal not supported yet
-}
-*/
-
 #[openmls_test]
 fn discard_commit_custom_proposal() {
     let alice_provider = &Provider::default();

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -424,7 +424,7 @@ fn discard_commit_psk() {
     let psk_id = PreSharedKeyId::new(ciphersuite, alice_provider.rand(), psk.clone()).unwrap();
 
     // store
-    // XXX: is this correct?
+    // TODO: is this correct?
     psk_id
         .store(alice_provider, &psk_bytes)
         .expect("Could not store psk in storage provider");

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -1,0 +1,849 @@
+use openmls::{prelude::*, schedule::psk::*, test_utils::storage_state::GroupStorageState, *};
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_test::openmls_test;
+use openmls_traits::{signatures::Signer, types::SignatureScheme};
+use treesync::LeafNodeParameters;
+
+fn generate_credential(
+    identity: Vec<u8>,
+    signature_algorithm: SignatureScheme,
+    provider: &impl crate::storage::OpenMlsProvider,
+) -> (CredentialWithKey, SignatureKeyPair) {
+    // ANCHOR: create_basic_credential
+    let credential = BasicCredential::new(identity);
+    // ANCHOR_END: create_basic_credential
+    // ANCHOR: create_credential_keys
+    let signature_keys = SignatureKeyPair::new(signature_algorithm).unwrap();
+    signature_keys.store(provider.storage()).unwrap();
+    // ANCHOR_END: create_credential_keys
+
+    (
+        CredentialWithKey {
+            credential: credential.into(),
+            signature_key: signature_keys.to_public_vec().into(),
+        },
+        signature_keys,
+    )
+}
+
+fn generate_key_package(
+    ciphersuite: Ciphersuite,
+    credential_with_key: CredentialWithKey,
+    extensions: Extensions,
+    provider: &impl crate::storage::OpenMlsProvider,
+    signer: &impl Signer,
+) -> KeyPackageBundle {
+    // ANCHOR: create_key_package
+    // Create the key package
+    KeyPackage::builder()
+        .key_package_extensions(extensions)
+        .build(ciphersuite, provider, signer, credential_with_key)
+        .unwrap()
+    // ANCHOR_END: create_key_package
+}
+#[openmls_test]
+fn discard_commit_add() {
+    let group_id = GroupId::from_slice(b"Test Group");
+
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    // Generate credentials with keys
+    let (alice_credential, alice_signature_keys) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    let (bob_credential, bob_signature_keys) = generate_credential(
+        "Bob".into(),
+        ciphersuite.signature_algorithm(),
+        bob_provider,
+    );
+
+    // Define the MlsGroup configuration
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true) // NOTE: important
+        .build();
+
+    // === Alice creates a group ===
+    let mut alice_group = MlsGroup::new_with_group_id(
+        alice_provider,
+        &alice_signature_keys,
+        &mls_group_create_config,
+        group_id.clone(),
+        alice_credential,
+    )
+    .expect("An unexpected error occurred.");
+
+    // Generate KeyPackages
+    let bob_key_package = generate_key_package(
+        ciphersuite,
+        bob_credential.clone(),
+        Extensions::default(),
+        bob_provider,
+        &bob_signature_keys,
+    );
+
+    let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+
+    // === Alice adds Bob ===
+    //ANCHOR: discard_commit_add_setup
+    let (_mls_message_out, _welcome, _group_info) = alice_group
+        .add_members(
+            alice_provider,
+            &alice_signature_keys,
+            &[bob_key_package.key_package().clone()],
+        )
+        .expect("Could not add members.");
+    //ANCHOR_END: discard_commit_add_setup
+
+    assert_ne!(
+        provider.storage().group_state(&group_id).unwrap(),
+        Some(MlsGroupState::Operational)
+    );
+
+    // === Commit rejected by delivery service ===
+    // Will need to clean up
+
+    assert_eq!(alice_group.members().count(), 1);
+    //ANCHOR: discard_commit_add
+    // clear pending commit and reset state
+    alice_group
+        .clear_pending_commit(alice_provider.storage())
+        .unwrap();
+    //ANCHOR_END: discard_commit_add
+    let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+    assert!(state_before == state_after);
+}
+
+#[openmls_test]
+fn discard_commit_update() {
+    let alice_provider = &Provider::default();
+
+    let group_id = GroupId::from_slice(b"Test Group");
+    // Generate credentials with keys
+    let (alice_credential, alice_signer) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    // Define the MlsGroup configuration
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true) // NOTE: important
+        .build();
+
+    // === Alice creates a group ===
+    let mut alice_group = MlsGroup::new_with_group_id(
+        alice_provider,
+        &alice_signer,
+        &mls_group_create_config,
+        group_id.clone(),
+        alice_credential.clone(),
+    )
+    .expect("An unexpected error occurred.");
+
+    // === Alice new credential ===
+    let basic_credential = BasicCredential::new("Alice".into());
+    let new_signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+    let new_credential = CredentialWithKey {
+        credential: basic_credential.into(),
+        signature_key: new_signer.to_public_vec().into(),
+    };
+
+    // store new credential
+    new_signer.store(alice_provider.storage()).unwrap();
+
+    // Check alice credential
+    let own_leaf_node_before = alice_group.own_leaf_node().unwrap().clone();
+    assert_eq!(
+        own_leaf_node_before.credential(),
+        &alice_credential.credential
+    );
+    // Check alice signature key
+    assert_eq!(
+        own_leaf_node_before.signature_key(),
+        &alice_credential.signature_key
+    );
+    let own_leaf_nodes_before: Vec<LeafNode> = alice_provider
+        .storage()
+        .own_leaf_nodes(&group_id)
+        .expect("could not get leaf nodes");
+
+    // NOTE: the list of own leaf nodes in the storage provider is empty.
+    // TODO: is this correct?
+    assert_eq!(own_leaf_nodes_before.len(), 0);
+
+    // save the storage state
+    let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+
+    // check that alice signer was stored
+    let alice_signer_still_stored = SignatureKeyPair::read(
+        alice_provider.storage(),
+        alice_signer.public(),
+        ciphersuite.signature_algorithm(),
+    )
+    .is_some();
+    assert_eq!(alice_signer_still_stored, true);
+    // check that the signer was stored
+    let new_signer_still_stored = SignatureKeyPair::read(
+        alice_provider.storage(),
+        new_signer.public(),
+        ciphersuite.signature_algorithm(),
+    )
+    .is_some();
+    assert_eq!(new_signer_still_stored, true);
+
+    // === Alice updates ===
+    // Alice updates own credential
+    // HPKE encryption key is also updated by the commit
+
+    let leaf_node_parameters = LeafNodeParameters::builder()
+        .with_credential_with_key(new_credential)
+        .build();
+    //ANCHOR: discard_commit_update_setup
+    let commit_message_bundle = alice_group
+        .self_update(alice_provider, &new_signer, leaf_node_parameters)
+        .expect("failed to update own leaf node");
+    //ANCHOR_END: discard_commit_update_setup
+
+    // Unused
+    let _commit_message_bundle = commit_message_bundle;
+
+    assert_ne!(
+        provider.storage().group_state(&group_id).unwrap(),
+        Some(MlsGroupState::Operational)
+    );
+
+    // Ensure own leaf node credential is still the same as before
+    let own_leaf_node_after = alice_group.own_leaf_node().unwrap();
+    assert_eq!(
+        own_leaf_node_after.credential(),
+        own_leaf_node_before.credential(),
+    );
+    // Ensure own leaf node signature key is still the same as before
+    assert_eq!(
+        own_leaf_node_after.signature_key(),
+        own_leaf_node_before.signature_key(),
+    );
+    // Ensure own leaf node encryption key is still the same as before
+    assert_eq!(
+        own_leaf_node_after.encryption_key(),
+        own_leaf_node_before.encryption_key(),
+    );
+
+    let own_leaf_nodes_after: Vec<LeafNode> = provider
+        .storage()
+        .own_leaf_nodes(&group_id)
+        .expect("could not get leaf nodes");
+    assert_eq!(own_leaf_nodes_after.len(), 0);
+
+    // Ensure that leaf nodes same in storage
+    assert_eq!(own_leaf_nodes_before, own_leaf_nodes_after);
+
+    // === Commit rejected by delivery service ===
+    //ANCHOR: discard_commit_update
+    // delete the unused signature key pair from the storage provider,
+    // if it was stored there earlier
+    SignatureKeyPair::delete(
+        alice_provider.storage(),
+        new_signer.public(),
+        ciphersuite.signature_algorithm(),
+    )
+    .expect("Could not delete unused signature key pair");
+
+    // clear pending commit and reset state
+    alice_group
+        .clear_pending_commit(alice_provider.storage())
+        .unwrap();
+    //ANCHOR_END: discard_commit_update
+
+    // check that alice signer still stored
+    let alice_signer_still_stored = SignatureKeyPair::read(
+        alice_provider.storage(),
+        alice_signer.public(),
+        ciphersuite.signature_algorithm(),
+    )
+    .is_some();
+    assert_eq!(alice_signer_still_stored, true);
+
+    let new_signer_still_stored = SignatureKeyPair::read(
+        alice_provider.storage(),
+        new_signer.public(),
+        ciphersuite.signature_algorithm(),
+    )
+    .is_some();
+    assert_eq!(new_signer_still_stored, false);
+
+    let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+    assert!(state_before == state_after);
+}
+
+#[openmls_test]
+fn discard_commit_remove() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let group_id = GroupId::from_slice(b"Test Group");
+    // Generate credentials with keys
+    let (alice_credential, alice_signer) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+    let (bob_credential, bob_signer) = generate_credential(
+        "Bob".into(),
+        ciphersuite.signature_algorithm(),
+        bob_provider,
+    );
+    // Create a new KeyPackageBundle for Bob
+    let bob_key_package = generate_key_package(
+        ciphersuite,
+        bob_credential,
+        Extensions::default(),
+        bob_provider,
+        &bob_signer,
+    );
+
+    // Define the MlsGroup configuration
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true) // NOTE: important
+        .build();
+
+    // === Alice creates a group ===
+    let mut alice_group = MlsGroup::new_with_group_id(
+        alice_provider,
+        &alice_signer,
+        &mls_group_create_config,
+        group_id.clone(),
+        alice_credential.clone(),
+    )
+    .expect("An unexpected error occurred.");
+
+    // === Alice adds Bob ===
+    let (_mls_message_out, welcome, _group_info) = alice_group
+        .add_members(
+            alice_provider,
+            &alice_signer,
+            &[bob_key_package.key_package().clone()],
+        )
+        .expect("Could not add members.");
+
+    alice_group
+        .merge_pending_commit(alice_provider)
+        .expect("error merging pending commit");
+
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected the message to be a welcome message");
+
+    let staged_join = StagedWelcome::new_from_welcome(
+        bob_provider,
+        &MlsGroupJoinConfig::default(),
+        welcome,
+        None,
+    )
+    .expect("Error constructing staged join");
+    let mut bob_group = staged_join
+        .into_group(bob_provider)
+        .expect("Error joining group from StagedWelcome");
+
+    // save the storage state
+    let state_before = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
+
+    // Bob removes Alice
+
+    let alice_member = bob_group
+        .members()
+        .find(
+            |Member {
+                 index: _,
+                 credential,
+                 ..
+             }| { credential.serialized_content() == b"Alice" },
+        )
+        .expect("Couldn't find Alice in the list of group members.");
+
+    let alice_leaf_node_index = alice_member.index;
+    let (_mls_message_out, _welcome, _group_info) = bob_group
+        .remove_members(bob_provider, &bob_signer, &[alice_leaf_node_index])
+        .expect("Could not remove Alice");
+
+    // === Delivery service rejected the commit ===
+
+    // Discard the commit
+    //ANCHOR: discard_commit_remove
+    bob_group
+        .clear_pending_commit(bob_provider.storage())
+        .expect("Could not clear pending commit");
+    //ANCHOR_END: discard_commit_remove
+
+    let state_after = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
+    assert!(state_before == state_after);
+}
+
+#[openmls_test]
+fn discard_commit_psk() {
+    let alice_provider = &Provider::default();
+
+    let group_id = GroupId::from_slice(b"Test Group");
+    // Generate credentials with keys
+    let (alice_credential, alice_signer) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    // Define the MlsGroup configuration
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true) // NOTE: important
+        .build();
+
+    // === Alice creates a group ===
+    let mut alice_group = MlsGroup::new_with_group_id(
+        alice_provider,
+        &alice_signer,
+        &mls_group_create_config,
+        group_id.clone(),
+        alice_credential.clone(),
+    )
+    .expect("An unexpected error occurred.");
+
+    // save the storage state
+    let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+
+    // TODO: create these values the correct way
+    let psk_bytes = vec![1; 32];
+    let psk = Psk::External(ExternalPsk::new(psk_bytes.clone()));
+    let psk_id = PreSharedKeyId::new(ciphersuite, alice_provider.rand(), psk.clone()).unwrap();
+
+    // store
+    // XXX: is this correct?
+    psk_id
+        .store(alice_provider, &psk_bytes)
+        .expect("Could not store psk in storage provider");
+
+    assert_eq!(alice_group.pending_proposals().count(), 0);
+
+    // Create commit including propose external psk
+    let (_message_out, _proposal_ref) = alice_group
+        .propose_external_psk(alice_provider, &alice_signer, psk_id)
+        .expect("Could not propose adding an external psk");
+
+    assert_eq!(alice_group.pending_proposals().count(), 1);
+
+    let (_commit, _welcome, _group_info) = alice_group
+        .commit_to_pending_proposals(alice_provider, &alice_signer)
+        .unwrap();
+
+    // === Delivery service rejected the commit ===
+
+    //ANCHOR: discard_commit_psk
+    // clear the psk that was stored earlier, if necessary
+    alice_provider
+        .storage()
+        .delete_psk(&psk)
+        .expect("Could not delete stored psk");
+
+    // clear pending commit and reset state
+    alice_group
+        .clear_pending_commit(alice_provider.storage())
+        .expect("Could not clear pending commit");
+    //ANCHOR_END: discard_commit_psk
+
+    // also delete the proposals so the state can be compared to the previous state
+    alice_group
+        .clear_pending_proposals(alice_provider.storage())
+        .expect("Could not clear pending proposals");
+
+    let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+    assert!(state_before == state_after);
+}
+
+/*
+#[openmls_test]
+fn discard_commit_reinit() {
+    let alice_provider = &Provider::default();
+
+    let group_id = GroupId::from_slice(b"Test Group");
+    // Generate credentials with keys
+    let (alice_credential, alice_signer) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    // Define the MlsGroup configuration
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true) // NOTE: important
+        .build();
+
+    // === Alice creates a group ===
+    let mut alice_group = MlsGroup::new_with_group_id(
+        alice_provider,
+        &alice_signer,
+        &mls_group_create_config,
+        group_id.clone(),
+        alice_credential.clone(),
+    )
+    .expect("An unexpected error occurred.");
+
+    // save the storage state
+    let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+
+    // TODO: is there a way to create this using the public API?
+    let reinit_proposal = todo!();
+
+    alice_group
+        .commit_builder()
+        .add_proposal(Proposal::ReInit(reinit_proposal))
+        .load_psks(alice_provider.storage())
+        .unwrap()
+        .build(
+            alice_provider.rand(),
+            alice_provider.crypto(),
+            &alice_signer,
+            |_| true,
+        )
+        .unwrap();
+    // === Delivery service rejected the commit ===
+
+    //ANCHOR: discard_commit_reinit
+    // Discard the commit
+    alice_group
+        .clear_pending_commit(alice_provider.storage())
+        .expect("Could not clear pending commit");
+    //ANCHOR_END: discard_commit_reinit
+
+    // also delete the proposals so the state can be compared to the previous state
+    alice_group
+        .clear_pending_proposals(alice_provider.storage())
+        .expect("Could not clear pending proposals");
+
+    let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+    assert!(state_before == state_after);
+}
+*/
+
+#[openmls_test]
+fn discard_commit_external_join() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let group_id = GroupId::from_slice(b"Test Group");
+    // Generate credentials with keys
+    let (alice_credential, alice_signer) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+    let (bob_credential, bob_signer) = generate_credential(
+        "Bob".into(),
+        ciphersuite.signature_algorithm(),
+        bob_provider,
+    );
+
+    // Define the MlsGroup configuration
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .build();
+
+    // === Alice creates a group ===
+    let alice_group = MlsGroup::new_with_group_id(
+        alice_provider,
+        &alice_signer,
+        &mls_group_create_config,
+        group_id.clone(),
+        alice_credential.clone(),
+    )
+    .expect("An unexpected error occurred.");
+
+    // export the group info so Bob can join
+    let group_info_msg_out = alice_group
+        .export_group_info(
+            alice_provider,
+            &alice_signer,
+            true, // with ratchet tree
+        )
+        .expect("Could not export group info");
+    let group_info_msg_in: MlsMessageIn = group_info_msg_out.into();
+
+    let verifiable_group_info = match group_info_msg_in.extract() {
+        MlsMessageBodyIn::GroupInfo(info) => info,
+        _ => unimplemented!(),
+    };
+
+    // save the storage state
+    let bob_state_before = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
+
+    // XXX: get correctly
+    let aad = vec![0; 32];
+
+    let (mut bob_group, _message, _group_info) = MlsGroup::join_by_external_commit(
+        bob_provider,
+        &bob_signer,
+        None,
+        verifiable_group_info,
+        &MlsGroupJoinConfig::default(),
+        None,
+        None,
+        &aad,
+        bob_credential,
+    )
+    .expect("could not create external join commit");
+
+    // === Delivery service rejected the commit ===
+
+    //ANCHOR: discard_commit_external_join
+    // delete the `MlsGroup`
+    bob_group
+        .delete(bob_provider.storage())
+        .expect("Could not delete the group");
+    //ANCHOR_END: discard_commit_external_join
+
+    let bob_state_after = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
+    assert!(bob_state_before == bob_state_after);
+}
+
+#[openmls_test]
+fn discard_commit_group_context_extensions() {
+    let alice_provider = &Provider::default();
+
+    let group_id = GroupId::from_slice(b"Test Group");
+    // Generate credentials with keys
+    let (alice_credential, alice_signer) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    let unknown_extension_type = 1;
+
+    // Define the MlsGroup configuration
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true) // NOTE: important
+        .capabilities(Capabilities::new(
+            None,
+            None,
+            Some(&[ExtensionType::Unknown(unknown_extension_type)]),
+            None,
+            None,
+        ))
+        .build();
+
+    // === Alice creates a group ===
+    let mut alice_group = MlsGroup::new_with_group_id(
+        alice_provider,
+        &alice_signer,
+        &mls_group_create_config,
+        group_id.clone(),
+        alice_credential.clone(),
+    )
+    .expect("An unexpected error occurred.");
+
+    // save the storage state
+    let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+
+    // FIXME: need a valid `Extensions` here
+    let extensions = Extensions::from_vec(vec![
+        Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
+            &[ExtensionType::Unknown(unknown_extension_type)],
+            &[],
+            &[],
+        )),
+        Extension::Unknown(unknown_extension_type, UnknownExtension(Vec::new())),
+    ])
+    .unwrap();
+
+    let (_message, _proposal_ref) = alice_group
+        .propose_group_context_extensions(alice_provider, extensions, &alice_signer)
+        .expect("Could not propose group context extensions");
+
+    let (_commit, _welcome, _group_info) = alice_group
+        .commit_to_pending_proposals(alice_provider, &alice_signer)
+        .unwrap();
+
+    // === Delivery service rejected the commit ===
+
+    //ANCHOR: discard_commit_group_context_extensions
+    // Discard the commit
+    alice_group
+        .clear_pending_commit(alice_provider.storage())
+        .expect("Could not clear pending commit");
+    //ANCHOR_END: discard_commit_group_context_extensions
+
+    // also delete the proposals so the state can be compared to the previous state
+    alice_group
+        .clear_pending_proposals(alice_provider.storage())
+        .expect("Could not clear pending proposals");
+
+    let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+    assert!(state_before == state_after);
+}
+
+#[openmls_test]
+fn discard_commit_self_remove() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let group_id = GroupId::from_slice(b"Test Group");
+    // Generate credentials with keys
+    let (alice_credential, alice_signer) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+    let (bob_credential, bob_signer) = generate_credential(
+        "Bob".into(),
+        ciphersuite.signature_algorithm(),
+        bob_provider,
+    );
+    // Create a new KeyPackageBundle for Bob
+    let bob_key_package = generate_key_package(
+        ciphersuite,
+        bob_credential,
+        Extensions::default(),
+        bob_provider,
+        &bob_signer,
+    );
+
+    // Define the MlsGroup configuration
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true) // NOTE: important
+        .build();
+
+    // === Alice creates a group ===
+    let mut alice_group = MlsGroup::new_with_group_id(
+        alice_provider,
+        &alice_signer,
+        &mls_group_create_config,
+        group_id.clone(),
+        alice_credential.clone(),
+    )
+    .expect("An unexpected error occurred.");
+
+    // === Alice adds Bob ===
+    let (_mls_message_out, welcome, _group_info) = alice_group
+        .add_members(
+            alice_provider,
+            &alice_signer,
+            &[bob_key_package.key_package().clone()],
+        )
+        .expect("Could not add members.");
+
+    alice_group
+        .merge_pending_commit(alice_provider)
+        .expect("error merging pending commit");
+
+    let welcome: MlsMessageIn = welcome.into();
+    let welcome = welcome
+        .into_welcome()
+        .expect("expected the message to be a welcome message");
+
+    let staged_join = StagedWelcome::new_from_welcome(
+        bob_provider,
+        mls_group_create_config.join_config(),
+        welcome,
+        None,
+    )
+    .expect("Error constructing staged join");
+    let mut bob_group = staged_join
+        .into_group(bob_provider)
+        .expect("Error joining group from StagedWelcome");
+
+    // save the storage state
+    let state_before = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
+
+    // Bob removes self
+
+    // TODO: ensure this is possible with current wire format
+    let _mls_message_out = bob_group
+        .leave_group_via_self_remove(bob_provider, &bob_signer)
+        .expect("Error leaving group via self remove");
+
+    // === Delivery service rejected the commit ===
+
+    // Discard the commit
+    bob_group
+        .clear_pending_commit(bob_provider.storage())
+        .expect("Could not clear pending commit");
+
+    // also delete the proposals so the state can be compared to the previous state
+    bob_group
+        .clear_pending_proposals(bob_provider.storage())
+        .expect("Could not clear pending proposals");
+
+    let state_after = GroupStorageState::from_storage(bob_provider.storage(), &group_id);
+    assert!(state_before == state_after);
+}
+
+#[openmls_test]
+fn discard_commit_app_ack() {
+
+    // TODO: AppAck proposal not supported yet
+}
+
+#[openmls_test]
+fn discard_commit_custom_proposal() {
+    let alice_provider = &Provider::default();
+
+    let group_id = GroupId::from_slice(b"Test Group");
+    // Generate credentials with keys
+    let (alice_credential, alice_signer) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    let custom_proposal_type = 0;
+
+    let capabilities = Capabilities::new(
+        None,
+        None,
+        None,
+        Some(&[ProposalType::Custom(custom_proposal_type)]),
+        None,
+    );
+
+    // === Alice creates a group ===
+    let mut alice_group = MlsGroup::builder()
+        .with_capabilities(capabilities.clone())
+        .ciphersuite(ciphersuite)
+        .build(alice_provider, &alice_signer, alice_credential.clone())
+        .expect("An unexpected error occurred.");
+
+    // save the storage state
+    let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+
+    let payload = vec![0; 100];
+    let custom_proposal = CustomProposal::new(custom_proposal_type, payload);
+
+    let (_mls_msg_out, _proposal_ref) = alice_group
+        .propose_custom_proposal_by_value(alice_provider, &alice_signer, custom_proposal)
+        .expect("could not propose custom proposal");
+
+    assert_eq!(alice_group.pending_proposals().count(), 1);
+
+    let (_commit, _welcome, _group_info) = alice_group
+        .commit_to_pending_proposals(alice_provider, &alice_signer)
+        .unwrap();
+
+    // === Delivery service rejected the commit ===
+
+    alice_group
+        .clear_pending_commit(alice_provider.storage())
+        .expect("Could not clear pending commit");
+
+    let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
+    assert!(state_before == state_after);
+}

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -128,7 +128,6 @@ fn discard_commit_update_with_new_signer() {
     let group_id = group_state.group_id();
 
     let [alice] = group_state.members_mut(&["alice"]);
-    let alice_group = &mut alice.group;
     let alice_provider = &alice_party.provider;
     let alice_credential = &alice.party.credential_with_key;
 
@@ -141,7 +140,7 @@ fn discard_commit_update_with_new_signer() {
     };
 
     // Check alice credential
-    let own_leaf_node_before = alice_group.own_leaf_node().unwrap().clone();
+    let own_leaf_node_before = alice.group.own_leaf_node().unwrap().clone();
     assert_eq!(
         own_leaf_node_before.credential(),
         &alice_credential.credential
@@ -161,7 +160,6 @@ fn discard_commit_update_with_new_signer() {
     // save the storage state for comparison later
     let state_before = alice.group_storage_state();
 
-    let [alice] = group_state.members_mut(&["alice"]);
     let old_signer = &alice.party.signer;
 
     // check that alice signer was stored

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -352,67 +352,6 @@ fn discard_commit_psk() {
     alice.assert_non_proposal_group_storage_state_matches(state_before);
 }
 
-/*
-#[openmls_test]
-fn discard_commit_reinit() {
-    let alice_provider = &Provider::default();
-
-    let group_id = GroupId::from_slice(b"Test Group");
-    // Generate credentials with keys
-    let (alice_credential, alice_signer) = generate_credential(
-        "Alice".into(),
-        ciphersuite.signature_algorithm(),
-        alice_provider,
-    );
-
-    // Define the MlsGroup configuration
-    let mls_group_create_config = MlsGroupCreateConfig::builder()
-        .ciphersuite(ciphersuite)
-        .use_ratchet_tree_extension(true) // NOTE: important
-        .build();
-
-    // === Alice creates a group ===
-    let mut alice_group = MlsGroup::new_with_group_id(
-        alice_provider,
-        &alice_signer,
-        &mls_group_create_config,
-        group_id.clone(),
-        alice_credential.clone(),
-    )
-    .expect("An unexpected error occurred.");
-
-    // save the storage state
-    let state_before = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
-
-    // TODO: is there a way to create this using the public API?
-    let reinit_proposal = todo!();
-
-    alice_group
-        .commit_builder()
-        .add_proposal(Proposal::ReInit(reinit_proposal))
-        .load_psks(alice_provider.storage())
-        .unwrap()
-        .build(
-            alice_provider.rand(),
-            alice_provider.crypto(),
-            &alice_signer,
-            |_| true,
-        )
-        .unwrap();
-    // === Delivery service rejected the commit ===
-
-    //ANCHOR: discard_commit_reinit
-    // Discard the commit
-    alice_group
-        .clear_pending_commit(alice_provider.storage())
-        .expect("Could not clear pending commit");
-    //ANCHOR_END: discard_commit_reinit
-
-    let state_after = GroupStorageState::from_storage(alice_provider.storage(), &group_id);
-    assert!(state_before.non_proposal_state == state_after.non_proposal_state);
-}
-*/
-
 #[openmls_test]
 fn discard_commit_external_join() {
     let bob_provider = &Provider::default();

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -10,11 +10,9 @@ use openmls_traits::types::SignatureScheme;
 fn generate_credential(
     identity: Vec<u8>,
     signature_algorithm: SignatureScheme,
-    provider: &impl openmls::storage::OpenMlsProvider,
 ) -> (CredentialWithKey, SignatureKeyPair) {
     let credential = BasicCredential::new(identity);
     let signature_keys = SignatureKeyPair::new(signature_algorithm).unwrap();
-    signature_keys.store(provider.storage()).unwrap();
 
     (
         CredentialWithKey {
@@ -356,11 +354,8 @@ fn discard_commit_psk() {
 #[openmls_test]
 fn discard_commit_external_join() {
     let bob_provider = &Provider::default();
-    let (bob_credential, bob_signer) = generate_credential(
-        "bob".into(),
-        ciphersuite.signature_algorithm(),
-        bob_provider,
-    );
+    let (bob_credential, bob_signer) =
+        generate_credential("bob".into(), ciphersuite.signature_algorithm());
 
     let group_id = GroupId::from_slice(b"Test Group");
 
@@ -478,11 +473,8 @@ fn discard_commit_custom_proposal() {
 
     let group_id = GroupId::from_slice(b"Test Group");
     // Generate credentials with keys
-    let (alice_credential, alice_signer) = generate_credential(
-        "alice".into(),
-        ciphersuite.signature_algorithm(),
-        alice_provider,
-    );
+    let (alice_credential, alice_signer) =
+        generate_credential("alice".into(), ciphersuite.signature_algorithm());
 
     let custom_proposal_type = 0;
 


### PR DESCRIPTION
This PR adds tests and examples (see issue #1723) for cleaning up local state when a Commit needs to be discarded. 

It adds test and examples for Commits containing these types of Proposals:
- Add
- Update (`MlsGroup::self_update_with_new_signer()`)
- Remove
- PreSharedKey
- ExternalInit
- GroupContextExtensions
- SelfRemove
- Custom

It also adds several smaller features to `test_utils::single_group_test_framework`, to further reduce boilerplate in the tests, including:
- Methods to access parts of the relevant state in the storage provider for a `MemberState`
- Assertions that ensure the group-related state in the `StorageProvider` is consistent with a provided state
- A methid to access the `GroupId` from the `GroupState`, and fix a bug where the `GroupId` was not passed in to the `MlsGroup`  creation method

Resolves #1734 