### PR TITLE
Bump openmls and openmls_test to -pre.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ resolver = "2"
 [workspace.dependencies]
 tls_codec = { version = "0.4.2", features = ["derive", "serde", "mls"] }
 
-openmls = { version = "0.7.0-pre.1", path = "openmls" }
+openmls = { version = "0.7.0-pre.2", path = "openmls" }
 
 openmls_traits = { version = "0.4.0-pre.1", path = "traits" }
-openmls_test = { version = "0.2.0-pre.1", path = "openmls_test" }
+openmls_test = { version = "0.2.0-pre.2", path = "openmls_test" }
 openmls_basic_credential = { version = "0.4.0-pre.1", path = "basic_credential" }
 
 openmls_rust_crypto = { version = "0.4.0-pre.1", path = "openmls_rust_crypto" }

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openmls"
-version = "0.7.0-pre.1"
+version = "0.7.0-pre.2"
 authors = ["OpenMLS Authors"]
 edition = "2021"
 description = "A Rust implementation of the Messaging Layer Security (MLS) protocol, as defined in RFC 9420."

--- a/openmls_test/Cargo.toml
+++ b/openmls_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openmls_test"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.2"
 authors = ["OpenMLS Authors"]
 edition = "2021"
 description = "Test utility used by OpenMLS"


### PR DESCRIPTION
These two had the issue with the yanked version in the lockfile. Bump to -pre.2 for another attempt.