### PR TITLE
Add references to validation check valn0113

### DIFF
--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -313,9 +313,10 @@ impl PublicGroup {
         Ok(())
     }
 
-    /// Validate capablities. This function implements the following checks:
+    /// Validate capabilities. This function implements the following checks:
     /// - ValSem106: Add Proposal: required capabilities
     /// - ValSem109: Update Proposal: required capabilities
+    /// Implements check [valn0113](https://validation.openmls.tech/#valn0113).
     pub(crate) fn validate_capabilities(
         &self,
         proposal_queue: &ProposalQueue,
@@ -327,7 +328,7 @@ impl PublicGroup {
         //   this supported by the node?
         // - Check that all extensions are contained in the capabilities.
         // - Check that the capabilities contain the leaf node's credential
-        //   type.
+        //   type (https://validation.openmls.tech/#valn0113).
         // - Check that the credential type is supported by all members of the
         //   group.
         // - Check that the capabilities field of this LeafNode indicates
@@ -604,6 +605,8 @@ impl PublicGroup {
         leaf_node: &LeafNode,
     ) -> Result<(), LeafNodeValidationError> {
         // Check that the data in the leaf node is self-consistent
+        // Check that the capabilities contain the leaf node's credential
+        // type (https://validation.openmls.tech/#valn0113)
         leaf_node.validate_locally()?;
 
         // Check if the ciphersuite and the version of the group are

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -316,7 +316,7 @@ impl PublicGroup {
     /// Validate capabilities. This function implements the following checks:
     /// - ValSem106: Add Proposal: required capabilities
     /// - ValSem109: Update Proposal: required capabilities
-    /// Implements check [valn0113](https://validation.openmls.tech/#valn0113).
+    /// - [valn0113](https://validation.openmls.tech/#valn0113).
     pub(crate) fn validate_capabilities(
         &self,
         proposal_queue: &ProposalQueue,

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -471,7 +471,7 @@ impl LeafNode {
     /// Perform all checks that can be done without further context:
     /// - the used extensions are not known to be invalid in leaf nodes
     /// - the types of the used extensions are covered by the capabilities
-    /// - the type of the credential is coveered by the capabilities
+    /// - the type of the credential is covered by the capabilities
     pub(crate) fn validate_locally(&self) -> Result<(), LeafNodeValidationError> {
         // Check that no extension is invalid when used in leaf nodes.
         let invalid_extension_types = self
@@ -500,6 +500,7 @@ impl LeafNode {
         }
 
         // Check that the capabilities contain the leaf node's credential type.
+        // (https://validation.openmls.tech/#valn0113)
         if !self
             .capabilities()
             .contains_credential(self.credential().credential_type())


### PR DESCRIPTION
This PR adds references to [valn0113](https://validation.openmls.tech/#valn0113)  to the comments in the codebase, to document where this `LeafNode` validation check takes place. This check was recently added to the dashboard, but is already implemented in the proposal validation by the `CommitBuilder`.

These annotations will also allow these locations to be searchable from the `search code` link that is provided in the validation dashboard.