### PR TITLE
Fix list of extensions valid in a leaf node

### DIFF
--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -121,12 +121,12 @@ impl ExtensionType {
     /// This is the case for unknown extensions.
     pub(crate) fn is_valid_in_leaf_node(self) -> Option<bool> {
         match self {
-            ExtensionType::ApplicationId
+            ExtensionType::LastResort
             | ExtensionType::RatchetTree
             | ExtensionType::RequiredCapabilities
             | ExtensionType::ExternalPub
             | ExtensionType::ExternalSenders => Some(false),
-            ExtensionType::LastResort => Some(true),
+            ExtensionType::ApplicationId => Some(true),
             ExtensionType::Unknown(_) => None,
         }
     }

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -1293,10 +1293,9 @@ fn builder_pattern() {
     assert_eq!(leaf_extensions, &test_leaf_extensions);
 
     // Make sure that building with an invalid leaf node extension fails
-    let invalid_leaf_extensions =
-        Extensions::single(Extension::ApplicationId(ApplicationIdExtension::new(&[
-            0x00, 0x01, 0x02,
-        ])));
+    let invalid_leaf_extensions = Extensions::single(Extension::RequiredCapabilities(
+        RequiredCapabilitiesExtension::new(&[], &[], &[]),
+    ));
 
     let builder_err = MlsGroup::builder()
         .with_leaf_node_extensions(invalid_leaf_extensions)


### PR DESCRIPTION
This PR upstreams a fix by @neekolas. In the validation function that checks which extension types are valid in leaf nodes, we use the wrong set of extensions. This PR addresses this.