### PR TITLE
Update libcrux provider to use pure Rust crates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
           sudo apt update && sudo apt install nodejs
           cargo install wasm-bindgen-cli
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
-          cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js libcrux-provider
+          cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider
 
       - name: Tests
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           targets: i686-pc-windows-msvc, i686-unknown-linux-gnu, wasm32-unknown-unknown
       - uses: baptiste0928/cargo-install@v3
+        # we only test wasm bindings using ubuntu-latest
+        if: matrix.os == 'ubuntu-latest'
         with:
           crate: wasm-bindgen-cli
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Tests Wasm32 on linux with libcrux provider
         if: matrix.os == 'ubuntu-latest'
         env:
-          RUSTFLAGS: --cfg getrandom_backend="wasm_js"
+          RUSTFLAGS: "--cfg getrandom_backend=\"wasm_js\""
         run: |
           sudo apt update && sudo apt install nodejs
           cargo install wasm-bindgen-cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,11 +47,10 @@ jobs:
 
       - name: Tests Wasm32 on linux with libcrux provider
         if: matrix.os == 'ubuntu-latest'
-        env:
-          RUSTFLAGS: "--cfg getrandom_backend=\"wasm_js\""
         run: |
           sudo apt update && sudo apt install nodejs
           cargo install wasm-bindgen-cli
+          export RUSTFLAGS="--cfg getrandom_backend=\"wasm_js\""
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt update && sudo apt install nodejs
-          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo-install/bin/wasm-bindgen-test-runner
+          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo-install/wasm-bindgen-cli/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
 
       - name: Tests Wasm32 on linux with libcrux provider
@@ -60,7 +60,7 @@ jobs:
         run: |
           sudo apt update && sudo apt install nodejs
           export RUSTFLAGS="--cfg getrandom_backend=\"wasm_js\""
-          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo-install/bin/wasm-bindgen-test-runner
+          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo-install/wasm-bindgen-cli/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider,libcrux-provider-js
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,8 @@ jobs:
           targets: i686-pc-windows-msvc, i686-unknown-linux-gnu, wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - uses: baptiste0928/cargo-install@v3
+        # we only test wasm bindings on ubuntu-latest
+        if: matrix.os == 'ubuntu-latest'
         with:
           crate: wasm-bindgen-cli
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,14 @@ jobs:
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
 
+      - name: Tests Wasm32 on linux with libcrux provder
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt update && sudo apt install nodejs
+          cargo install wasm-bindgen-cli
+          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
+          cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js libcrux-provider
+
       - name: Tests
         if: matrix.os != 'windows-latest'
         run: cargo test $TEST_MODE -p openmls --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,6 @@ jobs:
       - name: Tests Wasm32 on linux
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt update && sudo apt install nodejs
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo-install/wasm-bindgen-cli/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
 
@@ -62,7 +61,6 @@ jobs:
         env:
           RUSTFLAGS: --cfg getrandom_backend="wasm_js"
         run: |
-          sudo apt update && sudo apt install nodejs
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo-install/wasm-bindgen-cli/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider,libcrux-provider-js
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,6 @@ jobs:
         run: |
           sudo apt update && sudo apt install nodejs
           cargo install wasm-bindgen-cli
-          export RUSTFLAGS="--cfg getrandom_backend=\"wasm_js\""
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
 
@@ -61,7 +60,7 @@ jobs:
           cargo install wasm-bindgen-cli
           export RUSTFLAGS="--cfg getrandom_backend=\"wasm_js\""
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
-          cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider
+          cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider,libcrux-provider-js
 
 
       - name: Test with Fork Resolution helpers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,12 +34,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: i686-pc-windows-msvc, i686-unknown-linux-gnu, wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - uses: baptiste0928/cargo-install@v3
         # we only test wasm bindings using ubuntu-latest
         if: matrix.os == 'ubuntu-latest'
         with:
           crate: wasm-bindgen-cli
-      - uses: Swatinem/rust-cache@v2
 
       - name: Toggle rustc mode
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,10 +34,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: i686-pc-windows-msvc, i686-unknown-linux-gnu, wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: wasm-bindgen-cli
-      - uses: Swatinem/rust-cache@v2
 
       - name: Toggle rustc mode
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: --cfg getrandom_backend="wasm_js"
 
 jobs:
   tests:
@@ -48,6 +47,8 @@ jobs:
 
       - name: Tests Wasm32 on linux with libcrux provider
         if: matrix.os == 'ubuntu-latest'
+        env:
+          RUSTFLAGS: --cfg getrandom_backend="wasm_js"
         run: |
           sudo apt update && sudo apt install nodejs
           cargo install wasm-bindgen-cli

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,9 +59,10 @@ jobs:
 
       - name: Tests Wasm32 on linux with libcrux provider
         if: matrix.os == 'ubuntu-latest'
+        env:
+          RUSTFLAGS: --cfg getrandom_backend="wasm_js"
         run: |
           sudo apt update && sudo apt install nodejs
-          export RUSTFLAGS="--cfg getrandom_backend=\"wasm_js\""
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo-install/wasm-bindgen-cli/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider,libcrux-provider-js
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: i686-pc-windows-msvc, i686-unknown-linux-gnu, wasm32-unknown-unknown
+      - uses: baptiste0928/cargo-install@v3
+        with:
+          crate: wasm-bindgen-cli
       - uses: Swatinem/rust-cache@v2
 
       - name: Toggle rustc mode
@@ -49,7 +52,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt update && sudo apt install nodejs
-          cargo install wasm-bindgen-cli
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
 
@@ -57,7 +59,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt update && sudo apt install nodejs
-          cargo install wasm-bindgen-cli
           export RUSTFLAGS="--cfg getrandom_backend=\"wasm_js\""
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider,libcrux-provider-js
@@ -69,7 +70,6 @@ jobs:
       - name: Test with libcrux provider
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cargo install wasm-bindgen-cli
           cargo test $TEST_MODE -p openmls -vv -F libcrux-provider
 
       - name: Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
 
