### PR TITLE
feat: set migration table name for refinery migrations

### DIFF
--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -90,7 +90,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         fn default() -> Self {
                             let connection = Connection::open_in_memory().unwrap();
                             let mut storage = SqliteStorageProvider::new(connection);
-                            storage.initialize().unwrap();
+                            storage.run_migrations().unwrap();
                             Self {
                                 crypto: RustCrypto::default(),
                                 storage,

--- a/sqlite_storage/CHANGELOG.md
+++ b/sqlite_storage/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 (XXX-XX-XX)
+## 0.2.0 (2025-07-17)
+
+### Changed
+
+- [#1807](https://github.com/openmls/openmls/pull/1807): Deprecate `initialize` in favor of new `run_migrations` function.
+
+### Added
+
+- [#1807](https://github.com/openmls/openmls/pull/1807): `run_migrations` function that scopes refinery migrations in its own table.
+
+## 0.1.0 (2025-07-17)
 - initial release
 
 *Please disregard any previous versions.*

--- a/sqlite_storage/src/storage_provider.rs
+++ b/sqlite_storage/src/storage_provider.rs
@@ -46,8 +46,21 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> SqliteStorageProvider<C, Conne
 
 impl<C: Codec, ConnectionRef: BorrowMut<Connection>> SqliteStorageProvider<C, ConnectionRef> {
     /// Initialize the database with the necessary tables.
+    ///
+    /// This method is deprecated and replaced by `run_migrations`, which
+    /// specifies a unique name for the refinery migration table.
+    #[deprecated]
     pub fn initialize(&mut self) -> Result<(), refinery::Error> {
         migrations::runner().run(self.connection.borrow_mut())?;
+        Ok(())
+    }
+
+    /// Initialize the database with the necessary tables.
+    pub fn run_migrations(&mut self) -> Result<(), refinery::Error> {
+        let mut runner = migrations::runner();
+        runner.set_migration_table_name("openmls_sqlite_storage_migrations");
+
+        runner.run(self.connection.borrow_mut())?;
         Ok(())
     }
 }

--- a/sqlite_storage/tests/proposals.rs
+++ b/sqlite_storage/tests/proposals.rs
@@ -49,7 +49,7 @@ fn read_write_delete() {
     let mut storage =
         openmls_sqlite_storage::SqliteStorageProvider::<JsonCodec, Connection>::new(connection);
 
-    storage.initialize().unwrap();
+    storage.run_migrations().unwrap();
 
     // Store proposals
     for (i, proposal) in proposals.iter().enumerate() {


### PR DESCRIPTION
The sqlite storage provider uses refinery to manage migrations, i.e. creation of tables for storage provider data. So far, the migrations in the provider use the general migrations table used by refinery, which means that it doesn't compose well with external apps that want to use the same DB for other data (and have their own migrations). This PR mitigates that by storing OpenMLS-specific migrations in a separate, named table.