### PR TITLE
feat: group info creation flag in commit builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1731](https://github.com/openmls/openmls/pull/1731): Add helpers to recover from group state forks, hidden behind the new `fork-resolution` feature flag.
 - [#1750](https://github.com/openmls/openmls/pull/1750): Support add proposals from external senders, using `ExternalProposal::new_add()`.
 - [#1766](https://github.com/openmls/openmls/pull/1766): New error variant for commit creation: If a new signer is introduced via `self_update_with_new_signer` and additionally a `CredentialWithKey` is provided via `LeafNodeParameters`, an `InvalidLeafNodeParameters` error is thrown.
+- [#1774](https://github.com/openmls/openmls/pull/1774): Add flag to control the return of a `GroupInfo` when building a commit using the `CommitBuilder`. Setting that flag overrides the `use_ratchet_tree_extension` flag in `MlsGroupJoinConfig`.
 
 ### Fixed
 

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -173,8 +173,10 @@ impl MlsGroup {
 impl<'a> CommitBuilder<'a, Initial> {
     /// returns a new [`CommitBuilder`] for the given [`MlsGroup`].
     pub fn new(group: &'a mut MlsGroup) -> Self {
-        let mut stage = Initial::default();
-        stage.create_group_info = group.configuration().use_ratchet_tree_extension;
+        let stage = Initial {
+            create_group_info: group.configuration().use_ratchet_tree_extension,
+            ..Default::default()
+        };
         Self { group, stage }
     }
 

--- a/openmls/src/group/tests_and_kats/tests/group.rs
+++ b/openmls/src/group/tests_and_kats/tests/group.rs
@@ -1,4 +1,8 @@
-use crate::{framing::*, group::*, *};
+use crate::{
+    framing::*,
+    group::{mls_group::tests_and_kats::utils::setup_alice_group, *},
+    *,
+};
 use mls_group::tests_and_kats::utils::{setup_alice_bob, setup_alice_bob_group, setup_client};
 use prelude::KeyPackageBundle;
 use treesync::{node::leaf_node::Capabilities, LeafNodeParameters};
@@ -699,4 +703,40 @@ fn decrypt_after_leaf_index_reuse() {
     let _bob_incoming_appmsg = group_bob
         .process_message(&bob_provider, charlie_protocol_message)
         .unwrap();
+}
+
+#[openmls_test::openmls_test]
+fn create_group_info_flag() {
+    // The `use_ratchet_tree_extension` flag is set to `false` by default.
+    let (mut alice_group, _alice_credential, alice_signer, _alice_pk) =
+        setup_alice_group(ciphersuite, provider);
+
+    let commit_bundle = alice_group
+        .commit_builder()
+        .load_psks(provider.storage())
+        .unwrap()
+        .build(provider.rand(), provider.crypto(), &alice_signer, |_| true)
+        .unwrap()
+        .stage_commit(provider)
+        .unwrap();
+
+    assert!(commit_bundle.group_info().is_none());
+
+    // Now we set the `create_group_info` flag to `true`.
+    let commit_bundle = alice_group
+        .commit_builder()
+        .create_group_info(true)
+        .load_psks(provider.storage())
+        .unwrap()
+        .build(provider.rand(), provider.crypto(), &alice_signer, |_| true)
+        .unwrap()
+        .stage_commit(provider)
+        .unwrap();
+
+    let group_info = commit_bundle.into_group_info_msg().unwrap();
+    alice_group.merge_pending_commit(provider).unwrap();
+    let exported_group_info = alice_group
+        .export_group_info(provider, &alice_signer, false)
+        .unwrap();
+    assert_eq!(group_info, exported_group_info);
 }


### PR DESCRIPTION
This PR adds a way to control whether the `CommitBuilder` outputs a GroupInfo. It's backwards-compatible in that the newly added `create_group_info` flag defaults to the `use_ratchet_tree_extension` in the `MlsGroup`s `MlsGroupJoinConfig`.