### PR TITLE
add ability to rotate signature keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1666](https://github.com/openmls/openmls/pull/1666): Add `members()` and `group_context()` getter methods to `StagedWelcome`.
 - [#1672](https://github.com/openmls/openmls/pull/1672): Add `epoch()` getter method to `VerifiableGroupInfo`.
 - [#1673](https://github.com/openmls/openmls/pull/1673): Return more specific error when attemtping to decrypt own messages: `ProcessMessageError::ValidationError(ValidationError::CannotDecryptOwnMessage)`.
+- [#1735](https://github.com/openmls/openmls/pull/1735): Add `self_update_with_new_signer` function to `MlsGroup`, as well as a `build_with_new_signer` build option for the `CommitBuilder`. Both can be used to create commits that rotate the creator's signature key.
 
 ### Fixed
 

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -421,27 +421,27 @@ impl<'a> CommitBuilder<'a, LoadedPsks> {
                 // group context by updating the epoch and computing the new
                 // tree hash.
                 if let Some(new_signer) = new_signer {
-                diff.compute_path(
-                    rand,
-                    crypto,
-                    builder.group.own_leaf_index(),
-                    apply_proposals_values.exclusion_list(),
-                    &CommitType::Member,
-                    &cur_stage.leaf_node_parameters,
-                    new_signer,
-                    apply_proposals_values.extensions.clone()
-                )?
+                    diff.compute_path(
+                        rand,
+                        crypto,
+                        builder.group.own_leaf_index(),
+                        apply_proposals_values.exclusion_list(),
+                        &CommitType::Member,
+                        &cur_stage.leaf_node_parameters,
+                        new_signer,
+                        apply_proposals_values.extensions.clone()
+                    )?
                 } else {
-                diff.compute_path(
-                    rand,
-                    crypto,
-                    builder.group.own_leaf_index(),
-                    apply_proposals_values.exclusion_list(),
-                    &CommitType::Member,
-                    &cur_stage.leaf_node_parameters,
-                    old_signer,
-                    apply_proposals_values.extensions.clone()
-                )?
+                    diff.compute_path(
+                        rand,
+                        crypto,
+                        builder.group.own_leaf_index(),
+                        apply_proposals_values.exclusion_list(),
+                        &CommitType::Member,
+                        &cur_stage.leaf_node_parameters,
+                        old_signer,
+                        apply_proposals_values.extensions.clone()
+                    )?
                 }
             } else {
                 // If path is not needed, update the group context and return

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -280,8 +280,8 @@ impl<'a> CommitBuilder<'a, LoadedPsks> {
     /// the proposals that are considered for inclusion. This provides a way for
     /// the application to enforce custom policies in the creation of commits.
     ///
-    /// In contrast to `build`, this function can be used to create for commits
-    /// that rotate the own leaf node's signature key.
+    /// In contrast to `build`, this function can be used to create commits that
+    /// rotate the own leaf node's signature key.
     pub fn build_with_new_signer(
         self,
         rand: &impl OpenMlsRand,

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -265,11 +265,40 @@ impl<'a> CommitBuilder<'a, LoadedPsks> {
     /// Validates the inputs and builds the commit. The last argument `f` is a function that lets
     /// the caller filter the proposals that are considered for inclusion. This provides a way for
     /// the application to enforce custom policies in the creation of commits.
-    pub fn build(
+    pub fn build<S: Signer>(
         self,
         rand: &impl OpenMlsRand,
         crypto: &impl OpenMlsCrypto,
-        signer: &impl Signer,
+        signer: &S,
+        f: impl FnMut(&QueuedProposal) -> bool,
+    ) -> Result<CommitBuilder<'a, Complete>, CreateCommitError> {
+        self.build_internal(rand, crypto, signer, None::<&S>, f)
+    }
+
+    /// Just like `build`, this function validates the inputs and builds the
+    /// commit. The last argument `f` is a function that lets the caller filter
+    /// the proposals that are considered for inclusion. This provides a way for
+    /// the application to enforce custom policies in the creation of commits.
+    ///
+    /// In contrast to `build`, this function can be used to create for commits
+    /// that rotate the own leaf node's signature key.
+    pub fn build_with_new_signer(
+        self,
+        rand: &impl OpenMlsRand,
+        crypto: &impl OpenMlsCrypto,
+        old_signer: &impl Signer,
+        new_signer: &impl Signer,
+        f: impl FnMut(&QueuedProposal) -> bool,
+    ) -> Result<CommitBuilder<'a, Complete>, CreateCommitError> {
+        self.build_internal(rand, crypto, old_signer, Some(new_signer), f)
+    }
+
+    fn build_internal(
+        self,
+        rand: &impl OpenMlsRand,
+        crypto: &impl OpenMlsCrypto,
+        old_signer: &impl Signer,
+        new_signer: Option<&impl Signer>,
         f: impl FnMut(&QueuedProposal) -> bool,
     ) -> Result<CommitBuilder<'a, Complete>, CreateCommitError> {
         let ciphersuite = self.group.ciphersuite();
@@ -391,6 +420,7 @@ impl<'a> CommitBuilder<'a, LoadedPsks> {
                 // Process the path. This includes updating the provisional
                 // group context by updating the epoch and computing the new
                 // tree hash.
+                if let Some(new_signer) = new_signer {
                 diff.compute_path(
                     rand,
                     crypto,
@@ -398,9 +428,21 @@ impl<'a> CommitBuilder<'a, LoadedPsks> {
                     apply_proposals_values.exclusion_list(),
                     &CommitType::Member,
                     &cur_stage.leaf_node_parameters,
-                    signer,
+                    new_signer,
                     apply_proposals_values.extensions.clone()
                 )?
+                } else {
+                diff.compute_path(
+                    rand,
+                    crypto,
+                    builder.group.own_leaf_index(),
+                    apply_proposals_values.exclusion_list(),
+                    &CommitType::Member,
+                    &cur_stage.leaf_node_parameters,
+                    old_signer,
+                    apply_proposals_values.extensions.clone()
+                )?
+                }
             } else {
                 // If path is not needed, update the group context and return
                 // empty path processing results
@@ -425,7 +467,7 @@ impl<'a> CommitBuilder<'a, LoadedPsks> {
             sender,
             commit,
             builder.group.public_group.group_context(),
-            signer,
+            old_signer,
         )?;
 
         // Update the confirmed transcript hash using the commit we just created.
@@ -522,7 +564,7 @@ impl<'a> CommitBuilder<'a, LoadedPsks> {
                 )
             };
             // Sign to-be-signed group info.
-            Some(group_info_tbs.sign(signer)?)
+            Some(group_info_tbs.sign(old_signer)?)
         };
 
         let welcome_option = if !needs_welcome {

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -21,6 +21,7 @@ use crate::{
     schedule::{ExternalPsk, PreSharedKeyId, Psk},
     test_utils::{
         frankenstein::{FrankenFramedContentBody, FrankenPublicMessage},
+        single_group_test_framework::{AddMemberConfig, CorePartyState, GroupState},
         test_framework::{
             errors::ClientError, noop_authentication_service, ActionType::Commit, CodecUse,
             MlsGroupTestSetup,
@@ -2846,4 +2847,110 @@ fn proposal_application_after_self_was_removed_ref(
     let member = bob_members.next().unwrap();
     let bob_next_id = member.credential.serialized_content();
     assert_eq!(bob_next_id, b"Charlie");
+}
+
+// Test processing of own commits
+#[openmls_test::openmls_test]
+fn signature_key_rotation(
+    ciphersuite: Ciphersuite,
+    provider: &impl crate::storage::OpenMlsProvider,
+) {
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let bob_party = CorePartyState::<Provider>::new("bob");
+
+    let alice_pre_group = alice_party.generate_pre_group(ciphersuite);
+    let bob_pre_group = bob_party.generate_pre_group(ciphersuite);
+
+    // Create config
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .build();
+
+    // Join config
+    let mls_group_join_config = mls_group_create_config.join_config().clone();
+
+    // Initialize the group state
+    let group_id = GroupId::from_slice(b"test");
+    let mut group_state =
+        GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
+
+    group_state
+        .add_member(AddMemberConfig {
+            adder: "alice",
+            addees: vec![bob_pre_group],
+            join_config: mls_group_join_config.clone(),
+            tree: None,
+        })
+        .expect("Could not add member");
+
+    // Generate a new signer for Alice
+    let new_pre_group_state = alice_party.generate_pre_group(ciphersuite);
+
+    // Create a commit that updates Alice's signer
+    let [alice_group_state] = group_state.members_mut(&["alice"]);
+
+    let old_signature_key = alice_group_state
+        .party
+        .credential_with_key
+        .signature_key
+        .clone();
+    let new_signature_key = new_pre_group_state
+        .credential_with_key
+        .signature_key
+        .clone();
+    assert_ne!(old_signature_key, new_signature_key);
+
+    let leaf_node_parameters = LeafNodeParameters::builder()
+        .with_credential_with_key(new_pre_group_state.credential_with_key)
+        .build();
+
+    let bundle = alice_group_state
+        .group
+        .self_update_with_new_signer(
+            &alice_group_state.party.core_state.provider,
+            &alice_group_state.party.signer,
+            &new_pre_group_state.signer,
+            leaf_node_parameters,
+        )
+        .unwrap();
+
+    alice_group_state
+        .group
+        .merge_pending_commit(&alice_group_state.party.core_state.provider)
+        .unwrap();
+
+    group_state
+        .deliver_and_apply_if(bundle.into_commit().into(), |state| {
+            state.party.core_state.name != "alice"
+        })
+        .unwrap();
+
+    // Check that the signature key was rotated
+    let [bob_group_state] = group_state.members_mut(&["bob"]);
+    let alice_signature_key = bob_group_state
+        .group
+        .members()
+        .find(|m| m.index == LeafNodeIndex::new(0))
+        .unwrap()
+        .signature_key;
+    assert_eq!(alice_signature_key.as_slice(), new_signature_key.as_slice());
+
+    // Check that we can send messages using the new signer.
+    let [alice_group_state] = group_state.members_mut(&["alice"]);
+
+    let bundle = alice_group_state
+        .group
+        .self_update(
+            &alice_group_state.party.core_state.provider,
+            &new_pre_group_state.signer,
+            LeafNodeParameters::default(),
+        )
+        .unwrap();
+
+    group_state
+        .deliver_and_apply_if(bundle.into_commit().into(), |state| {
+            state.party.core_state.name != "alice"
+        })
+        .unwrap();
 }


### PR DESCRIPTION
This PR introduces a new `self_update_with_new_signer` function to `MlsGroup`, as well as a `build_with_new_signer` build option for the `CommitBuilder`. Both can be used to create commits that rotate the creator's signature key.