### PR TITLE
return error when external sender sends commit

### DIFF
--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -113,6 +113,9 @@ pub enum ProcessMessageError {
     /// External application messages are not permitted.
     #[error("External application messages are not permitted.")]
     UnauthorizedExternalApplicationMessage,
+    /// External commit messages are not permitted.
+    #[error("Commit messages from external senders are not permitted.")]
+    UnauthorizedExternalCommitMessage,
     /// The proposal is invalid for the Sender of type [External](crate::prelude::Sender::External)
     #[error("The proposal is invalid for the Sender of type External")]
     UnsupportedProposalType,

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -338,7 +338,9 @@ impl MlsGroup {
                     FramedContentBody::Proposal(_) => {
                         Err(ProcessMessageError::UnsupportedProposalType)
                     }
-                    FramedContentBody::Commit(_) => unimplemented!(),
+                    FramedContentBody::Commit(_) => {
+                        Err(ProcessMessageError::UnauthorizedExternalCommitMessage)
+                    }
                 }
             }
         }

--- a/openmls/src/group/public_group/process.rs
+++ b/openmls/src/group/public_group/process.rs
@@ -285,7 +285,9 @@ impl PublicGroup {
                     FramedContentBody::Proposal(_) => {
                         Err(ProcessMessageError::UnsupportedProposalType)
                     }
-                    FramedContentBody::Commit(_) => unimplemented!(),
+                    FramedContentBody::Commit(_) => {
+                        Err(ProcessMessageError::UnauthorizedExternalCommitMessage)
+                    }
                 }
             }
         }


### PR DESCRIPTION
While the `unimplemented` can't be reached at the moment because it would fail earlier, it's safer to just return errors.