-      - name: Tests Wasm32 on linux with libcrux provder
+      - name: Tests Wasm32 on linux with libcrux provider
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt update && sudo apt install nodejs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,12 +34,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: i686-pc-windows-msvc, i686-unknown-linux-gnu, wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
       - uses: baptiste0928/cargo-install@v3
-        # we only test wasm bindings using ubuntu-latest
-        if: matrix.os == 'ubuntu-latest'
         with:
           crate: wasm-bindgen-cli
+      - uses: Swatinem/rust-cache@v2
 
       - name: Toggle rustc mode
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: --cfg getrandom_backend="wasm_js"
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,15 @@ jobs:
             echo "TEST_MODE=--release" >> $GITHUB_ENV
           fi
 
+      - name: Tests Wasm32 on linux with libcrux provider
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt update && sudo apt install nodejs
+          cargo install wasm-bindgen-cli
+          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
+          cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider
+
+
       - name: Test with Fork Resolution helpers
         run: cargo test $TEST_MODE -p openmls -F fork-resolution
 
@@ -61,14 +70,6 @@ jobs:
           cargo install wasm-bindgen-cli
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
-
-      - name: Tests Wasm32 on linux with libcrux provider
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt update && sudo apt install nodejs
-          cargo install wasm-bindgen-cli
-          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
-          cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider
 
       - name: Tests
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           sudo apt update && sudo apt install nodejs
           cargo install wasm-bindgen-cli
+          export RUSTFLAGS="--cfg getrandom_backend=\"wasm_js\""
           export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,14 @@ jobs:
             echo "TEST_MODE=--release" >> $GITHUB_ENV
           fi
 
+      - name: Tests Wasm32 on linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt update && sudo apt install nodejs
+          cargo install wasm-bindgen-cli
+          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
+          cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
+
       - name: Tests Wasm32 on linux with libcrux provider
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -63,14 +71,6 @@ jobs:
         run: |
           cargo install wasm-bindgen-cli
           cargo test $TEST_MODE -p openmls -vv -F libcrux-provider
-
-      - name: Tests Wasm32 on linux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt update && sudo apt install nodejs
-          cargo install wasm-bindgen-cli
-          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
-          cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
 
       - name: Tests
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt update && sudo apt install nodejs
-          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
+          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo-install/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js
 
       - name: Tests Wasm32 on linux with libcrux provider
@@ -60,7 +60,7 @@ jobs:
         run: |
           sudo apt update && sudo apt install nodejs
           export RUSTFLAGS="--cfg getrandom_backend=\"wasm_js\""
-          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo/bin/wasm-bindgen-test-runner
+          export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=$HOME/.cargo-install/bin/wasm-bindgen-test-runner
           cargo test $TEST_MODE -p openmls -vv --target wasm32-unknown-unknown -F js,libcrux-provider,libcrux-provider-js
 
 

--- a/basic_credential/Cargo.toml
+++ b/basic_credential/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/openmls/openmls/tree/main/basic_credential"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { version = "0.3.0", path = "../traits" }
+openmls_traits = { version = "0.4.0", path = "../traits" }
 tls_codec = { workspace = true }
 serde = "1.0"
 

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -19,9 +19,6 @@ openmls_memory_storage = { version = "0.3.0", path = "../memory_storage" }
 rand = "0.9"
 tls_codec.workspace = true
 rand_chacha = "0.9"
-
 hpke_rs = { version = "0.2.1-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs" , features=["hazmat", "serialization"] }
-
 hpke_rs_crypto = { version = "0.3.0-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-crypto" }
-
 hpke_rs_libcrux = { version = "0.2.0-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-libcrux" }

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -21,3 +21,4 @@ openmls_memory_storage = { version = "0.3.0", path = "../memory_storage" }
 rand = "0.9.0"
 tls_codec.workspace = true
 rand_chacha = "0.9.0"
+hpke-rs = "0.2.0"

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -11,14 +11,18 @@ readme = "../README.md"
 
 [dependencies]
 getrandom = "0.2.12"
-libcrux = { version = "=0.0.2-alpha.3", features = ["rand"] }
 libcrux-chacha20poly1305 = { version = "0.0.2" }
 libcrux-ed25519 = { version = "0.0.2", features=["rand"] }
-libcrux-hkdf = { version = "0.0.2-alpha.3" }
+libcrux-hkdf = { version = "0.0.2" }
 libcrux-sha2 = { version = "0.0.2" }
 openmls_traits = { version = "0.3.0", path = "../traits" }
 openmls_memory_storage = { version = "0.3.0", path = "../memory_storage" }
 rand = "0.9.0"
 tls_codec.workspace = true
 rand_chacha = "0.9.0"
-hpke-rs = "0.2.0"
+
+hpke_rs = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs" , features=["hazmat", "serialization"] }
+
+hpke_rs_crypto = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-crypto" }
+
+hpke_rs_libcrux = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-libcrux" }

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -16,9 +16,9 @@ libcrux-hkdf = { version = "0.0.2" }
 libcrux-sha2 = { version = "0.0.2" }
 openmls_traits = { version = "0.4.0", path = "../traits" }
 openmls_memory_storage = { version = "0.3.0", path = "../memory_storage" }
-rand = "0.9.0"
+rand = "0.9"
 tls_codec.workspace = true
-rand_chacha = "0.9.0"
+rand_chacha = "0.9"
 
 hpke_rs = { version = "0.2.1-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs" , features=["hazmat", "serialization"] }
 

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/openmls/openmls/tree/main/openmls_libcrux_crypt
 readme = "../README.md"
 
 [dependencies]
