### PR TITLE
chore: expose LeafNodeSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#1700](https://github.com/openmls/openmls/pull/1700): During commit processing, OpenMLS will now return a `StorageError` if the storage provider fails while fetching `encryption_epoch_key_pairs`. Previously, it would ignore any error returned by the storage provider and just assume that no keys could be found (which typically lead to an error later during commit processing).
+- [#1762](https://github.com/openmls/openmls/pull/1762): Expose `LeafNodeSource` to allow handling output of `LeafNode::leaf_node_source()`.
 
 ## 0.6.0 (2024-09-04)
 

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -34,8 +34,7 @@ use self::{
     diff::{StagedTreeSyncDiff, TreeSyncDiff},
     node::{
         leaf_node::{
-            Capabilities, LeafNodeSource, NewLeafNodeParams, TreeInfoTbs, TreePosition,
-            VerifiableLeafNode,
+            Capabilities, NewLeafNodeParams, TreeInfoTbs, TreePosition, VerifiableLeafNode,
         },
         NodeIn,
     },
@@ -80,7 +79,10 @@ pub use node::encryption_keys::EncryptionKey;
 
 // Public re-exports
 pub use node::{
-    leaf_node::{LeafNode, LeafNodeParameters, LeafNodeParametersBuilder, LeafNodeUpdateError},
+    leaf_node::{
+        LeafNode, LeafNodeParameters, LeafNodeParametersBuilder, LeafNodeSource,
+        LeafNodeUpdateError,
+    },
     parent_node::ParentNode,
     Node,
 };

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -573,9 +573,12 @@ struct LeafNodePayload {
 )]
 #[repr(u8)]
 pub enum LeafNodeSource {
+    /// The leaf node was added to the group as part of a key package.
     #[tls_codec(discriminant = 1)]
     KeyPackage(Lifetime),
+    /// The leaf node was added through an Update proposal.
     Update,
+    /// The leaf node was added via a Commit.
     Commit(ParentHash),
 }
 

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -558,6 +558,7 @@ struct LeafNodePayload {
     extensions: Extensions,
 }
 
+/// The source of the `LeafNode`.
 #[derive(
     Debug,
     Clone,


### PR DESCRIPTION
There's a public `leaf_node_source` function that allows getting the `LeafNodeSource` of a leaf. However, the `LeafNodeSource` type is not actually public. This PR fixes that.