### PR TITLE
Add validation tests for valn0104

### DIFF
--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -3,7 +3,6 @@ use crate::test_utils::single_group_test_framework::*;
 use crate::treesync::errors::LeafNodeValidationError;
 
 // Helper macro for checking error matches a provided pattern
-#[cfg(test)]
 macro_rules! assert_err_matches {
     ($err:expr, $pattern:pat) => {
         assert!(matches!($err.expect_err("Expected an error"), $pattern));
@@ -11,7 +10,6 @@ macro_rules! assert_err_matches {
 }
 
 // Function to check that the correct error type was returned
-#[cfg(test)]
 fn test_valn0104_error<Provider: OpenMlsProvider>(error: Result<(), GroupError<Provider>>) {
     assert_err_matches!(
         error,
@@ -25,7 +23,6 @@ fn test_valn0104_error<Provider: OpenMlsProvider>(error: Result<(), GroupError<P
     );
 }
 
-#[cfg(test)]
 impl<'a, 'b: 'a, Provider: OpenMlsProvider + Default> GroupState<'b, Provider> {
     // add a member to the GroupState with the specified credential capabilities
     fn add_member_with_credential_capabilities(
@@ -84,7 +81,6 @@ impl<'a, 'b: 'a, Provider: OpenMlsProvider + Default> GroupState<'b, Provider> {
     }
 }
 
-#[cfg(test)]
 impl<'a, 'b: 'a, Provider: OpenMlsProvider> PreGroupPartyState<'b, Provider> {
     // Helper function to update the PreGroupPartyState to support the specified CredentialTypes in its Capabilities
     fn update_credential_capabilities(

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -10,7 +10,7 @@ macro_rules! assert_err_matches {
 }
 
 // Function to check that the correct error type was returned
-fn test_valn0104_error<Provider: OpenMlsProvider>(error: Result<(), GroupError<Provider>>) {
+fn expect_valn0104_error<Provider: OpenMlsProvider>(error: Result<(), GroupError<Provider>>) {
     assert_err_matches!(
         error,
         GroupError::<Provider>::AddMembers(AddMembersError::CreateCommitError(
@@ -214,7 +214,7 @@ fn test_valn0104_new_member_unsupported_credential_type() {
 
     // Should fail with CredentialType::X509
     // Alice adds Dave
-    test_valn0104_error::<Provider>(group_state.add_member_with_credential_type(
+    expect_valn0104_error::<Provider>(group_state.add_member_with_credential_type(
         &dave_party,
         "alice",
         ciphersuite,
@@ -223,7 +223,7 @@ fn test_valn0104_new_member_unsupported_credential_type() {
 
     // Should fail with CredentialType::Other(3)
     // Alice adds Dave
-    test_valn0104_error::<Provider>(group_state.add_member_with_credential_type(
+    expect_valn0104_error::<Provider>(group_state.add_member_with_credential_type(
         &dave_party,
         "alice",
         ciphersuite,
@@ -302,7 +302,7 @@ fn test_valn0104_new_member_capabilities_not_support_all_credential_types() {
 
     // Case with no credential capabilities; should fail
     // Alice adds Dave
-    test_valn0104_error::<Provider>(group_state.add_member_with_credential_capabilities(
+    expect_valn0104_error::<Provider>(group_state.add_member_with_credential_capabilities(
         &dave_party,
         "alice",
         ciphersuite,
@@ -311,7 +311,7 @@ fn test_valn0104_new_member_capabilities_not_support_all_credential_types() {
 
     // Case with wrong capabilities; should fail
     // Alice adds Dave
-    test_valn0104_error::<Provider>(group_state.add_member_with_credential_capabilities(
+    expect_valn0104_error::<Provider>(group_state.add_member_with_credential_capabilities(
         &dave_party,
         "alice",
         ciphersuite,

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -18,8 +18,6 @@ impl<Provider: OpenMlsProvider> PreGroupPartyState<'_, Provider> {
 
         let new_capabilities = Capabilities::builder()
             .versions(capabilities.versions().to_vec())
-            // FIXME: need to provide Ciphersuites, not VerifiableCiphersuites
-            //.ciphersuites(capabilities.ciphersuites().to_vec())
             .extensions(capabilities.extensions().to_vec())
             .proposals(capabilities.proposals().to_vec())
             .credentials(credential_types.clone())

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -34,7 +34,8 @@ macro_rules! test_valn_0104_supported_credential {
         let join_config = MlsGroupJoinConfig::builder()
             .use_ratchet_tree_extension(true)
             .build();
-        // Case with right capabilities plus more; should succeed
+
+        // Initialize party and pre-group
         let party = CorePartyState::<Provider>::new($addee);
         let mut pre_group = party.generate_pre_group($ciphersuite);
 
@@ -140,6 +141,8 @@ macro_rules! test_valn_0104_supported_caps {
         let join_config = MlsGroupJoinConfig::builder()
             .use_ratchet_tree_extension(true)
             .build();
+
+        // Initialize party and pre-group
         let party = CorePartyState::<Provider>::new($addee);
         let mut pre_group = party.generate_pre_group($ciphersuite);
 

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -67,6 +67,22 @@ fn test_valn_0104_new_member_unsupported_credential_type() {
     let bob_pre_group = bob_party.generate_pre_group(ciphersuite);
     let charlie_pre_group = charlie_party.generate_pre_group(ciphersuite);
 
+    // assert Bob and Charlie both are initialized to use the Basic credential type
+    assert_eq!(
+        bob_pre_group
+            .credential_with_key
+            .credential
+            .credential_type(),
+        CredentialType::Basic
+    );
+    assert_eq!(
+        charlie_pre_group
+            .credential_with_key
+            .credential
+            .credential_type(),
+        CredentialType::Basic
+    );
+
     // Create config
     let mls_group_create_config = MlsGroupCreateConfig::builder()
         .ciphersuite(ciphersuite)
@@ -89,17 +105,6 @@ fn test_valn_0104_new_member_unsupported_credential_type() {
             tree: None,
         })
         .expect("Could not add member");
-
-    let dave_party = CorePartyState::<Provider>::new("dave");
-    let dave_pre_group = dave_party.generate_pre_group(ciphersuite);
-
-    assert_eq!(
-        dave_pre_group
-            .credential_with_key
-            .credential
-            .credential_type(),
-        CredentialType::Basic
-    );
 
     // Should fail with CredentialType::X509
     // Alice adds Dave

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -14,7 +14,7 @@ macro_rules! assert_err_matches {
 //   - Test that the credential type is supported by all members of the group,
 //     as specified by the capabilities field of each member's leaf node
 #[openmls_test::openmls_test]
-fn test_valn_0104_new_member_unsupported_credential_type() {
+fn test_valn0104_new_member_unsupported_credential_type() {
     let alice_party = CorePartyState::<Provider>::new("alice");
     let bob_party = CorePartyState::<Provider>::new("bob");
     let charlie_party = CorePartyState::<Provider>::new("charlie");
@@ -93,7 +93,7 @@ fn test_valn_0104_new_member_unsupported_credential_type() {
 //     indicates support for all the credential types currently in use
 //     by other members.
 #[openmls_test::openmls_test]
-fn test_valn_0104_new_member_capabilities_not_support_all_credential_types() {
+fn test_valn0104_new_member_capabilities_not_support_all_credential_types() {
     // Set up Alice with multiple credential capabilities and Other(3) credential
     let alice_party = CorePartyState::<Provider>::new("alice");
     let mut alice_pre_group = alice_party.generate_pre_group(ciphersuite);

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -238,7 +238,7 @@ impl<'a, 'b: 'a, Provider: OpenMlsProvider + Default> GroupState<'b, Provider> {
             tree: None,
         };
 
-        self.add_member(add_member_config).map(move |_| ())
+        self.add_member(add_member_config)
     }
 
     fn add_member_with_credential_type(
@@ -265,7 +265,7 @@ impl<'a, 'b: 'a, Provider: OpenMlsProvider + Default> GroupState<'b, Provider> {
             tree: None,
         };
 
-        self.add_member(add_member_config).map(move |_| ())
+        self.add_member(add_member_config)
     }
 }
 

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -201,8 +201,7 @@ fn test_valn0104_new_member_unsupported_credential_type() {
     // Initialize the group state
     let group_id = GroupId::from_slice(b"test");
     let mut group_state =
-        GroupState::<Provider>::new_from_party(group_id, alice_pre_group, mls_group_create_config)
-            .unwrap();
+        GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
 
     group_state
         .add_member(AddMemberConfig {
@@ -288,8 +287,7 @@ fn test_valn0104_new_member_capabilities_not_support_all_credential_types() {
     // Initialize the group state
     let group_id = GroupId::from_slice(b"test");
     let mut group_state =
-        GroupState::<Provider>::new_from_party(group_id, alice_pre_group, mls_group_create_config)
-            .unwrap();
+        GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
 
     // Alice adds Bob and Charlie
     // This should succeed, since all used credential types used are supported

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -10,6 +10,7 @@ macro_rules! assert_err_matches {
     };
 }
 
+// Function to check that the correct error type was returned
 #[cfg(test)]
 fn test_valn0104_error<Provider: OpenMlsProvider>(error: Result<(), GroupError<Provider>>) {
     assert_err_matches!(
@@ -26,6 +27,7 @@ fn test_valn0104_error<Provider: OpenMlsProvider>(error: Result<(), GroupError<P
 
 #[cfg(test)]
 impl<'a, 'b: 'a, Provider: OpenMlsProvider + Default> GroupState<'b, Provider> {
+    // add a member to the GroupState with the specified credential capabilities
     fn add_member_with_credential_capabilities(
         &'a mut self,
         new_party: &'b CorePartyState<Provider>,
@@ -53,6 +55,7 @@ impl<'a, 'b: 'a, Provider: OpenMlsProvider + Default> GroupState<'b, Provider> {
         self.add_member(add_member_config)
     }
 
+    // add a member to the GroupState with the specified credential type
     fn add_member_with_credential_type(
         &'a mut self,
         new_party: &'b CorePartyState<Provider>,

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -128,7 +128,7 @@ fn test_valn_0104_new_member_unsupported_credential_type() {
         false
     );
 
-    // Should fail with CredentialType::Basic
+    // Should succeed with CredentialType::Basic
     // Alice adds Dave
     test_valn_0104_supported_credential!(
         "dave",

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -90,7 +90,6 @@ fn test_valn_0104_new_member_unsupported_credential_type() {
         })
         .expect("Could not add member");
 
-    // add Dave with different credential type
     let dave_party = CorePartyState::<Provider>::new("dave");
     let dave_pre_group = dave_party.generate_pre_group(ciphersuite);
 
@@ -103,6 +102,7 @@ fn test_valn_0104_new_member_unsupported_credential_type() {
     );
 
     // Should fail with CredentialType::X509
+    // Alice adds Dave
     test_valn_0104_supported_credential!(
         "dave",
         "alice",
@@ -113,6 +113,7 @@ fn test_valn_0104_new_member_unsupported_credential_type() {
     );
 
     // Should fail with CredentialType::Other(3)
+    // Alice adds Dave
     test_valn_0104_supported_credential!(
         "dave",
         "alice",
@@ -123,6 +124,7 @@ fn test_valn_0104_new_member_unsupported_credential_type() {
     );
 
     // Should fail with CredentialType::Basic
+    // Alice adds Dave
     test_valn_0104_supported_credential!(
         "dave",
         "alice",
@@ -225,6 +227,7 @@ fn test_valn_0104_new_member_capabilities_not_support_all_credential_types() {
     test_valn_0104_supported_caps!("dave", "alice", group_state, ciphersuite, Vec::new(), false);
 
     // Case with wrong capabilities; should fail
+    // Alice adds Dave
     test_valn_0104_supported_caps!(
         "dave",
         "alice",
@@ -235,6 +238,7 @@ fn test_valn_0104_new_member_capabilities_not_support_all_credential_types() {
     );
 
     // Case with right capabilities; should succeed
+    // Alice adds Dave
     test_valn_0104_supported_caps!(
         "dave",
         "alice",
@@ -245,6 +249,7 @@ fn test_valn_0104_new_member_capabilities_not_support_all_credential_types() {
     );
 
     // Case with right capabilities plus more; should succeed
+    // Dave adds Eve
     test_valn_0104_supported_caps!(
         "eve",
         "dave",

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -27,6 +27,8 @@ macro_rules! test_valn_0104_error {
 }
 
 // Helper macro for test cases
+// Creates a party and updates its credential type to the specified value,
+// then adds the member to the group, and asserts that the correct result is returned
 macro_rules! test_valn_0104_supported_credential {
     ($addee:expr, $adder:expr, $group_state:expr, $ciphersuite:expr, $credential_type:expr, $should_succeed:expr) => {
         let join_config = MlsGroupJoinConfig::builder()
@@ -35,13 +37,18 @@ macro_rules! test_valn_0104_supported_credential {
         // Case with right capabilities plus more; should succeed
         let party = CorePartyState::<Provider>::new($addee);
         let mut pre_group = party.generate_pre_group($ciphersuite);
+
+        // update the credential type of the credential
         pre_group.update_credential_type($credential_type, $ciphersuite);
+
         let add_member_config: AddMemberConfig<'_, Provider> = AddMemberConfig {
             adder: $adder,
             addees: vec![pre_group],
             join_config,
             tree: None,
         };
+
+        // add the member to the group and assert that the correct result is returned
         test_valn_0104_error!(pre_group, $group_state, add_member_config, $should_succeed);
     };
 }
@@ -126,21 +133,26 @@ fn test_valn_0104_new_member_unsupported_credential_type() {
 }
 
 // Helper macro for test cases
+// Creates a party and updates its supported credential types to the specified value,
+// then adds the member to the group, and asserts that the correct result is returned
 macro_rules! test_valn_0104_supported_caps {
     ($addee:expr, $adder:expr, $group_state:expr, $ciphersuite:expr, $credential_types:expr, $should_succeed:expr) => {
         let join_config = MlsGroupJoinConfig::builder()
             .use_ratchet_tree_extension(true)
             .build();
-        // Case with right capabilities plus more; should succeed
         let party = CorePartyState::<Provider>::new($addee);
         let mut pre_group = party.generate_pre_group($ciphersuite);
+
+        // update credential capabilities
         pre_group.update_credential_capabilities($credential_types, $ciphersuite);
+
         let add_member_config: AddMemberConfig<'_, Provider> = AddMemberConfig {
             adder: $adder,
             addees: vec![pre_group],
             join_config,
             tree: None,
         };
+        // add the member to the group and assert that the correct result is returned
         test_valn_0104_error!(pre_group, $group_state, add_member_config, $should_succeed);
     };
 }

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -229,6 +229,7 @@ fn test_valn_0104_new_member_capabilities_not_support_all_credential_types() {
         .expect("Could not add member");
 
     // Case with no credential capabilities; should fail
+    // Alice adds Dave
     test_valn_0104_supported_caps!("dave", "alice", group_state, ciphersuite, Vec::new(), false);
 
     // Case with wrong capabilities; should fail

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -1,0 +1,326 @@
+use crate::prelude::*;
+use crate::test_utils::single_group_test_framework::*;
+use crate::treesync::errors::LeafNodeValidationError;
+
+#[cfg(test)]
+impl<Provider: OpenMlsProvider> PreGroupPartyState<'_, Provider> {
+    // Helper function to update the PreGroupPartyState to support the specified CredentialTypes in its Capabilities
+    fn update_credential_capabilities(
+        &mut self,
+        credential_types: Vec<CredentialType>,
+        ciphersuite: Ciphersuite,
+    ) -> Capabilities {
+        let capabilities = self
+            .key_package_bundle
+            .key_package
+            .leaf_node()
+            .capabilities();
+
+        let new_capabilities = Capabilities::builder()
+            .versions(capabilities.versions().to_vec())
+            // FIXME: need to provide Ciphersuites, not VerifiableCiphersuites
+            //.ciphersuites(capabilities.ciphersuites().to_vec())
+            .extensions(capabilities.extensions().to_vec())
+            .proposals(capabilities.proposals().to_vec())
+            .credentials(credential_types.clone())
+            .build();
+
+        self.key_package_bundle = KeyPackage::builder()
+            .key_package_extensions(Extensions::default())
+            .leaf_node_capabilities(new_capabilities.clone())
+            .build(
+                ciphersuite,
+                &self.core_state.provider,
+                &self.signer,
+                CredentialWithKey {
+                    credential: self.credential_with_key.credential.clone(),
+                    signature_key: self.signer.to_public_vec().into(),
+                },
+            )
+            .unwrap();
+
+        // ensure updated correctly
+        let updated_capabilities = self
+            .key_package_bundle
+            .key_package
+            .leaf_node()
+            .capabilities();
+
+        assert_eq!(updated_capabilities.credentials(), credential_types);
+
+        // return the updated capabilities
+        new_capabilities
+    }
+
+    // Helper function to set the CredentialType of the PreGroupPartyState's credential to the
+    // specified value (keeping all else equal)
+    fn update_credential_type(
+        &mut self,
+        credential_type: CredentialType,
+        ciphersuite: Ciphersuite,
+    ) {
+        // update to a non-supported credential type
+        let new_credential = Credential::new(
+            credential_type,
+            self.credential_with_key
+                .credential
+                .serialized_content()
+                .to_vec(),
+        );
+
+        // Update only the new credential
+        self.credential_with_key.credential = new_credential.clone();
+        self.key_package_bundle = generate_key_package(
+            ciphersuite,
+            CredentialWithKey {
+                credential: new_credential,
+                signature_key: self.signer.to_public_vec().into(),
+            },
+            Extensions::default(),
+            &self.core_state.provider,
+            &self.signer,
+        );
+    }
+}
+
+// Macro that adds a member to a group and asserts that the correct error was received
+macro_rules! test_valn_0104_error {
+    ($pre_group:expr,$group_state:expr,$add_member_config:expr, $should_succeed:expr) => {
+        let result = $group_state.add_member($add_member_config);
+
+        if $should_succeed {
+            // check adding succeeded
+            let _ = result.expect("Should succeed");
+        } else {
+            // assert received correct error type
+            match result.unwrap_err() {
+                TestError::AddMembers(AddMembersError::CreateCommitError(
+                    CreateCommitError::ProposalValidationError(
+                        ProposalValidationError::LeafNodeValidation(
+                            LeafNodeValidationError::UnsupportedCredentials,
+                        ),
+                    ),
+                )) => {}
+                e => panic!("Incorrect error received: {:?}", e),
+            };
+        }
+    };
+}
+
+// Helper macro for test cases
+macro_rules! test_valn_0104_supported_credential {
+    ($addee:expr, $adder:expr, $group_state:expr, $ciphersuite:expr, $credential_type:expr, $should_succeed:expr) => {
+        let join_config = MlsGroupJoinConfig::builder()
+            .use_ratchet_tree_extension(true)
+            .build();
+        // Case with right capabilities plus more; should succeed
+        let party = CorePartyState::<Provider>::new($addee);
+        let mut pre_group = party.generate_pre_group($ciphersuite);
+        pre_group.update_credential_type($credential_type, $ciphersuite);
+        let add_member_config: AddMemberConfig<'_, Provider> = AddMemberConfig {
+            adder: $adder,
+            addees: vec![pre_group],
+            join_config,
+            tree: None,
+        };
+        test_valn_0104_error!(pre_group, $group_state, add_member_config, $should_succeed);
+    };
+}
+
+// Ensure that this check fails on invalid input:
+//   - Test that the credential type is supported by all members of the group,
+//     as specified by the capabilities field of each member's leaf node
+#[openmls_test::openmls_test]
+fn test_valn_0104_new_member_unsupported_credential_type() {
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let bob_party = CorePartyState::<Provider>::new("bob");
+    let charlie_party = CorePartyState::<Provider>::new("charlie");
+
+    let alice_pre_group = alice_party.generate_pre_group(ciphersuite);
+    let bob_pre_group = bob_party.generate_pre_group(ciphersuite);
+    let charlie_pre_group = charlie_party.generate_pre_group(ciphersuite);
+
+    // Create config
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .build();
+
+    // Join config
+    let mls_group_join_config = mls_group_create_config.join_config().clone();
+
+    // Initialize the group state
+    let group_id = GroupId::from_slice(b"test");
+    let mut group_state =
+        GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
+
+    group_state
+        .add_member(AddMemberConfig {
+            adder: "alice",
+            addees: vec![bob_pre_group, charlie_pre_group],
+            join_config: mls_group_join_config.clone(),
+            tree: None,
+        })
+        .expect("Could not add member");
+
+    // add Dave with different credential type
+    let dave_party = CorePartyState::<Provider>::new("dave");
+    let dave_pre_group = dave_party.generate_pre_group(ciphersuite);
+
+    assert_eq!(
+        dave_pre_group
+            .credential_with_key
+            .credential
+            .credential_type(),
+        CredentialType::Basic
+    );
+
+    // Should fail with CredentialType::X509
+    test_valn_0104_supported_credential!(
+        "dave",
+        "alice",
+        group_state,
+        ciphersuite,
+        CredentialType::X509,
+        false
+    );
+
+    // Should fail with CredentialType::Other(3)
+    test_valn_0104_supported_credential!(
+        "dave",
+        "alice",
+        group_state,
+        ciphersuite,
+        CredentialType::Other(3),
+        false
+    );
+
+    // Should fail with CredentialType::Basic
+    test_valn_0104_supported_credential!(
+        "dave",
+        "alice",
+        group_state,
+        ciphersuite,
+        CredentialType::Basic,
+        true
+    );
+}
+
+// Helper macro for test cases
+macro_rules! test_valn_0104_supported_caps {
+    ($addee:expr, $adder:expr, $group_state:expr, $ciphersuite:expr, $credential_types:expr, $should_succeed:expr) => {
+        let join_config = MlsGroupJoinConfig::builder()
+            .use_ratchet_tree_extension(true)
+            .build();
+        // Case with right capabilities plus more; should succeed
+        let party = CorePartyState::<Provider>::new($addee);
+        let mut pre_group = party.generate_pre_group($ciphersuite);
+        pre_group.update_credential_capabilities($credential_types, $ciphersuite);
+        let add_member_config: AddMemberConfig<'_, Provider> = AddMemberConfig {
+            adder: $adder,
+            addees: vec![pre_group],
+            join_config,
+            tree: None,
+        };
+        test_valn_0104_error!(pre_group, $group_state, add_member_config, $should_succeed);
+    };
+}
+
+// Ensure that this check fails on invalid input:
+//   - Verify that the capabilities field of the new member's leaf node
+//     indicates support for all the credential types currently in use
+//     by other members.
+#[openmls_test::openmls_test]
+fn test_valn_0104_new_member_capabilities_not_support_all_credential_types() {
+    // Set up Alice with multiple credential capabilities and Other(3) credential
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let mut alice_pre_group = alice_party.generate_pre_group(ciphersuite);
+    let alice_capabilities = alice_pre_group.update_credential_capabilities(
+        vec![CredentialType::Basic, CredentialType::Other(3)],
+        ciphersuite,
+    );
+    alice_pre_group.update_credential_type(CredentialType::Other(3), ciphersuite);
+
+    // Set up Bob with multiple credential capabilities and BasicCredential
+    let bob_party = CorePartyState::<Provider>::new("bob");
+    let mut bob_pre_group = bob_party.generate_pre_group(ciphersuite);
+    bob_pre_group.update_credential_capabilities(
+        vec![CredentialType::Basic, CredentialType::Other(3)],
+        ciphersuite,
+    );
+
+    // Set up Charlie with multiple credential capabilities and BasicCredential
+    let charlie_party = CorePartyState::<Provider>::new("charlie");
+    let mut charlie_pre_group = charlie_party.generate_pre_group(ciphersuite);
+    charlie_pre_group.update_credential_capabilities(
+        vec![
+            CredentialType::Basic,
+            CredentialType::Other(3),
+            CredentialType::Other(4),
+        ],
+        ciphersuite,
+    );
+
+    // Create config
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .capabilities(alice_capabilities)
+        .use_ratchet_tree_extension(true)
+        .build();
+
+    // Join config
+    let mls_group_join_config = mls_group_create_config.join_config().clone();
+
+    // Initialize the group state
+    let group_id = GroupId::from_slice(b"test");
+    let mut group_state =
+        GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
+
+    // Alice adds Bob and Charlie
+    // This should succeed, since all used credential types used are supported
+    group_state
+        .add_member(AddMemberConfig {
+            adder: "alice",
+            addees: vec![bob_pre_group, charlie_pre_group],
+            join_config: mls_group_join_config.clone(),
+            tree: None,
+        })
+        .expect("Could not add member");
+
+    // Case with no credential capabilities; should fail
+    test_valn_0104_supported_caps!("dave", "alice", group_state, ciphersuite, Vec::new(), false);
+
+    // Case with wrong capabilities; should fail
+    test_valn_0104_supported_caps!(
+        "dave",
+        "alice",
+        group_state,
+        ciphersuite,
+        vec![CredentialType::Basic, CredentialType::Other(2)],
+        false
+    );
+
+    // Case with right capabilities; should succeed
+    test_valn_0104_supported_caps!(
+        "dave",
+        "alice",
+        group_state,
+        ciphersuite,
+        vec![CredentialType::Basic, CredentialType::Other(3)],
+        true
+    );
+
+    // Case with right capabilities plus more; should succeed
+    test_valn_0104_supported_caps!(
+        "eve",
+        "dave",
+        group_state,
+        ciphersuite,
+        vec![
+            CredentialType::Basic,
+            CredentialType::Other(3),
+            CredentialType::Other(5)
+        ],
+        true
+    );
+}

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -310,6 +310,8 @@ fn test_valn0104_new_member_capabilities_not_support_all_credential_types() {
     ));
 
     // Case with wrong capabilities; should fail
+    // This is because Dave needs to support all the credential types currently in use by other
+    // members, which are `Other(3)` (Alice) and `Basic` (Bob, Charlie), but he is missing support for `Other(3)`.
     // Alice adds Dave
     expect_valn0104_error::<Provider>(group_state.add_member_with_credential_capabilities(
         &dave_party,

--- a/openmls/src/group/tests_and_kats/tests/mod.rs
+++ b/openmls/src/group/tests_and_kats/tests/mod.rs
@@ -1,6 +1,7 @@
 //! Unit tests for the core group
 
 mod aad;
+mod capabilities_check;
 mod commit_validation;
 mod encoding;
 mod external_add_proposal;

--- a/openmls/src/test_utils/single_group_test_framework/errors.rs
+++ b/openmls/src/test_utils/single_group_test_framework/errors.rs
@@ -14,6 +14,7 @@ pub type GroupError<Provider> =
     TestError<<<Provider as OpenMlsProvider>::StorageProvider as StorageProviderTrait<CURRENT_VERSION>>::Error>;
 #[derive(Error, Debug)]
 pub enum TestError<StorageError> {
+    AddMembers(#[from] AddMembersError<StorageError>),
     CreateCommit(#[from] CreateCommitError),
     CommitBuilderStage(#[from] CommitBuilderStageError<StorageError>),
     NewGroup(#[from] NewGroupError<StorageError>),

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -16,7 +16,8 @@ use crate::{
 mod assertions;
 
 mod errors;
-pub use errors::*;
+use errors::*;
+pub use errors::TestError;
 
 use std::collections::HashMap;
 

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 mod assertions;
 
 mod errors;
-use errors::*;
+pub use errors::*;
 
 use std::collections::HashMap;
 
@@ -323,14 +323,11 @@ impl<'a, Provider: OpenMlsProvider> GroupState<'a, Provider> {
             .map(|addee| addee.key_package_bundle.key_package.clone())
             .collect();
 
-        let (commit, welcome, _) = adder
-            .group
-            .add_members(
-                &adder.party.core_state.provider,
-                &adder.party.signer,
-                &key_packages,
-            )
-            .unwrap();
+        let (commit, welcome, _) = adder.group.add_members(
+            &adder.party.core_state.provider,
+            &adder.party.signer,
+            &key_packages,
+        )?;
 
         // Deliver_and_apply to all members but adder
         self.deliver_and_apply_if(commit.into(), |member| {

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 mod assertions;
 
 mod errors;
-pub use errors::TestError;
+pub use errors::GroupError;
 use errors::*;
 
 use std::collections::HashMap;

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -16,8 +16,8 @@ use crate::{
 mod assertions;
 
 mod errors;
-use errors::*;
 pub use errors::TestError;
+use errors::*;
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
This PR adds several validation tests corresponding to https://validation.openmls.tech/#valn0104:
- `test_valn_0104_new_member_unsupported_credential_type()`: Verify that the credential type is supported by all members of the group, as specified by the capabilities field of each member's LeafNode
- `fn test_valn_0104_new_member_capabilities_not_support_all_credential_types()`: Verify that the capabilities field of the [added] LeafNode indicates support for all the credential types currently in use by other members

In addition to these tests, this PR also contains a small update to the `single_group_test_framework` :

- `pub use` the `GroupError` error type (in order to be able to also the error types it wraps) 
-  add error handling for the call to `MlsGroup::add_members()` in `GroupState::add_member()`

Resolves issue #1740