### PR TITLE
fix: SelfRemove proposal type and free index calculation

### DIFF
--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use errors::NewGroupError;
 use openmls_traits::{signatures::Signer, storage::StorageProvider as StorageProviderTrait};
 
@@ -150,12 +152,10 @@ impl MlsGroup {
         // The `EpochSecrets` we create here are essentially zero, with the
         // exception of the `InitSecret`, which is all we need here for the
         // external commit.
-        let epoch_secrets = EpochSecrets::with_init_secret(
-            provider.crypto(),
-            group_info.group_context().ciphersuite(),
-            init_secret,
-        )
-        .map_err(LibraryError::unexpected_crypto_error)?;
+        let ciphersuite = group_info.group_context().ciphersuite();
+        let epoch_secrets =
+            EpochSecrets::with_init_secret(provider.crypto(), ciphersuite, init_secret)
+                .map_err(LibraryError::unexpected_crypto_error)?;
         let (group_epoch_secrets, message_secrets) = epoch_secrets.split_secrets(
             group_context
                 .tls_serialize_detached()
@@ -183,7 +183,8 @@ impl MlsGroup {
             inline_proposals.push(remove_proposal);
         };
 
-        let own_leaf_index = public_group.leftmost_free_index(inline_proposals.iter().map(Some))?;
+        let own_leaf_index =
+            public_group.leftmost_free_index(inline_proposals.iter(), iter::empty())?;
         params.set_inline_proposals(inline_proposals);
 
         let mut mls_group = MlsGroup {

--- a/openmls/src/group/public_group/mod.rs
+++ b/openmls/src/group/public_group/mod.rs
@@ -11,7 +11,7 @@
 //! To avoid duplication of code and functionality, [`MlsGroup`] internally
 //! relies on a [`PublicGroup`] as well.
 
-use std::collections::HashSet;
+use std::{collections::HashSet, iter};
 
 use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite};
 use serde::{Deserialize, Serialize};
@@ -34,10 +34,10 @@ use crate::{
     ciphersuite::{hash_ref::ProposalRef, signable::Verifiable},
     error::LibraryError,
     extensions::RequiredCapabilitiesExtension,
-    framing::InterimTranscriptHashInput,
+    framing::{InterimTranscriptHashInput, Sender},
     messages::{
         group_info::{GroupInfo, VerifiableGroupInfo},
-        proposals::{Proposal, ProposalOrRefType, ProposalType},
+        proposals::Proposal,
         ConfirmationTag, PathSecret,
     },
     schedule::CommitSecret,
@@ -288,13 +288,7 @@ impl PublicGroup {
         &self,
         commit: &StagedCommit,
     ) -> Result<LeafNodeIndex, LibraryError> {
-        self.leftmost_free_index(commit.queued_proposals().filter_map(|p| {
-            if matches!(p.proposal_or_ref_type(), ProposalOrRefType::Proposal) {
-                Some(Some(p.proposal()))
-            } else {
-                None
-            }
-        }))
+        self.leftmost_free_index(iter::empty(), commit.queued_proposals())
     }
 
     /// Returns the leftmost free leaf index.
@@ -305,33 +299,32 @@ impl PublicGroup {
     /// The proposals must be validated before calling this function.
     pub(crate) fn leftmost_free_index<'a>(
         &self,
-        mut inline_proposals: impl Iterator<Item = Option<&'a Proposal>>,
+        inline_proposals: impl Iterator<Item = &'a Proposal>,
+        queued_proposals: impl Iterator<Item = &'a QueuedProposal>,
     ) -> Result<LeafNodeIndex, LibraryError> {
         // Leftmost free leaf in the tree
         let free_leaf_index = self.treesync().free_leaf_index();
-        // Returns the first remove proposal (if there is one)
-        let remove_proposal_option = inline_proposals
-            .find(|proposal| match proposal {
-                Some(p) => p.is_type(ProposalType::Remove),
-                None => false,
-            })
-            .flatten();
-        let leaf_index = if let Some(remove_proposal) = remove_proposal_option {
-            if let Proposal::Remove(remove_proposal) = remove_proposal {
-                let removed_index = remove_proposal.removed();
-                // The committer should always be in the left-most leaf.
-                if removed_index < free_leaf_index {
-                    removed_index
-                } else {
-                    free_leaf_index
-                }
-            } else {
-                return Err(LibraryError::custom("missing key package"));
+        // Indices that are freed due to queued self-remove proposals or remove
+        // proposals.
+        let removed_indices = queued_proposals.filter_map(|proposal| {
+            match (proposal.proposal(), proposal.sender()) {
+                (Proposal::Remove(r), _) => Some(r.removed),
+                (Proposal::SelfRemove, Sender::Member(sender)) => Some(*sender),
+                _ => None, // SelfRemove proposals must come from group members
             }
-        } else {
-            free_leaf_index
-        };
-        Ok(leaf_index)
+        });
+        let more_removed_indices = inline_proposals.filter_map(|proposal| match proposal {
+            Proposal::Remove(r) => Some(r.removed),
+            _ => None,
+        });
+        // Find the leftmost free leaf index, which is either the free leaf index
+        // or the leftmost index of a self-remove proposal or remove proposal.
+        removed_indices
+            .into_iter()
+            .chain(more_removed_indices)
+            .chain(std::iter::once(free_leaf_index))
+            .min()
+            .ok_or_else(|| LibraryError::custom("No free leaf index found"))
     }
 
     /// Create an empty  [`PublicGroupDiff`] based on this [`PublicGroup`].

--- a/openmls/src/group/public_group/staged_commit.rs
+++ b/openmls/src/group/public_group/staged_commit.rs
@@ -4,7 +4,10 @@ use crate::{
     group::{
         mls_group::staged_commit::StagedCommitState, proposal_store::ProposalQueue, StagedCommit,
     },
-    messages::{proposals::ProposalOrRef, Commit},
+    messages::{
+        proposals::{ProposalOrRef, ProposalType},
+        Commit,
+    },
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -174,14 +177,7 @@ impl PublicGroup {
         let sender_index = match sender {
             Sender::Member(leaf_index) => *leaf_index,
             Sender::NewMemberCommit => {
-                let inline_proposals = commit.proposals.iter().filter_map(|p| {
-                    if let ProposalOrRef::Proposal(inline_proposal) = p {
-                        Some(Some(inline_proposal))
-                    } else {
-                        None
-                    }
-                });
-                self.leftmost_free_index(inline_proposals)?
+                self.leftmost_free_index(iter::empty(), proposal_queue.queued_proposals())?
             }
             _ => {
                 return Err(StageCommitError::SenderTypeExternal);

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -162,8 +162,8 @@ impl From<u16> for ProposalType {
             5 => ProposalType::Reinit,
             6 => ProposalType::ExternalInit,
             7 => ProposalType::GroupContextExtensions,
-            8 => ProposalType::AppAck,
-            0x000c => ProposalType::SelfRemove,
+            0x000a => ProposalType::SelfRemove,
+            0x000b => ProposalType::AppAck,
             other => ProposalType::Custom(other),
         }
     }
@@ -179,8 +179,8 @@ impl From<ProposalType> for u16 {
             ProposalType::Reinit => 5,
             ProposalType::ExternalInit => 6,
             ProposalType::GroupContextExtensions => 7,
-            ProposalType::AppAck => 8,
-            ProposalType::SelfRemove => 0x000c,
+            ProposalType::SelfRemove => 0x000a,
+            ProposalType::AppAck => 0x000b,
             ProposalType::Custom(id) => id,
         }
     }


### PR DESCRIPTION
- Takes SelfRemove proposals into account when computing leftmost free index. This is not particularly relevant at the moment, since SelfRemoves can't be given as input when creating an external commit. However, this is in preparation of a follow up.
- Aligns the proposal types of SelfRemove and AppAck with the extensions draft 06.

Fixes #1789.