### PR TITLE
fix: Tighten export functions API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1700](https://github.com/openmls/openmls/pull/1700): During commit processing, OpenMLS will now return a `StorageError` if the storage provider fails while fetching `encryption_epoch_key_pairs`. Previously, it would ignore any error returned by the storage provider and just assume that no keys could be found (which typically lead to an error later during commit processing).
 - [#1762](https://github.com/openmls/openmls/pull/1762): Expose `LeafNodeSource` to allow handling output of `LeafNode::leaf_node_source()`.
 - [#1767](https://github.com/openmls/openmls/pull/1767): Return a more specific error when private messages that are too old are processed. The error type has changed from `ProcessMessageError::ValidationError(ValidationError::UnableToDecrypt(MessageDecryptionError::AeadError))` to `ProcessMessageError::ValidationError(ValidationError::UnableToDecrypt(MessageDecryptoinError::SecretTree(SecretTreeError::TooDistantInThePast)))`.
+- [#1786](https://github.com/openmls/openmls/pull/1786): Tighten the requirements for the providers for `MlsGroup::export_secret()` and `MlsGroup::export_group_info()`. The function now only require the `OpenMlsCrypto` provider.
 
 ## 0.6.0 (2024-09-04)
 

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -581,7 +581,7 @@ impl MlsClient for MlsClientImpl {
         let exported_secret = interop_group
             .group
             .export_secret(
-                &interop_group.crypto_provider,
+                interop_group.crypto_provider.crypto(),
                 &request.label,
                 &request.context,
                 request.key_length as usize,
@@ -1249,7 +1249,7 @@ impl MlsClient for MlsClientImpl {
 
         let group_info = group
             .export_group_info(
-                &interop_group.crypto_provider,
+                interop_group.crypto_provider.crypto(),
                 &interop_group.signature_keys,
                 !request.external_tree,
             )

--- a/openmls-wasm/src/lib.rs
+++ b/openmls-wasm/src/lib.rs
@@ -268,7 +268,7 @@ impl Group {
         key_length: usize,
     ) -> Result<Vec<u8>, JsError> {
         self.mls_group
-            .export_secret(provider.as_ref(), label, context, key_length)
+            .export_secret(provider.as_ref().crypto(), label, context, key_length)
             .map_err(|e| {
                 println!("export key error: {e}");
                 e.into()

--- a/openmls/src/group/mls_group/tests_and_kats/tests/external_init.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/external_init.rs
@@ -17,7 +17,7 @@ fn test_external_init_broken_signature() {
 
     let verifiable_group_info = {
         let mut verifiable_group_info = group_alice
-            .export_group_info(provider, &alice_signer, true)
+            .export_group_info(provider.crypto(), &alice_signer, true)
             .unwrap()
             .into_verifiable_group_info()
             .unwrap();

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -63,13 +63,13 @@ fn test_mls_group_persistence<Provider: OpenMlsProvider>() {
         (
             alice_group.export_ratchet_tree(),
             alice_group
-                .export_secret(provider, "test", &[], 32)
+                .export_secret(provider.crypto(), "test", &[], 32)
                 .unwrap()
         ),
         (
             alice_group_deserialized.export_ratchet_tree(),
             alice_group_deserialized
-                .export_secret(provider, "test", &[], 32)
+                .export_secret(provider.crypto(), "test", &[], 32)
                 .unwrap()
         )
     );
@@ -250,18 +250,18 @@ fn export_secret() {
 
     assert!(
         alice_group
-            .export_secret(provider, "test1", &[], ciphersuite.hash_length())
+            .export_secret(provider.crypto(), "test1", &[], ciphersuite.hash_length())
             .expect("An unexpected error occurred.")
             != alice_group
-                .export_secret(provider, "test2", &[], ciphersuite.hash_length())
+                .export_secret(provider.crypto(), "test2", &[], ciphersuite.hash_length())
                 .expect("An unexpected error occurred.")
     );
     assert!(
         alice_group
-            .export_secret(provider, "test", &[0u8], ciphersuite.hash_length())
+            .export_secret(provider.crypto(), "test", &[0u8], ciphersuite.hash_length())
             .expect("An unexpected error occurred.")
             != alice_group
-                .export_secret(provider, "test", &[1u8], ciphersuite.hash_length())
+                .export_secret(provider.crypto(), "test", &[1u8], ciphersuite.hash_length())
                 .expect("An unexpected error occurred.")
     )
 }
@@ -324,10 +324,10 @@ fn staged_join() {
 
     assert_eq!(
         alice_group
-            .export_secret(provider, "test", &[], ciphersuite.hash_length())
+            .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
             .expect("An unexpected error occurred."),
         bob_group
-            .export_secret(provider, "test", &[], ciphersuite.hash_length())
+            .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
             .expect("An unexpected error occurred.")
     );
 }
@@ -524,10 +524,10 @@ fn test_verify_staged_commit_credentials(
     );
     assert_eq!(
         bob_group
-            .export_secret(provider, "test", &[], ciphersuite.hash_length())
+            .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
             .unwrap(),
         alice_group
-            .export_secret(provider, "test", &[], ciphersuite.hash_length())
+            .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
             .unwrap()
     );
     // Bob is added and the state aligns.
@@ -606,10 +606,10 @@ fn test_verify_staged_commit_credentials(
         );
         assert_eq!(
             bob_group
-                .export_secret(provider, "test", &[], ciphersuite.hash_length())
+                .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
                 .unwrap(),
             alice_group
-                .export_secret(provider, "test", &[], ciphersuite.hash_length())
+                .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
                 .unwrap()
         );
     } else {
@@ -707,10 +707,10 @@ fn test_commit_with_update_path_leaf_node(
     );
     assert_eq!(
         bob_group
-            .export_secret(provider, "test", &[], ciphersuite.hash_length())
+            .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
             .unwrap(),
         alice_group
-            .export_secret(provider, "test", &[], ciphersuite.hash_length())
+            .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
             .unwrap()
     );
     // Bob is added and the state aligns.
@@ -801,10 +801,10 @@ fn test_commit_with_update_path_leaf_node(
         );
         assert_eq!(
             bob_group
-                .export_secret(provider, "test", &[], ciphersuite.hash_length())
+                .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
                 .unwrap(),
             alice_group
-                .export_secret(provider, "test", &[], ciphersuite.hash_length())
+                .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
                 .unwrap()
         );
     } else {
@@ -971,10 +971,10 @@ fn test_pending_commit_logic(
     );
     assert_eq!(
         bob_group
-            .export_secret(provider, "test", &[], ciphersuite.hash_length())
+            .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
             .unwrap(),
         alice_group
-            .export_secret(provider, "test", &[], ciphersuite.hash_length())
+            .export_secret(provider.crypto(), "test", &[], ciphersuite.hash_length())
             .unwrap()
     );
 

--- a/openmls/src/group/public_group/tests.rs
+++ b/openmls/src/group/public_group/tests.rs
@@ -43,7 +43,7 @@ fn public_group<Provider: OpenMlsProvider>(ciphersuite: Ciphersuite, provider: &
 
     // === Create a public group that tracks the changes throughout this test ===
     let verifiable_group_info = alice_group
-        .export_group_info(provider, &alice_signer, false)
+        .export_group_info(provider.crypto(), &alice_signer, false)
         .unwrap()
         .into_verifiable_group_info()
         .unwrap();

--- a/openmls/src/group/tests_and_kats/kats/messages.rs
+++ b/openmls/src/group/tests_and_kats/kats/messages.rs
@@ -150,7 +150,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
 
     let alice_group_info = alice_group
         .export_group_info(
-            &provider,
+            provider.crypto(),
             &alice_credential_with_key_and_signer.signer,
             true,
         )

--- a/openmls/src/group/tests_and_kats/tests/external_commit.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_commit.rs
@@ -46,7 +46,7 @@ fn test_external_commit() {
     // Bob wants to commit externally.
 
     let verifiable_group_info = alice_group
-        .export_group_info(provider, &alice_credential.signer, false)
+        .export_group_info(provider.crypto(), &alice_credential.signer, false)
         .unwrap()
         .into_verifiable_group_info()
         .unwrap();
@@ -98,8 +98,8 @@ fn test_external_commit() {
     // Compare Alice's and Bob's private & public state
 
     assert_eq!(
-        alice_group.export_secret(provider, "label", b"context", 32),
-        bob_group.export_secret(provider, "label", b"context", 32)
+        alice_group.export_secret(provider.crypto(), "label", b"context", 32),
+        bob_group.export_secret(provider.crypto(), "label", b"context", 32)
     );
     assert_eq!(
         alice_group.export_ratchet_tree(),
@@ -111,7 +111,7 @@ fn test_external_commit() {
     // Charlie wants to commit externally.
 
     let verifiable_group_info = alice_group
-        .export_group_info(provider, &alice_credential.signer, false)
+        .export_group_info(provider.crypto(), &alice_credential.signer, false)
         .unwrap()
         .into_verifiable_group_info()
         .unwrap();
@@ -164,12 +164,12 @@ fn test_external_commit() {
     // Compare Alice's, Bob's and Charlie's private & public state
 
     assert_eq!(
-        alice_group.export_secret(provider, "label", b"context", 32),
-        bob_group.export_secret(provider, "label", b"context", 32)
+        alice_group.export_secret(provider.crypto(), "label", b"context", 32),
+        bob_group.export_secret(provider.crypto(), "label", b"context", 32)
     );
     assert_eq!(
-        alice_group.export_secret(provider, "label", b"context", 32),
-        charlie_group.export_secret(provider, "label", b"context", 32)
+        alice_group.export_secret(provider.crypto(), "label", b"context", 32),
+        charlie_group.export_secret(provider.crypto(), "label", b"context", 32)
     );
     assert_eq!(
         alice_group.export_ratchet_tree(),
@@ -185,7 +185,7 @@ fn test_external_commit() {
     // Alice wants to resync
 
     let verifiable_group_info = bob_group
-        .export_group_info(provider, &bob_credential.signer, false)
+        .export_group_info(provider.crypto(), &bob_credential.signer, false)
         .unwrap()
         .into_verifiable_group_info()
         .unwrap();
@@ -245,12 +245,12 @@ fn test_external_commit() {
     // Compare Alice's, Bob's and Charlie's private & public state
 
     assert_eq!(
-        alice_group.export_secret(provider, "label", b"context", 32),
-        bob_group.export_secret(provider, "label", b"context", 32)
+        alice_group.export_secret(provider.crypto(), "label", b"context", 32),
+        bob_group.export_secret(provider.crypto(), "label", b"context", 32)
     );
     assert_eq!(
-        alice_group.export_secret(provider, "label", b"context", 32),
-        charlie_group.export_secret(provider, "label", b"context", 32)
+        alice_group.export_secret(provider.crypto(), "label", b"context", 32),
+        charlie_group.export_secret(provider.crypto(), "label", b"context", 32)
     );
     assert_eq!(
         alice_group.export_ratchet_tree(),

--- a/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
@@ -191,7 +191,7 @@ fn test_valsem242() {
     alice_group.merge_pending_commit(provider).unwrap();
 
     let verifiable_group_info = alice_group
-        .export_group_info(provider, &alice_credential.signer, true)
+        .export_group_info(provider.crypto(), &alice_credential.signer, true)
         .unwrap()
         .into_verifiable_group_info()
         .unwrap();
@@ -571,7 +571,7 @@ fn test_pure_ciphertest() {
 
     // Have Alice export everything that bob needs.
     let verifiable_group_info = alice_group
-        .export_group_info(provider, &alice_credential.signer, true)
+        .export_group_info(provider.crypto(), &alice_credential.signer, true)
         .unwrap()
         .into_verifiable_group_info()
         .unwrap();
@@ -657,7 +657,7 @@ mod utils {
 
         // Have Alice export everything that bob needs.
         let verifiable_group_info = alice_group
-            .export_group_info(provider, &alice_credential.signer, false)
+            .export_group_info(provider.crypto(), &alice_credential.signer, false)
             .unwrap()
             .into_verifiable_group_info()
             .unwrap();

--- a/openmls/src/group/tests_and_kats/tests/group.rs
+++ b/openmls/src/group/tests_and_kats/tests/group.rs
@@ -542,7 +542,8 @@ fn group_operations() {
     // Now alice tries to derive an exporter with too large of a key length.
     let exporter_length: usize = u16::MAX.into();
     let exporter_length = exporter_length + 1;
-    let alice_exporter = alice_group.export_secret(provider, "export test", &[], exporter_length);
+    let alice_exporter =
+        alice_group.export_secret(provider.crypto(), "export test", &[], exporter_length);
     assert!(alice_exporter.is_err())
 }
 
@@ -736,7 +737,7 @@ fn create_group_info_flag() {
     let group_info = commit_bundle.into_group_info_msg().unwrap();
     alice_group.merge_pending_commit(provider).unwrap();
     let exported_group_info = alice_group
-        .export_group_info(provider, &alice_signer, false)
+        .export_group_info(provider.crypto(), &alice_signer, false)
         .unwrap();
     assert_eq!(group_info, exported_group_info);
 }

--- a/openmls/src/messages/tests/export_group_info.rs
+++ b/openmls/src/messages/tests/export_group_info.rs
@@ -14,7 +14,7 @@ fn export_group_info() {
     let (group_alice, _, signer, pk) = setup_alice_group(ciphersuite, provider);
 
     let group_info_message = group_alice
-        .export_group_info(provider, &signer, true)
+        .export_group_info(provider.crypto(), &signer, true)
         .unwrap();
 
     let group_info = match group_info_message.body() {

--- a/openmls/src/messages/tests/welcome.rs
+++ b/openmls/src/messages/tests/welcome.rs
@@ -347,7 +347,7 @@ fn test_welcome_processing() {
     let group_id = unverified_group_info.group_id();
     assert_eq!(group_id, alice_group.group_id());
     let alice_group_info = alice_group
-        .export_group_info(provider, &alice_signer, false)
+        .export_group_info(provider.crypto(), &alice_signer, false)
         .unwrap()
         .into_verifiable_group_info()
         .unwrap();

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -355,7 +355,7 @@ impl<Provider: OpenMlsProvider + Default> MlsGroupTestSetup<Provider> {
             .collect();
         group.public_tree = sender_group.export_ratchet_tree();
         group.exporter_secret = sender_group
-            .export_secret(&sender.provider, "test", &[], 32)
+            .export_secret(sender.provider.crypto(), "test", &[], 32)
             .map_err(ClientError::ExportSecretError)?;
         Ok(())
     }
@@ -387,7 +387,7 @@ impl<Provider: OpenMlsProvider + Default> MlsGroupTestSetup<Provider> {
                     assert_eq!(group_state.export_ratchet_tree(), group.public_tree);
                     assert_eq!(
                         group_state
-                            .export_secret(&m.provider, "test", &[], 32)
+                            .export_secret(m.provider.crypto(), "test", &[], 32)
                             .expect("An unexpected error occurred."),
                         group.exporter_secret
                     );
@@ -483,7 +483,8 @@ impl<Provider: OpenMlsProvider + Default> MlsGroupTestSetup<Provider> {
             .get(&group_id)
             .expect("An unexpected error occurred.");
         let public_tree = group.export_ratchet_tree();
-        let exporter_secret = group.export_secret(&group_creator.provider, "test", &[], 32)?;
+        let exporter_secret =
+            group.export_secret(group_creator.provider.crypto(), "test", &[], 32)?;
         let member_ids = vec![(0, group_creator_id)];
         let group = Group {
             group_id: group_id.clone(),

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -285,7 +285,7 @@ fn book_operations() {
 
     // ANCHOR: alice_exports_group_info
     let verifiable_group_info = alice_group
-        .export_group_info(provider, &alice_signature_keys, true)
+        .export_group_info(provider.crypto(), &alice_signature_keys, true)
         .expect("Cannot export group info")
         .into_verifiable_group_info()
         .expect("Could not get group info");
@@ -427,8 +427,12 @@ fn book_operations() {
 
     // Check that both groups have the same state
     assert_eq!(
-        alice_group.export_secret(provider, "", &[], 32).unwrap(),
-        bob_group.export_secret(provider, "", &[], 32).unwrap()
+        alice_group
+            .export_secret(provider.crypto(), "", &[], 32)
+            .unwrap(),
+        bob_group
+            .export_secret(provider.crypto(), "", &[], 32)
+            .unwrap()
     );
 
     // Make sure that both groups have the same public tree
@@ -527,8 +531,12 @@ fn book_operations() {
 
     // Check that both groups have the same state
     assert_eq!(
-        alice_group.export_secret(provider, "", &[], 32).unwrap(),
-        bob_group.export_secret(provider, "", &[], 32).unwrap()
+        alice_group
+            .export_secret(provider.crypto(), "", &[], 32)
+            .unwrap(),
+        bob_group
+            .export_secret(provider.crypto(), "", &[], 32)
+            .unwrap()
     );
 
     // Make sure that both groups have the same public tree
@@ -694,12 +702,20 @@ fn book_operations() {
 
     // Check that all groups have the same state
     assert_eq!(
-        alice_group.export_secret(provider, "", &[], 32).unwrap(),
-        bob_group.export_secret(provider, "", &[], 32).unwrap()
+        alice_group
+            .export_secret(provider.crypto(), "", &[], 32)
+            .unwrap(),
+        bob_group
+            .export_secret(provider.crypto(), "", &[], 32)
+            .unwrap()
     );
     assert_eq!(
-        alice_group.export_secret(provider, "", &[], 32).unwrap(),
-        charlie_group.export_secret(provider, "", &[], 32).unwrap()
+        alice_group
+            .export_secret(provider.crypto(), "", &[], 32)
+            .unwrap(),
+        charlie_group
+            .export_secret(provider.crypto(), "", &[], 32)
+            .unwrap()
     );
 
     // Make sure that all groups have the same public tree
@@ -1433,10 +1449,10 @@ fn book_operations() {
 
     assert_eq!(
         alice_group
-            .export_secret(provider, "before load", &[], 32)
+            .export_secret(provider.crypto(), "before load", &[], 32)
             .unwrap(),
         bob_group
-            .export_secret(provider, "before load", &[], 32)
+            .export_secret(provider.crypto(), "before load", &[], 32)
             .unwrap()
     );
 
@@ -1447,10 +1463,10 @@ fn book_operations() {
     // Make sure the state is still the same
     assert_eq!(
         alice_group
-            .export_secret(provider, "after load", &[], 32)
+            .export_secret(provider.crypto(), "after load", &[], 32)
             .unwrap(),
         bob_group
-            .export_secret(provider, "after load", &[], 32)
+            .export_secret(provider.crypto(), "after load", &[], 32)
             .unwrap()
     );
 }

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -373,7 +373,7 @@ fn discard_commit_external_join() {
     // export the group info so Bob can join
     let group_info_msg_out = alice_group
         .export_group_info(
-            alice_provider,
+            alice_provider.crypto(),
             alice_signer,
             true, // with ratchet tree
         )

--- a/openmls/tests/external_commit.rs
+++ b/openmls/tests/external_commit.rs
@@ -39,7 +39,7 @@ fn test_external_commit() {
     // ... and exports a group info (with ratchet_tree).
     let verifiable_group_info = {
         let group_info = alice_group
-            .export_group_info(provider, &alice_signer, true)
+            .export_group_info(provider.crypto(), &alice_signer, true)
             .unwrap();
 
         let serialized_group_info = group_info.tls_serialize_detached().unwrap();
@@ -52,7 +52,7 @@ fn test_external_commit() {
 
     let verifiable_group_info_broken = {
         let group_info = alice_group
-            .export_group_info(provider, &alice_signer, true)
+            .export_group_info(provider.crypto(), &alice_signer, true)
             .unwrap();
 
         let serialized_group_info = {

--- a/openmls/tests/mls_group.rs
+++ b/openmls/tests/mls_group.rs
@@ -550,9 +550,11 @@ fn mls_group_operations() {
         // Check that both groups have the same state
         assert_eq!(
             alice_group
-                .export_secret(alice_provider, "", &[], 32)
+                .export_secret(alice_provider.crypto(), "", &[], 32)
                 .unwrap(),
-            bob_group.export_secret(bob_provider, "", &[], 32).unwrap()
+            bob_group
+                .export_secret(bob_provider.crypto(), "", &[], 32)
+                .unwrap()
         );
 
         // Make sure that both groups have the same public tree
@@ -639,9 +641,11 @@ fn mls_group_operations() {
         // Check that both groups have the same state
         assert_eq!(
             alice_group
-                .export_secret(alice_provider, "", &[], 32)
+                .export_secret(alice_provider.crypto(), "", &[], 32)
                 .unwrap(),
-            bob_group.export_secret(bob_provider, "", &[], 32).unwrap()
+            bob_group
+                .export_secret(bob_provider.crypto(), "", &[], 32)
+                .unwrap()
         );
 
         // Make sure that both groups have the same public tree
@@ -806,16 +810,18 @@ fn mls_group_operations() {
         // Check that all groups have the same state
         assert_eq!(
             alice_group
-                .export_secret(alice_provider, "", &[], 32)
+                .export_secret(alice_provider.crypto(), "", &[], 32)
                 .unwrap(),
-            bob_group.export_secret(bob_provider, "", &[], 32).unwrap()
+            bob_group
+                .export_secret(bob_provider.crypto(), "", &[], 32)
+                .unwrap()
         );
         assert_eq!(
             alice_group
-                .export_secret(alice_provider, "", &[], 32)
+                .export_secret(alice_provider.crypto(), "", &[], 32)
                 .unwrap(),
             charlie_group
-                .export_secret(charlie_provider, "", &[], 32)
+                .export_secret(charlie_provider.crypto(), "", &[], 32)
                 .unwrap()
         );
 
@@ -1291,10 +1297,10 @@ fn mls_group_operations() {
 
         assert_eq!(
             alice_group
-                .export_secret(alice_provider, "before load", &[], 32)
+                .export_secret(alice_provider.crypto(), "before load", &[], 32)
                 .unwrap(),
             bob_group
-                .export_secret(bob_provider, "before load", &[], 32)
+                .export_secret(bob_provider.crypto(), "before load", &[], 32)
                 .unwrap()
         );
 
@@ -1305,10 +1311,10 @@ fn mls_group_operations() {
         // Make sure the state is still the same
         assert_eq!(
             alice_group
-                .export_secret(alice_provider, "after load", &[], 32)
+                .export_secret(alice_provider.crypto(), "after load", &[], 32)
                 .unwrap(),
             bob_group
-                .export_secret(bob_provider, "after load", &[], 32)
+                .export_secret(bob_provider.crypto(), "after load", &[], 32)
                 .unwrap()
         );
     }


### PR DESCRIPTION
Tighten the requirements for the providers for `MlsGroup::export_secret()` and `MlsGroup::export_group_info()`. The functions now only require the `OpenMlsCrypto` provider.