-getrandom = "0.2.12"
 libcrux-chacha20poly1305 = { version = "0.0.2" }
 libcrux-ed25519 = { version = "0.0.2", features=["rand"] }
 libcrux-hkdf = { version = "0.0.2" }

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -14,14 +14,14 @@ libcrux-chacha20poly1305 = { version = "0.0.2" }
 libcrux-ed25519 = { version = "0.0.2", features=["rand"] }
 libcrux-hkdf = { version = "0.0.2" }
 libcrux-sha2 = { version = "0.0.2" }
-openmls_traits = { version = "0.3.0", path = "../traits" }
+openmls_traits = { version = "0.4.0", path = "../traits" }
 openmls_memory_storage = { version = "0.3.0", path = "../memory_storage" }
 rand = "0.9.0"
 tls_codec.workspace = true
 rand_chacha = "0.9.0"
 
-hpke_rs = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs" , features=["hazmat", "serialization"] }
+hpke_rs = { version = "0.2.1-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs" , features=["hazmat", "serialization"] }
 
-hpke_rs_crypto = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-crypto" }
+hpke_rs_crypto = { version = "0.3.0-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-crypto" }
 
-hpke_rs_libcrux = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-libcrux" }
+hpke_rs_libcrux = { version = "0.2.0-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-libcrux" }

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -21,8 +21,8 @@ rand = "0.9.0"
 tls_codec.workspace = true
 rand_chacha = "0.9.0"
 
-hpke_rs = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs" , features=["hazmat", "serialization"] }
+hpke_rs = { git = "https://github.com/cryspen/hpke-rs", branch = "wysiwys/hpke-rs-libcrux", package = "hpke-rs" , features=["hazmat", "serialization"] }
 
-hpke_rs_crypto = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-crypto" }
+hpke_rs_crypto = { git = "https://github.com/cryspen/hpke-rs", branch = "wysiwys/hpke-rs-libcrux", package = "hpke-rs-crypto" }
 
-hpke_rs_libcrux = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-libcrux" }
+hpke_rs_libcrux = { git = "https://github.com/cryspen/hpke-rs", branch = "wysiwys/hpke-rs-libcrux", package = "hpke-rs-libcrux" }

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openmls_libcrux_crypto"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["OpenMLS Authors"]
 description = "A crypto backend for OpenMLS based on libcrux implementing openmls_traits."

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -21,8 +21,8 @@ rand = "0.9.0"
 tls_codec.workspace = true
 rand_chacha = "0.9.0"
 
-hpke_rs = { git = "https://github.com/cryspen/hpke-rs", branch = "wysiwys/hpke-rs-libcrux", package = "hpke-rs" , features=["hazmat", "serialization"] }
+hpke_rs = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs" , features=["hazmat", "serialization"] }
 
-hpke_rs_crypto = { git = "https://github.com/cryspen/hpke-rs", branch = "wysiwys/hpke-rs-libcrux", package = "hpke-rs-crypto" }
+hpke_rs_crypto = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-crypto" }
 
