### PR TITLE
Use SignerBundle instead of Signer for update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1673](https://github.com/openmls/openmls/pull/1673): Return more specific error when attemtping to decrypt own messages: `ProcessMessageError::ValidationError(ValidationError::CannotDecryptOwnMessage)`.
 - [#1731](https://github.com/openmls/openmls/pull/1731): Add helpers to recover from group state forks, hidden behind the new `fork-resolution` feature flag.
 - [#1750](https://github.com/openmls/openmls/pull/1750): Support add proposals from external senders, using `ExternalProposal::new_add()`.
+- [#1766](https://github.com/openmls/openmls/pull/1766): New error variant for commit creation: If a new signer is introduced via `self_update_with_new_signer` and additionally a `CredentialWithKey` is provided via `LeafNodeParameters`, an `InvalidLeafNodeParameters` error is thrown.
 
 ### Fixed
 

--- a/book/src/user_manual/updates.md
+++ b/book/src/user_manual/updates.md
@@ -9,8 +9,17 @@ By default, only the HPKE encryption key is updated. The application can however
 {{#include ../../../openmls/tests/book_code.rs:self_update}}
 ```
 
-The function returns the tuple `(MlsMessageOut, Option<Welcome>)`. The `MlsMessageOut` contains a Commit message that needs to be fanned out to existing group members.
-Even though the member updates its own leaf node only in this operation, the Commit message could potentially also cover Add Proposals that were previously received in the epoch. Therefore the function can also optionally return a `Welcome` message. The `Welcome` message must be sent to the newly added members.
+The function returns a `CommitMessageBundle`, which consists of the Commit message that needs to be fanned out to existing group members.
+Even though the member updates its own leaf node only in this operation, the Commit message could potentially also cover Add Proposals that were previously received in the epoch. Therefore the `CommitMessagBundle` can also contain a `Welcome` message. The `Welcome` message must be sent to the newly added members.
+
+Members can use the `.self_update_with_new_signer()` function to also update the `Signer` used to sign future MLS messages.
+
+```rust,no_run,noplayground
+{{#include ../../../openmls/tests/book_code.rs:alice_rotates_signature_key}}
+```
+
+When constructing the `NewSignerBundle`, the `Signer` must match the public key and credential in the `CredentialWithKey`. When using `self_update_with_new_signer`, `LeafNodeParameters` may not contain a `CredentialWithKey`.
+
 
 ## Proposal
 

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -26,6 +26,7 @@
 
 use std::io::{Read, Write};
 
+use openmls_traits::signatures::Signer;
 use serde::{Deserialize, Serialize};
 use tls_codec::{
     Deserialize as TlsDeserializeTrait, DeserializeBytes, Error, Serialize as TlsSerializeTrait,
@@ -288,6 +289,17 @@ impl TryFrom<Credential> for BasicCredential {
             _ => Err(errors::BasicCredentialError::WrongCredentialType),
         }
     }
+}
+
+/// Bundle consisting of a [`Signer`] and a [`CredentialWithKey`] to be used to
+/// update the signature key in an [`MlsGroup`]. The public key and credential
+/// in `credential_with_key` MUST match the signature key exposed by `signer`.
+#[derive(Debug, Clone)]
+pub struct NewSignerBundle<'a, S: Signer> {
+    /// The signer to be used with the group after the update.
+    pub signer: &'a S,
+    /// The credential and public key corresponding to the `signer`.
+    pub credential_with_key: CredentialWithKey,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -39,6 +39,9 @@ mod tests;
 use crate::{ciphersuite::SignaturePublicKey, group::Member, treesync::LeafNode};
 use errors::*;
 
+#[cfg(doc)]
+use crate::group::MlsGroup;
+
 // Public
 pub mod errors;
 

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -17,6 +17,9 @@ use crate::{
     treesync::errors::*,
 };
 
+#[cfg(doc)]
+use crate::treesync::LeafNodeParameters;
+
 /// Welcome error
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum WelcomeError<StorageError> {

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -248,6 +248,9 @@ pub enum CreateCommitError {
     /// See [`TreeSyncAddLeaf`] for more details.
     #[error(transparent)]
     TreeSyncAddLeaf(#[from] TreeSyncAddLeaf),
+    /// Invalid [`LeafNodeParameters`]. `[CredentialWithKey]` can't be set with new signer.
+    #[error("Invalid LeafNodeParameters. CredentialWithKey can't be set with new signer.")]
+    InvalidLeafNodeParameters,
 }
 
 /// Stage commit error

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -31,7 +31,7 @@ use crate::{
 use super::{
     mls_auth_content::AuthenticatedContent,
     staged_commit::{MemberStagedCommitState, StagedCommitState},
-    updates::SignerBundle,
+    updates::NewSignerBundle,
     AddProposal, CreateCommitResult, GroupContextExtensionProposal, MlsGroup, MlsGroupState,
     MlsMessageOut, PendingCommitState, Proposal, RemoveProposal, Sender,
 };
@@ -290,7 +290,7 @@ impl<'a> CommitBuilder<'a, LoadedPsks> {
         signer: &S,
         f: impl FnMut(&QueuedProposal) -> bool,
     ) -> Result<CommitBuilder<'a, Complete>, CreateCommitError> {
-        self.build_internal(rand, crypto, signer, None::<SignerBundle<'_, S>>, f)
+        self.build_internal(rand, crypto, signer, None::<NewSignerBundle<'_, S>>, f)
     }
 
     /// Just like `build`, this function validates the inputs and builds the
@@ -305,7 +305,7 @@ impl<'a> CommitBuilder<'a, LoadedPsks> {
         rand: &impl OpenMlsRand,
         crypto: &impl OpenMlsCrypto,
         old_signer: &impl Signer,
-        new_signer: SignerBundle<'_, S>,
+        new_signer: NewSignerBundle<'_, S>,
         f: impl FnMut(&QueuedProposal) -> bool,
     ) -> Result<CommitBuilder<'a, Complete>, CreateCommitError> {
         self.build_internal(rand, crypto, old_signer, Some(new_signer), f)
@@ -316,7 +316,7 @@ impl<'a> CommitBuilder<'a, LoadedPsks> {
         rand: &impl OpenMlsRand,
         crypto: &impl OpenMlsCrypto,
         old_signer: &impl Signer,
-        new_signer: Option<SignerBundle<'_, S>>,
+        new_signer: Option<NewSignerBundle<'_, S>>,
         f: impl FnMut(&QueuedProposal) -> bool,
     ) -> Result<CommitBuilder<'a, Complete>, CreateCommitError> {
         let ciphersuite = self.group.ciphersuite();

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -19,7 +19,7 @@ use crate::{
         group_info::{GroupInfo, GroupInfoTBS},
         Commit, Welcome,
     },
-    prelude::{LeafNodeParameters, LibraryError},
+    prelude::{LeafNodeParameters, LibraryError, NewSignerBundle},
     schedule::{
         psk::{load_psks, PskSecret},
         JoinerSecret, KeySchedule, PreSharedKeyId,
@@ -31,7 +31,6 @@ use crate::{
 use super::{
     mls_auth_content::AuthenticatedContent,
     staged_commit::{MemberStagedCommitState, StagedCommitState},
-    updates::NewSignerBundle,
     AddProposal, CreateCommitResult, GroupContextExtensionProposal, MlsGroup, MlsGroupState,
     MlsMessageOut, PendingCommitState, Proposal, RemoveProposal, Sender,
 };

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -70,8 +70,6 @@ pub(crate) mod proposal;
 pub(crate) mod proposal_store;
 pub(crate) mod staged_commit;
 
-pub use updates::NewSignerBundle;
-
 // Tests
 #[cfg(test)]
 pub(crate) mod tests_and_kats;

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -70,7 +70,7 @@ pub(crate) mod proposal;
 pub(crate) mod proposal_store;
 pub(crate) mod staged_commit;
 
-pub use updates::SignerBundle;
+pub use updates::NewSignerBundle;
 
 // Tests
 #[cfg(test)]

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -70,6 +70,8 @@ pub(crate) mod proposal;
 pub(crate) mod proposal_store;
 pub(crate) mod staged_commit;
 
+pub use updates::SignerBundle;
+
 // Tests
 #[cfg(test)]
 pub(crate) mod tests_and_kats;

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -12,7 +12,7 @@ use crate::{
     binary_tree::LeafNodeIndex,
     credentials::test_utils::new_credential,
     framing::*,
-    group::{errors::*, *},
+    group::{errors::*, mls_group::updates::SignerBundle, *},
     key_packages::*,
     messages::{
         group_info::GroupInfoTBS, proposals::*, EncryptedGroupSecrets, GroupSecretsError, Welcome,
@@ -2858,6 +2858,7 @@ fn signature_key_rotation(
     let bob_party = CorePartyState::<Provider>::new("bob");
 
     let alice_pre_group = alice_party.generate_pre_group(ciphersuite);
+    let old_credential_with_key = alice_pre_group.credential_with_key.clone();
     let bob_pre_group = bob_party.generate_pre_group(ciphersuite);
 
     // Create config
@@ -2900,17 +2901,39 @@ fn signature_key_rotation(
         .clone();
     assert_ne!(old_signature_key, new_signature_key);
 
+    // Pass leaf node parameters with old credential with key (to make it fail)
     let leaf_node_parameters = LeafNodeParameters::builder()
-        .with_credential_with_key(new_pre_group_state.credential_with_key)
+        .with_credential_with_key(old_credential_with_key)
         .build();
 
+    let new_signer = SignerBundle {
+        signer: &new_pre_group_state.signer,
+        credential_with_key: new_pre_group_state.credential_with_key,
+    };
+
+    let err = alice_group_state
+        .group
+        .self_update_with_new_signer(
+            &alice_group_state.party.core_state.provider,
+            &alice_group_state.party.signer,
+            new_signer.clone(),
+            leaf_node_parameters,
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        SelfUpdateError::CreateCommitError(CreateCommitError::InvalidLeafNodeParameters)
+    );
+
+    // Calling with default LeafNodeParameters should work
     let bundle = alice_group_state
         .group
         .self_update_with_new_signer(
             &alice_group_state.party.core_state.provider,
             &alice_group_state.party.signer,
-            &new_pre_group_state.signer,
-            leaf_node_parameters,
+            new_signer,
+            LeafNodeParameters::default(),
         )
         .unwrap();
 

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -10,9 +10,9 @@ use tls_codec::{Deserialize, Serialize};
 
 use crate::{
     binary_tree::LeafNodeIndex,
-    credentials::test_utils::new_credential,
+    credentials::{test_utils::new_credential, NewSignerBundle},
     framing::*,
-    group::{errors::*, mls_group::updates::NewSignerBundle, *},
+    group::{errors::*, *},
     key_packages::*,
     messages::{
         group_info::GroupInfoTBS, proposals::*, EncryptedGroupSecrets, GroupSecretsError, Welcome,

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -12,7 +12,7 @@ use crate::{
     binary_tree::LeafNodeIndex,
     credentials::test_utils::new_credential,
     framing::*,
-    group::{errors::*, mls_group::updates::SignerBundle, *},
+    group::{errors::*, mls_group::updates::NewSignerBundle, *},
     key_packages::*,
     messages::{
         group_info::GroupInfoTBS, proposals::*, EncryptedGroupSecrets, GroupSecretsError, Welcome,
@@ -2906,7 +2906,7 @@ fn signature_key_rotation(
         .with_credential_with_key(old_credential_with_key)
         .build();
 
-    let new_signer = SignerBundle {
+    let new_signer = NewSignerBundle {
         signer: &new_pre_group_state.signer,
         credential_with_key: new_pre_group_state.credential_with_key,
     };

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -2,9 +2,15 @@ use commit_builder::CommitMessageBundle;
 use errors::{ProposeSelfUpdateError, SelfUpdateError};
 use openmls_traits::{signatures::Signer, storage::StorageProvider as _};
 
-use crate::{storage::OpenMlsProvider, treesync::LeafNodeParameters};
+use crate::{prelude::CredentialWithKey, storage::OpenMlsProvider, treesync::LeafNodeParameters};
 
 use super::*;
+
+#[derive(Debug, Clone)]
+pub struct SignerBundle<'a, S: Signer> {
+    pub signer: &'a S,
+    pub credential_with_key: CredentialWithKey,
+}
 
 impl MlsGroup {
     /// Updates the own leaf node. The application can choose to update the
@@ -59,11 +65,11 @@ impl MlsGroup {
     /// Returns an error if there is a pending commit.
     ///
     /// [`Welcome`]: crate::messages::Welcome
-    pub fn self_update_with_new_signer<Provider: OpenMlsProvider>(
+    pub fn self_update_with_new_signer<Provider: OpenMlsProvider, S: Signer>(
         &mut self,
         provider: &Provider,
         old_signer: &impl Signer,
-        new_signer: &impl Signer,
+        new_signer: SignerBundle<'_, S>,
         leaf_node_parameters: LeafNodeParameters,
     ) -> Result<CommitMessageBundle, SelfUpdateError<Provider::StorageError>> {
         self.is_operational()?;

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -2,20 +2,9 @@ use commit_builder::CommitMessageBundle;
 use errors::{ProposeSelfUpdateError, SelfUpdateError};
 use openmls_traits::{signatures::Signer, storage::StorageProvider as _};
 
-use crate::{prelude::CredentialWithKey, storage::OpenMlsProvider, treesync::LeafNodeParameters};
+use crate::{credentials::NewSignerBundle, storage::OpenMlsProvider, treesync::LeafNodeParameters};
 
 use super::*;
-
-/// Bundle consisting of a [`Signer`] and a [`CredentialWithKey`] to be used to
-/// update the signature key in an [`MlsGroup`]. The public key and credential
-/// in `credential_with_key` MUST match the signature key exposed by `signer`.
-#[derive(Debug, Clone)]
-pub struct NewSignerBundle<'a, S: Signer> {
-    /// The signer to be used with the group after the update.
-    pub signer: &'a S,
-    /// The credential and public key corresponding to the `signer`.
-    pub credential_with_key: CredentialWithKey,
-}
 
 impl MlsGroup {
     /// Updates the own leaf node. The application can choose to update the

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -6,9 +6,14 @@ use crate::{prelude::CredentialWithKey, storage::OpenMlsProvider, treesync::Leaf
 
 use super::*;
 
+/// Bundle consisting of a [`Signer`] and a [`CredentialWithKey`] to be used to
+/// update the signature key in an [`MlsGroup`]. The public key and credential
+/// in `credential_with_key` MUST match the signature key exposed by `signer`.
 #[derive(Debug, Clone)]
-pub struct SignerBundle<'a, S: Signer> {
+pub struct NewSignerBundle<'a, S: Signer> {
+    /// The signer to be used with the group after the update.
     pub signer: &'a S,
+    /// The credential and public key corresponding to the `signer`.
     pub credential_with_key: CredentialWithKey,
 }
 
@@ -69,7 +74,7 @@ impl MlsGroup {
         &mut self,
         provider: &Provider,
         old_signer: &impl Signer,
-        new_signer: SignerBundle<'_, S>,
+        new_signer: NewSignerBundle<'_, S>,
         leaf_node_parameters: LeafNodeParameters,
     ) -> Result<CommitMessageBundle, SelfUpdateError<Provider::StorageError>> {
         self.is_operational()?;

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -98,6 +98,10 @@ impl LeafNodeParameters {
             && self.capabilities.is_none()
             && self.extensions.is_none()
     }
+
+    pub(crate) fn set_credential_with_key(&mut self, credential_with_key: CredentialWithKey) {
+        self.credential_with_key = Some(credential_with_key);
+    }
 }
 
 /// Builder for [`LeafNodeParameters`].

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -1692,3 +1692,42 @@ fn commit_builder() {
     // ANCHOR_END: alice_adds_bob_with_commit_builder
     _ = (mls_message_out, welcome, group_info)
 }
+
+#[openmls_test]
+fn new_signer() {
+    // Generate credentials with keys
+    let (alice_old_credential, alice_old_signature_keys) =
+        generate_credential("Alice".into(), ciphersuite.signature_algorithm(), provider);
+
+    let mut alice_group = MlsGroup::new(
+        provider,
+        &alice_old_signature_keys,
+        &MlsGroupCreateConfig::default(),
+        alice_old_credential.clone(),
+    )
+    .expect("An unexpected error occurred.");
+
+    let (alice_new_credential, alice_new_signature_keys) =
+        generate_credential("Alice".into(), ciphersuite.signature_algorithm(), provider);
+
+    // === Alice rotates her signature key ===
+    // ANCHOR: alice_rotates_signature_key
+
+    let new_signer_bundle = NewSignerBundle {
+        signer: &alice_new_signature_keys,
+        credential_with_key: alice_new_credential,
+    };
+
+    let message_bundle = alice_group
+        .self_update_with_new_signer(
+            provider,
+            &alice_old_signature_keys,
+            new_signer_bundle,
+            LeafNodeParameters::default(),
+        )
+        .unwrap();
+
+    let (mls_message_out, welcome, group_info) = message_bundle.into_contents();
+    // ANCHOR_END: alice_rotates_signature_key
+    _ = (mls_message_out, welcome, group_info)
+}

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -1699,10 +1699,13 @@ fn new_signer() {
     let (alice_old_credential, alice_old_signature_keys) =
         generate_credential("Alice".into(), ciphersuite.signature_algorithm(), provider);
 
+    let config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .build();
     let mut alice_group = MlsGroup::new(
         provider,
         &alice_old_signature_keys,
-        &MlsGroupCreateConfig::default(),
+        &config,
         alice_old_credential.clone(),
     )
     .expect("An unexpected error occurred.");

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -170,15 +170,16 @@ fn discard_commit_update_with_new_signer() {
     // Alice updates own credential
     // HPKE encryption key is also updated by the commit
 
-    let leaf_node_parameters = LeafNodeParameters::builder()
-        .with_credential_with_key(new_credential)
-        .build();
+    let signer_bundle = SignerBundle {
+        signer: &new_signer,
+        credential_with_key: new_credential,
+    };
     let _commit_message_bundle = alice_group
         .self_update_with_new_signer(
             alice_provider,
             old_signer,
-            &new_signer,
-            leaf_node_parameters,
+            signer_bundle,
+            LeafNodeParameters::default(),
         )
         .expect("failed to update own leaf node");
 

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -170,7 +170,7 @@ fn discard_commit_update_with_new_signer() {
     // Alice updates own credential
     // HPKE encryption key is also updated by the commit
 
-    let signer_bundle = SignerBundle {
+    let signer_bundle = NewSignerBundle {
         signer: &new_signer,
         credential_with_key: new_credential,
     };


### PR DESCRIPTION
This PR introduces a `NewSignerBundle` struct that allows passing a signer together with a CredentialWithKey when using `self_update_with_new_signer`. `self_update_with_new_signer` now also throws an error if a (non-matching) `CredentialWithKey` is passed in via `LeafNodeParameters`. All this is to avoid passing in mismatching signer and credentials/keys.