### PR TITLE
Path Required: Fix wrong negation in code comment

### DIFF
--- a/openmls/src/group/public_group/diff/apply_proposals.rs
+++ b/openmls/src/group/public_group/diff/apply_proposals.rs
@@ -173,7 +173,7 @@ impl PublicGroupDiff<'_> {
             .any(|p| p.proposal().is_path_required());
 
         // This flag determines if the commit requires a path. A path is required if:
-        // * none of the proposals require a path
+        // * at least one proposal requires a path
         // * (or) it is an external commit
         // * (or) the commit is empty which implicitly means it's a self-update
         let path_required = proposals_require_path

--- a/openmls/src/group/public_group/diff/apply_proposals.rs
+++ b/openmls/src/group/public_group/diff/apply_proposals.rs
@@ -174,12 +174,10 @@ impl PublicGroupDiff<'_> {
 
         // This flag determines if the commit requires a path. A path is required if:
         // * at least one proposal requires a path
-        // * (or) it is an external commit
         // * (or) the commit is empty which implicitly means it's a self-update
-        let path_required = proposals_require_path
-            // The fact that this is some implies that there's an external init proposal.
-            || external_init_proposal_option.is_some()
-            || proposal_queue.is_empty();
+        // * (or) it is an external commit
+        // External commits always have an ExternalInit proposal, which requires a path. Therefore the last check is redundant.
+        let path_required = proposals_require_path || proposal_queue.is_empty();
 
         Ok(ApplyProposalsValues {
             path_required,


### PR DESCRIPTION
The RFC says

> The path field MAY be omitted if (a) it covers at least one proposal and (b) none of the proposals covered by the Commit are of "path required" types.

https://www.rfc-editor.org/rfc/rfc9420.html#section-12.4-9

With a negation, this means that a path is required if there is no proposal or at least one proposal requires a path.

---

I also saw these lines were written, probably because of "External Commits MUST contain a path field" https://www.rfc-editor.org/rfc/rfc9420.html#section-12.4.3.2-11.1

            // * (or) it is an external commit
            || external_init_proposal_option.is_some()
            
But this is implied by `proposals_require_path` as far as I can tell:

External commits require "exactly one ExternalInit" proposal (https://www.rfc-editor.org/rfc/rfc9420.html#section-12.2-5), which is a proposal type that requires a path (https://www.rfc-editor.org/rfc/rfc9420.html#section-12.4-9).

I can remove this line if you agree.