### PR TITLE
fix: Return a more specific error message for old private messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1700](https://github.com/openmls/openmls/pull/1700): During commit processing, OpenMLS will now return a `StorageError` if the storage provider fails while fetching `encryption_epoch_key_pairs`. Previously, it would ignore any error returned by the storage provider and just assume that no keys could be found (which typically lead to an error later during commit processing).
 - [#1762](https://github.com/openmls/openmls/pull/1762): Expose `LeafNodeSource` to allow handling output of `LeafNode::leaf_node_source()`.
+- [#1767](https://github.com/openmls/openmls/pull/1767): Return a more specific error when private messages that are too old are processed. The error type has changed from `ProcessMessageError::ValidationError(ValidationError::UnableToDecrypt(MessageDecryptionError::AeadError))` to `ProcessMessageError::ValidationError(ValidationError::UnableToDecrypt(MessageDecryptoinError::SecretTree(SecretTreeError::TooDistantInThePast)))`.
 
 ## 0.6.0 (2024-09-04)
 

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -102,7 +102,7 @@ impl DecryptedMessage {
         //       Revisit when the transition is further along.
         let (message_secrets, _old_leaves) = group
             .message_secrets_and_leaves_mut(ciphertext.epoch())
-            .map_err(|_| MessageDecryptionError::AeadError)?;
+            .map_err(MessageDecryptionError::SecretTreeError)?;
         let sender_data = ciphertext.sender_data(message_secrets, crypto, ciphersuite)?;
         // Check if we are the sender
         if sender_data.leaf_index == group.own_leaf_index() {

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -545,13 +545,11 @@ impl MlsGroup {
     pub(crate) fn message_secrets_and_leaves_mut(
         &mut self,
         epoch: GroupEpoch,
-    ) -> Result<(&mut MessageSecrets, &[Member]), MessageDecryptionError> {
+    ) -> Result<(&mut MessageSecrets, &[Member]), SecretTreeError> {
         if epoch < self.context().epoch() {
             self.message_secrets_store
                 .secrets_and_leaves_for_epoch_mut(epoch)
-                .ok_or({
-                    MessageDecryptionError::SecretTreeError(SecretTreeError::TooDistantInThePast)
-                })
+                .ok_or(SecretTreeError::TooDistantInThePast)
         } else {
             // No need for leaves here. The tree of the current epoch is
             // available to the caller.

--- a/openmls/src/group/tests_and_kats/tests/past_secrets.rs
+++ b/openmls/src/group/tests_and_kats/tests/past_secrets.rs
@@ -1,5 +1,6 @@
 //! This module contains tests regarding the use of [`MessageSecretsStore`] in [`MlsGroup`]
 
+use crate::framing::SecretTreeError;
 use crate::group::tests_and_kats::utils::{generate_credential_with_key, generate_key_package};
 use crate::{
     framing::{MessageDecryptionError, MlsMessageIn, ProcessedMessageContent},
@@ -148,7 +149,7 @@ fn test_past_secrets_in_group<Provider: crate::storage::OpenMlsProvider>(
             assert!(matches!(
                 err,
                 ProcessMessageError::ValidationError(ValidationError::UnableToDecrypt(
-                    MessageDecryptionError::AeadError
+                    MessageDecryptionError::SecretTreeError(SecretTreeError::TooDistantInThePast)
                 ),)
             ));
         }


### PR DESCRIPTION
Return a more specific error when private messages that are too old are processed. 
The error type has changed from

`ProcessMessageError::ValidationError(ValidationError::UnableToDecrypt(MessageDecryptionError::AeadError))` 

to

`ProcessMessageError::ValidationError(ValidationError::UnableToDecrypt(MessageDecryptoinError::SecretTree(SecretTreeError::TooDistantInThePast)))`