### PR TITLE
James parrott patch 1

### DIFF
--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -24,4 +24,4 @@ hpke_rs = { version = "0.2.1-alpha.1", git = "https://github.com/cryspen/hpke-rs
   "serialization",
 ] }
 hpke_rs_crypto = { version = "0.3.0-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-crypto" }
-hpke_rs_libcrux = { version = "0.2.0-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-libcrux" }
+hpke_rs_libcrux = { version = "0.2.0-alpha.1", git = "https://github.com/JamesParrott/hpke-rs", branch = "main", package = "hpke-rs-libcrux" }

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -19,9 +19,9 @@ openmls_memory_storage = { version = "0.3.0", path = "../memory_storage" }
 rand = "0.9"
 tls_codec.workspace = true
 rand_chacha = "0.9"
-hpke_rs = { version = "0.2.1-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs", features = [
+hpke_rs = { version = "0.2.1-alpha.1", git = "https://github.com/JamesParrott/hpke-rs", branch = "main", package = "hpke-rs", features = [
   "hazmat",
   "serialization",
 ] }
-hpke_rs_crypto = { version = "0.3.0-alpha.1", git = "https://github.com/cryspen/hpke-rs", branch = "main", package = "hpke-rs-crypto" }
+hpke_rs_crypto = { version = "0.3.0-alpha.1", git = "https://github.com/JamesParrott/hpke-rs", branch = "main", package = "hpke-rs-crypto" }
 hpke_rs_libcrux = { version = "0.2.0-alpha.1", git = "https://github.com/JamesParrott/hpke-rs", branch = "main", package = "hpke-rs-libcrux" }


### PR DESCRIPTION
Fixes #1776

Replace https://github.com/cryspen/hpke-rs with https://github.com/JamesParrott/hpke-rs, my fork which pins the Github repo path in the further dep of LibcruxChaCha to the latest commit consistent with the specified version (0.0.2) to prevent cargo picking up 0.0.3-alpha.01 from the latest commit to main, which breaks the build