### PR TITLE
Single group test framework

### DIFF
--- a/openmls/src/test_utils/mod.rs
+++ b/openmls/src/test_utils/mod.rs
@@ -30,6 +30,8 @@ use crate::{
 pub mod frankenstein;
 pub mod test_framework;
 
+pub mod single_group_test_framework;
+
 pub(crate) fn write(file_name: &str, obj: impl Serialize) {
     let mut file = match File::create(file_name) {
         Ok(f) => f,

--- a/openmls/src/test_utils/single_group_test_framework/assertions.rs
+++ b/openmls/src/test_utils/single_group_test_framework/assertions.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+impl<Provider: OpenMlsProvider> GroupState<'_, Provider> {
+    pub fn assert_membership(&self) {
+        let mut names = self
+            .members
+            .keys()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        names.sort();
+
+        for state in self.members.values() {
+            let mut names_in_group = state
+                .group
+                .members()
+                .map(|member| {
+                    let credential: BasicCredential = member.credential.try_into().unwrap();
+
+                    String::from_utf8(credential.identity().to_owned()).unwrap()
+                })
+                .collect::<Vec<_>>();
+
+            names_in_group.sort();
+
+            assert_eq!(names, names_in_group);
+        }
+    }
+}

--- a/openmls/src/test_utils/single_group_test_framework/errors.rs
+++ b/openmls/src/test_utils/single_group_test_framework/errors.rs
@@ -2,14 +2,14 @@ use crate::prelude::{commit_builder::*, *};
 pub use crate::utils::*;
 
 pub use openmls_traits::{
-    storage::StorageProvider as StorageProviderTrait,
+    storage::{StorageProvider as StorageProviderTrait, CURRENT_VERSION},
     types::{Ciphersuite, HpkeKeyPair},
     OpenMlsProvider,
 };
 
 // type alias for `TestError`
 pub type GroupError<Provider> =
-    TestError<<<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error>;
+    TestError<<<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<CURRENT_VERSION>>::Error>;
 #[derive(Debug)]
 pub enum TestError<StorageError> {
     CreateCommit(CreateCommitError),

--- a/openmls/src/test_utils/single_group_test_framework/errors.rs
+++ b/openmls/src/test_utils/single_group_test_framework/errors.rs
@@ -19,6 +19,8 @@ pub enum TestError<StorageError> {
     Welcome(WelcomeError<StorageError>),
     ProtocolMessage(ProtocolMessageError),
     MergeCommit(MergeCommitError<StorageError>),
+    CommitToPendingProposals(CommitToPendingProposalsError<StorageError>),
+    NoSuchMember,
 }
 
 impl<StorageError> From<CreateCommitError> for TestError<StorageError> {
@@ -29,6 +31,12 @@ impl<StorageError> From<CreateCommitError> for TestError<StorageError> {
 impl<StorageError> From<CommitBuilderStageError<StorageError>> for TestError<StorageError> {
     fn from(e: CommitBuilderStageError<StorageError>) -> Self {
         TestError::CommitBuilderStage(e)
+    }
+}
+
+impl<StorageError> From<CommitToPendingProposalsError<StorageError>> for TestError<StorageError> {
+    fn from(e: CommitToPendingProposalsError<StorageError>) -> Self {
+        TestError::CommitToPendingProposals(e)
     }
 }
 

--- a/openmls/src/test_utils/single_group_test_framework/errors.rs
+++ b/openmls/src/test_utils/single_group_test_framework/errors.rs
@@ -1,3 +1,5 @@
+use thiserror::Error;
+
 use crate::prelude::{commit_builder::*, *};
 pub use crate::utils::*;
 
@@ -10,61 +12,15 @@ pub use openmls_traits::{
 // type alias for `TestError`
 pub type GroupError<Provider> =
     TestError<<<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<CURRENT_VERSION>>::Error>;
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum TestError<StorageError> {
-    CreateCommit(CreateCommitError),
-    CommitBuilderStage(CommitBuilderStageError<StorageError>),
-    NewGroup(NewGroupError<StorageError>),
-    ProcessMessage(ProcessMessageError),
-    Welcome(WelcomeError<StorageError>),
-    ProtocolMessage(ProtocolMessageError),
-    MergeCommit(MergeCommitError<StorageError>),
-    CommitToPendingProposals(CommitToPendingProposalsError<StorageError>),
+    CreateCommit(#[from] CreateCommitError),
+    CommitBuilderStage(#[from] CommitBuilderStageError<StorageError>),
+    NewGroup(#[from] NewGroupError<StorageError>),
+    ProcessMessage(#[from] ProcessMessageError),
+    Welcome(#[from] WelcomeError<StorageError>),
+    ProtocolMessage(#[from] ProtocolMessageError),
+    MergeCommit(#[from] MergeCommitError<StorageError>),
+    CommitToPendingProposals(#[from] CommitToPendingProposalsError<StorageError>),
     NoSuchMember,
-}
-
-impl<StorageError> From<CreateCommitError> for TestError<StorageError> {
-    fn from(e: CreateCommitError) -> Self {
-        TestError::CreateCommit(e)
-    }
-}
-impl<StorageError> From<CommitBuilderStageError<StorageError>> for TestError<StorageError> {
-    fn from(e: CommitBuilderStageError<StorageError>) -> Self {
-        TestError::CommitBuilderStage(e)
-    }
-}
-
-impl<StorageError> From<CommitToPendingProposalsError<StorageError>> for TestError<StorageError> {
-    fn from(e: CommitToPendingProposalsError<StorageError>) -> Self {
-        TestError::CommitToPendingProposals(e)
-    }
-}
-
-impl<StorageError> From<NewGroupError<StorageError>> for TestError<StorageError> {
-    fn from(e: NewGroupError<StorageError>) -> Self {
-        TestError::NewGroup(e)
-    }
-}
-impl<StorageError> From<WelcomeError<StorageError>> for TestError<StorageError> {
-    fn from(e: WelcomeError<StorageError>) -> Self {
-        TestError::Welcome(e)
-    }
-}
-
-impl<StorageError> From<ProcessMessageError> for TestError<StorageError> {
-    fn from(e: ProcessMessageError) -> Self {
-        TestError::ProcessMessage(e)
-    }
-}
-
-impl<StorageError> From<ProtocolMessageError> for TestError<StorageError> {
-    fn from(e: ProtocolMessageError) -> Self {
-        TestError::ProtocolMessage(e)
-    }
-}
-
-impl<StorageError> From<MergeCommitError<StorageError>> for TestError<StorageError> {
-    fn from(e: MergeCommitError<StorageError>) -> Self {
-        TestError::MergeCommit(e)
-    }
 }

--- a/openmls/src/test_utils/single_group_test_framework/errors.rs
+++ b/openmls/src/test_utils/single_group_test_framework/errors.rs
@@ -1,0 +1,53 @@
+use crate::prelude::{commit_builder::*, *};
+pub use crate::utils::*;
+
+#[derive(Debug)]
+pub enum TestError<StorageError> {
+    CreateCommit(CreateCommitError),
+    CommitBuilderStage(CommitBuilderStageError<StorageError>),
+    NewGroup(NewGroupError<StorageError>),
+    ProcessMessage(ProcessMessageError),
+    Welcome(WelcomeError<StorageError>),
+    ProtocolMessage(ProtocolMessageError),
+    MergeCommit(MergeCommitError<StorageError>),
+}
+
+impl<StorageError> From<CreateCommitError> for TestError<StorageError> {
+    fn from(e: CreateCommitError) -> Self {
+        TestError::CreateCommit(e)
+    }
+}
+impl<StorageError> From<CommitBuilderStageError<StorageError>> for TestError<StorageError> {
+    fn from(e: CommitBuilderStageError<StorageError>) -> Self {
+        TestError::CommitBuilderStage(e)
+    }
+}
+
+impl<StorageError> From<NewGroupError<StorageError>> for TestError<StorageError> {
+    fn from(e: NewGroupError<StorageError>) -> Self {
+        TestError::NewGroup(e)
+    }
+}
+impl<StorageError> From<WelcomeError<StorageError>> for TestError<StorageError> {
+    fn from(e: WelcomeError<StorageError>) -> Self {
+        TestError::Welcome(e)
+    }
+}
+
+impl<StorageError> From<ProcessMessageError> for TestError<StorageError> {
+    fn from(e: ProcessMessageError) -> Self {
+        TestError::ProcessMessage(e)
+    }
+}
+
+impl<StorageError> From<ProtocolMessageError> for TestError<StorageError> {
+    fn from(e: ProtocolMessageError) -> Self {
+        TestError::ProtocolMessage(e)
+    }
+}
+
+impl<StorageError> From<MergeCommitError<StorageError>> for TestError<StorageError> {
+    fn from(e: MergeCommitError<StorageError>) -> Self {
+        TestError::MergeCommit(e)
+    }
+}

--- a/openmls/src/test_utils/single_group_test_framework/errors.rs
+++ b/openmls/src/test_utils/single_group_test_framework/errors.rs
@@ -1,6 +1,15 @@
 use crate::prelude::{commit_builder::*, *};
 pub use crate::utils::*;
 
+pub use openmls_traits::{
+    storage::StorageProvider as StorageProviderTrait,
+    types::{Ciphersuite, HpkeKeyPair},
+    OpenMlsProvider,
+};
+
+// type alias for `TestError`
+pub type GroupError<Provider> =
+    TestError<<<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error>;
 #[derive(Debug)]
 pub enum TestError<StorageError> {
     CreateCommit(CreateCommitError),

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -227,10 +227,17 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         Ok(Self { group_id, members })
     }
 
-    /// Get mutable references to all `MemberState`s as a fixed-size array
+    /// Get mutable references to all `MemberState`s as a fixed-size array,
+    /// in alphabetical order of the members' `Name`s
     pub fn all_members_mut<const N: usize>(&mut self) -> [&mut MemberState<'a, Provider>; N] {
+        let mut members: Vec<(&Name, &mut MemberState<'a, Provider>)> =
+            self.members.iter_mut().collect();
+
+        // sort by name
+        members.sort_by(|a, b| a.0.cmp(b.0));
+
         let member_states: Vec<&mut MemberState<'a, Provider>> =
-            self.members.values_mut().collect();
+            members.into_iter().map(|(_, member)| member).collect();
 
         match member_states.try_into() {
             Ok(states) => states,

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -228,7 +228,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
     }
 
     /// Get mutable references to all `MemberState`s as a fixed-size array
-    pub fn groups_mut<const N: usize>(&mut self) -> [&mut MemberState<'a, Provider>; N] {
+    pub fn all_members_mut<const N: usize>(&mut self) -> [&mut MemberState<'a, Provider>; N] {
         let member_states: Vec<&mut MemberState<'a, Provider>> =
             self.members.values_mut().collect();
 
@@ -445,7 +445,7 @@ mod test {
             GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
 
         // Get a mutable reference to Alice's group representation
-        let [alice] = group_state.groups_mut();
+        let [alice] = group_state.all_members_mut();
 
         // Build a commit with a single add proposal
         let bundle = alice

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -54,7 +54,7 @@ pub(crate) fn generate_key_package(
         .unwrap()
 }
 
-// Struct representing a party's global state
+/// Struct representing a party's global state
 pub struct CorePartyState<Provider> {
     name: Name,
     provider: Provider,
@@ -69,7 +69,7 @@ impl<Provider: Default> CorePartyState<Provider> {
     }
 }
 
-// Struct representing a party's state before joining a group
+/// Struct representing a party's state before joining a group
 pub struct PreGroupPartyState<'a, Provider> {
     credential_with_key: CredentialWithKey,
     // TODO: regenerate?
@@ -79,7 +79,7 @@ pub struct PreGroupPartyState<'a, Provider> {
 }
 
 impl<Provider: OpenMlsProvider> CorePartyState<Provider> {
-    // Generates the pre-group state for a `CorePartyState`
+    /// Generates the pre-group state for a `CorePartyState`
     pub fn generate_pre_group(&self, ciphersuite: Ciphersuite) -> PreGroupPartyState<'_, Provider> {
         let (credential_with_key, signer) = generate_credential(
             self.name.into(),
@@ -104,14 +104,14 @@ impl<Provider: OpenMlsProvider> CorePartyState<Provider> {
     }
 }
 
-// Represents a group member's `MlsGroup` instance and pre-group state
+/// Represents a group member's `MlsGroup` instance and pre-group state
 pub struct MemberState<'a, Provider> {
     party: PreGroupPartyState<'a, Provider>,
     group: MlsGroup,
 }
 
 impl<Provider: OpenMlsProvider> MemberState<'_, Provider> {
-    // Deliver_and_apply a message to this member's `MlsGroup`
+    /// Deliver_and_apply a message to this member's `MlsGroup`
     pub fn deliver_and_apply(
         &mut self,
         message: MlsMessageIn,
@@ -145,7 +145,7 @@ impl<'commit_builder, 'b: 'commit_builder, 'a: 'b, Provider> MemberState<'a, Pro
 where
     Provider: openmls_traits::OpenMlsProvider,
 {
-    // Build and stage a commit, using the provided closure to add proposals
+    /// Build and stage a commit, using the provided closure to add proposals
     pub fn build_commit_and_stage(
         &'b mut self,
         f: impl FnOnce(
@@ -178,11 +178,8 @@ where
 }
 
 impl<'a, Provider: OpenMlsProvider> MemberState<'a, Provider> {
-    // Create a `MemberState` from a `PreGroupPartyState`. This creates a new `MlsGroup` with one
-    // member
-    // TODO: builder pattern?
-    // - GroupId
-    // - MlsGroupCreateConfig
+    /// Create a `MemberState` from a `PreGroupPartyState`. This creates a new `MlsGroup` with one
+    /// member
     pub fn create_from_pre_group(
         party: PreGroupPartyState<'a, Provider>,
         mls_group_create_config: MlsGroupCreateConfig,
@@ -202,8 +199,8 @@ impl<'a, Provider: OpenMlsProvider> MemberState<'a, Provider> {
 
         Ok(Self { party, group })
     }
-    // Create a `MemberState` from a `Welcome`, which creates a new `MlsGroup` using a `Welcome`
-    // invitation from an existing group
+    /// Create a `MemberState` from a `Welcome`, which creates a new `MlsGroup` using a `Welcome`
+    /// invitation from an existing group
     pub fn join_from_pre_group(
         party: PreGroupPartyState<'a, Provider>,
         mls_group_join_config: MlsGroupJoinConfig,
@@ -228,14 +225,14 @@ impl<'a, Provider: OpenMlsProvider> MemberState<'a, Provider> {
     }
 }
 
-// All of the state for a group and its members
+/// All of the state for a group and its members
 pub struct GroupState<'a, Provider> {
     // TODO: GroupId
     members: HashMap<Name, MemberState<'a, Provider>>,
 }
 
 impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
-    // Create a new `GroupState` from a single party
+    /// Create a new `GroupState` from a single party
     pub fn new_from_party(
         pre_group_state: PreGroupPartyState<'a, Provider>,
         mls_group_create_config: MlsGroupCreateConfig,
@@ -256,7 +253,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         Ok(Self { members })
     }
 
-    // Get mutable references to all `MemberState`s as a fixed-size array
+    /// Get mutable references to all `MemberState`s as a fixed-size array
     pub fn groups_mut<const N: usize>(&mut self) -> [&mut MemberState<'a, Provider>; N] {
         let member_states: Vec<&mut MemberState<'a, Provider>> =
             self.members.values_mut().collect();
@@ -267,7 +264,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         }
     }
 
-    // Deliver_and_apply a message to all parties
+    /// Deliver_and_apply a message to all parties
     pub fn deliver_and_apply(
         &'b mut self,
         message: MlsMessageIn,
@@ -279,7 +276,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
     > {
         self.deliver_and_apply_if(message, |_| true)
     }
-    // Deliver_and_apply a message to all parties if a provided condition is met
+    /// Deliver_and_apply a message to all parties if a provided condition is met
     pub fn deliver_and_apply_if(
         &'b mut self,
         message: MlsMessageIn,
@@ -298,7 +295,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         Ok(())
     }
 
-    // Deliver_and_apply a welcome to a single party, and initialize a group for that party
+    /// Deliver_and_apply a welcome to a single party, and initialize a group for that party
     pub fn deliver_and_apply_welcome(
         &'b mut self,
         recipient: PreGroupPartyState<'a, Provider>,
@@ -323,8 +320,8 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         Ok(())
     }
 
-    // Drop a member from the internal hashmap. This does not delete the member from any
-    // `MlsGroup`
+    /// Drop a member from the internal hashmap. This does not delete the member from any
+    /// `MlsGroup`
     pub fn untrack_member(&mut self, name: Name) {
         let _ = self.members.remove(&name);
     }

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -209,7 +209,7 @@ pub struct GroupState<'a, Provider> {
     members: HashMap<Name, MemberState<'a, Provider>>,
 }
 
-impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
+impl<'a, Provider: OpenMlsProvider> GroupState<'a, Provider> {
     /// Create a new `GroupState` from a single party
     pub fn new_from_party(
         group_id: GroupId,
@@ -259,15 +259,12 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
     }
 
     /// Deliver_and_apply a message to all parties
-    pub fn deliver_and_apply(
-        &'b mut self,
-        message: MlsMessageIn,
-    ) -> Result<(), GroupError<Provider>> {
+    pub fn deliver_and_apply(&mut self, message: MlsMessageIn) -> Result<(), GroupError<Provider>> {
         self.deliver_and_apply_if(message, |_| true)
     }
     /// Deliver_and_apply a message to all parties if a provided condition is met
     pub fn deliver_and_apply_if(
-        &'b mut self,
+        &mut self,
         message: MlsMessageIn,
         condition: impl Fn(&MemberState<'a, Provider>) -> bool,
     ) -> Result<(), GroupError<Provider>> {
@@ -281,7 +278,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
 
     /// Deliver_and_apply a welcome to a single party, and initialize a group for that party
     pub fn deliver_and_apply_welcome(
-        &'b mut self,
+        &mut self,
         recipient: PreGroupPartyState<'a, Provider>,
         mls_group_join_config: MlsGroupJoinConfig,
         welcome: Welcome,

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -252,7 +252,7 @@ impl<'a, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         // sort by index
         members.sort_by_key(|(pos, _member)| *pos);
 
-        // keep only the `MemberState`
+        // keep only the references to `MemberState`s
         let member_states: Vec<&mut MemberState<'a, Provider>> =
             members.into_iter().map(|(_, member)| member).collect();
 

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -112,15 +112,7 @@ pub struct MemberState<'a, Provider> {
 
 impl<Provider: OpenMlsProvider> MemberState<'_, Provider> {
     /// Deliver_and_apply a message to this member's `MlsGroup`
-    pub fn deliver_and_apply(
-        &mut self,
-        message: MlsMessageIn,
-    ) -> Result<
-        (),
-        TestError<
-            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
-        >,
-    > {
+    pub fn deliver_and_apply(&mut self, message: MlsMessageIn) -> Result<(), GroupError<Provider>> {
         let message = message.try_into_protocol_message()?;
 
         // process message
@@ -151,13 +143,7 @@ where
         f: impl FnOnce(
             CommitBuilder<'commit_builder, Initial>,
         ) -> CommitBuilder<'commit_builder, Initial>,
-        // XXX: is there a better way to express this type constraint?
-    ) -> Result<
-        CommitMessageBundle,
-        TestError<
-            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
-        >,
-    > {
+    ) -> Result<CommitMessageBundle, GroupError<Provider>> {
         let commit_builder = f(self.group.commit_builder());
 
         let provider = &self.party.core_state.provider;
@@ -183,12 +169,7 @@ impl<'a, Provider: OpenMlsProvider> MemberState<'a, Provider> {
     pub fn create_from_pre_group(
         party: PreGroupPartyState<'a, Provider>,
         mls_group_create_config: MlsGroupCreateConfig,
-    ) -> Result<
-        Self,
-        TestError<
-            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
-        >,
-    > {
+    ) -> Result<Self, GroupError<Provider>> {
         // initialize MlsGroup
         let group = MlsGroup::new(
             &party.core_state.provider,
@@ -206,12 +187,7 @@ impl<'a, Provider: OpenMlsProvider> MemberState<'a, Provider> {
         mls_group_join_config: MlsGroupJoinConfig,
         welcome: Welcome,
         tree: Option<RatchetTreeIn>,
-    ) -> Result<
-        Self,
-        TestError<
-            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
-        >,
-    > {
+    ) -> Result<Self, GroupError<Provider>> {
         let staged_join = StagedWelcome::new_from_welcome(
             &party.core_state.provider,
             &mls_group_join_config,
@@ -237,12 +213,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         group_id: GroupId,
         pre_group_state: PreGroupPartyState<'a, Provider>,
         mls_group_create_config: MlsGroupCreateConfig,
-    ) -> Result<
-        Self,
-        TestError<
-            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
-        >,
-    > {
+    ) -> Result<Self, GroupError<Provider>> {
         let mut members = HashMap::new();
 
         let name = pre_group_state.core_state.name;
@@ -269,12 +240,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
     pub fn deliver_and_apply(
         &'b mut self,
         message: MlsMessageIn,
-    ) -> Result<
-        (),
-        TestError<
-            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
-        >,
-    > {
+    ) -> Result<(), GroupError<Provider>> {
         self.deliver_and_apply_if(message, |_| true)
     }
     /// Deliver_and_apply a message to all parties if a provided condition is met
@@ -282,12 +248,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         &'b mut self,
         message: MlsMessageIn,
         condition: impl Fn(&MemberState<'a, Provider>) -> bool,
-    ) -> Result<
-        (),
-        TestError<
-            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
-        >,
-    > {
+    ) -> Result<(), GroupError<Provider>> {
         self.members
             .values_mut()
             .filter(|member| condition(member))
@@ -303,12 +264,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         mls_group_join_config: MlsGroupJoinConfig,
         welcome: Welcome,
         tree: Option<RatchetTreeIn>,
-    ) -> Result<
-        (),
-        TestError<
-            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
-        >,
-    > {
+    ) -> Result<(), GroupError<Provider>> {
         // create new group
         let name = recipient.core_state.name;
 

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -227,13 +227,14 @@ impl<'a, Provider: OpenMlsProvider> MemberState<'a, Provider> {
 
 /// All of the state for a group and its members
 pub struct GroupState<'a, Provider> {
-    // TODO: GroupId
+    group_id: GroupId,
     members: HashMap<Name, MemberState<'a, Provider>>,
 }
 
 impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
     /// Create a new `GroupState` from a single party
     pub fn new_from_party(
+        group_id: GroupId,
         pre_group_state: PreGroupPartyState<'a, Provider>,
         mls_group_create_config: MlsGroupCreateConfig,
     ) -> Result<
@@ -250,7 +251,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
 
         members.insert(name, member_state);
 
-        Ok(Self { members })
+        Ok(Self { group_id, members })
     }
 
     /// Get mutable references to all `MemberState`s as a fixed-size array
@@ -355,8 +356,9 @@ mod test {
         let mls_group_join_config = mls_group_create_config.join_config().clone();
 
         // Initialize the group state
+        let group_id = GroupId::from_slice(b"test");
         let mut group_state =
-            GroupState::new_from_party(alice_pre_group, mls_group_create_config).unwrap();
+            GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
 
         // Get a mutable reference to Alice's group representation
         let [alice] = group_state.groups_mut();

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -469,13 +469,6 @@ mod test {
             })
             .expect("Could not stage commit");
 
-        // Deliver_and_apply to all members but Alice
-        group_state
-            .deliver_and_apply_if(bundle.commit().clone().into(), |member| {
-                member.party.core_state.name != "alice"
-            })
-            .expect("Error deliver_and_applying commit");
-
         // Deliver_and_apply welcome to Bob
         let welcome = bundle.welcome().unwrap().clone();
         group_state

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -234,27 +234,28 @@ impl<'a, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         &mut self,
         names: &[Name; N],
     ) -> [&mut MemberState<'a, Provider>; N] {
-
         assert!(N > 0, "must request at least one member");
-        assert!(N <= self.members.len(), "cannot request more members than available");
+        assert!(
+            N <= self.members.len(),
+            "cannot request more members than available"
+        );
 
         // map each member in `self.members` to its name's index in `names`
-        let mut members: [(_,_); N] = self
+        let mut members: [(_, _); N] = self
             .members
             .iter_mut()
             .filter_map(|(member_name, member)| {
                 // Find the index of the member's name in `names`
                 // NOTE: the list of names provided to this method will generally be short,
                 // so not many comparisons are made here.
-                let index = names
-                    .iter()
-                    .position(|name| name == member_name)?;
+                let index = names.iter().position(|name| name == member_name)?;
 
                 Some((index, member))
             })
             // collect into Vec, then into fixed-size array
             .collect::<Vec<_>>()
-            .try_into().ok()
+            .try_into()
+            .ok()
             .expect("At least one requested member not found");
 
         // sort by index
@@ -449,16 +450,13 @@ mod test {
         assert_eq!(charlie.party.core_state.name, "charlie");
         assert_eq!(dave.party.core_state.name, "dave");
 
-        let [dave, bob] =
-            group_state.members_mut(&["dave", "bob"]);
+        let [dave, bob] = group_state.members_mut(&["dave", "bob"]);
         assert_eq!(bob.party.core_state.name, "bob");
         assert_eq!(dave.party.core_state.name, "dave");
 
-        let [alice, charlie] =
-            group_state.members_mut(&["alice", "charlie"]);
+        let [alice, charlie] = group_state.members_mut(&["alice", "charlie"]);
         assert_eq!(alice.party.core_state.name, "alice");
         assert_eq!(charlie.party.core_state.name, "charlie");
-
     }
     #[openmls_test]
     pub fn simpler_example() {

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -1,0 +1,395 @@
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_traits::{signatures::Signer, types::SignatureScheme};
+pub use openmls_traits::{
+    storage::StorageProvider as StorageProviderTrait,
+    types::{Ciphersuite, HpkeKeyPair},
+    OpenMlsProvider,
+};
+
+pub use crate::utils::*;
+use crate::{
+    credentials::CredentialWithKey,
+    key_packages::KeyPackageBuilder,
+    prelude::{commit_builder::*, *},
+};
+
+mod errors;
+use errors::*;
+
+use std::collections::HashMap;
+
+// type alias for &'static str
+type Name = &'static str;
+
+// TODO: only define this once
+pub(crate) fn generate_credential(
+    identity: Vec<u8>,
+    signature_algorithm: SignatureScheme,
+    provider: &impl crate::storage::OpenMlsProvider,
+) -> (CredentialWithKey, SignatureKeyPair) {
+    let credential = BasicCredential::new(identity);
+    let signature_keys = SignatureKeyPair::new(signature_algorithm).unwrap();
+    signature_keys.store(provider.storage()).unwrap();
+
+    (
+        CredentialWithKey {
+            credential: credential.into(),
+            signature_key: signature_keys.to_public_vec().into(),
+        },
+        signature_keys,
+    )
+}
+
+// TODO: only define this once
+pub(crate) fn generate_key_package(
+    ciphersuite: Ciphersuite,
+    credential_with_key: CredentialWithKey,
+    extensions: Extensions,
+    provider: &impl crate::storage::OpenMlsProvider,
+    signer: &impl Signer,
+) -> KeyPackageBundle {
+    KeyPackage::builder()
+        .key_package_extensions(extensions)
+        .build(ciphersuite, provider, signer, credential_with_key)
+        .unwrap()
+}
+
+// Struct representing a party's global state
+pub struct CorePartyState<Provider> {
+    name: Name,
+    provider: Provider,
+}
+
+impl<Provider: Default> CorePartyState<Provider> {
+    pub fn new(name: Name) -> Self {
+        Self {
+            name,
+            provider: Provider::default(),
+        }
+    }
+}
+
+// Struct representing a party's state before joining a group
+pub struct PreGroupPartyState<'a, Provider> {
+    credential_with_key: CredentialWithKey,
+    // TODO: regenerate?
+    key_package_bundle: KeyPackageBundle,
+    signer: SignatureKeyPair,
+    core_state: &'a CorePartyState<Provider>,
+}
+
+impl<Provider: OpenMlsProvider> CorePartyState<Provider> {
+    // Generates the pre-group state for a `CorePartyState`
+    pub fn generate_pre_group(&self, ciphersuite: Ciphersuite) -> PreGroupPartyState<'_, Provider> {
+        let (credential_with_key, signer) = generate_credential(
+            self.name.into(),
+            ciphersuite.signature_algorithm(),
+            &self.provider,
+        );
+
+        let key_package_bundle = generate_key_package(
+            ciphersuite,
+            credential_with_key.clone(),
+            Extensions::default(), // TODO: provide as argument?
+            &self.provider,
+            &signer,
+        );
+
+        PreGroupPartyState {
+            credential_with_key,
+            key_package_bundle,
+            signer,
+            core_state: self,
+        }
+    }
+}
+
+// Represents a group member's `MlsGroup` instance and pre-group state
+pub struct MemberState<'a, Provider> {
+    party: PreGroupPartyState<'a, Provider>,
+    group: MlsGroup,
+}
+
+impl<Provider: OpenMlsProvider> MemberState<'_, Provider> {
+    // Deliver_and_apply a message to this member's `MlsGroup`
+    pub fn deliver_and_apply(
+        &mut self,
+        message: MlsMessageIn,
+    ) -> Result<
+        (),
+        TestError<
+            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
+        >,
+    > {
+        let message = message.try_into_protocol_message()?;
+
+        // process message
+        let processed_message = self
+            .group
+            .process_message(&self.party.core_state.provider, message)?;
+
+        match processed_message.into_content() {
+            ProcessedMessageContent::ApplicationMessage(_) => todo!(),
+            ProcessedMessageContent::ProposalMessage(_) => todo!(),
+            ProcessedMessageContent::ExternalJoinProposalMessage(_) => todo!(),
+            ProcessedMessageContent::StagedCommitMessage(m) => self
+                .group
+                .merge_staged_commit(&self.party.core_state.provider, *m)?,
+        };
+
+        Ok(())
+    }
+}
+
+impl<'commit_builder, 'b: 'commit_builder, 'a: 'b, Provider> MemberState<'a, Provider>
+where
+    Provider: openmls_traits::OpenMlsProvider,
+{
+    // Build and stage a commit, using the provided closure to add proposals
+    pub fn build_commit_and_stage(
+        &'b mut self,
+        f: impl FnOnce(
+            CommitBuilder<'commit_builder, Initial>,
+        ) -> CommitBuilder<'commit_builder, Initial>,
+        // XXX: is there a better way to express this type constraint?
+    ) -> Result<
+        CommitMessageBundle,
+        TestError<
+            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
+        >,
+    > {
+        let commit_builder = f(self.group.commit_builder());
+
+        let provider = &self.party.core_state.provider;
+
+        // TODO: most of the steps here cannot be done via the closure (yet)
+        let bundle = commit_builder
+            .load_psks(provider.storage())?
+            .build(
+                provider.rand(),
+                provider.crypto(),
+                &self.party.signer,
+                |_| true,
+            )?
+            .stage_commit(provider)?;
+
+        Ok(bundle)
+    }
+}
+
+impl<'a, Provider: OpenMlsProvider> MemberState<'a, Provider> {
+    // Create a `MemberState` from a `PreGroupPartyState`. This creates a new `MlsGroup` with one
+    // member
+    // TODO: builder pattern?
+    // - GroupId
+    // - MlsGroupCreateConfig
+    pub fn create_from_pre_group(
+        party: PreGroupPartyState<'a, Provider>,
+        mls_group_create_config: MlsGroupCreateConfig,
+    ) -> Result<
+        Self,
+        TestError<
+            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
+        >,
+    > {
+        // initialize MlsGroup
+        let group = MlsGroup::new(
+            &party.core_state.provider,
+            &party.signer,
+            &mls_group_create_config,
+            party.credential_with_key.clone(),
+        )?;
+
+        Ok(Self { party, group })
+    }
+    // Create a `MemberState` from a `Welcome`, which creates a new `MlsGroup` using a `Welcome`
+    // invitation from an existing group
+    pub fn join_from_pre_group(
+        party: PreGroupPartyState<'a, Provider>,
+        mls_group_join_config: MlsGroupJoinConfig,
+        welcome: Welcome,
+        tree: Option<RatchetTreeIn>,
+    ) -> Result<
+        Self,
+        TestError<
+            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
+        >,
+    > {
+        let staged_join = StagedWelcome::new_from_welcome(
+            &party.core_state.provider,
+            &mls_group_join_config,
+            welcome,
+            tree,
+        )?;
+
+        let group = staged_join.into_group(&party.core_state.provider)?;
+
+        Ok(Self { party, group })
+    }
+}
+
+// All of the state for a group and its members
+pub struct GroupState<'a, Provider> {
+    // TODO: GroupId
+    members: HashMap<Name, MemberState<'a, Provider>>,
+}
+
+impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
+    // Create a new `GroupState` from a single party
+    pub fn new_from_party(
+        pre_group_state: PreGroupPartyState<'a, Provider>,
+        mls_group_create_config: MlsGroupCreateConfig,
+    ) -> Result<
+        Self,
+        TestError<
+            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
+        >,
+    > {
+        let mut members = HashMap::new();
+
+        let name = pre_group_state.core_state.name;
+        let member_state =
+            MemberState::create_from_pre_group(pre_group_state, mls_group_create_config)?;
+
+        members.insert(name, member_state);
+
+        Ok(Self { members })
+    }
+
+    // Get mutable references to all `MemberState`s as a fixed-size array
+    pub fn groups_mut<const N: usize>(&mut self) -> [&mut MemberState<'a, Provider>; N] {
+        let member_states: Vec<&mut MemberState<'a, Provider>> =
+            self.members.values_mut().collect();
+
+        match member_states.try_into() {
+            Ok(states) => states,
+            Err(_) => panic!("Could not construct array of length {N} from members"),
+        }
+    }
+
+    // Deliver_and_apply a message to all parties
+    pub fn deliver_and_apply(
+        &'b mut self,
+        message: MlsMessageIn,
+    ) -> Result<
+        (),
+        TestError<
+            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
+        >,
+    > {
+        self.deliver_and_apply_if(message, |_| true)
+    }
+    // Deliver_and_apply a message to all parties if a provided condition is met
+    pub fn deliver_and_apply_if(
+        &'b mut self,
+        message: MlsMessageIn,
+        condition: impl Fn(&MemberState<'a, Provider>) -> bool,
+    ) -> Result<
+        (),
+        TestError<
+            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
+        >,
+    > {
+        self.members
+            .values_mut()
+            .filter(|member| condition(member))
+            .try_for_each(|member| member.deliver_and_apply(message.clone()))?;
+
+        Ok(())
+    }
+
+    // Deliver_and_apply a welcome to a single party, and initialize a group for that party
+    pub fn deliver_and_apply_welcome(
+        &'b mut self,
+        recipient: PreGroupPartyState<'a, Provider>,
+        mls_group_join_config: MlsGroupJoinConfig,
+        welcome: Welcome,
+        tree: Option<RatchetTreeIn>,
+    ) -> Result<
+        (),
+        TestError<
+            <<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<1>>::Error,
+        >,
+    > {
+        // create new group
+        let name = recipient.core_state.name;
+
+        let member_state =
+            MemberState::join_from_pre_group(recipient, mls_group_join_config, welcome, tree)?;
+
+        // insert after success
+        self.members.insert(name, member_state);
+
+        Ok(())
+    }
+
+    // Drop a member from the internal hashmap. This does not delete the member from any
+    // `MlsGroup`
+    pub fn untrack_member(&mut self, name: Name) {
+        let _ = self.members.remove(&name);
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use openmls_test::openmls_test;
+
+    #[openmls_test]
+    pub fn simple_example() {
+        let alice_party = CorePartyState::<Provider>::new("alice");
+        let bob_party = CorePartyState::<Provider>::new("bob");
+
+        let alice_pre_group = alice_party.generate_pre_group(ciphersuite);
+        let bob_pre_group = bob_party.generate_pre_group(ciphersuite);
+
+        // Get the key package for Bob
+        // TODO: should key package be regenerated each time?
+        let bob_key_package = bob_pre_group.key_package_bundle.key_package.clone();
+
+        // Create config
+        let mls_group_create_config = MlsGroupCreateConfig::builder()
+            .ciphersuite(ciphersuite)
+            .use_ratchet_tree_extension(true)
+            .build();
+
+        // Join config
+        let mls_group_join_config = mls_group_create_config.join_config().clone();
+
+        // Initialize the group state
+        let mut group_state =
+            GroupState::new_from_party(alice_pre_group, mls_group_create_config).unwrap();
+
+        // Get a mutable reference to Alice's group representation
+        let [alice] = group_state.groups_mut();
+
+        // Build a commit with a single add proposal
+        let bundle = alice
+            .build_commit_and_stage(move |builder| {
+                let add_proposal = Proposal::Add(AddProposal {
+                    key_package: bob_key_package,
+                });
+
+                // ...add more proposals here...
+
+                builder
+                    .consume_proposal_store(false)
+                    .add_proposal(add_proposal)
+            })
+            .expect("Could not stage commit");
+
+        // Deliver_and_apply to all members but Alice
+        group_state
+            .deliver_and_apply_if(bundle.commit().clone().into(), |member| {
+                member.party.core_state.name != "alice"
+            })
+            .expect("Error deliver_and_applying commit");
+
+        // Deliver_and_apply welcome to Bob
+        let welcome = bundle.welcome().unwrap().clone();
+        group_state
+            .deliver_and_apply_welcome(bob_pre_group, mls_group_join_config, welcome, None)
+            .expect("Error deliver_and_applying welcome");
+    }
+}

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -56,8 +56,8 @@ pub(crate) fn generate_key_package(
 
 /// Struct representing a party's global state
 pub struct CorePartyState<Provider> {
-    name: Name,
-    provider: Provider,
+    pub name: Name,
+    pub provider: Provider,
 }
 
 impl<Provider: Default> CorePartyState<Provider> {
@@ -71,11 +71,11 @@ impl<Provider: Default> CorePartyState<Provider> {
 
 /// Struct representing a party's state before joining a group
 pub struct PreGroupPartyState<'a, Provider> {
-    credential_with_key: CredentialWithKey,
+    pub credential_with_key: CredentialWithKey,
     // TODO: regenerate?
-    key_package_bundle: KeyPackageBundle,
-    signer: SignatureKeyPair,
-    core_state: &'a CorePartyState<Provider>,
+    pub key_package_bundle: KeyPackageBundle,
+    pub signer: SignatureKeyPair,
+    pub core_state: &'a CorePartyState<Provider>,
 }
 
 impl<Provider: OpenMlsProvider> CorePartyState<Provider> {
@@ -106,8 +106,8 @@ impl<Provider: OpenMlsProvider> CorePartyState<Provider> {
 
 /// Represents a group member's `MlsGroup` instance and pre-group state
 pub struct MemberState<'a, Provider> {
-    party: PreGroupPartyState<'a, Provider>,
-    group: MlsGroup,
+    pub party: PreGroupPartyState<'a, Provider>,
+    pub group: MlsGroup,
 }
 
 impl<Provider: OpenMlsProvider> MemberState<'_, Provider> {

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -233,11 +233,14 @@ impl<'a, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         &mut self,
         names: &[Name; N],
     ) -> [&mut MemberState<'a, Provider>; N] {
+        // Map each member in `self.members` to its name's index in `names`
+        // NOTE: the list of names provided to this method will generally be short,
+        // so not many comparisons are made here.
         let mut members: Vec<(usize, &mut MemberState<'a, Provider>)> = self
             .members
             .iter_mut()
             .map(|(member_name, member)| {
-                // NOTE: the list of names provided to this method will generally be short
+                // Find the index of the member's name in `names`
                 let index = names
                     .iter()
                     .position(|name| name == member_name)
@@ -246,9 +249,10 @@ impl<'a, Provider: OpenMlsProvider> GroupState<'a, Provider> {
             })
             .collect();
 
-        // sort by index in `names`
+        // sort by index
         members.sort_by_key(|(pos, _member)| *pos);
 
+        // keep only the `MemberState`
         let member_states: Vec<&mut MemberState<'a, Provider>> =
             members.into_iter().map(|(_, member)| member).collect();
 

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -246,7 +246,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
             })
             .collect();
 
-        // sort by name
+        // sort by index in `names`
         members.sort_by_key(|(pos, _member)| *pos);
 
         let member_states: Vec<&mut MemberState<'a, Provider>> =

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -237,6 +237,7 @@ impl<'b, 'a: 'b, Provider: OpenMlsProvider> GroupState<'a, Provider> {
             .members
             .iter_mut()
             .map(|(member_name, member)| {
+                // NOTE: the list of names provided to this method will generally be short
                 let index = names
                     .iter()
                     .position(|name| name == member_name)

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -481,5 +481,16 @@ mod test {
         group_state
             .deliver_and_apply_welcome(bob_pre_group, mls_group_join_config, welcome, None)
             .expect("Error deliver_and_applying welcome");
+
+        let [alice, _bob] = group_state.all_members_mut();
+
+        let staged_commit = alice.group.pending_commit().unwrap().clone();
+
+        alice
+            .group
+            .merge_staged_commit(&alice.party.core_state.provider, staged_commit)
+            .expect("Error merging staged commit");
+
+        group_state.assert_membership();
     }
 }

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -227,7 +227,7 @@ impl<'a, Provider: OpenMlsProvider> GroupState<'a, Provider> {
         Ok(Self { group_id, members })
     }
 
-    /// Get mutable references to all `MemberState`s as a fixed-size array,
+    /// Get mutable references to specified `MemberState`s as a fixed-size array,
     /// in the order of the names provided in `names`.
     /// At least one member must be requested.
     pub fn members_mut<const N: usize>(

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -469,11 +469,11 @@ mod test {
             })
             .expect("Could not stage commit");
 
-        // Deliver_and_apply welcome to Bob
+        // Deliver and apply welcome to Bob
         let welcome = bundle.welcome().unwrap().clone();
         group_state
             .deliver_and_apply_welcome(bob_pre_group, mls_group_join_config, welcome, None)
-            .expect("Error deliver_and_applying welcome");
+            .expect("Error delivering and applying welcome");
 
         let [alice, _bob] = group_state.all_members_mut();
 


### PR DESCRIPTION
This pull request adds a lightweight test suite that aims to avoid boilerplate in many of the tests that involve a single group with multiple members. 

It provides functionality for:
- Setting up testing scenarios (creating groups with multiple, arbitrary members)
- Delivering and applying a message for all members of a group where a provided condition is met
- Individually accessing the underlying `MlsGroup`s and performing operations on them in a more granular way
- Asserting correctness of group membership