### PR TITLE
Add Helpers for resolving forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Test with Fork Resolution helpers
-        run cargo test $TEST_MODE -p openmls -F fork-resolution-helpers
+        run: cargo test $TEST_MODE -p openmls -F fork-resolution-helpers
 
       - name: Test with libcrux provider
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,10 @@ jobs:
           else
             echo "TEST_MODE=--release" >> $GITHUB_ENV
           fi
+
+      - name: Test with Fork Resolution helpers
+        run cargo test $TEST_MODE -p openmls -F fork-resolution-helpers
+
       - name: Test with libcrux provider
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Test with Fork Resolution helpers
-        run: cargo test $TEST_MODE -p openmls -F fork-resolution-helpers
+        run: cargo test $TEST_MODE -p openmls -F fork-resolution
 
       - name: Test with libcrux provider
         if: matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1666](https://github.com/openmls/openmls/pull/1666): Add `members()` and `group_context()` getter methods to `StagedWelcome`.
 - [#1672](https://github.com/openmls/openmls/pull/1672): Add `epoch()` getter method to `VerifiableGroupInfo`.
 - [#1673](https://github.com/openmls/openmls/pull/1673): Return more specific error when attempting to decrypt own messages: `ProcessMessageError::ValidationError(ValidationError::CannotDecryptOwnMessage)`.
-- [#1731](https://github.com/openmls/openmls/pull/1731): Add helpers to recover from group state forks
+- [#1731](https://github.com/openmls/openmls/pull/1731): Add helpers to recover from group state forks, hidden behind the new `fork-resolution` feature flag.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1688](https://github.com/openmls/openmls/pull/1688): Add `unknown()` getter method to `Extensions`.
 - [#1666](https://github.com/openmls/openmls/pull/1666): Add `members()` and `group_context()` getter methods to `StagedWelcome`.
 - [#1672](https://github.com/openmls/openmls/pull/1672): Add `epoch()` getter method to `VerifiableGroupInfo`.
-- [#1673](https://github.com/openmls/openmls/pull/1673): Return more specific error when attemtping to decrypt own messages: `ProcessMessageError::ValidationError(ValidationError::CannotDecryptOwnMessage)`.
+- [#1673](https://github.com/openmls/openmls/pull/1673): Return more specific error when attempting to decrypt own messages: `ProcessMessageError::ValidationError(ValidationError::CannotDecryptOwnMessage)`.
+- [#1731](https://github.com/openmls/openmls/pull/1731): Add helpers to recover from group state forks
 
 ### Fixed
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -21,6 +21,7 @@
   - [Persistence of group state](user_manual/persistence.md)
   - [Credential validation](user_manual/credential_validation.md)
   - [WebAssembly](user_manual/wasm.md)
+  - [Fork Resolution](user_manual/fork-resolution.md)
 - [Traits & External Types](./traits/README.md)
   - [Traits](./traits/traits.md)
   - [Types](./traits/types.md)

--- a/book/src/user_manual/fork-resolution.md
+++ b/book/src/user_manual/fork-resolution.md
@@ -1,0 +1,77 @@
+# Fork Resolution
+
+If members of a group merge different commits, the group state is called forked.
+At this point, the group members have different keys and will not be able to decrypt
+each others' messages. While this should not happen in normal operation, it may
+still occur due to bugs. When enabling the `fork-resolution-helpers` feature,
+OpenMLS comes with helpers to get a working group again. There are two helpers,
+and they use different mechanisms.
+
+The `readd` helper removes and then re-adds members that are forked. This requires
+that the caller knows the set of members that are forked. It is relatively
+efficient, especially if only a small number of members forked.
+
+The `reboot` helper creates a new group and helps with migrating the entire group
+state over. This includes extensions in the group context, as well as re-inviting
+all the members.
+
+We provide examples for how to use both, and in the end provide some guidance on
+detecting forks.
+
+## `readd` Example
+
+First, let's create a forked group. In this example, Alice creates a group and
+adds Bob. Then, they both merge different commits to add Charlie.
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code_fork_resolution.rs:readd_prepare_group}}
+```
+
+Then, Alice removes and re-adds Bob using the helper.
+We assume here that Alice knows that only Bob merged the wrong commit. This
+information needs to be transferred somehow, see [Fork Detection].
+Notice how Alice needs to provide a new key package for Bob.
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code_fork_resolution.rs:readd_do_it}}
+```
+
+In the end, they all can communicate again.
+
+## `reboot` Example
+
+Again, let's create a forked group. In this example, Alice creates a group and
+adds Bob. Then, they both merge different commits to add Charlie.
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code_fork_resolution.rs:reboot_prepare_group}}
+```
+
+Then, Alice sets up a new group and adds everyone from the old group. In this
+approach, she not only needs to provide key packages for all members, but also
+set a new group id and migrate the group context extensions, because these might
+be contain e.g. the old group id. This is the responsibility of the application,
+so the API just exposes the old extensions and expects the new ones.
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code_fork_resolution.rs:reboot_do_it}}
+```
+
+In the end, they all can communicate again.
+
+## Fork Detection
+
+Before initiating fork resolution, we first need to detect that a fork happened.
+In addition, for using the `readd` mechanism, we also need to know the members
+that forked.
+
+One simple technique that may work, depending on how the delivery service works,
+is to consider all incoming non-decryptable messages as a sign that there is a fork.
+However, this may lead to false positives and is not enough to know the membership.
+
+One way to learn about this that every member send a message when they merges a
+commit, encrypted for the old epoch, that contains the hash of the commit they are
+merging. This way, all group members know which commits are merged, and the `readd`
+strategy can be used to resolve possible forks.
+
+[Fork Detection]: #fork-detection

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -69,7 +69,7 @@ js = [
   "dep:getrandom",
   "dep:fluvio-wasm-timer",
 ] # enable js randomness source for provider
-fork-resolution-helpers = []
+fork-resolution = []
 
 [dev-dependencies]
 criterion = { version = "^0.5", default-features = false } # need to disable default features for wasm

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -69,6 +69,7 @@ js = [
   "dep:getrandom",
   "dep:fluvio-wasm-timer",
 ] # enable js randomness source for provider
+fork-resolution-helpers = []
 
 [dev-dependencies]
 criterion = { version = "^0.5", default-features = false } # need to disable default features for wasm

--- a/openmls/src/ciphersuite/kdf_label.rs
+++ b/openmls/src/ciphersuite/kdf_label.rs
@@ -29,7 +29,7 @@ impl KdfLabel {
         label: String,
         length: usize,
     ) -> Result<Vec<u8>, CryptoError> {
-        if length > u16::MAX.into() {
+        if length > u16::MAX as usize {
             debug_assert!(
                 false,
                 "Library error: Trying to derive a key with a too large length field!"

--- a/openmls/src/framing/tests.rs
+++ b/openmls/src/framing/tests.rs
@@ -394,8 +394,15 @@ fn unknown_sender<Provider: OpenMlsProvider>(ciphersuite: Ciphersuite, provider:
         _charlie_public_signature_key,
     ) = setup_client("Charlie", ciphersuite, provider);
 
-    let (mut alice_group, alice_signature_keys, _bob_group, _bob_signature_keys, _bob_credential) =
-        setup_alice_bob_group(ciphersuite, provider);
+    // TODO: don't let alice and bob share the provider
+    let (
+        mut alice_group,
+        alice_signature_keys,
+        _bob_group,
+        _bob_signature_keys,
+        _alice_credential,
+        _bob_credential,
+    ) = setup_alice_bob_group(ciphersuite, provider, provider);
 
     // Alice adds Charlie
     let (_commit, welcome, _group_info_option) = alice_group
@@ -487,13 +494,15 @@ fn unknown_sender<Provider: OpenMlsProvider>(ciphersuite: Ciphersuite, provider:
 
 #[openmls_test::openmls_test]
 fn confirmation_tag_presence<Provider: OpenMlsProvider>() {
+    // TODO: don't let alice and bob share the provider
     let (
         mut alice_group,
         alice_signature_keys,
         mut bob_group,
         _bob_signature_keys,
+        _alice_credential,
         _bob_credential,
-    ) = setup_alice_bob_group(ciphersuite, provider);
+    ) = setup_alice_bob_group(ciphersuite, provider, provider);
 
     // Alice does an update
     let (commit, _welcome_option, _group_info_option) = alice_group

--- a/openmls/src/group/fork_resolution/mod.rs
+++ b/openmls/src/group/fork_resolution/mod.rs
@@ -1,0 +1,15 @@
+//! This module contains facilities for dealing with state forks, i.e. situations in which
+//! different parts of a group merged different commits. Here, we provide helpers for two
+//! approaches, that come with different requirements and performance profiles.
+//!
+//! The [`readd`] module contains helpers for removing and re-adding members that merged a wrong
+//! commit. It is the responsibility of the application to determine which commit is the right one,
+//! as well as which members need to be re-added. This is a relatively cheap mechanism, but it
+//! requires knowing about the partitions.
+//!
+//! The [`reboot`] module contains helpers to set up a new group and add all members of the current
+//! group. The application needs to determine who should set that new group up and how to migrate
+//! the group context extensions from the old group. This is the more expensive mechanism.
+
+mod readd;
+mod reboot;

--- a/openmls/src/group/fork_resolution/readd.rs
+++ b/openmls/src/group/fork_resolution/readd.rs
@@ -37,7 +37,7 @@ impl MlsGroup {
         // Fail if there is a leaf node index that is not a member
         let own_partition = own_partition.ok_or(ReAddError::InvalidLeafNodeIndex)?;
 
-        // Compute the complement parition, i.e. the list of members that are not in our partition
+        // Compute the complement partition, i.e. the list of members that are not in our partition
         let complement_partition = complement(&own_partition, self.members()).collect();
 
         let stage = ReAddExpectKeyPackages {

--- a/openmls/src/group/fork_resolution/readd.rs
+++ b/openmls/src/group/fork_resolution/readd.rs
@@ -27,14 +27,14 @@ impl MlsGroup {
         &mut self,
         own_partition: &[LeafNodeIndex],
     ) -> Result<CommitBuilder<ReAddExpectKeyPackages>, ReAddError> {
-        // Load member info. This is None of at least one of the indexes is not a valid member
+        // Load member info. This is None if at least one of the indexes is not a valid member
         let own_partition: Option<Vec<_>> = own_partition
             .iter()
             .cloned()
             .map(|leaf_index| self.member_at(leaf_index))
             .collect();
 
-        // Fail if ther eis a leaf node index that is not a member
+        // Fail if there is a leaf node index that is not a member
         let own_partition = own_partition.ok_or(ReAddError::InvalidLeafNodeIndex)?;
 
         // Compute the complement parition, i.e. the list of members that are not in our partition
@@ -49,7 +49,7 @@ impl MlsGroup {
 }
 
 impl<'a> CommitBuilder<'a, ReAddExpectKeyPackages> {
-    /// Returns the complemennt partition, i.e. the list of members that are not in our partition
+    /// Returns the complement partition, i.e. the list of members that are not in our partition.
     pub fn complement_partition(&self) -> &[Member] {
         self.stage().complement_partition.as_slice()
     }

--- a/openmls/src/group/fork_resolution/readd.rs
+++ b/openmls/src/group/fork_resolution/readd.rs
@@ -106,15 +106,10 @@ mod test {
 
     #[openmls_test::openmls_test]
     fn example_readd() {
-        let alice_provider_ = Provider::default();
-        let bob_provider_ = Provider::default();
-        let charlie_provider_ = Provider::default();
-        let dave_provider_ = Provider::default();
-
-        let alice_provider = &alice_provider_;
-        let bob_provider = &bob_provider_;
-        let charlie_provider = &charlie_provider_;
-        let dave_provider = &dave_provider_;
+        let alice_provider = &Provider::default();
+        let bob_provider = &Provider::default();
+        let charlie_provider = &Provider::default();
+        let dave_provider = &Provider::default();
 
         // Create group with alice and bob
         let (mut alice_group, alice_signer, mut bob_group, bob_signer, _alice_cwk, bob_cwk) =

--- a/openmls/src/group/fork_resolution/readd.rs
+++ b/openmls/src/group/fork_resolution/readd.rs
@@ -1,0 +1,256 @@
+//! This module contains helpers for removing and re-adding members that merged a wrong
+//! commit. It is the responsibility of the application to determine which commit is the right one,
+//! as well as which members need to be re-added. This is a relatively cheap mechanism, but it
+//! requires knowing about the partitions.
+
+use crate::binary_tree::LeafNodeIndex;
+
+use crate::{
+    group::{
+        commit_builder::{CommitBuilder, Initial},
+        Member, MlsGroup,
+    },
+    prelude::KeyPackage,
+};
+
+/// A stage for the [`CommitBuilder`] for removing and re-adding members from other partitions.
+pub struct ReAddExpectKeyPackages {
+    complement_partition: Vec<Member>,
+}
+
+impl MlsGroup {
+    /// Create a [`CommitBuilder`] that is preparing to remove and re-add members from other fork
+    /// partitions. `own_partition` is the list of [`LeafNodeIndex`] that are members in the
+    /// partition that the initiating client is in. This should include the [`LeafNodeIndex`] of
+    /// the initiating client.
+    pub fn recover_fork_by_readding(
+        &mut self,
+        own_partition: &[LeafNodeIndex],
+    ) -> Result<CommitBuilder<ReAddExpectKeyPackages>, ReAddError> {
+        // Load member info. This is None of at least one of the indexes is not a valid member
+        let own_partition: Option<Vec<_>> = own_partition
+            .iter()
+            .cloned()
+            .map(|leaf_index| self.member_at(leaf_index))
+            .collect();
+
+        // Fail if ther eis a leaf node index that is not a member
+        let own_partition = own_partition.ok_or(ReAddError::InvalidLeafNodeIndex)?;
+
+        // Compute the complement parition, i.e. the list of members that are not in our partition
+        let complement_partition = complement(&own_partition, self.members()).collect();
+
+        let stage = ReAddExpectKeyPackages {
+            complement_partition,
+        };
+
+        Ok(self.commit_builder().into_stage(stage))
+    }
+}
+
+impl<'a> CommitBuilder<'a, ReAddExpectKeyPackages> {
+    /// Returns the complemennt partition, i.e. the list of members that are not in our partition
+    pub fn complement_partition(&self) -> &[Member] {
+        self.stage().complement_partition.as_slice()
+    }
+
+    /// Takes the key packages needed to re-add the other members and returns the prepared
+    /// [`CommitBuilder`].
+    pub fn provide_key_packages(
+        self,
+        new_key_packages: Vec<KeyPackage>,
+    ) -> CommitBuilder<'a, Initial> {
+        let (stage, builder) = self.replace_stage(Initial::default());
+
+        builder
+            .propose_removals(stage.complement_partition.iter().map(|member| member.index))
+            .propose_adds(new_key_packages)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+/// Indicates an error occurred during re-adding
+pub enum ReAddError {
+    /// An invalid leaf node index was provided
+    #[error("An invalid leaf node index was provided.")]
+    InvalidLeafNodeIndex,
+}
+
+/// Computes the complement partition of the provided list of members.
+// NOTE: If we require that the list of LeafNodeIndex is ordered, we can make this O(n) instead
+// of O(n^2).
+fn complement<'a, MembersIter>(
+    partition: &'a [Member],
+    members: MembersIter,
+) -> impl Iterator<Item = Member> + 'a
+where
+    MembersIter: IntoIterator<Item = Member> + 'a,
+{
+    members.into_iter().filter(|member| {
+        partition
+            .iter()
+            .all(|own_member| member.index != own_member.index)
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        framing::MlsMessageIn,
+        group::{
+            mls_group::tests_and_kats::utils::{setup_alice_bob_group, setup_client},
+            tests_and_kats::utils::{generate_key_package, CredentialWithKeyAndSigner},
+            Extensions, StagedWelcome,
+        },
+    };
+
+    #[openmls_test::openmls_test]
+    fn example_readd() {
+        let alice_provider_ = Provider::default();
+        let bob_provider_ = Provider::default();
+        let charlie_provider_ = Provider::default();
+        let dave_provider_ = Provider::default();
+
+        let alice_provider = &alice_provider_;
+        let bob_provider = &bob_provider_;
+        let charlie_provider = &charlie_provider_;
+        let dave_provider = &dave_provider_;
+
+        // Create group with alice and bob
+        let (mut alice_group, alice_signer, mut bob_group, bob_signer, _alice_cwk, bob_cwk) =
+            setup_alice_bob_group(ciphersuite, alice_provider, bob_provider);
+
+        let (charlie_cwk, charlie_kpb, charlie_signer, _charlie_sig_pk) =
+            setup_client("Charlie", ciphersuite, charlie_provider);
+
+        let (_dave_cwk, dave_kpb, _dave_signer, _dave_sig_pk) =
+            setup_client("Dave", ciphersuite, dave_provider);
+
+        let bob_cwkas = CredentialWithKeyAndSigner {
+            credential_with_key: bob_cwk.clone(),
+            signer: bob_signer.clone(),
+        };
+
+        let charlie_cwkas = CredentialWithKeyAndSigner {
+            credential_with_key: charlie_cwk.clone(),
+            signer: charlie_signer.clone(),
+        };
+
+        // Alice and Bob concurrently invite someone and merge for whatever reason
+        alice_group
+            .commit_builder()
+            .propose_adds(Some(charlie_kpb.key_package().clone()))
+            .load_psks(alice_provider.storage())
+            .unwrap()
+            .build(
+                alice_provider.rand(),
+                alice_provider.crypto(),
+                &alice_signer,
+                |_| true,
+            )
+            .unwrap()
+            .stage_commit(alice_provider)
+            .unwrap();
+
+        bob_group
+            .commit_builder()
+            .propose_adds(Some(dave_kpb.key_package().clone()))
+            .load_psks(bob_provider.storage())
+            .unwrap()
+            .build(
+                bob_provider.rand(),
+                bob_provider.crypto(),
+                &bob_signer,
+                |_| true,
+            )
+            .unwrap()
+            .stage_commit(bob_provider)
+            .unwrap();
+
+        alice_group.merge_pending_commit(alice_provider).unwrap();
+        bob_group.merge_pending_commit(bob_provider).unwrap();
+
+        // We are forked now! Let's try to recover by rebooting. first get new key packages
+        let bob_new_kpb =
+            generate_key_package(ciphersuite, Extensions::empty(), bob_provider, bob_cwkas);
+
+        let charlie_new_kpb = generate_key_package(
+            ciphersuite,
+            Extensions::empty(),
+            charlie_provider,
+            charlie_cwkas,
+        );
+
+        // Now, re-add bob to the group
+        let builder = alice_group
+            .recover_fork_by_readding(&[alice_group.own_leaf_index()])
+            .unwrap();
+        let key_packages = builder
+            .complement_partition()
+            .iter()
+            .map(|member| match member.credential.serialized_content() {
+                b"Bob" => bob_new_kpb.key_package().clone(),
+                b"Charlie" => charlie_new_kpb.key_package().clone(),
+                _ => unreachable!(),
+            })
+            .collect();
+
+        let message_bundle = builder
+            .provide_key_packages(key_packages)
+            .load_psks(alice_provider.storage())
+            .unwrap()
+            .build(
+                alice_provider.rand(),
+                alice_provider.crypto(),
+                &alice_signer,
+                |_| true,
+            )
+            .unwrap()
+            .stage_commit(alice_provider)
+            .unwrap();
+
+        let (_commit, welcome, _group_info) = message_bundle.into_messages();
+        alice_group.merge_pending_commit(alice_provider).unwrap();
+
+        // Invite everyone
+        let welcome = welcome.unwrap();
+        let welcome: MlsMessageIn = welcome.into();
+        let welcome = welcome.into_welcome().unwrap();
+        let ratchet_tree = alice_group.export_ratchet_tree();
+
+        let new_group_bob = StagedWelcome::new_from_welcome(
+            bob_provider,
+            alice_group.configuration(),
+            welcome.clone(),
+            Some(ratchet_tree.clone().into()),
+        )
+        .unwrap()
+        .into_group(bob_provider)
+        .unwrap();
+
+        let new_group_charlie = StagedWelcome::new_from_welcome(
+            charlie_provider,
+            alice_group.configuration(),
+            welcome.clone(),
+            Some(ratchet_tree.clone().into()),
+        )
+        .unwrap()
+        .into_group(bob_provider)
+        .unwrap();
+
+        let alice_comparison = alice_group
+            .export_secret(alice_provider, "comparison", b"", 32)
+            .unwrap();
+
+        let bob_comparison = new_group_bob
+            .export_secret(bob_provider, "comparison", b"", 32)
+            .unwrap();
+
+        let charlie_comparison = new_group_charlie
+            .export_secret(charlie_provider, "comparison", b"", 32)
+            .unwrap();
+
+        assert_eq!(alice_comparison, bob_comparison);
+        assert_eq!(alice_comparison, charlie_comparison);
+    }
+}

--- a/openmls/src/group/fork_resolution/reboot.rs
+++ b/openmls/src/group/fork_resolution/reboot.rs
@@ -1,0 +1,279 @@
+//! The [`reboot`] module contains helpers to set up a new group and add all members of the current
+//! group. The application needs to determine who should set that new group up and how to migrate
+//! the group context extensions from the old group. This is the more expensive mechanism.
+
+use openmls_traits::signatures::Signer;
+
+use crate::{
+    credentials::CredentialWithKey,
+    extensions::errors::InvalidExtensionError,
+    group::{
+        commit_builder::{CommitBuilder, CommitMessageBundle, Initial},
+        group_builder::MlsGroupBuilder,
+        CommitBuilderStageError, CreateCommitError, Extensions, GroupId, Member, MlsGroup,
+        NewGroupError,
+    },
+    prelude::KeyPackage,
+    storage::OpenMlsProvider,
+};
+
+impl MlsGroup {
+    /// The first step towards creating a new group based on the parameters and membership list of
+    /// the current one.
+    pub fn reboot(&self, group_id: GroupId) -> RebootBuilder {
+        let group_builder = MlsGroup::builder()
+            .with_wire_format_policy(self.configuration().wire_format_policy)
+            .padding_size(self.configuration().padding_size)
+            .max_past_epochs(self.configuration().max_past_epochs)
+            .number_of_resumption_psks(self.configuration().number_of_resumption_psks)
+            .use_ratchet_tree_extension(self.configuration().use_ratchet_tree_extension)
+            .sender_ratchet_configuration(self.configuration().sender_ratchet_configuration)
+            .ciphersuite(self.ciphersuite())
+            .with_group_id(group_id);
+
+        RebootBuilder {
+            group: self,
+            group_builder,
+        }
+    }
+}
+
+/// The builder type for a group reboot.
+pub struct RebootBuilder<'a> {
+    group: &'a MlsGroup,
+    group_builder: MlsGroupBuilder,
+}
+
+impl<'a> RebootBuilder<'a> {
+    /// Returns the group context extensions of the old group, so they can be updated and passed
+    /// into the new group.
+    pub fn old_group_context_extensions(&self) -> &Extensions {
+        self.group.context().extensions()
+    }
+
+    /// The members of the old group, so new key packages for other members can be retrieved.
+    pub fn old_members(&self) -> impl Iterator<Item = Member> + 'a {
+        self.group
+            .members()
+            .filter(|member| member.index != self.group.own_leaf_index())
+    }
+
+    /// Lets the caller make changes to the [`MlsGroupBuilder`] before the group is created.
+    pub fn refine_group_builder(
+        self,
+        mut f: impl FnMut(MlsGroupBuilder) -> MlsGroupBuilder,
+    ) -> Self {
+        Self {
+            group_builder: f(self.group_builder),
+            ..self
+        }
+    }
+
+    /// Creates the group and commit using the provided `extensions` and `new_members`. The caller
+    /// can also make further changes to the [`CommitBuilder`] using the `refine_commit_builder`
+    /// argument. If that is not desired, provide the identity function (`|b| b`).
+    pub fn finish<Provider: OpenMlsProvider>(
+        self,
+        extensions: Extensions,
+        new_members: Vec<KeyPackage>,
+        refine_commit_builder: impl FnMut(CommitBuilder<Initial>) -> CommitBuilder<Initial>,
+        provider: &Provider,
+        signer: &impl Signer,
+        credential_with_key: CredentialWithKey,
+    ) -> Result<(MlsGroup, CommitMessageBundle), RebootError<Provider::StorageError>> {
+        let group_builder = self
+            .group_builder
+            .with_group_context_extensions(extensions)?;
+
+        let mut new_group = group_builder.build(provider, signer, credential_with_key)?;
+
+        new_group
+            .commit_builder()
+            .propose_adds(new_members)
+            .pipe_through(refine_commit_builder)
+            .load_psks(provider.storage())?
+            .build(provider.rand(), provider.crypto(), signer, |_| true)?
+            .stage_commit(provider)
+            .map_err(RebootError::CommitBuilderStage)
+            .map(|message_bundle| (new_group, message_bundle))
+    }
+}
+
+/// Indicates an error occurred during reboot.
+#[derive(Debug, thiserror::Error)]
+pub enum RebootError<StorageError> {
+    /// An invalid extension was provided.
+    #[error(transparent)]
+    InvalidExtension(#[from] InvalidExtensionError),
+    /// An error occurred while creating the new group.
+    #[error(transparent)]
+    NewGroup(#[from] NewGroupError<StorageError>),
+    /// An error occurred while creating the commit.
+    #[error(transparent)]
+    CreateCommit(#[from] CreateCommitError),
+    /// An error occurred while staging the commit.
+    #[error(transparent)]
+    CommitBuilderStage(#[from] CommitBuilderStageError<StorageError>),
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        framing::MlsMessageIn,
+        group::{
+            mls_group::tests_and_kats::utils::{setup_alice_bob_group, setup_client},
+            tests_and_kats::utils::{generate_key_package, CredentialWithKeyAndSigner},
+            Extensions, GroupId, StagedWelcome,
+        },
+    };
+
+    #[openmls_test::openmls_test]
+    fn example_reboot() {
+        let alice_provider_ = Provider::default();
+        let bob_provider_ = Provider::default();
+        let charlie_provider_ = Provider::default();
+        let dave_provider_ = Provider::default();
+
+        let alice_provider = &alice_provider_;
+        let bob_provider = &bob_provider_;
+        let charlie_provider = &charlie_provider_;
+        let dave_provider = &dave_provider_;
+
+        // Create group with alice and bob
+        let (mut alice_group, alice_signer, mut bob_group, bob_signer, alice_cwk, bob_cwk) =
+            setup_alice_bob_group(ciphersuite, alice_provider, bob_provider);
+
+        let (charlie_cwk, charlie_kpb, charlie_signer, _charlie_sig_pk) =
+            setup_client("Charlie", ciphersuite, charlie_provider);
+
+        let (_dave_cwk, dave_kpb, _dave_signer, _dave_sig_pk) =
+            setup_client("Dave", ciphersuite, dave_provider);
+
+        let bob_cwkas = CredentialWithKeyAndSigner {
+            credential_with_key: bob_cwk.clone(),
+            signer: bob_signer.clone(),
+        };
+
+        let charlie_cwkas = CredentialWithKeyAndSigner {
+            credential_with_key: charlie_cwk.clone(),
+            signer: charlie_signer.clone(),
+        };
+
+        // Alice and Bob concurrently invite someone and merge for whatever reason
+        alice_group
+            .commit_builder()
+            .propose_adds(Some(charlie_kpb.key_package().clone()))
+            .load_psks(alice_provider.storage())
+            .unwrap()
+            .build(
+                alice_provider.rand(),
+                alice_provider.crypto(),
+                &alice_signer,
+                |_| true,
+            )
+            .unwrap()
+            .stage_commit(alice_provider)
+            .unwrap();
+
+        bob_group
+            .commit_builder()
+            .propose_adds(Some(dave_kpb.key_package().clone()))
+            .load_psks(bob_provider.storage())
+            .unwrap()
+            .build(
+                bob_provider.rand(),
+                bob_provider.crypto(),
+                &bob_signer,
+                |_| true,
+            )
+            .unwrap()
+            .stage_commit(bob_provider)
+            .unwrap();
+
+        alice_group.merge_pending_commit(alice_provider).unwrap();
+        bob_group.merge_pending_commit(bob_provider).unwrap();
+
+        // We are forked now! Let's try to recover by rebooting. first get new key packages
+        let bob_new_kpb =
+            generate_key_package(ciphersuite, Extensions::empty(), bob_provider, bob_cwkas);
+
+        let charlie_new_kpb = generate_key_package(
+            ciphersuite,
+            Extensions::empty(),
+            charlie_provider,
+            charlie_cwkas,
+        );
+
+        // Now, reboot the group
+        let (mut new_group_alice, message_bundle) = alice_group
+            .reboot(GroupId::from_slice(b"new group id"))
+            .finish(
+                Extensions::empty(),
+                vec![
+                    bob_new_kpb.key_package().clone(),
+                    charlie_new_kpb.key_package().clone(),
+                ],
+                |builder| builder,
+                alice_provider,
+                &alice_signer,
+                alice_cwk.clone(),
+            )
+            .unwrap();
+
+        let (_commit, welcome, _group_info) = message_bundle.into_messages();
+        new_group_alice
+            .merge_pending_commit(alice_provider)
+            .unwrap();
+
+        // Invite everyone
+        let welcome = welcome.unwrap();
+        let welcome: MlsMessageIn = welcome.into();
+        let welcome = welcome.into_welcome().unwrap();
+        let ratchet_tree = new_group_alice.export_ratchet_tree();
+
+        let new_group_bob = StagedWelcome::new_from_welcome(
+            bob_provider,
+            alice_group.configuration(),
+            welcome.clone(),
+            Some(ratchet_tree.clone().into()),
+        )
+        .unwrap()
+        .into_group(bob_provider)
+        .unwrap();
+
+        let new_group_charlie = StagedWelcome::new_from_welcome(
+            charlie_provider,
+            alice_group.configuration(),
+            welcome.clone(),
+            Some(ratchet_tree.clone().into()),
+        )
+        .unwrap()
+        .into_group(bob_provider)
+        .unwrap();
+
+        let alice_comparison = new_group_alice
+            .export_secret(alice_provider, "comparison", b"", 32)
+            .unwrap();
+
+        let bob_comparison = new_group_bob
+            .export_secret(bob_provider, "comparison", b"", 32)
+            .unwrap();
+
+        let charlie_comparison = new_group_charlie
+            .export_secret(charlie_provider, "comparison", b"", 32)
+            .unwrap();
+
+        assert_eq!(alice_comparison, bob_comparison);
+        assert_eq!(alice_comparison, charlie_comparison);
+    }
+}
+
+/// Defines a method that consumes self, passes it into a closure and returns the output of the
+/// closure. Comes in handy in long builder chains.
+trait PipeThrough: Sized {
+    fn pipe_through<T: Sized, F: FnMut(Self) -> T>(self, mut f: F) -> T {
+        f(self)
+    }
+}
+
+impl<T> PipeThrough for T {}

--- a/openmls/src/group/fork_resolution/reboot.rs
+++ b/openmls/src/group/fork_resolution/reboot.rs
@@ -9,7 +9,7 @@ use crate::{
     extensions::errors::InvalidExtensionError,
     group::{
         commit_builder::{CommitBuilder, CommitMessageBundle, Initial},
-        group_builder::MlsGroupBuilder,
+        mls_group::builder::MlsGroupBuilder,
         CommitBuilderStageError, CreateCommitError, Extensions, GroupId, Member, MlsGroup,
         NewGroupError,
     },

--- a/openmls/src/group/fork_resolution/reboot.rs
+++ b/openmls/src/group/fork_resolution/reboot.rs
@@ -139,15 +139,10 @@ mod test {
 
     #[openmls_test::openmls_test]
     fn example_reboot() {
-        let alice_provider_ = Provider::default();
-        let bob_provider_ = Provider::default();
-        let charlie_provider_ = Provider::default();
-        let dave_provider_ = Provider::default();
-
-        let alice_provider = &alice_provider_;
-        let bob_provider = &bob_provider_;
-        let charlie_provider = &charlie_provider_;
-        let dave_provider = &dave_provider_;
+        let alice_provider = &Provider::default();
+        let bob_provider = &Provider::default();
+        let charlie_provider = &Provider::default();
+        let dave_provider = &Provider::default();
 
         // Create group with alice and bob
         let (mut alice_group, alice_signer, mut bob_group, bob_signer, alice_cwk, bob_cwk) =

--- a/openmls/src/group/fork_resolution/reboot.rs
+++ b/openmls/src/group/fork_resolution/reboot.rs
@@ -116,6 +116,16 @@ pub enum RebootError<StorageError> {
     CommitBuilderStage(#[from] CommitBuilderStageError<StorageError>),
 }
 
+/// Defines a method that consumes self, passes it into a closure and returns the output of the
+/// closure. Comes in handy in long builder chains.
+trait PipeThrough: Sized {
+    fn pipe_through<T: Sized, F: FnMut(Self) -> T>(self, mut f: F) -> T {
+        f(self)
+    }
+}
+
+impl<T> PipeThrough for T {}
+
 #[cfg(test)]
 mod test {
     use crate::{
@@ -267,13 +277,3 @@ mod test {
         assert_eq!(alice_comparison, charlie_comparison);
     }
 }
-
-/// Defines a method that consumes self, passes it into a closure and returns the output of the
-/// closure. Comes in handy in long builder chains.
-trait PipeThrough: Sized {
-    fn pipe_through<T: Sized, F: FnMut(Self) -> T>(self, mut f: F) -> T {
-        f(self)
-    }
-}
-
-impl<T> PipeThrough for T {}

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -151,7 +151,7 @@ impl<'a, T> CommitBuilder<'a, T> {
         (aux, CommitBuilder { group, stage })
     }
 
-    #[cfg(feature = "fork-resolution-helpers")]
+    #[cfg(feature = "fork-resolution")]
     pub(crate) fn stage(&self) -> &T {
         &self.stage
     }

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -46,6 +46,17 @@ pub struct Initial {
     consume_proposal_store: bool,
 }
 
+impl Default for Initial {
+    fn default() -> Self {
+        Initial {
+            consume_proposal_store: true,
+            force_self_update: false,
+            leaf_node_parameters: LeafNodeParameters::default(),
+            own_proposals: vec![],
+        }
+    }
+}
+
 /// This stage is after the PSKs were loaded, ready for validation
 pub struct LoadedPsks {
     own_proposals: Vec<Proposal>,
@@ -111,19 +122,25 @@ pub struct CommitBuilder<'a, T> {
 }
 
 impl<'a, T> CommitBuilder<'a, T> {
-    fn replace_stage<NextStage>(self, next_stage: NextStage) -> (T, CommitBuilder<'a, NextStage>) {
+    pub(crate) fn replace_stage<NextStage>(
+        self,
+        next_stage: NextStage,
+    ) -> (T, CommitBuilder<'a, NextStage>) {
         self.map_stage(|prev_stage| (prev_stage, next_stage))
     }
 
-    fn into_stage<NextStage>(self, next_stage: NextStage) -> CommitBuilder<'a, NextStage> {
+    pub(crate) fn into_stage<NextStage>(
+        self,
+        next_stage: NextStage,
+    ) -> CommitBuilder<'a, NextStage> {
         self.replace_stage(next_stage).1
     }
 
-    fn take_stage(self) -> (T, CommitBuilder<'a, ()>) {
+    pub(crate) fn take_stage(self) -> (T, CommitBuilder<'a, ()>) {
         self.replace_stage(())
     }
 
-    fn map_stage<NextStage, Aux, F: FnOnce(T) -> (Aux, NextStage)>(
+    pub(crate) fn map_stage<NextStage, Aux, F: FnOnce(T) -> (Aux, NextStage)>(
         self,
         f: F,
     ) -> (Aux, CommitBuilder<'a, NextStage>) {
@@ -132,6 +149,18 @@ impl<'a, T> CommitBuilder<'a, T> {
         let (aux, stage) = f(stage);
 
         (aux, CommitBuilder { group, stage })
+    }
+
+    pub(crate) fn group(&self) -> &MlsGroup {
+        self.group
+    }
+
+    pub(crate) fn group_mut(&mut self) -> &mut MlsGroup {
+        self.group
+    }
+
+    pub(crate) fn stage(&self) -> &T {
+        &self.stage
     }
 }
 
@@ -147,12 +176,7 @@ impl<'a> CommitBuilder<'a, Initial> {
     pub fn new(group: &'a mut MlsGroup) -> Self {
         Self {
             group,
-            stage: Initial {
-                consume_proposal_store: true,
-                force_self_update: false,
-                leaf_node_parameters: LeafNodeParameters::default(),
-                own_proposals: vec![],
-            },
+            stage: Initial::default(),
         }
     }
 

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -151,14 +151,7 @@ impl<'a, T> CommitBuilder<'a, T> {
         (aux, CommitBuilder { group, stage })
     }
 
-    pub(crate) fn group(&self) -> &MlsGroup {
-        self.group
-    }
-
-    pub(crate) fn group_mut(&mut self) -> &mut MlsGroup {
-        self.group
-    }
-
+    #[cfg(feature = "fork-resolution-helpers")]
     pub(crate) fn stage(&self) -> &T {
         &self.stage
     }

--- a/openmls/src/group/mls_group/exporting.rs
+++ b/openmls/src/group/mls_group/exporting.rs
@@ -26,7 +26,7 @@ impl MlsGroup {
     ) -> Result<Vec<u8>, ExportSecretError> {
         let crypto = provider.crypto();
 
-        if key_length > u16::MAX.into() {
+        if key_length > u16::MAX as usize {
             log::error!("Got a key that is larger than u16::MAX");
             return Err(ExportSecretError::KeyLengthTooLong);
         }

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -51,7 +51,6 @@ use openmls_traits::{signatures::Signer, storage::StorageProvider as _, types::C
 
 // Private
 mod application;
-mod builder;
 mod creation;
 mod exporting;
 mod updates;
@@ -59,6 +58,7 @@ mod updates;
 use config::*;
 
 // Crate
+pub(crate) mod builder;
 pub(crate) mod commit_builder;
 pub(crate) mod config;
 pub(crate) mod create_commit;
@@ -69,6 +69,7 @@ pub(crate) mod processing;
 pub(crate) mod proposal;
 pub(crate) mod proposal_store;
 pub(crate) mod staged_commit;
+pub(crate) use builder as group_builder;
 
 // Tests
 #[cfg(test)]

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -69,7 +69,6 @@ pub(crate) mod processing;
 pub(crate) mod proposal;
 pub(crate) mod proposal_store;
 pub(crate) mod staged_commit;
-pub(crate) use builder as group_builder;
 
 // Tests
 #[cfg(test)]

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     messages::{
         group_info::{GroupInfo, GroupInfoTBS, VerifiableGroupInfo},
         proposals::*,
-        Commit, GroupSecrets, Welcome,
+        Commit, ConfirmationTag, GroupSecrets, Welcome,
     },
     schedule::{
         message_secrets::MessageSecrets,
@@ -291,6 +291,11 @@ impl MlsGroup {
     /// Returns the group's ciphersuite.
     pub fn ciphersuite(&self) -> Ciphersuite {
         self.public_group.ciphersuite()
+    }
+
+    /// Get confirmation tag.
+    pub fn confirmation_tag(&self) -> &ConfirmationTag {
+        self.public_group.confirmation_tag()
     }
 
     /// Returns whether the own client is still a member of the group or if it

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -51,8 +51,7 @@ impl MlsGroup {
         }
 
         // Parse the message
-        let sender_ratchet_configuration =
-            self.configuration().sender_ratchet_configuration().clone();
+        let sender_ratchet_configuration = *self.configuration().sender_ratchet_configuration();
 
         // Checks the following semantic validation:
         //  - ValSem002

--- a/openmls/src/group/mls_group/tests_and_kats/tests/external_init.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/external_init.rs
@@ -7,8 +7,9 @@ use crate::group::{
 
 #[openmls_test::openmls_test]
 fn test_external_init_broken_signature() {
-    let (group_alice, alice_signer, _group_bob, _bob_signer, _bob_credential_with_key) =
-        setup_alice_bob_group(ciphersuite, provider);
+    let (group_alice, alice_signer, _group_bob, _bob_signer, _alice_credetial_with_key, _bob_credential_with_key) =
+        // TODO: don't let alice and bob share the provider
+        setup_alice_bob_group(ciphersuite, provider, provider);
 
     // Now set up charly and try to init externally.
     let (charlie_credential, _charlie_kpb, charlie_signer, _charlie_pk) =

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -1234,7 +1234,7 @@ fn builder_pattern() {
     let alice_group = MlsGroup::builder()
         .with_group_id(test_group_id.clone())
         .padding_size(test_padding_size)
-        .sender_ratchet_configuration(test_sender_ratchet_config.clone())
+        .sender_ratchet_configuration(test_sender_ratchet_config)
         .with_group_context_extensions(test_gc_extensions.clone())
         .expect("error adding group context extension to builder")
         .ciphersuite(test_ciphersuite)

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -2253,13 +2253,15 @@ fn failed_groupinfo_decryption(
 #[openmls_test::openmls_test]
 fn update_path() {
     // === Alice creates a group with her and Bob ===
+    // TODO: don't let alice and bob share the provider
     let (
         mut group_alice,
         _alice_signature_keys,
         mut group_bob,
         bob_signature_keys,
+        _alice_credential_with_key,
         _bob_credential_with_key,
-    ) = setup_alice_bob_group(ciphersuite, provider);
+    ) = setup_alice_bob_group(ciphersuite, provider, provider);
 
     // === Bob updates and commits ===
     let mut bob_new_leaf_node = group_bob.own_leaf_node().unwrap().clone();

--- a/openmls/src/group/mls_group/tests_and_kats/tests/proposals.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/proposals.rs
@@ -451,8 +451,9 @@ fn group_context_extension_proposal(
     provider: &impl crate::storage::OpenMlsProvider,
 ) {
     // Basic group setup.
-    let (mut alice_group, alice_signer, mut bob_group, bob_signer, _bob_credential) =
-        setup_alice_bob_group(ciphersuite, provider);
+    let (mut alice_group, alice_signer, mut bob_group, bob_signer, _alice_credential, _bob_credential) =
+        // TODO: don't let alice and bob share the provider
+        setup_alice_bob_group(ciphersuite, provider, provider);
 
     // Alice adds a required capability.
     let required_application_id =

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -31,7 +31,7 @@ pub use mls_group::{Member, *};
 pub use public_group::*;
 
 // Private
-#[cfg(feature = "fork-resolution-helpers")]
+#[cfg(feature = "fork-resolution")]
 mod fork_resolution;
 mod group_context;
 

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -31,6 +31,8 @@ pub use mls_group::{Member, *};
 pub use public_group::*;
 
 // Private
+#[cfg(feature = "fork-resolution-helpers")]
+mod fork_resolution;
 mod group_context;
 
 // Tests

--- a/openmls/src/group/tests_and_kats/tests/group.rs
+++ b/openmls/src/group/tests_and_kats/tests/group.rs
@@ -97,7 +97,11 @@ fn create_commit_optional_path(
 
 #[openmls_test::openmls_test]
 fn basic_group_setup() {
-    let (mut alice_group, alice_signer, _, _, _) = setup_alice_bob_group(ciphersuite, provider);
+    let alice_provider = Provider::default();
+    let bob_provider = Provider::default();
+
+    let (mut alice_group, alice_signer, _, _, _, _) =
+        setup_alice_bob_group(ciphersuite, &alice_provider, &bob_provider);
 
     let _result =
         match alice_group.self_update(provider, &alice_signer, LeafNodeParameters::default()) {
@@ -161,8 +165,9 @@ fn wrong_group_create_config() {
 #[openmls_test::openmls_test]
 fn group_operations() {
     // Create group with alice and bob
-    let (mut alice_group, alice_signer, mut bob_group, bob_signer, _) =
-        setup_alice_bob_group(ciphersuite, provider);
+    let (mut alice_group, alice_signer, mut bob_group, bob_signer, _, _) =
+        // TODO: don't let alice and bob share the provider
+        setup_alice_bob_group(ciphersuite, provider, provider);
 
     // Make sure that both groups have the same public tree
     assert_eq!(

--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -29,7 +29,7 @@ pub(crate) type Generation = u32;
 /// - maximum_forward_distance:
 ///   This parameter defines how many incoming messages can be skipped. This is useful if the DS
 ///   drops application messages. The default value is 1000.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SenderRatchetConfiguration {
     out_of_order_tolerance: Generation,
     maximum_forward_distance: Generation,

--- a/openmls/tests/book_code_fork_resolution.rs
+++ b/openmls/tests/book_code_fork_resolution.rs
@@ -7,13 +7,9 @@ use openmls_traits::{signatures::Signer, types::SignatureScheme};
 
 #[openmls_test]
 fn book_example_readd() {
-    let alice_provider_ = Provider::default();
-    let bob_provider_ = Provider::default();
-    let charlie_provider_ = Provider::default();
-
-    let alice_provider = &alice_provider_;
-    let bob_provider = &bob_provider_;
-    let charlie_provider = &charlie_provider_;
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+    let charlie_provider = &Provider::default();
 
     // Generate credentials with keys
     let (alice_credential, alice_signature_keys) = generate_credential(
@@ -239,13 +235,9 @@ fn book_example_readd() {
 
 #[openmls_test]
 fn book_example_reboot() {
-    let alice_provider_ = Provider::default();
-    let bob_provider_ = Provider::default();
-    let charlie_provider_ = Provider::default();
-
-    let alice_provider = &alice_provider_;
-    let bob_provider = &bob_provider_;
-    let charlie_provider = &charlie_provider_;
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+    let charlie_provider = &Provider::default();
 
     // Generate credentials with keys
     let (alice_credential, alice_signature_keys) = generate_credential(

--- a/openmls/tests/book_code_fork_resolution.rs
+++ b/openmls/tests/book_code_fork_resolution.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "fork-resolution-helpers")]
+#![cfg(feature = "fork-resolution")]
 
 use openmls::prelude::*;
 use openmls_basic_credential::SignatureKeyPair;
@@ -141,7 +141,7 @@ fn book_example_readd() {
             .into_group(charlie_provider)
             .unwrap();
 
-    // We shoulkd be forked now, double-check
+    // We should be forked now, double-check
     // Alice and Charlie are on the same state
     assert_eq!(
         alice_group.confirmation_tag(),

--- a/openmls/tests/book_code_fork_resolution.rs
+++ b/openmls/tests/book_code_fork_resolution.rs
@@ -1,0 +1,487 @@
+#![cfg(feature = "fork-resolution-helpers")]
+
+use openmls::prelude::*;
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_test::openmls_test;
+use openmls_traits::{signatures::Signer, types::SignatureScheme};
+
+#[openmls_test]
+fn book_example_readd() {
+    let alice_provider_ = Provider::default();
+    let bob_provider_ = Provider::default();
+    let charlie_provider_ = Provider::default();
+
+    let alice_provider = &alice_provider_;
+    let bob_provider = &bob_provider_;
+    let charlie_provider = &charlie_provider_;
+
+    // Generate credentials with keys
+    let (alice_credential, alice_signature_keys) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    let (bob_credential, bob_signature_keys) = generate_credential(
+        "Bob".into(),
+        ciphersuite.signature_algorithm(),
+        bob_provider,
+    );
+
+    let (charlie_credential, charlie_signature_keys) = generate_credential(
+        "Charlie".into(),
+        ciphersuite.signature_algorithm(),
+        charlie_provider,
+    );
+
+    let bob_kpb = generate_key_package(
+        ciphersuite,
+        bob_credential.clone(),
+        Extensions::empty(),
+        bob_provider,
+        &bob_signature_keys,
+    );
+
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .padding_size(100)
+        .sender_ratchet_configuration(SenderRatchetConfiguration::new(
+            10,   // out_of_order_tolerance
+            2000, // maximum_forward_distance
+        ))
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .build();
+
+    let mls_group_config = mls_group_create_config.join_config();
+
+    // ANCHOR: readd_prepare_group
+    // Alice creates a group
+    let mut alice_group = MlsGroup::new(
+        alice_provider,
+        &alice_signature_keys,
+        &mls_group_create_config,
+        alice_credential.clone(),
+    )
+    .unwrap();
+
+    // Alice adds Bob and merges the commit
+    let add_bob_messages = alice_group
+        .commit_builder()
+        .propose_adds(vec![bob_kpb.key_package().clone()])
+        .load_psks(alice_provider.storage())
+        .unwrap()
+        .build(
+            alice_provider.rand(),
+            alice_provider.crypto(),
+            &alice_signature_keys,
+            |_| true,
+        )
+        .unwrap()
+        .stage_commit(alice_provider)
+        .unwrap();
+
+    alice_group.merge_pending_commit(alice_provider).unwrap();
+
+    // Bob joins from the welcome
+    let welcome = add_bob_messages.into_welcome().unwrap();
+    let mut bob_group =
+        StagedWelcome::new_from_welcome(bob_provider, mls_group_config, welcome.clone(), None)
+            .unwrap()
+            .into_group(bob_provider)
+            .unwrap();
+
+    // Now Alice and Bob both add Charlie and merge their own commit.
+    // This forks the group.
+    let charlie_kpb = generate_key_package(
+        ciphersuite,
+        charlie_credential,
+        Extensions::empty(),
+        charlie_provider,
+        &charlie_signature_keys,
+    );
+
+    let add_charlie_messages = alice_group
+        .commit_builder()
+        .propose_adds(vec![charlie_kpb.key_package().clone()])
+        .load_psks(alice_provider.storage())
+        .unwrap()
+        .build(
+            alice_provider.rand(),
+            alice_provider.crypto(),
+            &alice_signature_keys,
+            |_| true,
+        )
+        .unwrap()
+        .stage_commit(alice_provider)
+        .unwrap();
+
+    bob_group
+        .commit_builder()
+        .propose_adds(vec![charlie_kpb.key_package().clone()])
+        .load_psks(bob_provider.storage())
+        .unwrap()
+        .build(
+            bob_provider.rand(),
+            bob_provider.crypto(),
+            &bob_signature_keys,
+            |_| true,
+        )
+        .unwrap()
+        .stage_commit(bob_provider)
+        .unwrap();
+
+    alice_group.merge_pending_commit(alice_provider).unwrap();
+    bob_group.merge_pending_commit(bob_provider).unwrap();
+
+    // Charlie joins using Alice's invite
+    let welcome = add_charlie_messages.into_welcome().unwrap();
+    let mut charlie_group =
+        StagedWelcome::new_from_welcome(charlie_provider, mls_group_config, welcome, None)
+            .unwrap()
+            .into_group(charlie_provider)
+            .unwrap();
+
+    // We shoulkd be forked now, double-check
+    // Alice and Charlie are on the same state
+    assert_eq!(
+        alice_group.confirmation_tag(),
+        charlie_group.confirmation_tag()
+    );
+    // But Bob is different from the other two
+    assert_ne!(bob_group.confirmation_tag(), alice_group.confirmation_tag());
+    assert_ne!(
+        bob_group.confirmation_tag(),
+        charlie_group.confirmation_tag()
+    );
+
+    // ANCHOR_END: readd_prepare_group
+
+    // ANCHOR: readd_do_it
+    // Let Alice re-add Bob
+    let bob_new_kpb = generate_key_package(
+        ciphersuite,
+        bob_credential,
+        Extensions::empty(),
+        bob_provider,
+        &bob_signature_keys,
+    );
+
+    let readd_messages = alice_group
+        .recover_fork_by_readding(&[alice_group.own_leaf_index()])
+        .unwrap()
+        .provide_key_packages(vec![bob_new_kpb.key_package().clone()])
+        .load_psks(alice_provider.storage())
+        .unwrap()
+        .build(
+            alice_provider.rand(),
+            alice_provider.crypto(),
+            &alice_signature_keys,
+            |_| true,
+        )
+        .unwrap()
+        .stage_commit(alice_provider)
+        .unwrap();
+
+    // Make Bob re-join the group and Alice and Charlie merge the commit that adds Bob.
+    let (commit, welcome, _) = readd_messages.into_contents();
+    let welcome = welcome.unwrap();
+    let bob_group = StagedWelcome::new_from_welcome(bob_provider, mls_group_config, welcome, None)
+        .unwrap()
+        .into_group(bob_provider)
+        .unwrap();
+
+    alice_group.merge_pending_commit(alice_provider).unwrap();
+
+    if let ProcessedMessageContent::StagedCommitMessage(staged_commit) = charlie_group
+        .process_message(charlie_provider, commit.into_protocol_message().unwrap())
+        .unwrap()
+        .into_content()
+    {
+        charlie_group
+            .merge_staged_commit(charlie_provider, *staged_commit)
+            .unwrap()
+    } else {
+        panic!("expected a commit")
+    }
+
+    // The fork should be fixed now, double-check
+    assert_eq!(alice_group.confirmation_tag(), bob_group.confirmation_tag());
+    assert_eq!(
+        alice_group.confirmation_tag(),
+        charlie_group.confirmation_tag()
+    );
+    assert_eq!(
+        charlie_group.confirmation_tag(),
+        bob_group.confirmation_tag()
+    );
+    // ANCHOR_END: readd_do_it
+}
+
+#[openmls_test]
+fn book_example_reboot() {
+    let alice_provider_ = Provider::default();
+    let bob_provider_ = Provider::default();
+    let charlie_provider_ = Provider::default();
+
+    let alice_provider = &alice_provider_;
+    let bob_provider = &bob_provider_;
+    let charlie_provider = &charlie_provider_;
+
+    // Generate credentials with keys
+    let (alice_credential, alice_signature_keys) = generate_credential(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    let (bob_credential, bob_signature_keys) = generate_credential(
+        "Bob".into(),
+        ciphersuite.signature_algorithm(),
+        bob_provider,
+    );
+
+    let (charlie_credential, charlie_signature_keys) = generate_credential(
+        "Charlie".into(),
+        ciphersuite.signature_algorithm(),
+        charlie_provider,
+    );
+
+    let bob_kpb = generate_key_package(
+        ciphersuite,
+        bob_credential.clone(),
+        Extensions::empty(),
+        bob_provider,
+        &bob_signature_keys,
+    );
+
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .padding_size(100)
+        .sender_ratchet_configuration(SenderRatchetConfiguration::new(
+            10,   // out_of_order_tolerance
+            2000, // maximum_forward_distance
+        ))
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .build();
+
+    let mls_group_config = mls_group_create_config.join_config();
+
+    // ANCHOR: reboot_prepare_group
+    // Alice creates a group
+    let mut alice_group = MlsGroup::new(
+        alice_provider,
+        &alice_signature_keys,
+        &mls_group_create_config,
+        alice_credential.clone(),
+    )
+    .unwrap();
+
+    // Alice adds Bob and merges the commit
+    let add_bob_messages = alice_group
+        .commit_builder()
+        .propose_adds(vec![bob_kpb.key_package().clone()])
+        .load_psks(alice_provider.storage())
+        .unwrap()
+        .build(
+            alice_provider.rand(),
+            alice_provider.crypto(),
+            &alice_signature_keys,
+            |_| true,
+        )
+        .unwrap()
+        .stage_commit(alice_provider)
+        .unwrap();
+
+    alice_group.merge_pending_commit(alice_provider).unwrap();
+
+    // Bob joins from the welcome
+    let welcome = add_bob_messages.into_welcome().unwrap();
+    let mut bob_group =
+        StagedWelcome::new_from_welcome(bob_provider, mls_group_config, welcome, None)
+            .unwrap()
+            .into_group(bob_provider)
+            .unwrap();
+
+    // Now Alice and Bob both add Charlie and merge their own commit.
+    // This forks the group.
+    let charlie_kpb = generate_key_package(
+        ciphersuite,
+        charlie_credential.clone(),
+        Extensions::empty(),
+        charlie_provider,
+        &charlie_signature_keys,
+    );
+
+    let add_charlie_messages = alice_group
+        .commit_builder()
+        .propose_adds(vec![charlie_kpb.key_package().clone()])
+        .load_psks(alice_provider.storage())
+        .unwrap()
+        .build(
+            alice_provider.rand(),
+            alice_provider.crypto(),
+            &alice_signature_keys,
+            |_| true,
+        )
+        .unwrap()
+        .stage_commit(alice_provider)
+        .unwrap();
+
+    bob_group
+        .commit_builder()
+        .propose_adds(vec![charlie_kpb.key_package().clone()])
+        .load_psks(bob_provider.storage())
+        .unwrap()
+        .build(
+            bob_provider.rand(),
+            bob_provider.crypto(),
+            &bob_signature_keys,
+            |_| true,
+        )
+        .unwrap()
+        .stage_commit(bob_provider)
+        .unwrap();
+
+    alice_group.merge_pending_commit(alice_provider).unwrap();
+    bob_group.merge_pending_commit(bob_provider).unwrap();
+
+    // Charlie joins using Alice's invite
+    let welcome = add_charlie_messages.into_welcome().unwrap();
+    let charlie_group =
+        StagedWelcome::new_from_welcome(charlie_provider, mls_group_config, welcome, None)
+            .unwrap()
+            .into_group(charlie_provider)
+            .unwrap();
+
+    // We shoulkd be forked now, double-check
+    // Alice and Charlie are on the same state
+    assert_eq!(
+        alice_group.confirmation_tag(),
+        charlie_group.confirmation_tag()
+    );
+    // But Bob is different from the other two
+    assert_ne!(bob_group.confirmation_tag(), alice_group.confirmation_tag());
+    assert_ne!(
+        bob_group.confirmation_tag(),
+        charlie_group.confirmation_tag()
+    );
+    // ANCHOR_END: reboot_prepare_group
+
+    // ANCHOR: reboot_do_it
+    // Let Alice reboot the group. For that she needs new key packages for Bob and Charlie, a;s
+    // well as a new group ID.
+    let bob_new_kpb = generate_key_package(
+        ciphersuite,
+        bob_credential,
+        Extensions::empty(),
+        bob_provider,
+        &bob_signature_keys,
+    );
+
+    let charlie_new_kpb = generate_key_package(
+        ciphersuite,
+        charlie_credential,
+        Extensions::empty(),
+        charlie_provider,
+        &charlie_signature_keys,
+    );
+
+    let new_group_id: GroupId = GroupId::from_slice(
+        alice_group
+            .group_id()
+            .as_slice()
+            .iter()
+            .copied()
+            .chain(b"-new".iter().copied())
+            .collect::<Vec<_>>()
+            .as_slice(),
+    );
+
+    let (mut alice_group, reboot_messages) = alice_group
+        .reboot(new_group_id)
+        .finish(
+            Extensions::empty(),
+            vec![
+                bob_new_kpb.key_package().clone(),
+                charlie_new_kpb.key_package().clone(),
+            ],
+            // We can use this closure to add more proposals to the commit builder that is used to
+            // create the commit that readds all the other members, but in this case we will leave
+            // it as-is.
+            |builder| builder,
+            alice_provider,
+            &alice_signature_keys,
+            alice_credential,
+        )
+        .unwrap();
+
+    alice_group.merge_pending_commit(alice_provider).unwrap();
+
+    // Bob and Charlie join the new group
+    let welcome = reboot_messages.into_welcome().unwrap();
+    let bob_group =
+        StagedWelcome::new_from_welcome(bob_provider, mls_group_config, welcome.clone(), None)
+            .unwrap()
+            .into_group(bob_provider)
+            .unwrap();
+    assert_eq!(bob_group.own_leaf_index(), LeafNodeIndex::new(1));
+
+    let charlie_group =
+        StagedWelcome::new_from_welcome(charlie_provider, mls_group_config, welcome, None)
+            .unwrap()
+            .into_group(charlie_provider)
+            .unwrap();
+    assert_eq!(charlie_group.own_leaf_index(), LeafNodeIndex::new(2));
+
+    // The fork should be fixed now, double-check
+    assert_eq!(alice_group.confirmation_tag(), bob_group.confirmation_tag());
+    assert_eq!(
+        alice_group.confirmation_tag(),
+        charlie_group.confirmation_tag()
+    );
+    assert_eq!(
+        bob_group.confirmation_tag(),
+        charlie_group.confirmation_tag()
+    );
+    // ANCHOR_END: reboot_do_it
+}
+
+// Everythiong below is copied from book_code.rs
+
+fn generate_credential(
+    identity: Vec<u8>,
+    signature_algorithm: SignatureScheme,
+    provider: &impl openmls::storage::OpenMlsProvider,
+) -> (CredentialWithKey, SignatureKeyPair) {
+    // ANCHOR: create_basic_credential
+    let credential = BasicCredential::new(identity);
+    // ANCHOR_END: create_basic_credential
+    // ANCHOR: create_credential_keys
+    let signature_keys = SignatureKeyPair::new(signature_algorithm).unwrap();
+    signature_keys.store(provider.storage()).unwrap();
+    // ANCHOR_END: create_credential_keys
+
+    (
+        CredentialWithKey {
+            credential: credential.into(),
+            signature_key: signature_keys.to_public_vec().into(),
+        },
+        signature_keys,
+    )
+}
+
+fn generate_key_package(
+    ciphersuite: Ciphersuite,
+    credential_with_key: CredentialWithKey,
+    extensions: Extensions,
+    provider: &impl openmls::storage::OpenMlsProvider,
+    signer: &impl Signer,
+) -> KeyPackageBundle {
+    // ANCHOR: create_key_package
+    // Create the key package
+    KeyPackage::builder()
+        .key_package_extensions(extensions)
+        .build(ciphersuite, provider, signer, credential_with_key)
+        .unwrap()
+    // ANCHOR_END: create_key_package
+}


### PR DESCRIPTION
This PR adds helpers for resolving forks in MLS groups. A state is forked if the group does not agree on the sequence of commits that were merged. This can happen due to state handling bugs in clients or a buggy DS.

The helpers are implemented on top of MlsGroup. Existing clients can already do this themselves, but the helpers take some of the burden of implementing this manually. They also are behind the `fork-resolution-helpers` feature flag, in order to make it opt-in.

This PR adds helpers based on two different strategies:

1. Remove and Re-Add. This requires the client initiating the resolution to know which members are in a different state. Given that information a commit that first removes all these clients and re-adds them.

2. Reboot the Group. Creates a new group and adds the same clients again. This does not require to know which clients are forked, but is more expensive.

Both of these are written using a builder style, so the caller can provide new key packages. For the reboot helper we had to work around the fact that we couldn't return both the new group and the commit builder, so instead any changes to the commit builder have to be done through a closure. 