### PR TITLE
Documentation fixes and pub use `commit_builder::*` 

### DIFF
--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! The MLS protocol allows the [`Credential`] representing a client in a group
 //! to change over time. Concretely, members can issue an Update proposal or a
-//! Full Commit to update their [`LeafNode`](crate::treesync::LeafNode),
+//! Full Commit to update their [`LeafNode`],
 //! including the [`Credential`] in it. The Update must be authenticated using
 //! the signature public key corresponding to the old [`Credential`].
 //!

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -230,6 +230,8 @@ impl<'a> CommitBuilder<'a, Initial> {
         self
     }
 
+    /// Adds a Remove proposal for the provided [`LeafNodeIndex`]es to the list of proposals to be
+    /// committed.
     pub fn propose_removals(mut self, removed: impl IntoIterator<Item = LeafNodeIndex>) -> Self {
         self.stage.own_proposals.extend(
             removed
@@ -239,6 +241,8 @@ impl<'a> CommitBuilder<'a, Initial> {
         self
     }
 
+    /// Adds a GroupContextExtensions proposal for the provided [`Extensions`] to the list of
+    /// proposals to be committed.
     pub fn propose_group_context_extensions(mut self, extensions: Extensions) -> Self {
         self.stage
             .own_proposals

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod public_group;
 // Public
 pub use errors::*;
 pub use group_context::GroupContext;
+pub use mls_group::commit_builder::*;
 pub use mls_group::config::*;
 pub use mls_group::membership::*;
 pub use mls_group::proposal_store::*;


### PR DESCRIPTION
This pull request adds a \`pub use\` declaration for `commit_builder::*` to `openmls/src/group/mod.rs`, alongside the other public exports in this module. In the Rust documentation generated from this crate, the `CommitBuilder` and its documentation will now be included.

This PR also includes missing doc comments for two public methods on `CommitBuilder`, as well as a minor fix to a module-level comment in `openmls/src/credentials/mod.rs`, which previously led to a warning when generating the docs.