### PR TITLE
Remove `binary_tree::test_new_tree_error()` (segfault on 32-bit platforms)

### DIFF
--- a/openmls/src/binary_tree/tests.rs
+++ b/openmls/src/binary_tree/tests.rs
@@ -153,26 +153,6 @@ fn test_diff_merging() {
     assert_eq!(tree, original_tree);
 }
 
-/*
-// Disabled due to #1727
-#[test]
-fn test_new_tree_error() {
-    // Let's test what happens when the tree is getting too large.
-    let mut nodes: Vec<TreeNode<u32, u32>> = Vec::new();
-
-    // We allow uninitialized vectors because we don't want to allocate so much memory
-    #[allow(clippy::uninit_vec)]
-    unsafe {
-        nodes.set_len(u32::MAX as usize);
-
-        assert_eq!(
-            MlsBinaryTree::new(nodes).expect_err("no error adding beyond TREE_MAX"),
-            MlsBinaryTreeError::OutOfRange
-        )
-    }
-}
-*/
-
 #[test]
 fn test_diff_iter() {
     let nodes = (0..101)


### PR DESCRIPTION
This PR removes the test `binary_tree::test_new_tree_error()`, which segfaults on 32-bit platforms. 

This test is removed here because it is not guaranteed to work as expected, because the test constructs a vector with a large number of elements, but without initializing the underlying memory.

Fixes #1727 