-hpke_rs_libcrux = { git = "https://github.com/cryspen/hpke-rs", branch = "wysiwys/hpke-rs-libcrux", package = "hpke-rs-libcrux" }
+hpke_rs_libcrux = { git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-libcrux" }

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 
 [dependencies]
 libcrux-chacha20poly1305 = { version = "0.0.2" }
-libcrux-ed25519 = { version = "0.0.2", features=["rand"] }
+libcrux-ed25519 = { version = "0.0.2", features = ["rand"] }
 libcrux-hkdf = { version = "0.0.2" }
 libcrux-sha2 = { version = "0.0.2" }
 openmls_traits = { version = "0.4.0", path = "../traits" }
@@ -19,6 +19,9 @@ openmls_memory_storage = { version = "0.3.0", path = "../memory_storage" }
 rand = "0.9"
 tls_codec.workspace = true
 rand_chacha = "0.9"
-hpke_rs = { version = "0.2.1-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs" , features=["hazmat", "serialization"] }
+hpke_rs = { version = "0.2.1-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs", features = [
+  "hazmat",
+  "serialization",
+] }
 hpke_rs_crypto = { version = "0.3.0-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-crypto" }
 hpke_rs_libcrux = { version = "0.2.0-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-libcrux" }

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -377,7 +377,7 @@ fn hpke_kem(kem: HpkeKemType) -> hpke_rs_crypto::types::KemAlgorithm {
         HpkeKemType::DhKemP521 => hpke_rs_crypto::types::KemAlgorithm::DhKemP521,
         HpkeKemType::DhKem25519 => hpke_rs_crypto::types::KemAlgorithm::DhKem25519,
         HpkeKemType::DhKem448 => hpke_rs_crypto::types::KemAlgorithm::DhKem448,
-        HpkeKemType::XWingKemDraft2 => todo!(),
+        HpkeKemType::XWingKemDraft2 => todo!("Implement XWingKemDraft2"),
     }
 }
 

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -119,11 +119,11 @@ impl OpenMlsCrypto for CryptoProvider {
         // TODO: instead, use key conversion from the libcrux-chacha20poly1305 crate, when available
         let key = <&[u8; 32]>::try_from(key).map_err(|_| CryptoError::InvalidLength)?;
 
-        let mut msg_ctx: Vec<u8> = vec![0; data.len() + 16];
-        libcrux_chacha20poly1305::encrypt(key, data, &mut msg_ctx, aad, iv)
+        let mut msg_ctxt: Vec<u8> = vec![0; data.len() + 16];
+        libcrux_chacha20poly1305::encrypt(key, data, &mut msg_ctxt, aad, iv)
             .map_err(|_| CryptoError::CryptoLibraryError)?;
 
-        Ok(msg_ctx)
+        Ok(msg_ctxt)
     }
 
     fn aead_decrypt(

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -377,7 +377,7 @@ fn hpke_kem(kem: HpkeKemType) -> hpke_rs_crypto::types::KemAlgorithm {
         HpkeKemType::DhKemP521 => hpke_rs_crypto::types::KemAlgorithm::DhKemP521,
         HpkeKemType::DhKem25519 => hpke_rs_crypto::types::KemAlgorithm::DhKem25519,
         HpkeKemType::DhKem448 => hpke_rs_crypto::types::KemAlgorithm::DhKem448,
-        HpkeKemType::XWingKemDraft2 => hpke_rs_crypto::types::KemAlgorithm::XWingDraft06,
+        HpkeKemType::XWingKemDraft6 => hpke_rs_crypto::types::KemAlgorithm::XWingDraft06,
     }
 }
 

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -149,7 +149,7 @@ impl OpenMlsCrypto for CryptoProvider {
 
         let iv = <&[u8; 12]>::try_from(nonce).map_err(|_| CryptoError::InvalidLength)?;
 
-        // TODO: instead, use key conversion from the libcrux-chacha20poly1305 crate, when available,
+        // TODO: instead, use key conversion from the libcrux-chacha20poly1305 crate, when available
         let key = <&[u8; 32]>::try_from(key).map_err(|_| CryptoError::InvalidLength)?;
 
         libcrux_chacha20poly1305::decrypt(key, &mut ptext, ct_tag, aad, iv).map_err(

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -290,7 +290,7 @@ impl OpenMlsCrypto for CryptoProvider {
 
         let (enc, ctx) = config
             .setup_sender(&pk_r, info, None, None, None)
-            .map_err(|_| CryptoError::ReceiverSetupError)?;
+            .map_err(|_| CryptoError::SenderSetupError)?;
 
         ctx.export(exporter_context, exporter_length)
             .map_err(|_| CryptoError::ExporterError)

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -116,7 +116,7 @@ impl OpenMlsCrypto for CryptoProvider {
         // only fails on wrong length
         let iv = <&[u8; 12]>::try_from(nonce).map_err(|_| CryptoError::InvalidLength)?;
 
-        // TODO: instead, use key conversion from the libcrux-chacha20poly1305 crate, when available,
+        // TODO: instead, use key conversion from the libcrux-chacha20poly1305 crate, when available
         let key = <&[u8; 32]>::try_from(key).map_err(|_| CryptoError::InvalidLength)?;
 
         let mut msg_ctx: Vec<u8> = vec![0; data.len() + 16];

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -18,12 +18,14 @@ pub struct CryptoProvider {
     rng: Mutex<ReseedingRng<ChaCha20Core, OsRng>>,
 }
 
-impl Default for CryptoProvider {
-    fn default() -> Self {
-        let reseeding_rng = ReseedingRng::<ChaCha20Core, _>::new(0x100000000, OsRng).unwrap();
-        Self {
+impl CryptoProvider {
+    pub fn new() -> Result<Self, CryptoError> {
+        let reseeding_rng = ReseedingRng::<ChaCha20Core, _>::new(0x100000000, OsRng)
+            .map_err(|_| CryptoError::InsufficientRandomness)?;
+
+        Ok(Self {
             rng: Mutex::new(reseeding_rng),
-        }
+        })
     }
 }
 

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -395,9 +395,10 @@ struct GuardedRng<'a, Rng: RngCore>(MutexGuard<'a, Rng>);
 impl<Rng: RngCore> GuardedRng<'_, Rng> {
     fn generate_vec(&mut self, len: usize) -> Result<Vec<u8>, CryptoError> {
         let mut output = vec![0u8; len];
-        self.fill_bytes(&mut output);
 
         // TODO: evaluate whether try_fill_bytes() should be used here
+        self.fill_bytes(&mut output);
+
         Ok(output)
     }
 }

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -345,8 +345,6 @@ impl OpenMlsCrypto for CryptoProvider {
 fn hpke_config(config: HpkeConfig) -> hpke_rs::Hpke<HpkeLibcrux> {
     let kem = hpke_kem(config.0);
     let kdf = hpke_kdf(config.1);
-
-    // TODO: should we return an error on unsupported AES algorithms here?
     let aead = hpke_aead(config.2);
 
     hpke_rs::Hpke::new(hpke_rs::Mode::Base, kem, kdf, aead)

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -234,9 +234,8 @@ impl OpenMlsCrypto for CryptoProvider {
         let (kem_output, ciphertext) = config
             .seal(&pk_r, info, aad, ptxt, None, None, None)
             .map_err(|e| match e {
-                // TODO: is this correct?
-                hpke_rs::HpkeError::InvalidInput => CryptoError::InvalidPublicKey,
-                _ => CryptoError::CryptoLibraryError,
+                hpke_rs::HpkeError::InvalidConfig => CryptoError::SenderSetupError,
+                _ => CryptoError::HpkeEncryptionError,
             })?;
 
         let kem_output = kem_output.into();
@@ -271,10 +270,9 @@ impl OpenMlsCrypto for CryptoProvider {
                 None,
                 None,
             )
-            // TODO: should more error types be handled?
             .map_err(|e| match e {
-                hpke_rs::HpkeError::OpenError => CryptoError::HpkeDecryptionError,
-                _ => CryptoError::CryptoLibraryError,
+                hpke_rs::HpkeError::InvalidConfig => CryptoError::ReceiverSetupError,
+                _ => CryptoError::HpkeDecryptionError,
             })
     }
 

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -15,7 +15,7 @@ use tls_codec::SecretVLBytes;
 
 /// The libcrux-backed cryptography provider for OpenMLS
 pub struct CryptoProvider {
-    rng: Mutex<ReseedingRng<ChaCha20Core, OsRng>>,
+    pub(super) rng: Mutex<ReseedingRng<ChaCha20Core, OsRng>>,
 }
 
 impl CryptoProvider {

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -342,6 +342,8 @@ impl OpenMlsCrypto for CryptoProvider {
 fn hpke_config(config: HpkeConfig) -> hpke_rs::Hpke<HpkeLibcrux> {
     let kem = hpke_kem(config.0);
     let kdf = hpke_kdf(config.1);
+
+    // TODO: should we return an error on unsupported AES algorithms here?
     let aead = hpke_aead(config.2);
 
     hpke_rs::Hpke::new(hpke_rs::Mode::Base, kem, kdf, aead)

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -136,7 +136,7 @@ impl OpenMlsCrypto for CryptoProvider {
         nonce: &[u8],
         aad: &[u8],
     ) -> Result<Vec<u8>, CryptoError> {
-        // The only supported AeadType (as of openmls_traits v0.3.0) is ChaCha20Poly1305
+        // The only supported AeadType (as of openmls_traits v0.4.0) is ChaCha20Poly1305
         if !matches!(alg, AeadType::ChaCha20Poly1305) {
             return Err(CryptoError::UnsupportedAeadAlgorithm);
         }

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -121,7 +121,6 @@ impl OpenMlsCrypto for CryptoProvider {
         // only fails on wrong length
         let iv = <&[u8; 12]>::try_from(nonce).map_err(|_| CryptoError::InvalidLength)?;
 
-        // TODO: instead, use key conversion from the libcrux-chacha20poly1305 crate, when available
         let key = <&[u8; 32]>::try_from(key).map_err(|_| CryptoError::InvalidLength)?;
 
         let mut msg_ctxt: Vec<u8> = vec![0; data.len() + TAG_LEN];
@@ -155,7 +154,6 @@ impl OpenMlsCrypto for CryptoProvider {
 
         let iv = <&[u8; 12]>::try_from(nonce).map_err(|_| CryptoError::InvalidLength)?;
 
-        // TODO: instead, use key conversion from the libcrux-chacha20poly1305 crate, when available
         let key = <&[u8; 32]>::try_from(key).map_err(|_| CryptoError::InvalidLength)?;
 
         libcrux_chacha20poly1305::decrypt(key, &mut ptext, ct_tag, aad, iv).map_err(

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -19,6 +19,7 @@ pub struct CryptoProvider {
 }
 
 impl CryptoProvider {
+    /// Instantiate a libcrux-based CryptoProvider
     pub fn new() -> Result<Self, CryptoError> {
         let reseeding_rng = ReseedingRng::<ChaCha20Core, _>::new(0x100000000, OsRng)
             .map_err(|_| CryptoError::InsufficientRandomness)?;

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -111,7 +111,7 @@ impl OpenMlsCrypto for CryptoProvider {
         // only fails on wrong length
         let iv = <&[u8; 12]>::try_from(nonce).map_err(|_| CryptoError::InvalidLength)?;
 
-        // TODO: instead, use key conversion from chachapoly crate, when available,
+        // TODO: instead, use key conversion from the libcrux-chacha20poly1305 crate, when available,
         let key = <&[u8; 32]>::try_from(key).map_err(|_| CryptoError::InvalidLength)?;
 
         let mut msg_ctx: Vec<u8> = vec![0; data.len() + 16];
@@ -144,7 +144,7 @@ impl OpenMlsCrypto for CryptoProvider {
 
         let iv = <&[u8; 12]>::try_from(nonce).map_err(|_| CryptoError::InvalidLength)?;
 
-        // TODO: instead, use key conversion from chachapoly crate, when available,
+        // TODO: instead, use key conversion from the libcrux-chacha20poly1305 crate, when available,
         let key = <&[u8; 32]>::try_from(key).map_err(|_| CryptoError::InvalidLength)?;
 
         libcrux_chacha20poly1305::decrypt(key, &mut ptext, ct_tag, aad, iv).map_err(

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -377,7 +377,7 @@ fn hpke_kem(kem: HpkeKemType) -> hpke_rs_crypto::types::KemAlgorithm {
         HpkeKemType::DhKemP521 => hpke_rs_crypto::types::KemAlgorithm::DhKemP521,
         HpkeKemType::DhKem25519 => hpke_rs_crypto::types::KemAlgorithm::DhKem25519,
         HpkeKemType::DhKem448 => hpke_rs_crypto::types::KemAlgorithm::DhKem448,
-        HpkeKemType::XWingKemDraft2 => todo!("Implement XWingKemDraft2"),
+        HpkeKemType::XWingKemDraft2 => hpke_rs_crypto::types::KemAlgorithm::XWingDraft06,
     }
 }
 

--- a/libcrux_crypto/src/lib.rs
+++ b/libcrux_crypto/src/lib.rs
@@ -14,6 +14,9 @@ pub struct Provider {
 }
 
 impl Provider {
+    /// Instantiate a libcrux-based Provider
+    /// This method uses non-panicking instantiation of the underlying CryptoProvider,
+    /// and should be preferred to `Provider::default()`.
     pub fn new() -> Result<Self, CryptoError> {
         let crypto = crypto::CryptoProvider::new()?;
         let storage = openmls_memory_storage::MemoryStorage::default();

--- a/libcrux_crypto/src/lib.rs
+++ b/libcrux_crypto/src/lib.rs
@@ -1,4 +1,4 @@
-use openmls_traits::OpenMlsProvider;
+use openmls_traits::{types::CryptoError, OpenMlsProvider};
 
 mod crypto;
 mod rand;
@@ -8,11 +8,24 @@ pub use rand::RandError;
 pub use rand::RandProvider;
 
 /// The libcrux-backed provider for OpenMLS.
-#[derive(Default)]
 pub struct Provider {
     crypto: crypto::CryptoProvider,
     rand: rand::RandProvider,
     storage: openmls_memory_storage::MemoryStorage,
+}
+
+impl Provider {
+    pub fn new() -> Result<Self, CryptoError> {
+        let crypto = crypto::CryptoProvider::new()?;
+        let rand = todo!();
+        let storage = openmls_memory_storage::MemoryStorage::default();
+
+        Ok(Self {
+            crypto,
+            rand,
+            storage,
+        })
+    }
 }
 
 impl OpenMlsProvider for Provider {

--- a/libcrux_crypto/src/lib.rs
+++ b/libcrux_crypto/src/lib.rs
@@ -5,32 +5,35 @@ mod rand;
 
 pub use crypto::CryptoProvider;
 pub use rand::RandError;
-pub use rand::RandProvider;
 
 /// The libcrux-backed provider for OpenMLS.
 pub struct Provider {
+    // The CryptoProvider serves as both the Rand and Crypto provider
     crypto: crypto::CryptoProvider,
-    rand: rand::RandProvider,
     storage: openmls_memory_storage::MemoryStorage,
 }
 
 impl Provider {
     pub fn new() -> Result<Self, CryptoError> {
         let crypto = crypto::CryptoProvider::new()?;
-        let rand = todo!();
         let storage = openmls_memory_storage::MemoryStorage::default();
 
-        Ok(Self {
-            crypto,
-            rand,
-            storage,
-        })
+        Ok(Self { crypto, storage })
+    }
+}
+
+impl Default for Provider {
+    fn default() -> Self {
+        let crypto = crypto::CryptoProvider::new().unwrap();
+        let storage = openmls_memory_storage::MemoryStorage::default();
+
+        Self { crypto, storage }
     }
 }
 
 impl OpenMlsProvider for Provider {
     type CryptoProvider = CryptoProvider;
-    type RandProvider = RandProvider;
+    type RandProvider = CryptoProvider;
     type StorageProvider = openmls_memory_storage::MemoryStorage;
 
     fn storage(&self) -> &Self::StorageProvider {
@@ -42,6 +45,6 @@ impl OpenMlsProvider for Provider {
     }
 
     fn rand(&self) -> &Self::RandProvider {
-        &self.rand
+        &self.crypto
     }
 }

--- a/libcrux_crypto/src/rand.rs
+++ b/libcrux_crypto/src/rand.rs
@@ -2,7 +2,7 @@ use std::sync::RwLock;
 
 use openmls_traits::random::OpenMlsRand;
 
-use rand::{rngs::OsRng, rngs::ReseedingRng, RngCore};
+use rand::{rngs::OsRng, rngs::ReseedingRng, TryRngCore};
 use rand_chacha::ChaCha20Core;
 
 /// The libcrux-backed randomness provider for OpenMLS
@@ -39,8 +39,9 @@ impl OpenMlsRand for RandProvider {
         let mut rng = self.rng.write().unwrap();
 
         let mut output = [0u8; N];
-        // TODO: evaluate whether try_fill_bytes() should be used here
-        rng.fill_bytes(&mut output);
+
+        rng.try_fill_bytes(&mut output)
+            .map_err(|_| RandError::UnableToGenerate)?;
 
         Ok(output)
     }
@@ -49,8 +50,9 @@ impl OpenMlsRand for RandProvider {
         let mut rng = self.rng.write().unwrap();
 
         let mut output = vec![0u8; len];
-        // TODO: evaluate whether try_fill_bytes() should be used here
-        rng.fill_bytes(&mut output);
+
+        rng.try_fill_bytes(&mut output)
+            .map_err(|_| RandError::UnableToGenerate)?;
 
         Ok(output)
     }

--- a/libcrux_crypto/src/rand.rs
+++ b/libcrux_crypto/src/rand.rs
@@ -5,7 +5,7 @@ use openmls_traits::random::OpenMlsRand;
 use rand::{rngs::OsRng, rngs::ReseedingRng, TryRngCore};
 use rand_chacha::ChaCha20Core;
 
-/// The libcrux-backed randomness provider for OpenMLS
+/// The randomness provider for the libcrux-backed OpenMLS provider
 pub struct RandProvider {
     rng: RwLock<ReseedingRng<ChaCha20Core, OsRng>>,
 }

--- a/memory_storage/Cargo.toml
+++ b/memory_storage/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/openmls/openmls/tree/main/memory_storage"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { version = "0.3.0", path = "../traits" }
+openmls_traits = { version = "0.4.0", path = "../traits" }
 thiserror = "2.0"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = { version = "1.0", optional = true }
 itertools = { version = "0.14", optional = true }
 wasm-bindgen-test = { version = "0.3.40", optional = true }
 getrandom = { version = "0.3.2", optional = true }
+getrandom_old = { package = "getrandom", version = "0.2.15", optional = true }
 fluvio-wasm-timer = { version = "0.2.5", optional = true }
 once_cell = { version = "1.19.0", optional = true }
 
@@ -67,8 +68,10 @@ crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
 js = [
   "dep:getrandom",
+  "dep:getrandom_old",
   "dep:fluvio-wasm-timer",
   "getrandom/wasm_js",
+  "getrandom_old/js",
 ] # enable js randomness source for provider
 fork-resolution = []
 

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -23,7 +23,7 @@ openmls_memory_storage = { version = "0.3.0", path = "../memory_storage", featur
 ], optional = true }
 openmls_sqlite_storage = { version = "0.1.0", path = "../sqlite_storage", optional = true }
 openmls_test = { version = "0.1.0", path = "../openmls_test", optional = true }
-openmls_libcrux_crypto = { version = "0.1.0", path = "../libcrux_crypto", optional = true }
+openmls_libcrux_crypto = { version = "0.2.0", path = "../libcrux_crypto", optional = true }
 serde = { version = "^1.0", features = ["derive"] }
 log = { version = "0.4", features = ["std"] }
 tls_codec = { workspace = true }

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -72,8 +72,8 @@ js = [
   "dep:fluvio-wasm-timer",
 
   # enable randomness source features for both versions of getrandom
-  "getrandom/wasm_js",
   "getrandom_old/js",
+  "getrandom/wasm_js",
 ]
 fork-resolution = []
 
@@ -101,7 +101,10 @@ openmls = { path = ".", features = [
   "libcrux-provider",
 ] }
 
-[target.'cfg(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows")))'.dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dev_dependencies]
+openmls = { path = ".", features = ["test-utils", "libcrux-provider"] }
+
+[target.'cfg(all(target_arch = "x86", target_os = "windows"))'.dev-dependencies]
 openmls = { path = ".", features = ["test-utils"] }
 
 [[bench]]

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = { version = "1.0", optional = true }
 # Crypto providers required for KAT and testing - "test-utils" feature
 itertools = { version = "0.14", optional = true }
 wasm-bindgen-test = { version = "0.3.40", optional = true }
-getrandom = { version = "0.2.12", optional = true, features = ["js"] }
+getrandom = { version = "0.3.2", optional = true }
 fluvio-wasm-timer = { version = "0.2.5", optional = true }
 once_cell = { version = "1.19.0", optional = true }
 
@@ -68,6 +68,7 @@ content-debug = [] # ☣️ Enable logging of sensitive message content
 js = [
   "dep:getrandom",
   "dep:fluvio-wasm-timer",
+  "getrandom?/wasm_js",
 ] # enable js randomness source for provider
 fork-resolution = []
 

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -68,7 +68,7 @@ content-debug = [] # ☣️ Enable logging of sensitive message content
 js = [
   "dep:getrandom",
   "dep:fluvio-wasm-timer",
-  "getrandom?/wasm_js",
+  "getrandom/wasm_js",
 ] # enable js randomness source for provider
 fork-resolution = []
 

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -35,7 +35,7 @@ rand = { version = "0.8", optional = true }
 serde_json = { version = "1.0", optional = true }
 # Crypto providers required for KAT and testing - "test-utils" feature
 itertools = { version = "0.14", optional = true }
-wasm-bindgen-test = { version = "0.3.40", optional = true }
+wasm-bindgen-test = { version = "0.3.50", optional = true }
 getrandom = { version = "0.3.2", optional = true }
 getrandom_old = { package = "getrandom", version = "0.2.15", optional = true }
 fluvio-wasm-timer = { version = "0.2.5", optional = true }
@@ -70,9 +70,11 @@ js = [
   "dep:getrandom",
   "dep:getrandom_old",
   "dep:fluvio-wasm-timer",
+
+  # enable randomness source features for both versions of getrandom
   "getrandom/wasm_js",
   "getrandom_old/js",
-] # enable js randomness source for provider
+]
 fork-resolution = []
 
 [dev-dependencies]
@@ -84,8 +86,8 @@ openmls_traits = { version = "0.3.0", path = "../traits", features = [
 ] }
 pretty_env_logger = "0.5"
 tempfile = "3"
-wasm-bindgen = "0.2"
-wasm-bindgen-test = "0.3"
+wasm-bindgen = "0.2.100"
+wasm-bindgen-test = "0.3.50"
 clap = { version = "4", features = ["derive"] }
 base64 = "0.22.1"
 flate2 = "1.0"
@@ -99,7 +101,13 @@ openmls = { path = ".", features = [
   "libcrux-provider",
 ] }
 
-[target.'cfg(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows")))'.dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+openmls = { path = ".", features = [
+  "test-utils",
+  "libcrux-provider",
+] }
+
+[target.'cfg(all(target_arch = "x86", target_os = "windows"))'.dev-dependencies]
 openmls = { path = ".", features = ["test-utils"] }
 
 [[bench]]

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -67,13 +67,18 @@ sqlite-provider = [
 crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
 js = [
-  "dep:getrandom",
   "dep:getrandom_old",
   "dep:fluvio-wasm-timer",
 
-  # enable randomness source features for both versions of getrandom
+  # enable randomness source
   "getrandom_old/js",
+]
+
+libcrux-provider-js = [
+  "dep:getrandom",
+  # enable randomness source
   "getrandom/wasm_js",
+  
 ]
 fork-resolution = []
 
@@ -101,10 +106,7 @@ openmls = { path = ".", features = [
   "libcrux-provider",
 ] }
 
-[target.'cfg(target_arch = "wasm32")'.dev_dependencies]
-openmls = { path = ".", features = ["test-utils", "libcrux-provider"] }
-
-[target.'cfg(all(target_arch = "x86", target_os = "windows"))'.dev-dependencies]
+[target.'cfg(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows")))'.dev-dependencies]
 openmls = { path = ".", features = ["test-utils"] }
 
 [[bench]]

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -101,13 +101,7 @@ openmls = { path = ".", features = [
   "libcrux-provider",
 ] }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-openmls = { path = ".", features = [
-  "test-utils",
-  "libcrux-provider",
-] }
-
-[target.'cfg(all(target_arch = "x86", target_os = "windows"))'.dev-dependencies]
+[target.'cfg(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows")))'.dev-dependencies]
 openmls = { path = ".", features = ["test-utils"] }
 
 [[bench]]

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["MLS", "IETF", "RFC9420", "Encryption", "E2EE"]
 exclude = ["/test_vectors"]
 
 [dependencies]
-openmls_traits = { version = "0.3.0", path = "../traits" }
+openmls_traits = { version = "0.4.0", path = "../traits" }
 openmls_rust_crypto = { version = "0.3.0", path = "../openmls_rust_crypto", optional = true }
 openmls_basic_credential = { version = "0.3.0", path = "../basic_credential", optional = true, features = [
   "clonable",
@@ -86,7 +86,7 @@ fork-resolution = []
 criterion = { version = "^0.5", default-features = false } # need to disable default features for wasm
 hex = { version = "0.4", features = ["serde"] }
 lazy_static = "1.4"
-openmls_traits = { version = "0.3.0", path = "../traits", features = [
+openmls_traits = { version = "0.4.0", path = "../traits", features = [
   "test-utils",
 ] }
 pretty_env_logger = "0.5"

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/openmls/openmls/tree/main/openmls_rust_crypto"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { version = "0.3.0", path = "../traits" }
+openmls_traits = { version = "0.4.0", path = "../traits" }
 openmls_memory_storage = { version = "0.3.0", path = "../memory_storage" }
 hpke = { version = "0.2.0", package = "hpke-rs", default-features = false, features = [
   "hazmat",

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -56,8 +56,8 @@ fn kem_mode(kem: HpkeKemType) -> hpke_types::KemAlgorithm {
         HpkeKemType::DhKemP521 => hpke_types::KemAlgorithm::DhKemP521,
         HpkeKemType::DhKem25519 => hpke_types::KemAlgorithm::DhKem25519,
         HpkeKemType::DhKem448 => hpke_types::KemAlgorithm::DhKem448,
-        HpkeKemType::XWingKemDraft2 => {
-            unimplemented!("XWingKemDraft1 is not supported by the RustCrypto provider.")
+        HpkeKemType::XWingKemDraft6 => {
+            unimplemented!("XWingKemDraft6 is not supported by the RustCrypto provider.")
         }
     }
 }

--- a/openmls_test/Cargo.toml
+++ b/openmls_test/Cargo.toml
@@ -26,5 +26,5 @@ rstest = { version = "0.24" }
 rstest_reuse = { version = "0.7" }
 openmls_rust_crypto = { version = "0.3.0", path = "../openmls_rust_crypto" }
 openmls_libcrux_crypto = { version = "0.2.0", path = "../libcrux_crypto", optional = true }
-openmls_traits = { version = "0.3.0", path = "../traits" }
+openmls_traits = { version = "0.4.0", path = "../traits" }
 openmls_sqlite_storage = { version = "0.1.0", path = "../sqlite_storage", optional = true }

--- a/openmls_test/Cargo.toml
+++ b/openmls_test/Cargo.toml
@@ -25,6 +25,6 @@ quote = "1.0"
 rstest = { version = "0.24" }
 rstest_reuse = { version = "0.7" }
 openmls_rust_crypto = { version = "0.3.0", path = "../openmls_rust_crypto" }
-openmls_libcrux_crypto = { version = "0.1.0", path = "../libcrux_crypto", optional = true }
+openmls_libcrux_crypto = { version = "0.2.0", path = "../libcrux_crypto", optional = true }
 openmls_traits = { version = "0.3.0", path = "../traits" }
 openmls_sqlite_storage = { version = "0.1.0", path = "../sqlite_storage", optional = true }

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -138,7 +138,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
         not(all(target_arch = "x86", target_os = "windows"))
     ))]
     {
-        let libcrux = openmls_libcrux_crypto::Provider::new().unwrap();
+        let libcrux = openmls_libcrux_crypto::Provider::default();
         let libcrux_ciphersuites = libcrux.crypto().supported_ciphersuites();
 
         for ciphersuite in libcrux_ciphersuites {

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -135,7 +135,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     #[cfg(all(
         feature = "libcrux-provider",
-        not(any(all(target_arch = "x86", target_os = "windows")))
+        not(all(target_arch = "x86", target_os = "windows"))
     ))]
     {
         let libcrux = openmls_libcrux_crypto::Provider::default();

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -136,7 +136,6 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     #[cfg(all(
         feature = "libcrux-provider",
         not(any(
-            target_arch = "wasm32",
             all(target_arch = "x86", target_os = "windows")
         ))
     ))]

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -138,7 +138,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
         not(all(target_arch = "x86", target_os = "windows"))
     ))]
     {
-        let libcrux = openmls_libcrux_crypto::Provider::default();
+        let libcrux = openmls_libcrux_crypto::Provider::new().unwrap();
         let libcrux_ciphersuites = libcrux.crypto().supported_ciphersuites();
 
         for ciphersuite in libcrux_ciphersuites {

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -135,9 +135,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     #[cfg(all(
         feature = "libcrux-provider",
-        not(any(
-            all(target_arch = "x86", target_os = "windows")
-        ))
+        not(any(all(target_arch = "x86", target_os = "windows")))
     ))]
     {
         let libcrux = openmls_libcrux_crypto::Provider::default();

--- a/sqlite_storage/Cargo.toml
+++ b/sqlite_storage/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/openmls/openmls/tree/main/sqlite_storage"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { version = "0.3.0", path = "../traits" }
+openmls_traits = { version = "0.4.0", path = "../traits" }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = { version = "0.4" }

--- a/traits/CHANGELOG.md
+++ b/traits/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [#1760](https://github.com/openmls/openmls/pull/1760): Drop support for `XWingKemDraft2` and add support for `XWingKemDraft6`
 
 ### Changed
 - [#909](https://github.com/openmls/openmls/pull/909): Use thiserror crate for errors

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openmls_traits"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["OpenMLS Authors"]
 edition = "2021"
 description = "Traits used by OpenMLS"

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -181,7 +181,7 @@ pub enum HpkeKemType {
     DhKem448 = 0x0021,
 
     /// XWing combiner for ML-KEM and X25519
-    XWingKemDraft2 = 0x004D,
+    XWingKemDraft6 = 0x004D,
 }
 
 /// KDF Types for HPKE
@@ -548,7 +548,7 @@ impl Ciphersuite {
             Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => HpkeKemType::DhKemP384,
             Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521 => HpkeKemType::DhKemP521,
             Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 => {
-                HpkeKemType::XWingKemDraft2
+                HpkeKemType::XWingKemDraft6
             }
         }
     }


### PR DESCRIPTION
This PR updates the libcrux provider to use pure Rust crates where possible (see #1751):
- `libcrux-chacha20poly1305`
- `libcrux-ed25519`
- `libcrux-hkdf`
- `libcrux-sha2`
- `hpke-rs`

For now, in the crypto and rand providers, the `libcrux::drbg::Drbg` is also replaced with a `rand::rngs::ReseedingRng<rand_chacha::ChaCha20Core,rand::rngs::OsRng>`.

This PR also drops AES support from the libcrux provider.