### PR TITLE
Disable `test_new_tree_error()` due to segfault

### DIFF
--- a/openmls/src/binary_tree/tests.rs
+++ b/openmls/src/binary_tree/tests.rs
@@ -153,6 +153,8 @@ fn test_diff_merging() {
     assert_eq!(tree, original_tree);
 }
 
+/*
+// Disabled due to #1727
 #[test]
 fn test_new_tree_error() {
     // Let's test what happens when the tree is getting too large.
@@ -169,6 +171,7 @@ fn test_new_tree_error() {
         )
     }
 }
+*/
 
 #[test]
 fn test_diff_iter() {


### PR DESCRIPTION
This PR disables the test `test_new_tree_error()` due to a segfault on 32-bit platforms (see #1727)