### PR TITLE
Update external proposal documentation with links to validation checks

### DIFF
--- a/openmls/src/framing/mls_auth_content_in.rs
+++ b/openmls/src/framing/mls_auth_content_in.rs
@@ -160,6 +160,7 @@ impl VerifiableAuthenticatedContentIn {
             }
             Sender::NewMemberProposal => {
                 // only External Add proposals can have a sender type `NewMemberProposal`
+                // https://validation.openmls.tech/#valn1503
                 // https://validation.openmls.tech/#valn1504
                 match &self.tbs.content.body {
                     FramedContentBodyIn::Proposal(ProposalIn::Add(add_proposal)) => {

--- a/openmls/src/framing/mls_auth_content_in.rs
+++ b/openmls/src/framing/mls_auth_content_in.rs
@@ -160,6 +160,7 @@ impl VerifiableAuthenticatedContentIn {
             }
             Sender::NewMemberProposal => {
                 // only External Add proposals can have a sender type `NewMemberProposal`
+                // https://validation.openmls.tech/#valn1504
                 match &self.tbs.content.body {
                     FramedContentBodyIn::Proposal(ProposalIn::Add(add_proposal)) => {
                         Ok(add_proposal.unverified_credential())

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -159,8 +159,6 @@ impl DecryptedMessage {
     ///  - Prepares ValSem246 by setting the right credential. The remainder
     ///    of ValSem246 is validated as part of ValSem010.
     ///  - [valn1301](https://validation.openmls.tech/#valn1301)
-    ///  - [valn1501](https://validation.openmls.tech/#valn1501)
-    ///  - [valn1504](https://validation.openmls.tech/#valn1504)
     ///
     /// Returns the [`Credential`] and the leaf's [`SignaturePublicKey`].
     pub(crate) fn credential(

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -159,6 +159,8 @@ impl DecryptedMessage {
     ///  - Prepares ValSem246 by setting the right credential. The remainder
     ///    of ValSem246 is validated as part of ValSem010.
     ///  - [valn1301](https://validation.openmls.tech/#valn1301)
+    ///  - [valn1501](https://validation.openmls.tech/#valn1501)
+    ///  - [valn1504](https://validation.openmls.tech/#valn1504)
     ///
     /// Returns the [`Credential`] and the leaf's [`SignaturePublicKey`].
     pub(crate) fn credential(

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -285,6 +285,7 @@ impl MlsGroup {
                         )?);
 
                         if matches!(sender, Sender::NewMemberProposal) {
+                            // TODO: https://validation.openmls.tech/#valn1504
                             ProcessedMessageContent::ExternalJoinProposalMessage(proposal)
                         } else {
                             ProcessedMessageContent::ProposalMessage(proposal)
@@ -317,6 +318,7 @@ impl MlsGroup {
                     FramedContentBody::Application(_) => {
                         Err(ProcessMessageError::UnauthorizedExternalApplicationMessage)
                     }
+                    // TODO: https://validation.openmls.tech/#valn1502
                     FramedContentBody::Proposal(Proposal::Remove(_)) => {
                         let content = ProcessedMessageContent::ProposalMessage(Box::new(
                             QueuedProposal::from_authenticated_content_by_ref(

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -285,7 +285,6 @@ impl MlsGroup {
                         )?);
 
                         if matches!(sender, Sender::NewMemberProposal) {
-                            // TODO: https://validation.openmls.tech/#valn1504
                             ProcessedMessageContent::ExternalJoinProposalMessage(proposal)
                         } else {
                             ProcessedMessageContent::ProposalMessage(proposal)

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -313,6 +313,7 @@ impl MlsGroup {
             Sender::External(_) => {
                 let sender = content.sender().clone();
                 let data = content.authenticated_data().to_owned();
+                // https://validation.openmls.tech/#valn1501
                 match content.content() {
                     FramedContentBody::Application(_) => {
                         Err(ProcessMessageError::UnauthorizedExternalApplicationMessage)

--- a/openmls/src/group/public_group/process.rs
+++ b/openmls/src/group/public_group/process.rs
@@ -237,7 +237,6 @@ impl PublicGroup {
                             content,
                         )?);
                         if matches!(sender, Sender::NewMemberProposal) {
-                            // TODO: https://validation.openmls.tech/#valn1504
                             ProcessedMessageContent::ExternalJoinProposalMessage(proposal)
                         } else {
                             ProcessedMessageContent::ProposalMessage(proposal)

--- a/openmls/src/group/public_group/process.rs
+++ b/openmls/src/group/public_group/process.rs
@@ -237,6 +237,7 @@ impl PublicGroup {
                             content,
                         )?);
                         if matches!(sender, Sender::NewMemberProposal) {
+                            // TODO: https://validation.openmls.tech/#valn1504
                             ProcessedMessageContent::ExternalJoinProposalMessage(proposal)
                         } else {
                             ProcessedMessageContent::ProposalMessage(proposal)
@@ -264,6 +265,7 @@ impl PublicGroup {
                     FramedContentBody::Application(_) => {
                         Err(ProcessMessageError::UnauthorizedExternalApplicationMessage)
                     }
+                    // TODO: https://validation.openmls.tech/#valn1502
                     FramedContentBody::Proposal(Proposal::Remove(_)) => {
                         let content = ProcessedMessageContent::ProposalMessage(Box::new(
                             QueuedProposal::from_authenticated_content_by_ref(

--- a/openmls/src/messages/external_proposals.rs
+++ b/openmls/src/messages/external_proposals.rs
@@ -2,7 +2,7 @@
 //!
 //! Contains the types and methods to build external proposal to add/remove a client from a MLS group
 //!
-//! `Add` (from external sender), `Remove` & `ReInit are not yet implemented`
+//! `ReInit` is not yet implemented
 
 use crate::{
     binary_tree::LeafNodeIndex,


### PR DESCRIPTION
This PR adds links to the OpenMLS validation dashboard for the following validation checks, at the locations in the codebase where the checks occur:
- valn1501
- valn1502
- valn1503
- valn1504

It also updates a line documenting the implementation status of external proposals.