### PR TITLE
Update rusqlite to 0.32

### DIFF
--- a/sqlite_storage/Cargo.toml
+++ b/sqlite_storage/Cargo.toml
@@ -14,7 +14,7 @@ openmls_traits = { version = "0.3.0", path = "../traits" }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = { version = "0.4" }
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 refinery = { version = "0.8", features = ["rusqlite"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This updates rusqlite to version 0.32 to fix bundled sqlite linking issues. I'm not 100% sure this is the best solution here but I couldn't get patch working given we're dealing with linking a native library. 