### PR TITLE
export `mls_group::builder::*`

### DIFF
--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -23,6 +23,7 @@ use crate::{
 
 use super::{past_secrets::MessageSecretsStore, MlsGroup, MlsGroupState};
 
+/// Builder struct for an [`MlsGroup`].
 #[derive(Default, Debug)]
 pub struct MlsGroupBuilder {
     group_id: Option<GroupId>,

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod public_group;
 // Public
 pub use errors::*;
 pub use group_context::GroupContext;
+pub use mls_group::builder::*;
 pub use mls_group::commit_builder::*;
 pub use mls_group::config::*;
 pub use mls_group::membership::*;


### PR DESCRIPTION
This PR exports `mls_group::builder::*` alongside the other public exports for the `openmls` crate, so that the documentation for the `MlsGroupBuilder` struct will appear in the rustdocs for this crate. 

It also adds a doc comment to `MlsGroupBuilder`.