### PR TITLE
fix(doc): `SqliteStorageProvider` database initialization

### DIFF
--- a/sqlite_storage/src/lib.rs
+++ b/sqlite_storage/src/lib.rs
@@ -6,8 +6,8 @@
 //! ## Usage
 //!
 //! Generally, the [`SqliteStorageProvider`] can be used like any other storage
-//! provider. However, before first use, the tables need to be created. This can
-//! be done using the [`SqliteStorageProvider::create_tables`] method.
+//! provider. However, before first use, the database needs to be initialized.
+//! This is done using the [`SqliteStorageProvider::run_migrations()`] method.
 //!
 //! ### Codec
 //!

--- a/sqlite_storage/src/storage_provider.rs
+++ b/sqlite_storage/src/storage_provider.rs
@@ -49,7 +49,7 @@ impl<C: Codec, ConnectionRef: BorrowMut<Connection>> SqliteStorageProvider<C, Co
     ///
     /// This method is deprecated and replaced by `run_migrations`, which
     /// specifies a unique name for the refinery migration table.
-    #[deprecated]
+    #[deprecated(since = "0.2.0", note = "use `run_migrations()` instead")]
     pub fn initialize(&mut self) -> Result<(), refinery::Error> {
         migrations::runner().run(self.connection.borrow_mut())?;
         Ok(())


### PR DESCRIPTION
Replace non-existing reference to `SqliteStorageProvider::create_tables` with `SqliteStorageProvider::run_migrations()` in module introduction.

Enhance depreciation warning for `SqliteStorageProvider::initialize()`.

Tested with `cargo doc` to confirm everything renders as expected.