### PR TITLE
Allow configuration of leaf node lifetime checks on join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- [#...](https://github.com/openmls/openmls/pull/): Added
+  - `MlsGroup::from_external_commit`: Replaces `join_by_external_commit` with a builder pattern that allows disabling checking of lifetimes in the ratchet tree.
+  - `StagedWelcome::build_from_welcome`: Alternative to `new_from_welcome` in a builder style that allows disabling lifetime validation of the incoming ratchet tree.
+  - `Lifetime::init`: Set explicit lifetimes for a key package.
+
+### Fixed
+
+### Deprecated
+- [#...](https://github.com/openmls/openmls/pull/): Deprecated `MlsGroup::join_by_external_commit` in favor of `MlsGroup::from_external_commit`.
+
 ## 0.7.0 (2025-07-17)
 
 ### Added

--- a/book/src/user_manual/join_from_external_commit.md
+++ b/book/src/user_manual/join_from_external_commit.md
@@ -16,7 +16,7 @@ Or from a call to a function that results in a staged commit:
 {{#include ../../../openmls/tests/book_code.rs:alice_exports_group_info}}
 ```
 
-Calling `join_by_external_commit` requires an `MlsGroupJoinConfig` (see [Group configuration](./group_config.md) for more details). The function creates an `MlsGroup` and leave it with a commit pending to be merged.
+Calling `from_external_commit` requires an `MlsGroupJoinConfig` (see [Group configuration](./group_config.md) for more details). The function creates an `MlsGroup` and leave it with a commit pending to be merged.
 
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code.rs:charlie_joins_external_commit}}

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -491,18 +491,17 @@ impl MlsClient for MlsClientImpl {
                     .build()
             };
 
-            let (mut group, commit, _group_info) = MlsGroup::join_by_external_commit(
+            let mut external_commit = MlsGroup::from_external_commit(
                 &provider,
                 &signer,
-                ratchet_tree,
                 verifiable_group_info,
                 &mls_group_config,
-                None,
-                None,
-                b"",
-                credential_with_key,
-            )
-            .unwrap();
+                &credential_with_key,
+            );
+            if let Some(ratchet_tree) = ratchet_tree {
+                external_commit = external_commit.with_ratchet_tree(ratchet_tree);
+            }
+            let (mut group, commit, _group_info) = external_commit.build().unwrap();
 
             trace!(?commit, "Commit created.");
             debug!(commit=?group.pending_commit(), "Merging pending commit.");

--- a/openmls/src/framing/sender.rs
+++ b/openmls/src/framing/sender.rs
@@ -56,7 +56,7 @@ pub enum Sender {
     /// an [External Add proposal](crate::messages::external_proposals::JoinProposal)
     NewMemberProposal,
     /// The sender is a new member of the group that joins itself through
-    /// an [External Commit](crate::group::mls_group::MlsGroup::join_by_external_commit)
+    /// an [External Commit](crate::group::mls_group::MlsGroup::from_external_commit)
     NewMemberCommit,
 }
 

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -2,16 +2,16 @@ use openmls_traits::{signatures::Signer, types::Ciphersuite};
 use tls_codec::Serialize;
 
 use crate::{
-    binary_tree::array_representation::TreeSize,
+    binary_tree::{array_representation::TreeSize, LeafNodeIndex},
     credentials::CredentialWithKey,
     error::LibraryError,
     extensions::{errors::InvalidExtensionError, Extensions},
     group::{
-        public_group::errors::PublicGroupBuildError, GroupId, MlsGroupCreateConfig,
-        MlsGroupCreateConfigBuilder, NewGroupError, PublicGroup, WireFormatPolicy,
+        past_secrets::MessageSecretsStore, public_group::errors::PublicGroupBuildError, GroupId,
+        MlsGroup, MlsGroupCreateConfig, MlsGroupCreateConfigBuilder, MlsGroupState, NewGroupError,
+        PublicGroup, WireFormatPolicy,
     },
     key_packages::Lifetime,
-    prelude::LeafNodeIndex,
     schedule::{
         psk::{load_psks, store::ResumptionPskStore, PskSecret},
         InitSecret, JoinerSecret, KeySchedule, PreSharedKeyId,
@@ -20,8 +20,6 @@ use crate::{
     tree::sender_ratchet::SenderRatchetConfiguration,
     treesync::{errors::LeafNodeValidationError, node::leaf_node::Capabilities},
 };
-
-use super::{past_secrets::MessageSecretsStore, MlsGroup, MlsGroupState};
 
 /// Builder struct for an [`MlsGroup`].
 #[derive(Default, Debug)]

--- a/openmls/src/group/mls_group/create_commit.rs
+++ b/openmls/src/group/mls_group/create_commit.rs
@@ -12,7 +12,7 @@ pub(crate) enum CommitType {
 
 pub(crate) struct CreateCommitParams<'a> {
     framing_parameters: Option<FramingParameters<'a>>,
-    credential_with_key: CredentialWithKey,
+    credential_with_key: &'a CredentialWithKey,
 
     inline_proposals: Vec<Proposal>,          // Optional
     force_self_update: bool,                  // Optional
@@ -26,11 +26,11 @@ pub(crate) struct CreateCommitParamsBuilder<'a> {
 }
 
 impl TempBuilderCCPM0 {
-    pub(crate) fn external_commit(
+    pub(crate) fn external_commit<'a>(
         self,
-        credential_with_key: CredentialWithKey,
-        framing_parameters: FramingParameters,
-    ) -> CreateCommitParamsBuilder {
+        credential_with_key: &'a CredentialWithKey,
+        framing_parameters: FramingParameters<'a>,
+    ) -> CreateCommitParamsBuilder<'a> {
         CreateCommitParamsBuilder {
             ccp: CreateCommitParams {
                 framing_parameters: Some(framing_parameters),
@@ -69,7 +69,7 @@ impl CreateCommitParams<'_> {
         self.force_self_update
     }
     pub(crate) fn credential_with_key(&self) -> &CredentialWithKey {
-        &self.credential_with_key
+        self.credential_with_key
     }
     pub(crate) fn leaf_node_parameters(&self) -> &LeafNodeParameters {
         &self.leaf_node_parameters

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -336,7 +336,7 @@ impl ProcessedWelcome {
         &self.group_secrets.psks
     }
 
-    /// Consume the `ProcessedWelcome` and combine it witht he ratchet tree into
+    /// Consume the `ProcessedWelcome` and combine it with the ratchet tree into
     /// a `StagedWelcome`.
     pub fn into_staged_welcome<Provider: OpenMlsProvider>(
         mut self,

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -1,7 +1,9 @@
 use std::iter;
 
 use errors::NewGroupError;
-use openmls_traits::{signatures::Signer, storage::StorageProvider as StorageProviderTrait};
+use openmls_traits::{
+    signatures::Signer as SignerTrait, storage::StorageProvider as StorageProviderTrait,
+};
 
 use super::{builder::MlsGroupBuilder, *};
 use crate::{
@@ -88,6 +90,10 @@ impl MlsGroup {
     /// Note: If there is a group member in the group with the same identity as
     /// us, this will create a remove proposal.
     #[allow(clippy::too_many_arguments)]
+    #[deprecated(
+        since = "0.7.1",
+        note = "This function has too many arguments and doesn't allow disabling ratchet tree lifetime validation. Use the builder through `MlsGroup::from_exernal_commit` instead"
+    )]
     pub fn join_by_external_commit<Provider: OpenMlsProvider>(
         provider: &Provider,
         signer: &impl Signer,
@@ -100,127 +106,64 @@ impl MlsGroup {
         credential_with_key: CredentialWithKey,
     ) -> Result<(Self, MlsMessageOut, Option<GroupInfo>), ExternalCommitError<Provider::StorageError>>
     {
-        // Prepare the commit parameters
-        let framing_parameters = FramingParameters::new(aad, WireFormat::PublicMessage);
-
-        let leaf_node_parameters = LeafNodeParameters::builder()
-            .with_capabilities(capabilities.unwrap_or_default())
-            .with_extensions(extensions.unwrap_or_default())
-            .build();
-        let mut params = CreateCommitParams::builder()
-            .external_commit(credential_with_key, framing_parameters)
-            .leaf_node_parameters(leaf_node_parameters)
-            .build();
-
-        // Build the ratchet tree
-
-        // Set nodes either from the extension or from the `nodes_option`.
-        // If we got a ratchet tree extension in the welcome, we enable it for
-        // this group. Note that this is not strictly necessary. But there's
-        // currently no other mechanism to enable the extension.
-        let ratchet_tree = match verifiable_group_info.extensions().ratchet_tree() {
-            Some(extension) => extension.ratchet_tree().clone(),
-            None => match ratchet_tree {
-                Some(ratchet_tree) => ratchet_tree,
-                None => return Err(ExternalCommitError::MissingRatchetTree),
-            },
-        };
-
-        let (public_group, group_info) = PublicGroup::from_external_internal(
-            provider.crypto(),
-            ratchet_tree,
+        let mut builder = FromExternalCommitBuilder::new(
+            provider,
+            signer,
             verifiable_group_info,
-            // Existing proposals are discarded when joining by external commit.
-            ProposalStore::new(),
-        )?;
-        let group_context = public_group.group_context();
-
-        // Obtain external_pub from GroupInfo extensions.
-        let external_pub = group_info
-            .extensions()
-            .external_pub()
-            .ok_or(ExternalCommitError::MissingExternalPub)?
-            .external_pub();
-
-        let (init_secret, kem_output) = InitSecret::from_group_context(
-            provider.crypto(),
-            group_context,
-            external_pub.as_slice(),
-        )
-        .map_err(|_| ExternalCommitError::UnsupportedCiphersuite)?;
-
-        // The `EpochSecrets` we create here are essentially zero, with the
-        // exception of the `InitSecret`, which is all we need here for the
-        // external commit.
-        let ciphersuite = group_info.group_context().ciphersuite();
-        let epoch_secrets =
-            EpochSecrets::with_init_secret(provider.crypto(), ciphersuite, init_secret)
-                .map_err(LibraryError::unexpected_crypto_error)?;
-        let (group_epoch_secrets, message_secrets) = epoch_secrets.split_secrets(
-            group_context
-                .tls_serialize_detached()
-                .map_err(LibraryError::missing_bound_check)?,
-            public_group.tree_size(),
-            // We use a fake own index of 0 here, as we're not going to use the
-            // tree for encryption until after the first commit. This issue is
-            // tracked in #767.
-            LeafNodeIndex::new(0u32),
+            mls_group_config,
+            &credential_with_key,
         );
-        let message_secrets_store = MessageSecretsStore::new_with_secret(0, message_secrets);
 
-        let external_init_proposal = Proposal::ExternalInit(ExternalInitProposal::from(kem_output));
+        if let Some(ratchet_tree) = ratchet_tree {
+            builder = builder.with_ratchet_tree(ratchet_tree);
+        }
 
-        let mut inline_proposals = vec![external_init_proposal];
+        if let Some(capabilities) = capabilities {
+            builder = builder.with_capabilities(capabilities);
+        }
 
-        // If there is a group member in the group with the same identity as us,
-        // commit a remove proposal.
-        let signature_key = params.credential_with_key().signature_key.as_slice();
-        if let Some(us) = public_group
-            .members()
-            .find(|member| member.signature_key == signature_key)
-        {
-            let remove_proposal = Proposal::Remove(RemoveProposal { removed: us.index });
-            inline_proposals.push(remove_proposal);
-        };
+        if let Some(extensions) = extensions {
+            builder = builder.with_extensions(extensions);
+        }
 
-        let own_leaf_index =
-            public_group.leftmost_free_index(inline_proposals.iter(), iter::empty())?;
-        params.set_inline_proposals(inline_proposals);
+        if !aad.is_empty() {
+            builder = builder.with_aad(aad);
+        }
 
-        let mut mls_group = MlsGroup {
-            mls_group_config: mls_group_config.clone(),
-            own_leaf_nodes: vec![],
-            aad: vec![],
-            group_state: MlsGroupState::Operational,
-            public_group,
-            group_epoch_secrets,
-            own_leaf_index,
-            message_secrets_store,
-            resumption_psk_store: ResumptionPskStore::new(32),
-        };
+        builder.build()
+    }
 
-        mls_group.set_max_past_epochs(mls_group_config.max_past_epochs);
-
-        // Immediately create the commit to add ourselves to the group.
-        let create_commit_result = mls_group
-            .create_external_commit(params, provider, signer)
-            .map_err(|_| ExternalCommitError::CommitError)?;
-
-        mls_group.group_state = MlsGroupState::PendingCommit(Box::new(
-            PendingCommitState::External(create_commit_result.staged_commit),
-        ));
-
-        mls_group
-            .store(provider.storage())
-            .map_err(ExternalCommitError::StorageError)?;
-
-        let public_message: PublicMessage = create_commit_result.commit.into();
-
-        Ok((
-            mls_group,
-            public_message.into(),
-            create_commit_result.group_info,
-        ))
+    /// Join an existing group through an External Commit.
+    /// The resulting [`MlsGroup`] instance starts off with a pending
+    /// commit (the external commit, which adds this client to the group).
+    /// Merging this commit is necessary for this [`MlsGroup`] instance to
+    /// function properly, as, for example, this client is not yet part of the
+    /// tree. As a result, it is not possible to clear the pending commit. If
+    /// the external commit was rejected due to an epoch change, the
+    /// [`MlsGroup`] instance has to be discarded and a new one has to be
+    /// created using this function based on the latest `ratchet_tree` and
+    /// group info. For more information on the external init process,
+    /// please see Section 11.2.1 in the MLS specification.
+    ///
+    /// Note: If there is a group member in the group with the same identity as
+    /// us, this will create a remove proposal.
+    ///
+    /// Returns a [`FromExternalCommitBuilder`] (see for more details).
+    /// Use [`FromExternalCommitBuilder::build`] to generate the group and commit.
+    pub fn from_external_commit<'a, Provider: OpenMlsProvider, Signer: SignerTrait>(
+        provider: &'a Provider,
+        signer: &'a Signer,
+        verifiable_group_info: VerifiableGroupInfo,
+        mls_group_config: &'a MlsGroupJoinConfig,
+        credential_with_key: &'a CredentialWithKey,
+    ) -> FromExternalCommitBuilder<'a, Provider, Signer> {
+        FromExternalCommitBuilder::new(
+            provider,
+            signer,
+            verifiable_group_info,
+            mls_group_config,
+            credential_with_key,
+        )
     }
 }
 
@@ -339,9 +282,20 @@ impl ProcessedWelcome {
     /// Consume the `ProcessedWelcome` and combine it with the ratchet tree into
     /// a `StagedWelcome`.
     pub fn into_staged_welcome<Provider: OpenMlsProvider>(
+        self,
+        provider: &Provider,
+        ratchet_tree: Option<RatchetTreeIn>,
+    ) -> Result<StagedWelcome, WelcomeError<Provider::StorageError>> {
+        self.into_staged_welcome_inner(provider, ratchet_tree, LeafNodeLifetime::Verify)
+    }
+
+    /// Consume the `ProcessedWelcome` and combine it with the ratchet tree into
+    /// a `StagedWelcome`.
+    pub(crate) fn into_staged_welcome_inner<Provider: OpenMlsProvider>(
         mut self,
         provider: &Provider,
         ratchet_tree: Option<RatchetTreeIn>,
+        validate_lifetimes: LeafNodeLifetime,
     ) -> Result<StagedWelcome, WelcomeError<Provider::StorageError>> {
         // Build the ratchet tree and group
 
@@ -359,11 +313,12 @@ impl ProcessedWelcome {
 
         // Since there is currently only the external pub extension, there is no
         // group info extension of interest here.
-        let (public_group, _group_info_extensions) = PublicGroup::from_external_internal(
+        let (public_group, _group_info_extensions) = PublicGroup::from_ratchet_tree(
             provider.crypto(),
             ratchet_tree,
             self.verifiable_group_info.clone(),
             ProposalStore::new(),
+            validate_lifetimes,
         )?;
 
         // Find our own leaf in the tree.
@@ -498,6 +453,23 @@ impl StagedWelcome {
         processed_welcome.into_staged_welcome(provider, ratchet_tree)
     }
 
+    /// Similar to [`StagedWelcome::new_from_welcome`] but as a builder.
+    ///
+    /// The builder allows to set the ratchet tree, skip leaf node lifetime
+    /// validation, and get the [`ProcessedWelcome`] for inspection before staging.
+    pub fn build_from_welcome<'a, Provider: OpenMlsProvider>(
+        provider: &'a Provider,
+        mls_group_config: &MlsGroupJoinConfig,
+        welcome: Welcome,
+        // ratchet_tree: Option<RatchetTreeIn>,
+    ) -> Result<JoinBuilder<'a, Provider>, WelcomeError<Provider::StorageError>> {
+        let processed_welcome =
+            ProcessedWelcome::new_from_welcome(provider, mls_group_config, welcome)?;
+
+        // processed_welcome.into_staged_welcome(provider, ratchet_tree)
+        Ok(JoinBuilder::new(provider, processed_welcome))
+    }
+
     /// Returns the [`LeafNodeIndex`] of the group member that authored the [`Welcome`] message.
     ///
     /// [`Welcome`]: crate::messages::Welcome
@@ -598,4 +570,293 @@ fn keys_for_welcome<Provider: OpenMlsProvider>(
         log::debug!("Key package has last resort extension, not deleting");
     }
     Ok((resumption_psk_store, key_package_bundle))
+}
+
+/// Verify or skip the validation of leaf node lifetimes in the ratchet tree
+/// when joining a group.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LeafNodeLifetime {
+    /// Verify the lifetime of leaf nodes in the ratchet tree.
+    ///
+    /// **NOTE:** that only leaf nodes that have never been updated have a lifetime.
+    #[default]
+    Verify,
+
+    /// Skip the verification of the lifeimte in leaf nodes in the ratchet tree.
+    Skip,
+}
+
+/// Builder for joining a group with an external commit.
+///
+/// This should be preferred over [`MlsGroup::join_by_external_commit`].
+pub struct FromExternalCommitBuilder<'a, Provider: OpenMlsProvider, Signer: SignerTrait> {
+    provider: &'a Provider,
+    signer: &'a Signer,
+    ratchet_tree: Option<RatchetTreeIn>,
+    verifiable_group_info: VerifiableGroupInfo,
+    mls_group_config: &'a MlsGroupJoinConfig,
+    capabilities: Option<Capabilities>,
+    extensions: Option<Extensions>,
+    aad: &'a [u8],
+    credential_with_key: &'a CredentialWithKey,
+    validate_lifetimes: LeafNodeLifetime,
+}
+
+impl<'a, Provider: OpenMlsProvider, Signer: SignerTrait>
+    FromExternalCommitBuilder<'a, Provider, Signer>
+{
+    /// Creates a new builder for constructing an `MlsGroup` from an external commit.
+    ///
+    /// This function initializes the builder with all the mandatory fields.
+    /// Optional fields can be added later using the `with_*` methods.
+    ///
+    /// # Arguments
+    ///
+    /// * `provider` - A reference to an [`OpenMlsProvider`] instance.
+    /// * `signer` - A reference to a [`Signer`].
+    /// * `verifiable_group_info` - The [`VerifiableGroupInfo`] for the group.
+    /// * `mls_group_config` - The join configuration for the [`MlsGroup`].
+    /// * `credential_with_key` - The credential and private key of the new member.
+    pub fn new(
+        provider: &'a Provider,
+        signer: &'a Signer,
+        verifiable_group_info: VerifiableGroupInfo,
+        mls_group_config: &'a MlsGroupJoinConfig,
+        credential_with_key: &'a CredentialWithKey,
+    ) -> Self {
+        Self {
+            provider,
+            signer,
+            ratchet_tree: None, // Optional, defaults to None
+            verifiable_group_info,
+            mls_group_config,
+            capabilities: None, // Optional, defaults to None
+            extensions: None,   // Optional, defaults to None
+            aad: &[],           // Optional, defaults to empty
+            credential_with_key,
+            validate_lifetimes: LeafNodeLifetime::default(),
+        }
+    }
+
+    /// Sets the ratchet tree for the group.
+    ///
+    /// This is an optional field. If not provided, the provided group info must
+    /// contain the ratchet tree.
+    pub fn with_ratchet_tree(mut self, ratchet_tree: RatchetTreeIn) -> Self {
+        self.ratchet_tree = Some(ratchet_tree);
+        self
+    }
+
+    /// Sets the own capabilities .
+    pub fn with_capabilities(mut self, capabilities: Capabilities) -> Self {
+        self.capabilities = Some(capabilities);
+        self
+    }
+
+    /// Sets the extensions for the new own leaf node.
+    pub fn with_extensions(mut self, extensions: Extensions) -> Self {
+        self.extensions = Some(extensions);
+        self
+    }
+
+    /// Configures whether to validate the lifetimes of leaf nodes in the ratchet
+    /// tree or not.
+    ///
+    /// By default they are validated.
+    pub fn validate_lifetimes(mut self, validate: LeafNodeLifetime) -> Self {
+        self.validate_lifetimes = validate;
+        self
+    }
+
+    /// Additional authenticated data, used in the framing of the external commit.
+    ///
+    /// By default this is empty.
+    pub fn with_aad(mut self, aad: &'a [u8]) -> Self {
+        self.aad = aad;
+        self
+    }
+
+    /// Consumes the builder and creates the [`MlsGroup`], [`MlsMessageOut`], and
+    /// (optionally) the [`GroupInfo`].
+    pub fn build(
+        self,
+    ) -> Result<
+        (MlsGroup, MlsMessageOut, Option<GroupInfo>),
+        ExternalCommitError<Provider::StorageError>,
+    > {
+        // Prepare the commit parameters
+        let framing_parameters = FramingParameters::new(self.aad, WireFormat::PublicMessage);
+
+        let leaf_node_parameters = LeafNodeParameters::builder()
+            .with_capabilities(self.capabilities.unwrap_or_default())
+            .with_extensions(self.extensions.unwrap_or_default())
+            .build();
+        let mut params = CreateCommitParams::builder()
+            .external_commit(self.credential_with_key, framing_parameters)
+            .leaf_node_parameters(leaf_node_parameters)
+            .build();
+
+        // Build the ratchet tree
+
+        // Set nodes either from the extension or from the `nodes_option`.
+        // If we got a ratchet tree extension in the welcome, we enable it for
+        // this group. Note that this is not strictly necessary. But there's
+        // currently no other mechanism to enable the extension.
+        let ratchet_tree = match self.verifiable_group_info.extensions().ratchet_tree() {
+            Some(extension) => extension.ratchet_tree().clone(),
+            None => match self.ratchet_tree {
+                Some(ratchet_tree) => ratchet_tree,
+                None => return Err(ExternalCommitError::MissingRatchetTree),
+            },
+        };
+
+        let (public_group, group_info) = PublicGroup::from_ratchet_tree(
+            self.provider.crypto(),
+            ratchet_tree,
+            self.verifiable_group_info,
+            // Existing proposals are discarded when joining by external commit.
+            ProposalStore::new(),
+            self.validate_lifetimes,
+        )?;
+        let group_context = public_group.group_context();
+
+        // Obtain external_pub from GroupInfo extensions.
+        let external_pub = group_info
+            .extensions()
+            .external_pub()
+            .ok_or(ExternalCommitError::MissingExternalPub)?
+            .external_pub();
+
+        let (init_secret, kem_output) = InitSecret::from_group_context(
+            self.provider.crypto(),
+            group_context,
+            external_pub.as_slice(),
+        )
+        .map_err(|_| ExternalCommitError::UnsupportedCiphersuite)?;
+
+        // The `EpochSecrets` we create here are essentially zero, with the
+        // exception of the `InitSecret`, which is all we need here for the
+        // external commit.
+        let ciphersuite = group_info.group_context().ciphersuite();
+        let epoch_secrets =
+            EpochSecrets::with_init_secret(self.provider.crypto(), ciphersuite, init_secret)
+                .map_err(LibraryError::unexpected_crypto_error)?;
+        let (group_epoch_secrets, message_secrets) = epoch_secrets.split_secrets(
+            group_context
+                .tls_serialize_detached()
+                .map_err(LibraryError::missing_bound_check)?,
+            public_group.tree_size(),
+            // We use a fake own index of 0 here, as we're not going to use the
+            // tree for encryption until after the first commit. This issue is
+            // tracked in #767.
+            LeafNodeIndex::new(0u32),
+        );
+        let message_secrets_store = MessageSecretsStore::new_with_secret(0, message_secrets);
+
+        let external_init_proposal = Proposal::ExternalInit(ExternalInitProposal::from(kem_output));
+
+        let mut inline_proposals = vec![external_init_proposal];
+
+        // If there is a group member in the group with the same identity as us,
+        // commit a remove proposal.
+        let signature_key = params.credential_with_key().signature_key.as_slice();
+        if let Some(us) = public_group
+            .members()
+            .find(|member| member.signature_key == signature_key)
+        {
+            let remove_proposal = Proposal::Remove(RemoveProposal { removed: us.index });
+            inline_proposals.push(remove_proposal);
+        };
+
+        let own_leaf_index =
+            public_group.leftmost_free_index(inline_proposals.iter(), iter::empty())?;
+        params.set_inline_proposals(inline_proposals);
+
+        let mut mls_group = MlsGroup {
+            mls_group_config: self.mls_group_config.clone(),
+            own_leaf_nodes: vec![],
+            aad: vec![],
+            group_state: MlsGroupState::Operational,
+            public_group,
+            group_epoch_secrets,
+            own_leaf_index,
+            message_secrets_store,
+            resumption_psk_store: ResumptionPskStore::new(32),
+        };
+
+        mls_group.set_max_past_epochs(self.mls_group_config.max_past_epochs);
+
+        // Immediately create the commit to add ourselves to the group.
+        let create_commit_result = mls_group
+            .create_external_commit(params, self.provider, self.signer)
+            .map_err(|_| ExternalCommitError::CommitError)?;
+
+        mls_group.group_state = MlsGroupState::PendingCommit(Box::new(
+            PendingCommitState::External(create_commit_result.staged_commit),
+        ));
+
+        mls_group
+            .store(self.provider.storage())
+            .map_err(ExternalCommitError::StorageError)?;
+
+        let public_message: PublicMessage = create_commit_result.commit.into();
+
+        Ok((
+            mls_group,
+            public_message.into(),
+            create_commit_result.group_info,
+        ))
+    }
+}
+
+/// Builder for joining a group.
+///
+/// Create this with [`StagedWelcome::build_from_welcome`].
+pub struct JoinBuilder<'a, Provider: OpenMlsProvider> {
+    provider: &'a Provider,
+    processed_welcome: ProcessedWelcome,
+    ratchet_tree: Option<RatchetTreeIn>,
+    validate_lifetimes: LeafNodeLifetime,
+}
+
+impl<'a, Provider: OpenMlsProvider> JoinBuilder<'a, Provider> {
+    /// Create a new builder for the [`JoinBuilder`].
+    pub(crate) fn new(provider: &'a Provider, processed_welcome: ProcessedWelcome) -> Self {
+        Self {
+            provider,
+            processed_welcome,
+            ratchet_tree: None,
+            validate_lifetimes: LeafNodeLifetime::Verify,
+        }
+    }
+
+    /// The ratchet tree to use for the new group.
+    pub fn with_ratchet_tree(mut self, ratchet_tree: RatchetTreeIn) -> Self {
+        self.ratchet_tree = Some(ratchet_tree);
+        self
+    }
+
+    /// Skip the validation of lifetimes in leaf nodes in the ratchet tree.
+    ///
+    /// Note that only the leaf nodes are checked that were never updated.
+    pub fn skip_lifetime_validation(mut self) -> Self {
+        self.validate_lifetimes = LeafNodeLifetime::Skip;
+        self
+    }
+
+    /// Get a reference to the [`ProcessedWelcome`].
+    ///
+    /// Use this to inspect the [`Welcome`] message before validation.
+    pub fn processed_welcome(&self) -> &ProcessedWelcome {
+        &self.processed_welcome
+    }
+
+    /// Build the [`StagedWelcome`].
+    pub fn build(self) -> Result<StagedWelcome, WelcomeError<Provider::StorageError>> {
+        self.processed_welcome.into_staged_welcome_inner(
+            self.provider,
+            self.ratchet_tree,
+            self.validate_lifetimes,
+        )
+    }
 }

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -51,7 +51,6 @@ use openmls_traits::{signatures::Signer, storage::StorageProvider as _, types::C
 
 // Private
 mod application;
-mod creation;
 mod exporting;
 mod updates;
 
@@ -62,6 +61,7 @@ pub(crate) mod builder;
 pub(crate) mod commit_builder;
 pub(crate) mod config;
 pub(crate) mod create_commit;
+pub(crate) mod creation;
 pub(crate) mod errors;
 pub(crate) mod membership;
 pub(crate) mod past_secrets;
@@ -150,7 +150,7 @@ impl From<PendingCommitState> for StagedCommit {
 ///   allows access to all of its functionality, (except merging pending commits,
 ///   see the [`MlsGroupState::PendingCommit`] for more information) and it's the
 ///   state the group starts in (except when created via
-///   [`MlsGroup::join_by_external_commit()`], see the functions documentation for
+///   [`MlsGroup::from_external_commit()`], see the functions documentation for
 ///   more information). From this `Operational`, the group state can either
 ///   transition to [`MlsGroupState::Inactive`], when it processes a commit that
 ///   removes this client from the group, or to [`MlsGroupState::PendingCommit`],
@@ -180,12 +180,12 @@ impl From<PendingCommitState> for StagedCommit {
 ///
 ///   * A group can enter the [`PendingCommitState::External`] sub-state only as
 ///     the initial state when the group is created via
-///     [`MlsGroup::join_by_external_commit()`]. In contrast to the
+///     [`MlsGroup::from_external_commit()`]. In contrast to the
 ///     [`PendingCommitState::Member`] `PendingCommit` state, the only possible
 ///     functionality that can be used is the [`MlsGroup::merge_pending_commit()`]
 ///     function, which merges the pending external commit and transitions the
 ///     state to [`MlsGroupState::PendingCommit`]. For more information on the
-///     external commit process, see [`MlsGroup::join_by_external_commit()`] or
+///     external commit process, see [`MlsGroup::from_external_commit()`] or
 ///     Section 11.2.1 of the MLS specification.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
@@ -359,7 +359,7 @@ impl MlsGroup {
     ///
     /// Note that this has no effect if the group was created through an external commit and
     /// the resulting external commit has not been merged yet. For more
-    /// information, see [`MlsGroup::join_by_external_commit()`].
+    /// information, see [`MlsGroup::from_external_commit()`].
     ///
     /// Use with caution! This function should only be used if it is clear that
     /// the pending commit will not be used in the group. In particular, if a

--- a/openmls/src/group/mls_group/tests_and_kats/tests/external_init.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/external_init.rs
@@ -25,17 +25,14 @@ fn test_external_init_broken_signature() {
         verifiable_group_info
     };
 
-    let result = MlsGroup::join_by_external_commit(
+    let result = MlsGroup::from_external_commit(
         provider,
         &charlie_signer,
-        None,
         verifiable_group_info,
         &MlsGroupJoinConfig::default(),
-        None,
-        None,
-        &[],
-        charlie_credential,
+        &charlie_credential,
     )
+    .build()
     .expect_err("Signature was corrupted. This should have failed.");
     assert!(matches!(
         result,

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -26,6 +26,7 @@ pub use group_context::GroupContext;
 pub use mls_group::builder::*;
 pub use mls_group::commit_builder::*;
 pub use mls_group::config::*;
+pub use mls_group::creation::*;
 pub use mls_group::membership::*;
 pub use mls_group::proposal_store::*;
 pub use mls_group::staged_commit::StagedCommit;

--- a/openmls/src/group/public_group/mod.rs
+++ b/openmls/src/group/public_group/mod.rs
@@ -278,7 +278,7 @@ impl PublicGroup {
         public_group
             .treesync
             .full_leaves()
-            .try_for_each(|leaf_node| public_group.validate_leaf_node(leaf_node))?;
+            .try_for_each(|leaf_node| public_group.validate_leaf_node_inner(leaf_node, true))?;
 
         Ok((public_group, group_info))
     }

--- a/openmls/src/group/public_group/mod.rs
+++ b/openmls/src/group/public_group/mod.rs
@@ -35,6 +35,7 @@ use crate::{
     error::LibraryError,
     extensions::RequiredCapabilitiesExtension,
     framing::{InterimTranscriptHashInput, Sender},
+    group::mls_group::creation::LeafNodeLifetime,
     messages::{
         group_info::{GroupInfo, VerifiableGroupInfo},
         proposals::Proposal,
@@ -123,11 +124,12 @@ impl PublicGroup {
     where
         StorageProvider: PublicStorageProvider<Error = StorageError>,
     {
-        let (public_group, group_info) = PublicGroup::from_external_internal(
+        let (public_group, group_info) = PublicGroup::from_ratchet_tree(
             crypto,
             ratchet_tree,
             verifiable_group_info,
             proposal_store,
+            LeafNodeLifetime::Verify,
         )?;
 
         public_group
@@ -136,11 +138,13 @@ impl PublicGroup {
 
         Ok((public_group, group_info))
     }
-    pub(crate) fn from_external_internal<StorageError>(
+
+    pub(crate) fn from_ratchet_tree<StorageError>(
         crypto: &impl OpenMlsCrypto,
         ratchet_tree: RatchetTreeIn,
         verifiable_group_info: VerifiableGroupInfo,
         proposal_store: ProposalStore,
+        validate_lifetimes: LeafNodeLifetime,
     ) -> Result<(Self, GroupInfo), CreationFromExternalError<StorageError>> {
         let ciphersuite = verifiable_group_info.ciphersuite();
 
@@ -278,7 +282,9 @@ impl PublicGroup {
         public_group
             .treesync
             .full_leaves()
-            .try_for_each(|leaf_node| public_group.validate_leaf_node_inner(leaf_node, true))?;
+            .try_for_each(|leaf_node| {
+                public_group.validate_leaf_node_inner(leaf_node, validate_lifetimes)
+            })?;
 
         Ok((public_group, group_info))
     }

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -7,6 +7,7 @@ use openmls_traits::types::VerifiableCiphersuite;
 
 use super::PublicGroup;
 use crate::extensions::RequiredCapabilitiesExtension;
+use crate::group::creation::LeafNodeLifetime;
 use crate::group::proposal_store::ProposalQueue;
 use crate::group::GroupContextExtensionsProposalValidationError;
 use crate::prelude::LibraryError;
@@ -657,7 +658,7 @@ impl PublicGroup {
         leaf_node: &crate::treesync::LeafNode,
     ) -> Result<(), LeafNodeValidationError> {
         // Call the validation function and validate the lifetime
-        self.validate_leaf_node_inner(leaf_node, false)
+        self.validate_leaf_node_inner(leaf_node, LeafNodeLifetime::Verify)
     }
 
     /// Validate a leaf node.
@@ -666,7 +667,7 @@ impl PublicGroup {
     pub(crate) fn validate_leaf_node_inner(
         &self,
         leaf_node: &crate::treesync::LeafNode,
-        ratchet_tree: bool,
+        validate_lifetimes: LeafNodeLifetime,
     ) -> Result<(), LeafNodeValidationError> {
         // https://validation.openmls.tech/#valn0103
         // https://validation.openmls.tech/#valn0104
@@ -686,12 +687,13 @@ impl PublicGroup {
         // but acknowledges already that this may cause issues.
         // https://www.rfc-editor.org/rfc/rfc9420.html#section-7.3-4.5.1
         // See #1810 for more background.
-        // We therefore DO NOT check the lifetime if this is a leaf node check
-        // for a ratchet tree.
+        // We therefore check the lifetime by default, but skip it if ...
         //
         // Some KATs use key packages that are expired by now. In order to run these tests, we
         // provide a way to turn off this check.
-        if !ratchet_tree && !crate::skip_validation::is_disabled::leaf_node_lifetime() {
+        if matches!(validate_lifetimes, LeafNodeLifetime::Verify)
+            && !crate::skip_validation::is_disabled::leaf_node_lifetime()
+        {
             if let Some(lifetime) = leaf_node.life_time() {
                 if !lifetime.is_valid() {
                     log::warn!("offending lifetime: {lifetime:?}");

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -154,6 +154,7 @@ impl<'a, 'b: 'a, Provider: OpenMlsProvider> PreGroupPartyState<'b, Provider> {
             },
             Extensions::default(),
             &self.core_state.provider,
+            None,
             &self.signer,
         );
     }

--- a/openmls/src/group/tests_and_kats/tests/external_commit.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_commit.rs
@@ -50,19 +50,17 @@ fn test_external_commit() {
         .unwrap()
         .into_verifiable_group_info()
         .unwrap();
-    let tree_option = alice_group.export_ratchet_tree();
+    let tree = alice_group.export_ratchet_tree();
 
-    let (mut bob_group, public_message_commit, _) = MlsGroup::join_by_external_commit(
+    let (mut bob_group, public_message_commit, _) = MlsGroup::from_external_commit(
         provider,
         &bob_credential.signer,
-        Some(tree_option.into()),
         verifiable_group_info,
         alice_group.configuration(),
-        None,
-        None,
-        &[],
-        bob_credential.credential_with_key.clone(),
+        &bob_credential.credential_with_key,
     )
+    .with_ratchet_tree(tree.into())
+    .build()
     .unwrap();
     bob_group.merge_pending_commit(provider).unwrap();
 
@@ -115,19 +113,17 @@ fn test_external_commit() {
         .unwrap()
         .into_verifiable_group_info()
         .unwrap();
-    let tree_option = alice_group.export_ratchet_tree();
+    let tree = alice_group.export_ratchet_tree();
 
-    let (mut charlie_group, public_message_commit, _) = MlsGroup::join_by_external_commit(
+    let (mut charlie_group, public_message_commit, _) = MlsGroup::from_external_commit(
         provider,
         &charlie_credential.signer,
-        Some(tree_option.into()),
         verifiable_group_info,
         alice_group.configuration(),
-        None,
-        None,
-        &[],
-        charlie_credential.credential_with_key.clone(),
+        &charlie_credential.credential_with_key,
     )
+    .with_ratchet_tree(tree.into())
+    .build()
     .unwrap();
     charlie_group.merge_pending_commit(provider).unwrap();
 
@@ -189,19 +185,17 @@ fn test_external_commit() {
         .unwrap()
         .into_verifiable_group_info()
         .unwrap();
-    let tree_option = bob_group.export_ratchet_tree();
+    let tree = bob_group.export_ratchet_tree();
 
-    let (mut alice_group, public_message_commit, _) = MlsGroup::join_by_external_commit(
+    let (mut alice_group, public_message_commit, _) = MlsGroup::from_external_commit(
         provider,
         &alice_credential.signer,
-        Some(tree_option.into()),
         verifiable_group_info,
         bob_group.configuration(),
-        None,
-        None,
-        &[],
-        alice_credential.credential_with_key.clone(),
+        &alice_credential.credential_with_key,
     )
+    .with_ratchet_tree(tree.into())
+    .build()
     .unwrap();
     alice_group.merge_pending_commit(provider).unwrap();
 

--- a/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
@@ -196,17 +196,14 @@ fn test_valsem242() {
         .into_verifiable_group_info()
         .unwrap();
 
-    let (_, public_message_commit, _) = MlsGroup::join_by_external_commit(
+    let (_, public_message_commit, _) = MlsGroup::from_external_commit(
         provider,
         &bob_credential.signer,
-        None,
         verifiable_group_info,
         alice_group.configuration(),
-        None,
-        None,
-        &[],
-        bob_credential.credential_with_key.clone(),
+        &bob_credential.credential_with_key,
     )
+    .build()
     .unwrap();
 
     let public_message_commit = {
@@ -576,17 +573,14 @@ fn test_pure_ciphertest() {
         .into_verifiable_group_info()
         .unwrap();
 
-    let (_bob_group, message, _) = MlsGroup::join_by_external_commit(
+    let (_bob_group, message, _) = MlsGroup::from_external_commit(
         provider,
         &bob_credential.signer,
-        None,
         verifiable_group_info,
         alice_group.configuration(),
-        None,
-        None,
-        &[],
-        bob_credential.credential_with_key.clone(),
+        &bob_credential.credential_with_key,
     )
+    .build()
     .expect("Error initializing group externally.");
 
     let mls_message_in: MlsMessageIn = message.into();
@@ -661,19 +655,17 @@ mod utils {
             .unwrap()
             .into_verifiable_group_info()
             .unwrap();
-        let tree_option = alice_group.export_ratchet_tree();
+        let tree = alice_group.export_ratchet_tree();
 
-        let (_, public_message_commit, _) = MlsGroup::join_by_external_commit(
+        let (_, public_message_commit, _) = MlsGroup::from_external_commit(
             provider,
             &bob_credential.signer,
-            Some(tree_option.into()),
             verifiable_group_info,
             alice_group.configuration(),
-            None,
-            None,
-            &[],
-            bob_credential.credential_with_key.clone(),
+            &bob_credential.credential_with_key,
         )
+        .with_ratchet_tree(tree.into())
+        .build()
         .unwrap();
 
         let public_message_commit = {

--- a/openmls/src/key_packages/lifetime.rs
+++ b/openmls/src/key_packages/lifetime.rs
@@ -73,6 +73,14 @@ impl Lifetime {
         }
     }
 
+    /// Initialize raw lifetime without skew and explicit dates.
+    pub fn init(not_before: u64, not_after: u64) -> Self {
+        Self {
+            not_before,
+            not_after,
+        }
+    }
+
     /// Returns true if this lifetime is valid.
     pub fn is_valid(&self) -> bool {
         match SystemTime::now()

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -292,17 +292,14 @@ fn book_operations() {
     // ANCHOR_END: alice_exports_group_info
 
     // ANCHOR: charlie_joins_external_commit
-    let (mut dave_group, _out, _group_info) = MlsGroup::join_by_external_commit(
+    let (mut dave_group, _out, _group_info) = MlsGroup::from_external_commit(
         provider,
         &dave_signature_keys,
-        None, // No ratchtet tree extension
         verifiable_group_info,
         &mls_group_config,
-        None, // No special capabilities
-        None, // No special extensions
-        &[],
-        dave_credential,
+        &dave_credential,
     )
+    .build()
     .expect("Error joining from external commit");
     dave_group
         .merge_pending_commit(provider)

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -390,17 +390,15 @@ fn discard_commit_external_join() {
 
     let aad = vec![0; 32];
 
-    let (mut bob_group, _message, _group_info) = MlsGroup::join_by_external_commit(
+    let (mut bob_group, _message, _group_info) = MlsGroup::from_external_commit(
         bob_provider,
         &bob_signer,
-        None,
         verifiable_group_info,
         &MlsGroupJoinConfig::default(),
-        None,
-        None,
-        &aad,
-        bob_credential,
+        &bob_credential,
     )
+    .with_aad(&aad)
+    .build()
     .expect("could not create external join commit");
 
     // === Delivery service rejected the commit ===

--- a/openmls/tests/external_commit.rs
+++ b/openmls/tests/external_commit.rs
@@ -78,17 +78,14 @@ fn test_external_commit() {
         let (bob_credential, bob_signature_keys) =
             new_credential(provider, b"Bob", ciphersuite.signature_algorithm());
 
-        let (_bob_group, _, _) = MlsGroup::join_by_external_commit(
+        let (_bob_group, _, _) = MlsGroup::from_external_commit(
             provider,
             &bob_signature_keys,
-            None,
             verifiable_group_info,
             &MlsGroupJoinConfig::default(),
-            None,
-            None,
-            b"",
-            bob_credential,
+            &bob_credential,
         )
+        .build()
         .unwrap();
     }
 
@@ -97,17 +94,14 @@ fn test_external_commit() {
         let (bob_credential, bob_signature_keys) =
             new_credential(provider, b"Bob", ciphersuite.signature_algorithm());
 
-        let got_error = MlsGroup::join_by_external_commit(
+        let got_error = MlsGroup::from_external_commit(
             provider,
             &bob_signature_keys,
-            None,
             verifiable_group_info_broken,
             &MlsGroupJoinConfig::default(),
-            None,
-            None,
-            b"",
-            bob_credential,
+            &bob_credential,
         )
+        .build()
         .unwrap_err();
 
         assert!(matches!(
@@ -140,19 +134,16 @@ fn test_group_info() {
 
         VerifiableGroupInfo::tls_deserialize(&mut serialized_group_info.as_slice()).unwrap()
     };
-    let (mut bob_group, msg, group_info) = MlsGroup::join_by_external_commit(
+    let (mut bob_group, msg, group_info) = MlsGroup::from_external_commit(
         provider,
         &bob_signature_keys,
-        None,
         verifiable_group_info,
         &MlsGroupJoinConfig::builder()
             .use_ratchet_tree_extension(true)
             .build(),
-        None,
-        None,
-        b"",
-        bob_credential,
+        &bob_credential,
     )
+    .build()
     .map(|(group, msg, group_info)| (group, MlsMessageIn::from(msg), group_info))
     .unwrap();
     bob_group.merge_pending_commit(provider).unwrap();
@@ -193,17 +184,14 @@ fn test_group_info() {
 
         VerifiableGroupInfo::tls_deserialize(&mut serialized_group_info.as_slice()).unwrap()
     };
-    let (mut bob_group, ..) = MlsGroup::join_by_external_commit(
+    let (mut bob_group, ..) = MlsGroup::from_external_commit(
         provider,
         &bob_signature_keys,
-        None,
         verifiable_group_info,
         &MlsGroupJoinConfig::default(),
-        None,
-        None,
-        b"",
-        bob_credential,
+        &bob_credential,
     )
+    .build()
     .unwrap();
     bob_group.merge_pending_commit(provider).unwrap();
 }

--- a/openmls/tests/join.rs
+++ b/openmls/tests/join.rs
@@ -8,89 +8,121 @@ use openmls_test::openmls_test;
 
 #[openmls_test]
 fn join_tree_with_outdated_leafnodes() {
-    // The validity of the key package into the future.
-    // This has to be short to keep the test run fast, but not too short to produce
-    // failing tests.
-    const VALIDITY: u64 = 2;
+    let setup = || {
+        // The validity of the key package into the future.
+        // This has to be short to keep the test run fast, but not too short to produce
+        // failing tests.
+        const VALIDITY: u64 = 2;
 
-    let alice_party = CorePartyState::<Provider>::new("alice");
-    let bob_party = CorePartyState::<Provider>::new("bob");
-    let charlie_party = CorePartyState::<Provider>::new("charlie");
+        let alice_party = CorePartyState::<Provider>::new("alice");
+        let bob_party = CorePartyState::<Provider>::new("bob");
+        let charlie_party = CorePartyState::<Provider>::new("charlie");
 
-    // Create group
-    let create_config = MlsGroupCreateConfig::test_default_from_ciphersuite(ciphersuite);
-    let join_config = create_config.join_config().clone();
-    let mut group_state = {
-        let group_id = GroupId::from_slice(b"Test Group");
+        // Create group
+        let create_config = MlsGroupCreateConfig::test_default_from_ciphersuite(ciphersuite);
+        let join_config = create_config.join_config().clone();
+        let mut group_state = {
+            let group_id = GroupId::from_slice(b"Test Group");
 
-        let group_state = GroupState::new_from_party(
-            group_id,
-            alice_party.generate_pre_group(ciphersuite),
-            create_config,
-        )
-        .unwrap();
-        group_state
+            let group_state = GroupState::new_from_party(
+                group_id,
+                alice_party.generate_pre_group(ciphersuite),
+                create_config,
+            )
+            .unwrap();
+            group_state
+        };
+
+        // Create Charlie key package
+        let charlie_pre_group = charlie_party.generate_pre_group(ciphersuite);
+        let charlie_key_package = charlie_pre_group.key_package_bundle.key_package().clone();
+
+        // Generate a key package for Bob that is outdated when inviting Charlie.
+        // This test assumes that the setup goes through within VALIDITY seconds.
+        // After that the key package is invalid already.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("SystemTime before UNIX EPOCH!")
+            .as_secs();
+        let bob_pre_group = bob_party
+            .generate_pre_group_lifetime(ciphersuite, Lifetime::init(now - 60, now + VALIDITY));
+        let bob_key_package = bob_pre_group.key_package_bundle.key_package().clone();
+
+        let [alice] = group_state.members_mut(&["alice"]);
+
+        // Alice adds Bob
+        let (_mls_message_out, _welcome, _group_info) = alice
+            .group
+            .add_members(
+                &alice_party.provider,
+                &alice.party.signer,
+                &[bob_key_package],
+            )
+            .expect("Could not add Bob.");
+
+        alice
+            .group
+            .merge_pending_commit(&alice_party.provider)
+            .unwrap();
+
+        // We don't care about Bob actually processing the Welcome.
+        // Let's wait for VALIDITY seconds to ensure that the leaf node is invalid.
+        thread::sleep(Duration::from_secs(VALIDITY));
+
+        // Alice adds Charlie
+        // At this point Bob's key package is outdated in the tree.
+        let (_mls_message_out, welcome, _group_info) = alice
+            .group
+            .add_members(
+                &alice_party.provider,
+                &alice.party.signer,
+                &[charlie_key_package],
+            )
+            .expect("Could not add Charlie.");
+
+        alice
+            .group
+            .merge_pending_commit(&alice_party.provider)
+            .unwrap();
+
+        (welcome, charlie_party, join_config)
     };
 
-    // Create Charlie key package
-    let charlie_pre_group = charlie_party.generate_pre_group(ciphersuite);
-    let charlie_key_package = charlie_pre_group.key_package_bundle.key_package().clone();
-
-    // Generate a key package for Bob that is outdated when inviting Charlie.
-    // This test assumes that the setup goes through within VALIDITY seconds.
-    // After that the key package is invalid already.
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("SystemTime before UNIX EPOCH!")
-        .as_secs();
-    let bob_pre_group = bob_party
-        .generate_pre_group_lifetime(ciphersuite, Lifetime::init(now - 60, now + VALIDITY));
-    let bob_key_package = bob_pre_group.key_package_bundle.key_package().clone();
-
-    let [alice] = group_state.members_mut(&["alice"]);
-
-    // Alice adds Bob
-    let (_mls_message_out, _welcome, _group_info) = alice
-        .group
-        .add_members(
-            &alice_party.provider,
-            &alice.party.signer,
-            &[bob_key_package],
-        )
-        .expect("Could not add Bob.");
-
-    alice
-        .group
-        .merge_pending_commit(&alice_party.provider)
-        .unwrap();
-
-    // We don't care about Bob actually processing the Welcome.
-    // Let's wait for VALIDITY seconds to ensure that the leaf node is invalid.
-    thread::sleep(Duration::from_secs(VALIDITY));
-
-    // Alice adds Charlie
-    // At this point Bob's key package is outdated in the tree.
-    let (_mls_message_out, welcome, _group_info) = alice
-        .group
-        .add_members(
-            &alice_party.provider,
-            &alice.party.signer,
-            &[charlie_key_package],
-        )
-        .expect("Could not add Charlie.");
-
-    alice
-        .group
-        .merge_pending_commit(&alice_party.provider)
-        .unwrap();
+    let (welcome, charlie_party, join_config) = setup();
 
     // Charlie tries to join the group
-    let _charlie_group = StagedWelcome::new_from_welcome(
+    // Here joining fails because the lifetimes are validated.
+    let _error = StagedWelcome::build_from_welcome(
+        &charlie_party.provider,
+        &join_config,
+        MlsMessageIn::from(welcome).into_welcome().unwrap(),
+    )
+    .unwrap()
+    .build()
+    .expect_err("Created group even if this should've failed.");
+
+    let (welcome, charlie_party, join_config) = setup();
+
+    let _error = StagedWelcome::new_from_welcome(
         &charlie_party.provider,
         &join_config,
         MlsMessageIn::from(welcome).into_welcome().unwrap(),
         None,
     )
+    .expect_err("Created group even if this should've failed.");
+
+    let (welcome, charlie_party, join_config) = setup();
+
+    // Charlie tries to join the group
+    // Here joining should succeed because lifetimes aren't validated.
+    let _charlie_group = StagedWelcome::build_from_welcome(
+        &charlie_party.provider,
+        &join_config,
+        MlsMessageIn::from(welcome).into_welcome().unwrap(),
+    )
+    .unwrap()
+    .skip_lifetime_validation()
+    .build()
     .expect("Failed to create group due to an invalid lifetime in a leaf node in the tree.")
     .into_group(provider)
     .unwrap();

--- a/openmls/tests/join.rs
+++ b/openmls/tests/join.rs
@@ -1,0 +1,97 @@
+use std::{
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use openmls::{prelude::*, test_utils::single_group_test_framework::*};
+use openmls_test::openmls_test;
+
+#[openmls_test]
+fn join_tree_with_outdated_leafnodes() {
+    // The validity of the key package into the future.
+    // This has to be short to keep the test run fast, but not too short to produce
+    // failing tests.
+    const VALIDITY: u64 = 2;
+
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let bob_party = CorePartyState::<Provider>::new("bob");
+    let charlie_party = CorePartyState::<Provider>::new("charlie");
+
+    // Create group
+    let create_config = MlsGroupCreateConfig::test_default_from_ciphersuite(ciphersuite);
+    let join_config = create_config.join_config().clone();
+    let mut group_state = {
+        let group_id = GroupId::from_slice(b"Test Group");
+
+        let group_state = GroupState::new_from_party(
+            group_id,
+            alice_party.generate_pre_group(ciphersuite),
+            create_config,
+        )
+        .unwrap();
+        group_state
+    };
+
+    // Create Charlie key package
+    let charlie_pre_group = charlie_party.generate_pre_group(ciphersuite);
+    let charlie_key_package = charlie_pre_group.key_package_bundle.key_package().clone();
+
+    // Generate a key package for Bob that is outdated when inviting Charlie.
+    // This test assumes that the setup goes through within VALIDITY seconds.
+    // After that the key package is invalid already.
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("SystemTime before UNIX EPOCH!")
+        .as_secs();
+    let bob_pre_group = bob_party
+        .generate_pre_group_lifetime(ciphersuite, Lifetime::init(now - 60, now + VALIDITY));
+    let bob_key_package = bob_pre_group.key_package_bundle.key_package().clone();
+
+    let [alice] = group_state.members_mut(&["alice"]);
+
+    // Alice adds Bob
+    let (_mls_message_out, _welcome, _group_info) = alice
+        .group
+        .add_members(
+            &alice_party.provider,
+            &alice.party.signer,
+            &[bob_key_package],
+        )
+        .expect("Could not add Bob.");
+
+    alice
+        .group
+        .merge_pending_commit(&alice_party.provider)
+        .unwrap();
+
+    // We don't care about Bob actually processing the Welcome.
+    // Let's wait for VALIDITY seconds to ensure that the leaf node is invalid.
+    thread::sleep(Duration::from_secs(VALIDITY));
+
+    // Alice adds Charlie
+    // At this point Bob's key package is outdated in the tree.
+    let (_mls_message_out, welcome, _group_info) = alice
+        .group
+        .add_members(
+            &alice_party.provider,
+            &alice.party.signer,
+            &[charlie_key_package],
+        )
+        .expect("Could not add Charlie.");
+
+    alice
+        .group
+        .merge_pending_commit(&alice_party.provider)
+        .unwrap();
+
+    // Charlie tries to join the group
+    let _charlie_group = StagedWelcome::new_from_welcome(
+        &charlie_party.provider,
+        &join_config,
+        MlsMessageIn::from(welcome).into_welcome().unwrap(),
+        None,
+    )
+    .expect("Failed to create group due to an invalid lifetime in a leaf node in the tree.")
+    .into_group(provider)
+    .unwrap();
+}


### PR DESCRIPTION
Allow configuration of leaf node validation when joining a group.
To this end this changes the `join_by_external_commit` into a builder,
and introduces new functions `MlsGroup::from_external_commit` and
`StagedWelcome::build_from_welcome` to make joining of a group more
ergonomic with the new option. As part of this,
`MlsGroup::join_by_external_commit` is deprecated.

This also renames `PublicGroup::from_external_internal` to
`from_ratchet_tree` and introduces `Lifetime::init` to set lifetime
values explicitly.

Fixes #1810 