### PR TITLE
chore: Drop stale TODOs

### DIFF
--- a/openmls/src/framing/message_out.rs
+++ b/openmls/src/framing/message_out.rs
@@ -82,8 +82,6 @@ pub enum MlsMessageBodyOut {
 impl From<PublicMessage> for MlsMessageOut {
     fn from(public_message: PublicMessage) -> Self {
         Self {
-            // TODO #34: The version should be set explicitly here instead of
-            // the default.
             version: ProtocolVersion::default(),
             body: MlsMessageBodyOut::PublicMessage(public_message),
         }
@@ -93,8 +91,6 @@ impl From<PublicMessage> for MlsMessageOut {
 impl From<PrivateMessage> for MlsMessageOut {
     fn from(private_message: PrivateMessage) -> Self {
         Self {
-            // TODO #34: The version should be set explicitly here instead of
-            // the default.
             version: ProtocolVersion::default(),
             body: MlsMessageBodyOut::PrivateMessage(private_message),
         }

--- a/openmls/src/framing/public_message.rs
+++ b/openmls/src/framing/public_message.rs
@@ -98,16 +98,6 @@ impl PublicMessage {
     pub(crate) fn is_handshake_message(&self) -> bool {
         self.content_type().is_handshake_message()
     }
-    // TODO: #727 - Remove if not needed.
-    // #[cfg(test)]
-    // pub(super) fn set_signature(&mut self, signature: Signature) {
-    //     self.signature = signature;
-    // }
-
-    // #[cfg(test)]
-    // pub(super) fn set_membership_tag_test(&mut self, tag: MembershipTag) {
-    //     self.membership_tag = Some(tag);
-    // }
 }
 
 impl From<AuthenticatedContent> for PublicMessage {
@@ -161,14 +151,6 @@ impl PublicMessage {
     pub(crate) fn set_membership_tag_test(&mut self, membership_tag: MembershipTag) {
         self.membership_tag = Some(membership_tag);
     }
-
-    // TODO: #727 - Remove if not needed.
-    // #[cfg(test)]
-    // pub(crate) fn invalidate_signature(&mut self) {
-    //     let mut modified_signature = self.signature().as_slice().to_vec();
-    //     modified_signature[0] ^= 0xFF;
-    //     self.signature.modify(&modified_signature);
-    // }
 }
 
 #[cfg(test)]

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -21,7 +21,6 @@
 //!                          ProcessedMessage
 //!
 //! ```
-// TODO #106/#151: Update the above diagram
 
 use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite};
 use proposal_store::QueuedProposal;

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -419,14 +419,12 @@ pub enum ExternalCommitValidationError {
     /// Found inline Add or Update proposals.
     #[error("Found inline Add or Update proposals.")]
     InvalidInlineProposals,
-    // TODO #803: this seems unused
     /// Found multiple inline Remove proposals.
     #[error("Found multiple inline Remove proposals.")]
     MultipleRemoveProposals,
     /// Remove proposal targets the wrong group member.
     #[error("Remove proposal targets the wrong group member.")]
     InvalidRemoveProposal,
-    // TODO #803: this seems unused
     /// External Commit has to contain a path.
     #[error("External Commit has to contain a path.")]
     NoPath,

--- a/openmls/src/group/group_context.rs
+++ b/openmls/src/group/group_context.rs
@@ -1,6 +1,4 @@
 //! # Group Context
-//!
-//! TODO: #779
 
 use openmls_traits::crypto::OpenMlsCrypto;
 use openmls_traits::types::Ciphersuite;

--- a/openmls/src/group/mls_group/create_commit.rs
+++ b/openmls/src/group/mls_group/create_commit.rs
@@ -115,7 +115,6 @@ impl MlsGroup {
             }
         })?;
 
-        // TODO: #581 Filter proposals by support
         // 11.2:
         // Proposals with a non-default proposal type MUST NOT be included in a commit
         // unless the proposal type is supported by all the members of the group that

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -365,10 +365,6 @@ impl MlsGroup {
 
                 self.public_group.merge_diff(state.staged_diff);
 
-                // TODO #1194: Group storage and key storage should be
-                // correlated s.t. there is no divergence between key material
-                // and group state.
-
                 let leaf_keypair = if let Some(keypair) = &state.new_leaf_keypair_option {
                     vec![keypair.clone()]
                 } else {

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -226,8 +226,6 @@ fn remover() {
     charlie_group
         .merge_pending_commit(provider)
         .expect("error merging pending commit");
-
-    // TODO #524: Check that Alice removed Bob
 }
 
 #[openmls_test]

--- a/openmls/src/group/public_group/diff/apply_proposals.rs
+++ b/openmls/src/group/public_group/diff/apply_proposals.rs
@@ -141,7 +141,6 @@ impl PublicGroupDiff<'_> {
             let leaf_index = self
                 .diff
                 .add_leaf(leaf_node.clone())
-                // TODO #810
                 .map_err(|_| LibraryError::custom("Tree full: cannot add more members"))?;
             invitation_list.push((leaf_index, add_proposal.clone()))
         }

--- a/openmls/src/group/tests_and_kats/kats/messages.rs
+++ b/openmls/src/group/tests_and_kats/kats/messages.rs
@@ -209,7 +209,6 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     };
 
     // Create proposal to remove a user
-    // TODO #525: This is not a valid RemoveProposal since random_u32() is not a valid KeyPackageRef.
     let remove_proposal = RemoveProposal {
         removed: LeafNodeIndex::new(random_u32()),
     };

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -473,8 +473,6 @@ impl From<Vec<u8>> for ExternalInitProposal {
     }
 }
 
-// TODO: #291 Implement AppAck
-
 /// AppAck Proposal.
 ///
 /// This is not yet supported.
@@ -639,7 +637,6 @@ impl ProposalRef {
     }
 }
 
-/// TODO: #291 Implement AppAck
 /// ```text
 /// struct {
 ///     KeyPackageRef sender;

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -258,7 +258,7 @@ impl From<Secret> for InitSecret {
 
 /// Creates a string from the given MLS `ProtocolVersion` for the computation of
 /// the `init_secret` when creating or processing a commit with an external init
-/// proposal. TODO: #628.
+/// proposal.
 fn hpke_info_from_version(version: ProtocolVersion) -> &'static str {
     match version {
         ProtocolVersion::Mls10 => "MLS 1.0 external init secret",

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -515,7 +515,6 @@ impl TreeSyncDiff<'_> {
                         for leaf_index in parent.unmerged_leaves() {
                             if !excluded_indices.contains(&leaf_index) {
                                 let leaf = self.diff.leaf(*leaf_index);
-                                // TODO #800: unmerged leaves should be checked
                                 if let Some(leaf_node) = leaf.node() {
                                     resolution.push((
                                         TreeNodeIndex::Leaf(*leaf_index),

--- a/openmls/src/treesync/errors.rs
+++ b/openmls/src/treesync/errors.rs
@@ -76,7 +76,6 @@ pub enum ApplyUpdatePathError {
 
 // === Crate errors ===
 
-// TODO: This will go away in #819 again.
 // `UnsupportedExtension` is only used in tests for now
 #[allow(dead_code)]
 /// TreeSync error

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -164,7 +164,6 @@ impl LeafNodeParametersBuilder {
 ///     opaque signature<V>;
 /// } LeafNode;
 /// ```
-// TODO(#1242): Do not derive `TlsDeserialize`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsSize)]
 pub struct LeafNode {
     payload: LeafNodePayload,

--- a/openmls/tests/interop_scenarios.rs
+++ b/openmls/tests/interop_scenarios.rs
@@ -180,8 +180,6 @@ fn multiple_joins() {
     setup.check_group_states(group, noop_authentication_service);
 }
 
-// TODO #192, #286, #289: The external join test should go here.
-
 // # Update
 // A:    Create group
 // B->A: KeyPackage
@@ -279,9 +277,6 @@ fn remove() {
     // Check that group members agree on a group state.
     setup.check_group_states(group, noop_authentication_service);
 }
-
-// TODO #141, #284: The external PSK, resumption and re-init tests should go
-// here.
 
 // # Large Group, Full Lifecycle
 // * Create group


### PR DESCRIPTION
This PR conservatively drops stale TODOs. The criteria were:
 - The issue has been addressed and closed
 - The TODOs no longer made sense