### PR TITLE
Fix doc comment on `LeafNode::credential()`

### DIFF
--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -398,7 +398,7 @@ impl LeafNode {
         &self.payload.signature_key
     }
 
-    /// Returns the `signature_key` as byte slice.
+    /// Returns the `credential`.
     pub fn credential(&self) -> &Credential {
         &self.payload.credential
     }


### PR DESCRIPTION
This pull request fixes the doc comment on the `LeafNode::credential()` method, which had previously referred to the `signature_key` instead of the `credential`.