### PR TITLE
fix `uninlined_format_args` lint

### DIFF
--- a/cli/src/networking.rs
+++ b/cli/src/networking.rs
@@ -8,8 +8,8 @@ use openmls::prelude::tls_codec::Serialize;
 
 pub fn post(url: &Url, msg: &impl Serialize) -> Result<Vec<u8>, String> {
     let serialized_msg = msg.tls_serialize_detached().unwrap();
-    log::debug!("Post {:?}", url);
-    log::trace!("Payload: {:?}", serialized_msg);
+    log::debug!("Post {url:?}");
+    log::trace!("Payload: {serialized_msg:?}");
     let client = Client::new();
     let response = client.post(url.to_string()).body(serialized_msg).send();
     if let Ok(r) = response {
@@ -35,11 +35,11 @@ pub fn get_with_body(url: &Url, body: &impl Serialize) -> Result<Vec<u8>, String
 }
 
 fn get_internal(url: &Url, msg: Option<&impl Serialize>) -> Result<Vec<u8>, String> {
-    log::debug!("Get {:?}", url);
+    log::debug!("Get {url:?}");
     let client = Client::new().get(url.to_string());
     let client = if let Some(msg) = msg {
         let serialized_msg = msg.tls_serialize_detached().unwrap();
-        log::trace!("Payload: {:?}", serialized_msg);
+        log::trace!("Payload: {serialized_msg:?}");
         client.body(serialized_msg)
     } else {
         client

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -213,7 +213,7 @@ impl User {
                 log::debug!("Created new user: {:?}", self.username());
                 self.set_auth_token(token)
             }
-            Err(e) => log::error!("Error creating user: {:?}", e),
+            Err(e) => log::error!("Error creating user: {e:?}"),
         }
     }
 
@@ -304,7 +304,7 @@ impl User {
             .map_err(|e| format!("{e}"))?;
 
         let msg = GroupMessage::new(message_out.into(), &self.recipients(group));
-        log::debug!(" >>> send: {:?}", msg);
+        log::debug!(" >>> send: {msg:?}");
         match self.backend.send_msg(&msg) {
             Ok(()) => (),
             Err(e) => println!("Error sending group message: {e:?}"),
@@ -345,7 +345,7 @@ impl User {
                     }
                 }
             }
-            Err(e) => log::debug!("update_clients::Error reading clients from DS: {:?}", e),
+            Err(e) => log::debug!("update_clients::Error reading clients from DS: {e:?}"),
         }
         log::debug!("update::Processing clients done, contact list is:");
         for contact_id in self.contacts.borrow().keys() {
@@ -386,10 +386,7 @@ impl User {
         processed_message = match mls_group.process_message(&self.provider, message) {
             Ok(msg) => msg,
             Err(e) => {
-                log::error!(
-                    "Error processing unverified message: {:?} -  Dropping message.",
-                    e
-                );
+                log::error!("Error processing unverified message: {e:?} -  Dropping message.");
                 return Err("error".to_string());
             }
         };
@@ -570,7 +567,7 @@ impl User {
         };
 
         if self.groups.borrow().contains_key(&name) {
-            panic!("Group '{}' existed already", name);
+            panic!("Group '{name}' existed already");
         }
 
         self.groups.borrow_mut().insert(name, group);
@@ -715,7 +712,7 @@ impl User {
             mls_group: RefCell::new(mls_group),
         };
 
-        log::trace!("   {}", group_name);
+        log::trace!("   {group_name}");
 
         match self.groups.borrow_mut().insert(group_name, group) {
             Some(old) => Err(format!("Overrode the group {:?}", old.group_name)),

--- a/delivery-service/ds/src/main.rs
+++ b/delivery-service/ds/src/main.rs
@@ -94,7 +94,7 @@ async fn register_client(mut body: Payload, data: web::Data<DsData>) -> impl Res
     let req = match RegisterClientRequest::tls_deserialize(&mut &bytes[..]) {
         Ok(i) => i,
         Err(_) => {
-            log::error!("Invalid payload for /clients/register\n{:?}", bytes);
+            log::error!("Invalid payload for /clients/register\n{bytes:?}");
             return actix_web::HttpResponse::BadRequest().finish();
         }
     };
@@ -176,7 +176,7 @@ async fn get_key_packages(path: web::Path<String>, data: web::Data<DsData>) -> i
         Err(_) => return actix_web::HttpResponse::BadRequest().finish(),
     };
 
-    log::debug!("Getting key packages for {:?}", id);
+    log::debug!("Getting key packages for {id:?}");
 
     let client = match clients.get(&id) {
         Some(c) => c,
@@ -213,11 +213,7 @@ async fn publish_key_packages(
     let req = match PublishKeyPackagesRequest::tls_deserialize(&mut &bytes[..]) {
         Ok(i) => i,
         Err(_) => {
-            log::error!(
-                "Invalid payload for /clients/key_packages/{:?}\n{:?}",
-                id,
-                bytes
-            );
+            log::error!("Invalid payload for /clients/key_packages/{id:?}\n{bytes:?}");
             return actix_web::HttpResponse::BadRequest().finish();
         }
     };
@@ -227,7 +223,7 @@ async fn publish_key_packages(
         return actix_web::HttpResponse::Unauthorized().finish();
     }
 
-    log::debug!("Add key package for {:?}", id);
+    log::debug!("Add key package for {id:?}");
 
     let client = match clients.get_mut(&id) {
         Some(client) => client,
@@ -254,13 +250,13 @@ async fn consume_key_package(path: web::Path<String>, data: web::Data<DsData>) -
         Ok(v) => v,
         Err(_) => return actix_web::HttpResponse::BadRequest().finish(),
     };
-    log::debug!("Consuming key package for {:?}", id);
+    log::debug!("Consuming key package for {id:?}");
 
     let key_package = match clients.get_mut(&id) {
         Some(c) => match c.consume_kp() {
             Ok(kp) => kp,
             Err(e) => {
-                log::debug!("Error consuming key package: {}", e);
+                log::debug!("Error consuming key package: {e}");
                 return actix_web::HttpResponse::NoContent().finish();
             }
         },
@@ -281,7 +277,7 @@ async fn send_welcome(mut body: Payload, data: web::Data<DsData>) -> impl Respon
     }
     let welcome_msg = unwrap_data!(MlsMessageIn::tls_deserialize(&mut &bytes[..]));
     let welcome = welcome_msg.clone().into_welcome().unwrap();
-    log::debug!("Storing welcome message: {:?}", welcome_msg);
+    log::debug!("Storing welcome message: {welcome_msg:?}");
 
     let mut clients = unwrap_data!(data.clients.lock());
     for secret in welcome.secrets().iter() {
@@ -315,7 +311,7 @@ async fn msg_send(mut body: Payload, data: web::Data<DsData>) -> impl Responder 
         bytes.extend_from_slice(&unwrap_item!(item));
     }
     let group_msg = unwrap_data!(GroupMessage::tls_deserialize(&mut &bytes[..]));
-    log::debug!("Storing group message: {:?}", group_msg);
+    log::debug!("Storing group message: {group_msg:?}");
 
     let mut clients = unwrap_data!(data.clients.lock());
     let mut groups = unwrap_data!(data.groups.lock());
@@ -390,11 +386,7 @@ async fn msg_recv(
     let req = match RecvMessageRequest::tls_deserialize(&mut &bytes[..]) {
         Ok(i) => i,
         Err(_) => {
-            log::error!(
-                "Invalid payload for /clients/key_packages/{:?}\n{:?}",
-                id,
-                bytes
-            );
+            log::error!("Invalid payload for /clients/key_packages/{id:?}\n{bytes:?}");
             return actix_web::HttpResponse::BadRequest().finish();
         }
     };
@@ -403,7 +395,7 @@ async fn msg_recv(
         return actix_web::HttpResponse::Unauthorized().finish();
     }
 
-    log::debug!("Getting messages for client {:?}", id);
+    log::debug!("Getting messages for client {id:?}");
 
     let mut out: Vec<MlsMessageIn> = Vec::new();
     let mut welcomes: Vec<MlsMessageIn> = client.welcome_queue.drain(..).collect();
@@ -445,7 +437,7 @@ async fn main() -> std::io::Result<()> {
 
     let ip = "127.0.0.1";
     let addr = format!("{ip}:{port}");
-    log::info!("Listening on: {}", addr);
+    log::info!("Listening on: {addr}");
 
     // Start the server.
     HttpServer::new(move || {

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -358,7 +358,7 @@ async fn test_group() {
 
     let welcome = match welcome_msg.body() {
         MlsMessageBodyOut::Welcome(welcome) => welcome,
-        other => panic!("expected a welcome message, got {:?}", other),
+        other => panic!("expected a welcome message, got {other:?}"),
     };
 
     let mut group_on_client2 = StagedWelcome::new_from_welcome(

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -125,7 +125,7 @@ fn _into_bytes(obj: impl serde::Serialize) -> Vec<u8> {
 pub fn write(file_name: &str, payload: &[u8]) {
     let mut file = match File::create(file_name) {
         Ok(f) => f,
-        Err(_) => panic!("Couldn't open file {}.", file_name),
+        Err(_) => panic!("Couldn't open file {file_name}."),
     };
     file.write_all(payload)
         .expect("Error writing test vector file");

--- a/openmls/src/ciphersuite/aead.rs
+++ b/openmls/src/ciphersuite/aead.rs
@@ -40,7 +40,7 @@ impl AeadKey {
     /// Create an `AeadKey` from a `Secret`. TODO: This function should
     /// disappear when tackling issue #103.
     pub(crate) fn from_secret(secret: Secret, ciphersuite: Ciphersuite) -> Self {
-        log::trace!("AeadKey::from_secret with {}", ciphersuite);
+        log::trace!("AeadKey::from_secret with {ciphersuite}");
         AeadKey {
             aead_mode: ciphersuite.aead_algorithm(),
             value: secret.value,

--- a/openmls/src/ciphersuite/secret.rs
+++ b/openmls/src/ciphersuite/secret.rs
@@ -133,7 +133,7 @@ impl Secret {
         context: &[u8],
         length: usize,
     ) -> Result<Secret, CryptoError> {
-        let full_label = format!("MLS 1.0 {}", label);
+        let full_label = format!("MLS 1.0 {label}");
         log::trace!(
             "KDF expand with label \"{}\" and {:?} with context {:x?}",
             &full_label,
@@ -141,7 +141,7 @@ impl Secret {
             context
         );
         let info = KdfLabel::serialized_label(context, full_label, length)?;
-        log::trace!("  serialized info: {:x?}", info);
+        log::trace!("  serialized info: {info:x?}");
         log_crypto!(trace, "  secret: {:x?}", self.value);
         self.hkdf_expand(crypto, ciphersuite, &info, length)
     }

--- a/openmls/src/ciphersuite/signable.rs
+++ b/openmls/src/ciphersuite/signable.rs
@@ -79,7 +79,7 @@ pub trait Signable: Sized {
         {
             Ok(p) => p,
             Err(e) => {
-                log::error!("Serializing SignContent failed, {:?}", e);
+                log::error!("Serializing SignContent failed, {e:?}");
                 return Err(SignatureError::SigningError);
             }
         };
@@ -149,7 +149,7 @@ pub trait Verifiable: Sized {
         let payload = match sign_content.tls_serialize_detached() {
             Ok(p) => p,
             Err(e) => {
-                log::error!("Serializing SignContent failed, {:?}", e);
+                log::error!("Serializing SignContent failed, {e:?}");
                 return Err(SignatureError::VerificationError);
             }
         };

--- a/openmls/src/credentials/tests.rs
+++ b/openmls/src/credentials/tests.rs
@@ -40,7 +40,7 @@ fn that_unknown_credential_types_are_de_serialized_correctly() {
             CredentialType::Other(got_proposal_type) => {
                 assert_eq!(credential_type, got_proposal_type);
             }
-            other => panic!("Expected `CredentialType::Unknown`, got `{:?}`.", other),
+            other => panic!("Expected `CredentialType::Unknown`, got `{other:?}`."),
         }
 
         // Test serialization.

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -640,7 +640,7 @@ mod test {
                         assert_eq!(extension_type, got_extension_type);
                         assert_eq!(extension_data, &got_extension_data.0);
                     }
-                    other => panic!("Expected `Extension::Unknown`, got {:?}", other),
+                    other => panic!("Expected `Extension::Unknown`, got {other:?}"),
                 }
 
                 // Test serialization.

--- a/openmls/src/framing/private_message.rs
+++ b/openmls/src/framing/private_message.rs
@@ -75,7 +75,7 @@ impl PrivateMessage {
         padding_size: usize,
     ) -> Result<PrivateMessage, MessageEncryptionError<T>> {
         log::debug!("PrivateMessage::try_from_authenticated_content");
-        log::trace!("  ciphersuite: {}", ciphersuite);
+        log::trace!("  ciphersuite: {ciphersuite}");
         // Check the message has the correct wire format
         if public_message.wire_format() != WireFormat::PrivateMessage {
             return Err(MessageEncryptionError::WrongWireFormat);
@@ -198,7 +198,7 @@ impl PrivateMessage {
                 &prepared_nonce,
             )
             .map_err(LibraryError::unexpected_crypto_error)?;
-        log::trace!("Encrypted ciphertext {:x?}", ciphertext);
+        log::trace!("Encrypted ciphertext {ciphertext:x?}");
         // Derive the sender data key from the key schedule using the ciphertext.
         let sender_data_key = message_secrets
             .sender_data_secret()

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -109,7 +109,7 @@ impl MlsGroupBuilder {
         let psk_secret = load_psks(provider.storage(), &resumption_psk_store, &self.psk_ids)
             .and_then(|psks| PskSecret::new(provider.crypto(), ciphersuite, psks))
             .map_err(|e| {
-                log::debug!("Unexpected PSK error: {:?}", e);
+                log::debug!("Unexpected PSK error: {e:?}");
                 LibraryError::custom("Unexpected PSK error")
             })?;
 

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -251,7 +251,7 @@ impl ProcessedWelcome {
         // seem like a bad idea.
         if welcome.ciphersuite() != key_package_bundle.key_package().ciphersuite() {
             let e = WelcomeError::CiphersuiteMismatch;
-            log::debug!("new_from_welcome {:?}", e);
+            log::debug!("new_from_welcome {e:?}");
             return Err(e);
         }
 
@@ -306,7 +306,7 @@ impl ProcessedWelcome {
         // KeyPackage.
         if verifiable_group_info.ciphersuite() != key_package_bundle.key_package().ciphersuite() {
             let e = WelcomeError::CiphersuiteMismatch;
-            log::debug!("new_from_welcome {:?}", e);
+            log::debug!("new_from_welcome {e:?}");
             return Err(e);
         }
 

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -204,7 +204,7 @@ impl MlsGroup {
     ) -> Result<(Vec<EncryptionKeyPair>, Vec<EncryptionKeyPair>), StageCommitError> {
         // All keys from the previous epoch are potential decryption keypairs.
         let old_epoch_keypairs = self.read_epoch_keypairs(provider.storage()).map_err(|e| {
-            log::error!("Error reading epoch keypairs: {:?}", e);
+            log::error!("Error reading epoch keypairs: {e:?}");
             StageCommitError::MissingDecryptionKey
         })?;
 

--- a/openmls/src/group/mls_group/proposal_store.rs
+++ b/openmls/src/group/mls_group/proposal_store.rs
@@ -229,14 +229,14 @@ impl ProposalQueue {
                 queued_proposal.clone(),
             );
         }
-        log::trace!("   known proposals:\n{:#?}", proposals_by_reference_queue);
+        log::trace!("   known proposals:\n{proposals_by_reference_queue:#?}");
         // Build the actual queue
         let mut proposal_queue = ProposalQueue::default();
 
         // Iterate over the committed proposals and insert the proposals in the queue
         log::trace!("   committed proposals ...");
         for proposal_or_ref in committed_proposals.into_iter() {
-            log::trace!("       proposal_or_ref:\n{:#?}", proposal_or_ref);
+            log::trace!("       proposal_or_ref:\n{proposal_or_ref:#?}");
             let queued_proposal = match proposal_or_ref {
                 ProposalOrRef::Proposal(proposal) => {
                     // ValSem200

--- a/openmls/src/group/mls_group/tests_and_kats/kats/passive_client.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/kats/passive_client.rs
@@ -119,7 +119,7 @@ pub fn run_test_vector(test_vector: PassiveClientWelcomeTestVector) {
     let provider = OpenMlsRustCrypto::default();
     let cipher_suite = test_vector.cipher_suite.try_into().unwrap();
     if provider.crypto().supports(cipher_suite).is_err() {
-        warn!("Skipping {}", cipher_suite);
+        warn!("Skipping {cipher_suite}");
         return;
     }
 
@@ -162,7 +162,7 @@ pub fn run_test_vector(test_vector: PassiveClientWelcomeTestVector) {
     );
 
     for (i, epoch) in test_vector.epochs.into_iter().enumerate() {
-        info!("Epoch #{}", i);
+        info!("Epoch #{i}");
 
         for proposal in epoch.proposals {
             let message = MlsMessageIn::tls_deserialize_exact(&proposal.0).unwrap();
@@ -291,7 +291,7 @@ impl PassiveClient {
     }
 
     fn process_message(&mut self, message: MlsMessageIn) {
-        println!("{:#?}", message);
+        println!("{message:#?}");
         let processed_message = self
             .group
             .as_mut()

--- a/openmls/src/group/tests_and_kats/kats/messages.rs
+++ b/openmls/src/group/tests_and_kats/kats/messages.rs
@@ -343,8 +343,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
         .unwrap();
     if tv_mls_welcome != my_mls_welcome {
         log::error!("  Welcome encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_mls_welcome);
-        log::debug!("    Expected: {:x?}", tv_mls_welcome);
+        log::debug!("    Encoded: {my_mls_welcome:x?}");
+        log::debug!("    Expected: {tv_mls_welcome:x?}");
         if cfg!(test) {
             panic!("Welcome encoding mismatch");
         }
@@ -359,8 +359,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
         .unwrap();
     if tv_mls_group_info != my_mls_group_info {
         log::error!("  VerifiableGroupInfo encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_mls_group_info);
-        log::debug!("    Expected: {:x?}", tv_mls_group_info);
+        log::debug!("    Encoded: {my_mls_group_info:x?}");
+        log::debug!("    Expected: {tv_mls_group_info:x?}");
         if cfg!(test) {
             panic!("VerifiableGroupInfo encoding mismatch");
         }
@@ -375,8 +375,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
         .unwrap();
     if tv_mls_key_package != my_key_package {
         log::error!("  KeyPackage encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_key_package);
-        log::debug!("    Expected: {:x?}", tv_mls_key_package);
+        log::debug!("    Encoded: {my_key_package:x?}");
+        log::debug!("    Expected: {tv_mls_key_package:x?}");
         if cfg!(test) {
             panic!("KeyPackage encoding mismatch");
         }
@@ -389,8 +389,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
     let my_ratchet_tree = dec_ratchet_tree.tls_serialize_detached().unwrap();
     if tv_ratchet_tree != my_ratchet_tree {
         log::error!("  RatchetTree encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_ratchet_tree);
-        log::debug!("    Expected: {:x?}", tv_ratchet_tree);
+        log::debug!("    Encoded: {my_ratchet_tree:x?}");
+        log::debug!("    Expected: {tv_ratchet_tree:x?}");
         if cfg!(test) {
             panic!("RatchetTree encoding mismatch");
         }
@@ -404,8 +404,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
         GroupSecrets::new_encoded(&gs.joiner_secret, gs.path_secret.as_ref(), &gs.psks).unwrap();
     if tv_group_secrets != my_group_secrets {
         log::error!("  GroupSecrets encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_group_secrets);
-        log::debug!("    Expected: {:x?}", tv_group_secrets);
+        log::debug!("    Encoded: {my_group_secrets:x?}");
+        log::debug!("    Expected: {tv_group_secrets:x?}");
         if cfg!(test) {
             panic!("GroupSecrets encoding mismatch");
         }
@@ -420,8 +420,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
         .unwrap();
     if tv_add_proposal != my_add_proposal {
         log::error!("  AddProposal encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_add_proposal);
-        log::debug!("    Expected: {:x?}", tv_add_proposal);
+        log::debug!("    Encoded: {my_add_proposal:x?}");
+        log::debug!("    Expected: {tv_add_proposal:x?}");
         if cfg!(test) {
             panic!("AddProposal encoding mismatch");
         }
@@ -437,8 +437,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
         .unwrap();
     if tv_update_proposal != my_update_proposal {
         log::error!("  UpdateProposal encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_update_proposal);
-        log::debug!("    Expected: {:x?}", tv_update_proposal);
+        log::debug!("    Encoded: {my_update_proposal:x?}");
+        log::debug!("    Expected: {tv_update_proposal:x?}");
         if cfg!(test) {
             panic!("UpdateProposal encoding mismatch");
         }
@@ -453,8 +453,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
         .unwrap();
     if tv_remove_proposal != my_remove_proposal {
         log::error!("  RemoveProposal encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_remove_proposal);
-        log::debug!("    Expected: {:x?}", tv_remove_proposal);
+        log::debug!("    Encoded: {my_remove_proposal:x?}");
+        log::debug!("    Expected: {tv_remove_proposal:x?}");
         if cfg!(test) {
             panic!("RemoveProposal encoding mismatch");
         }
@@ -470,8 +470,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
             .unwrap();
     if tv_pre_shared_key_proposal != my_pre_shared_key_proposal {
         log::error!("  PreSharedKeyProposal encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_pre_shared_key_proposal);
-        log::debug!("    Expected: {:x?}", tv_pre_shared_key_proposal);
+        log::debug!("    Encoded: {my_pre_shared_key_proposal:x?}");
+        log::debug!("    Expected: {tv_pre_shared_key_proposal:x?}");
         if cfg!(test) {
             panic!("PreSharedKeyProposal encoding mismatch");
         }
@@ -488,8 +488,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
         .unwrap();
     if tv_commit != my_commit {
         log::error!("  Commit encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_commit);
-        log::debug!("    Expected: {:x?}", tv_commit);
+        log::debug!("    Encoded: {my_commit:x?}");
+        log::debug!("    Expected: {tv_commit:x?}");
         if cfg!(test) {
             panic!("Commit encoding mismatch");
         }
@@ -505,8 +505,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
             .unwrap();
     if tv_public_message_application != my_public_message_application {
         log::error!("  MlsPlaintextApplication encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_public_message_application);
-        log::debug!("    Expected: {:x?}", tv_public_message_application);
+        log::debug!("    Encoded: {my_public_message_application:x?}");
+        log::debug!("    Expected: {tv_public_message_application:x?}");
         if cfg!(test) {
             panic!("MlsPlaintextApplication encoding mismatch");
         }
@@ -522,8 +522,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
             .unwrap();
     if tv_public_message_proposal != my_public_message_proposal {
         log::error!("  PublicMessage(Proposal) encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_public_message_proposal);
-        log::debug!("    Expected: {:x?}", tv_public_message_proposal);
+        log::debug!("    Encoded: {my_public_message_proposal:x?}");
+        log::debug!("    Expected: {tv_public_message_proposal:x?}");
         if cfg!(test) {
             panic!("PublicMessage(Proposal) encoding mismatch");
         }
@@ -538,8 +538,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
         .unwrap();
     if tv_public_message_commit != my_public_message_commit {
         log::error!("  PublicMessage(Commit) encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_public_message_commit);
-        log::debug!("    Expected: {:x?}", tv_public_message_commit);
+        log::debug!("    Encoded: {my_public_message_commit:x?}");
+        log::debug!("    Expected: {tv_public_message_commit:x?}");
         if cfg!(test) {
             panic!("PublicMessage(Commit) encoding mismatch");
         }
@@ -554,8 +554,8 @@ pub fn run_test_vector(tv: MessagesTestVector) -> Result<(), EncodingMismatch> {
         .unwrap();
     if tv_private_message != my_private_message {
         log::error!("  PrivateMessage encoding mismatch");
-        log::debug!("    Encoded: {:x?}", my_private_message);
-        log::debug!("    Expected: {:x?}", tv_private_message);
+        log::debug!("    Encoded: {my_private_message:x?}");
+        log::debug!("    Expected: {tv_private_message:x?}");
         if cfg!(test) {
             panic!("PrivateMessage encoding mismatch");
         }

--- a/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
@@ -1340,8 +1340,7 @@ fn test_valsem105() {
                                 ),
                             )
                         ),
-                        "unexpected error: {:?}",
-                        err
+                        "unexpected error: {err:?}"
                     );
                 }
                 KeyPackageTestVersion::UnsupportedCiphersuite => {
@@ -1356,8 +1355,7 @@ fn test_valsem105() {
                                 ),
                             )
                         ),
-                        "unexpected error: {:?}",
-                        err
+                        "unexpected error: {err:?}"
                     );
                 }
             };

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -719,7 +719,7 @@ mod tests {
                 ProposalType::Custom(got_proposal_type) => {
                     assert_eq!(proposal_type, got_proposal_type);
                 }
-                other => panic!("Expected `ProposalType::Unknown`, got `{:?}`.", other),
+                other => panic!("Expected `ProposalType::Unknown`, got `{other:?}`."),
             }
 
             // Test serialization.

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -418,7 +418,7 @@ impl KeySchedule {
         joiner_secret: &JoinerSecret,
         psk: PskSecret,
     ) -> Result<Self, LibraryError> {
-        log::debug!("Initializing the key schedule with {:?} ...", ciphersuite);
+        log::debug!("Initializing the key schedule with {ciphersuite:?} ...");
         log_crypto!(
             trace,
             "  joiner_secret: {:x?}",
@@ -465,10 +465,7 @@ impl KeySchedule {
         crypto: &impl OpenMlsCrypto,
         serialized_group_context: &[u8],
     ) -> Result<(), KeyScheduleError> {
-        log::trace!(
-            "Adding context to key schedule. {:?}",
-            serialized_group_context
-        );
+        log::trace!("Adding context to key schedule. {serialized_group_context:?}");
         if self.state != State::Initial || self.intermediate_secret.is_none() {
             log::error!(
                 "Trying to add context to the key schedule while not in the initial state."
@@ -583,7 +580,7 @@ impl WelcomeSecret {
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
     ) -> Result<AeadKey, CryptoError> {
-        log::trace!("WelcomeSecret.derive_aead_key with {}", ciphersuite);
+        log::trace!("WelcomeSecret.derive_aead_key with {ciphersuite}");
         let aead_secret = self.secret.kdf_expand_label(
             crypto,
             ciphersuite,
@@ -919,7 +916,7 @@ impl MembershipKey {
 // Get a ciphertext sample of `hash_length` from the ciphertext.
 fn ciphertext_sample(ciphersuite: Ciphersuite, ciphertext: &[u8]) -> &[u8] {
     let sample_length = ciphersuite.hash_length();
-    log::debug!("Getting ciphertext sample of length {:?}", sample_length);
+    log::debug!("Getting ciphertext sample of length {sample_length:?}");
     if ciphertext.len() <= sample_length {
         ciphertext
     } else {
@@ -958,10 +955,7 @@ impl SenderDataSecret {
         ciphertext: &[u8],
     ) -> Result<AeadKey, CryptoError> {
         let ciphertext_sample = ciphertext_sample(ciphersuite, ciphertext);
-        log::debug!(
-            "SenderDataSecret::derive_aead_key ciphertext sample: {:x?}",
-            ciphertext_sample
-        );
+        log::debug!("SenderDataSecret::derive_aead_key ciphertext sample: {ciphertext_sample:x?}");
         let secret = self.secret.kdf_expand_label(
             crypto,
             ciphersuite,
@@ -981,8 +975,7 @@ impl SenderDataSecret {
     ) -> Result<AeadNonce, CryptoError> {
         let ciphertext_sample = ciphertext_sample(ciphersuite, ciphertext);
         log::debug!(
-            "SenderDataSecret::derive_aead_nonce ciphertext sample: {:x?}",
-            ciphertext_sample
+            "SenderDataSecret::derive_aead_nonce ciphertext sample: {ciphertext_sample:x?}"
         );
         let nonce_secret = self.secret.kdf_expand_label(
             crypto,
@@ -1130,10 +1123,7 @@ impl EpochSecrets {
         ciphersuite: Ciphersuite,
         epoch_secret: EpochSecret,
     ) -> Result<Self, CryptoError> {
-        log::debug!(
-            "Computing EpochSecrets from epoch secret with {}",
-            ciphersuite
-        );
+        log::debug!("Computing EpochSecrets from epoch secret with {ciphersuite}");
         log_crypto!(
             trace,
             "  epoch_secret: {:x?}",

--- a/openmls/src/schedule/tests_and_kats/kats/key_schedule.rs
+++ b/openmls/src/schedule/tests_and_kats/kats/key_schedule.rs
@@ -280,7 +280,7 @@ pub fn run_test_vector(
     provider: &impl OpenMlsProvider,
 ) -> Result<(), KsTestVectorError> {
     let ciphersuite = Ciphersuite::try_from(test_vector.cipher_suite).expect("Invalid ciphersuite");
-    log::trace!("  {:?}", test_vector);
+    log::trace!("  {test_vector:?}");
 
     if !provider
         .crypto()
@@ -354,8 +354,8 @@ pub fn run_test_vector(
             .expect("An unexpected error occurred.");
         if group_context_serialized != expected_group_context {
             log::error!("  Group context mismatch");
-            log::debug!("    Computed: {:x?}", group_context_serialized);
-            log::debug!("    Expected: {:x?}", expected_group_context);
+            log::debug!("    Computed: {group_context_serialized:x?}");
+            log::debug!("    Expected: {expected_group_context:x?}");
             if cfg!(test) {
                 panic!("Group context mismatch");
             }

--- a/openmls/src/storage/kat_storage_stability.rs
+++ b/openmls/src/storage/kat_storage_stability.rs
@@ -704,7 +704,7 @@ fn test(ciphersuite: Ciphersuite, provider: &Provider) {
                 &BasicCredential::new(b"charlie".to_vec()).into()
             )
         }
-        other => panic!("expected add proposal, got {:?}", other),
+        other => panic!("expected add proposal, got {other:?}"),
     }
 
     // there is no pending commit

--- a/openmls/src/tree/secret_tree.rs
+++ b/openmls/src/tree/secret_tree.rs
@@ -82,10 +82,7 @@ pub(crate) fn derive_tree_secret(
     crypto: &impl OpenMlsCrypto,
 ) -> Result<Secret, SecretTreeError> {
     log::debug!(
-        "Derive tree secret with label \"{}\" in generation {} of length {}",
-        label,
-        generation,
-        length
+        "Derive tree secret with label \"{label}\" in generation {generation} of length {length}"
     );
     log_crypto!(trace, "Input secret {:x?}", secret.as_slice());
 
@@ -206,7 +203,7 @@ impl SecretTree {
             // found
             let mut empty_nodes: Vec<ParentNodeIndex> = Vec::new();
             let direct_path = direct_path(index, self.size);
-            log::trace!("Direct path for node {index:?}: {:?}", direct_path);
+            log::trace!("Direct path for node {index:?}: {direct_path:?}");
             for parent_node in direct_path {
                 empty_nodes.push(parent_node);
                 // Stop if we find a non-empty node
@@ -307,11 +304,7 @@ impl SecretTree {
         configuration: &SenderRatchetConfiguration,
     ) -> Result<RatchetKeyMaterial, SecretTreeError> {
         log::debug!(
-            "Generating {:?} decryption secret for {:?} in generation {} with {}",
-            secret_type,
-            index,
-            generation,
-            ciphersuite,
+            "Generating {secret_type:?} decryption secret for {index:?} in generation {generation} with {ciphersuite}",
         );
         // Check tree bounds
         if index.u32() >= self.size.leaf_count() {

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -487,7 +487,7 @@ pub fn run_test_vector(
     }
     let size = TreeSize::from_leaf_count(n_leaves);
     let ciphersuite = Ciphersuite::try_from(test_vector.cipher_suite).expect("Invalid ciphersuite");
-    log::debug!("Running test vector with {:?}", ciphersuite);
+    log::debug!("Running test vector with {ciphersuite:?}");
 
     let sender_data_secret =
         SenderDataSecret::from_slice(hex_to_bytes(&test_vector.sender_data_secret).as_slice());
@@ -565,9 +565,7 @@ pub fn run_test_vector(
                 )
                 .expect("Error getting decryption secret");
             log::debug!(
-                "  Secret tree after deriving application keys for leaf {:?} in generation {:?}",
-                leaf_index,
-                generation
+                "  Secret tree after deriving application keys for leaf {leaf_index:?} in generation {generation:?}"
             );
             log_crypto!(debug, "  {:?}", secret_tree);
             if hex_to_bytes(&application.key) != application_secret_key.as_slice() {
@@ -805,7 +803,7 @@ pub fn run_test_vector(
                 .message_secrets_test_mut()
                 .replace_secret_tree(fresh_secret_tree.clone());
         }
-        log::trace!("Finished test vector for leaf {:?}", leaf_index);
+        log::trace!("Finished test vector for leaf {leaf_index:?}");
     }
     log::trace!("Finished test vector verification");
     Ok(())

--- a/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
@@ -125,10 +125,10 @@ pub fn run_test_vector(
         .supported_ciphersuites()
         .contains(&ciphersuite)
     {
-        log::debug!("Skipping unsupported ciphersuite {:?}", ciphersuite);
+        log::debug!("Skipping unsupported ciphersuite {ciphersuite:?}");
         return Ok(());
     }
-    log::debug!("Testing tv with ciphersuite {:?}", ciphersuite);
+    log::debug!("Testing tv with ciphersuite {ciphersuite:?}");
 
     let group_context = GroupContext::new(
         ciphersuite,

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -483,10 +483,7 @@ impl LeafNode {
             .filter(|ext| ext.extension_type().is_valid_in_leaf_node() == Some(false))
             .collect::<Vec<_>>();
         if !invalid_extension_types.is_empty() {
-            log::error!(
-                "Invalid extension used in leaf node: {:?}",
-                invalid_extension_types
-            );
+            log::error!("Invalid extension used in leaf node: {invalid_extension_types:?}");
             return Err(LeafNodeValidationError::UnsupportedExtensions);
         }
 

--- a/openmls/src/versions.rs
+++ b/openmls/src/versions.rs
@@ -87,7 +87,7 @@ impl fmt::Display for ProtocolVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             ProtocolVersion::Mls10 => write!(f, "MLS 1.0"),
-            ProtocolVersion::Other(v) => write!(f, "Other version: {}", v),
+            ProtocolVersion::Other(v) => write!(f, "Other version: {v}"),
         }
     }
 }

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -21,7 +21,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     for ciphersuite in rc_ciphersuites {
         let val = ciphersuite as u16;
-        let ciphersuite_name = format!("{:?}", ciphersuite);
+        let ciphersuite_name = format!("{ciphersuite:?}");
         let name = format_ident!("{}_rustcrypto_{}", fn_name, ciphersuite_name);
         let test_fun = quote! {
             #(#attrs)*
@@ -54,7 +54,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
         let rc_ciphersuites = rc.crypto().supported_ciphersuites();
         for ciphersuite in rc_ciphersuites {
             let val = ciphersuite as u16;
-            let ciphersuite_name = format!("{:?}", ciphersuite);
+            let ciphersuite_name = format!("{ciphersuite:?}");
             let name = format_ident!("{}_sqlite_{}", fn_name, ciphersuite_name);
             let test_fun = quote! {
                 #(#attrs)*
@@ -143,7 +143,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         for ciphersuite in libcrux_ciphersuites {
             let val = ciphersuite as u16;
-            let ciphersuite_name = format!("{:?}", ciphersuite);
+            let ciphersuite_name = format!("{ciphersuite:?}");
             let name = format_ident!("{}_libcrux_{}", fn_name, ciphersuite_name);
             let test_fun = quote! {
                 #(#attrs)*


### PR DESCRIPTION
This PR fixes the clippy lint [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) across the workspace.