### PR TITLE
fix: validate GCE proposals against RC of group

### DIFF
--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -570,7 +570,9 @@ impl PublicGroup {
                             self.check_extension_support(required_capabilities_new.extension_types()).map_err(|_| GroupContextExtensionsProposalValidationError::RequiredExtensionNotSupportedByAllMembers)?;
                             required_capabilities_new
                         }
-                        None => &default_required_capabilities,
+                        None => self
+                            .required_capabilities()
+                            .unwrap_or(&default_required_capabilities),
                     };
 
                     // Make sure that all other extensions are known to be supported, by checking


### PR DESCRIPTION
This PR fixes validation of group context extension proposals. 

Previously, OpenMLS would validate that the extensions in the proposal are present either in the default required capabilities or in a required capabilities extension _added in the same proposal_.

This PR makes is so that extensions in the proposal are validated against the first of the following required capabilities extensions that is present:
- required capabilities extension in the proposal itself
- required capabilities extension in the group's group context extensions
- default required capabilities.

This PR also adds a test.