### PR TITLE
adding the hmac function to OpenMlsCrypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `StagedWelcome::build_from_welcome`: Alternative to `new_from_welcome` in a builder style that allows disabling lifetime validation of the incoming ratchet tree.
   - `Lifetime::init`: Set explicit lifetimes for a key package.
 - [#1801](https://github.com/openmls/openmls/pull/1801): Added `MlsGroup::external_commit_builder`.
-- [#1825](https://github.com/openmls/openmls/pull/1825): Add the `hmac` method for hashing to the `OpenMlsCrypto` trait.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `StagedWelcome::build_from_welcome`: Alternative to `new_from_welcome` in a builder style that allows disabling lifetime validation of the incoming ratchet tree.
   - `Lifetime::init`: Set explicit lifetimes for a key package.
 - [#1801](https://github.com/openmls/openmls/pull/1801): Added `MlsGroup::external_commit_builder`.
+- [#1825](https://github.com/openmls/openmls/pull/1825): Add the `hmac` method for hashing to the `OpenMlsCrypto` trait.
 
 ### Fixed
 

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -14,6 +14,7 @@ libcrux-chacha20poly1305 = { version = "0.0.3" }
 libcrux-ed25519 = { version = "0.0.3", features = ["rand"] }
 libcrux-hkdf = { version = "0.0.3" }
 libcrux-sha2 = { version = "0.0.3" }
+libcrux-hmac = { version = "0.0.3" }
 
 openmls_traits = { workspace = true }
 openmls_memory_storage = { workspace = true }

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -395,6 +395,7 @@ fn hkdf_alg(hash_type: HashType) -> libcrux_hkdf::Algorithm {
         HashType::Sha2_512 => libcrux_hkdf::Algorithm::Sha512,
     }
 }
+
 fn hash_alg(hash_type: HashType) -> libcrux_hmac::Algorithm {
     match hash_type {
         HashType::Sha2_256 => libcrux_hmac::Algorithm::Sha256,
@@ -402,6 +403,7 @@ fn hash_alg(hash_type: HashType) -> libcrux_hmac::Algorithm {
         HashType::Sha2_512 => libcrux_hmac::Algorithm::Sha512,
     }
 }
+
 struct GuardedRng<'a, Rng: RngCore>(MutexGuard<'a, Rng>);
 
 impl<Rng: RngCore> RngCore for GuardedRng<'_, Rng> {

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -76,6 +76,17 @@ impl OpenMlsCrypto for CryptoProvider {
         Ok(out.into())
     }
 
+    fn hmac(
+        &self,
+        hash_type: HashType,
+        key: &[u8],
+        message: &[u8],
+    ) -> Result<SecretVLBytes, CryptoError> {
+        let alg = hash_alg(hash_type);
+        let out = libcrux_hmac::hmac(alg, key, message, None);
+        Ok(out.into())
+    }
+
     fn hkdf_expand(
         &self,
         hash_type: HashType,
@@ -382,6 +393,13 @@ fn hkdf_alg(hash_type: HashType) -> libcrux_hkdf::Algorithm {
         HashType::Sha2_256 => libcrux_hkdf::Algorithm::Sha256,
         HashType::Sha2_384 => libcrux_hkdf::Algorithm::Sha384,
         HashType::Sha2_512 => libcrux_hkdf::Algorithm::Sha512,
+    }
+}
+fn hash_alg(hash_type: HashType) -> libcrux_hmac::Algorithm {
+    match hash_type {
+        HashType::Sha2_256 => libcrux_hmac::Algorithm::Sha256,
+        HashType::Sha2_384 => libcrux_hmac::Algorithm::Sha384,
+        HashType::Sha2_512 => libcrux_hmac::Algorithm::Sha512,
     }
 }
 struct GuardedRng<'a, Rng: RngCore>(MutexGuard<'a, Rng>);

--- a/openmls/src/ciphersuite/mac.rs
+++ b/openmls/src/ciphersuite/mac.rs
@@ -20,16 +20,16 @@ impl PartialEq for Mac {
 impl Mac {
     /// HMAC-Hash(salt, IKM). For all supported ciphersuites this is the same
     /// HMAC that is also used in HKDF.
-    /// Compute the HMAC on `salt` with key `ikm`.
+    /// Compute the HMAC on `message` with key `key`.
     pub(crate) fn new(
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
-        salt: &Secret,
-        ikm: &[u8],
+        key: &Secret,
+        message: &[u8],
     ) -> Result<Self, CryptoError> {
         Ok(Mac {
-            mac_value: salt
-                .hkdf_extract(crypto, ciphersuite, &Secret::from_slice(ikm))?
+            mac_value: key
+                .hmac(crypto, ciphersuite, &Secret::from_slice(message))?
                 .value
                 .as_slice()
                 .into(),

--- a/openmls/src/ciphersuite/secret.rs
+++ b/openmls/src/ciphersuite/secret.rs
@@ -105,17 +105,19 @@ impl Secret {
         &self,
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
-        ikm: impl Into<&'a Secret>,
+        message: impl Into<&'a Secret>,
     ) -> Result<Self, CryptoError> {
         log::trace!("HMAC with");
         log_crypto!(trace, "  salt: {:x?}", self.value);
-        log_crypto!(trace, "  message:  {:x?}", ikm.value);
+
+        let message_tbh = message.into();
+        log_crypto!(trace, "  message:  {:x?}", message_tbh.value);
 
         Ok(Self {
             value: crypto.hmac(
                 ciphersuite.hash_algorithm(),
                 self.value.as_slice(),
-                ikm.into().as_slice(),
+                message_tbh.as_slice(),
             )?,
         })
     }
@@ -133,7 +135,7 @@ impl Secret {
                 ciphersuite.hash_algorithm(),
                 self.value.as_slice(),
                 info,
-                okm_len,
+        okm_len,
             )
             .map_err(|_| CryptoError::CryptoLibraryError)?;
         if key.as_slice().is_empty() {
@@ -168,7 +170,7 @@ impl Secret {
     /// Derive a new `Secret` from the this one by expanding it with the given
     /// `label` and an empty `context`.
     pub(crate) fn derive_secret(
-        &self,
+&self,
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
         label: &str,

--- a/openmls/src/ciphersuite/secret.rs
+++ b/openmls/src/ciphersuite/secret.rs
@@ -135,7 +135,7 @@ impl Secret {
                 ciphersuite.hash_algorithm(),
                 self.value.as_slice(),
                 info,
-        okm_len,
+                okm_len,
             )
             .map_err(|_| CryptoError::CryptoLibraryError)?;
         if key.as_slice().is_empty() {
@@ -170,7 +170,7 @@ impl Secret {
     /// Derive a new `Secret` from the this one by expanding it with the given
     /// `label` and an empty `context`.
     pub(crate) fn derive_secret(
-&self,
+        &self,
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
         label: &str,

--- a/openmls/src/ciphersuite/secret.rs
+++ b/openmls/src/ciphersuite/secret.rs
@@ -101,6 +101,25 @@ impl Secret {
         })
     }
 
+    pub(crate) fn hmac<'a>(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        ikm: impl Into<&'a Secret>,
+    ) -> Result<Self, CryptoError> {
+        log::trace!("HMAC with");
+        log_crypto!(trace, "  salt: {:x?}", self.value);
+        log_crypto!(trace, "  message:  {:x?}", ikm.value);
+
+        Ok(Self {
+            value: crypto.hmac(
+                ciphersuite.hash_algorithm(),
+                self.value.as_slice(),
+                ikm.into().as_slice(),
+            )?,
+        })
+    }
+
     /// HKDF expand where `self` is `prk`.
     pub(crate) fn hkdf_expand(
         &self,

--- a/openmls/src/test_utils/frankenstein/crypto.rs
+++ b/openmls/src/test_utils/frankenstein/crypto.rs
@@ -12,7 +12,7 @@ pub fn compute_membership_tag(
 ) -> VLBytes {
     let serialized_auth_content_tbm = &auth_content_tbm.tls_serialize_detached().unwrap();
     crypto
-        .hkdf_extract(
+        .hmac(
             ciphersuite.hash_algorithm(),
             membership_key,              // Extract salt is HMAC key
             serialized_auth_content_tbm, // Extract ikm is HMAC message

--- a/openmls_rust_crypto/src/hmac.rs
+++ b/openmls_rust_crypto/src/hmac.rs
@@ -12,7 +12,7 @@ macro_rules! hmac_digest {
     ($hash_t:ty, $key:ident, $message:ident) => {{
         let mut hmac = <$hash_t>::new_from_slice($key).map_err(|_e| CryptoError::InvalidLength)?;
         hmac.update($message);
-        hmac.finalize().into_bytes().into_iter().collect()
+        hmac.finalize().into_bytes().as_slice().to_vec()
     }};
 }
 

--- a/openmls_rust_crypto/src/hmac.rs
+++ b/openmls_rust_crypto/src/hmac.rs
@@ -1,0 +1,30 @@
+use hmac::Mac;
+use openmls_traits::types;
+use openmls_traits::types::{CryptoError, HashType};
+use sha2::{Sha256, Sha384, Sha512};
+use tls_codec::SecretVLBytes;
+
+type HmacSha256 = hmac::Hmac<Sha256>;
+type HmacSha384 = hmac::Hmac<Sha384>;
+type HmacSha512 = hmac::Hmac<Sha512>;
+
+macro_rules! hmac_digest {
+    ($hash_t:ty, $key:ident, $message:ident) => {{
+        let mut hmac = <$hash_t>::new_from_slice($key).map_err(|_e| CryptoError::InvalidLength)?;
+        hmac.update($message);
+        hmac.finalize().into_bytes().into_iter().collect()
+    }};
+}
+
+pub(crate) fn hmac(
+    hash_type: HashType,
+    key: &[u8],
+    message: &[u8],
+) -> Result<SecretVLBytes, types::CryptoError> {
+    let digest: Vec<u8> = match hash_type {
+        HashType::Sha2_256 => hmac_digest!(HmacSha256, key, message),
+        HashType::Sha2_384 => hmac_digest!(HmacSha384, key, message),
+        HashType::Sha2_512 => hmac_digest!(HmacSha512, key, message),
+    };
+    Ok(SecretVLBytes::new(digest))
+}

--- a/openmls_rust_crypto/src/lib.rs
+++ b/openmls_rust_crypto/src/lib.rs
@@ -9,6 +9,8 @@ use openmls_traits::OpenMlsProvider;
 mod provider;
 pub use provider::*;
 
+mod hmac;
+
 #[derive(Default, Debug)]
 #[cfg_attr(feature = "test-utils", derive(Clone))]
 pub struct OpenMlsRustCrypto {

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -26,6 +26,8 @@ use rand::{RngCore, SeedableRng};
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use tls_codec::SecretVLBytes;
 
+use crate::hmac;
+
 #[derive(Debug)]
 pub struct RustCrypto {
     rng: RwLock<rand_chacha::ChaCha20Rng>,
@@ -110,6 +112,15 @@ impl OpenMlsCrypto for RustCrypto {
             HashType::Sha2_384 => Ok(Hkdf::<Sha384>::extract(Some(salt), ikm).0.as_slice().into()),
             HashType::Sha2_512 => Ok(Hkdf::<Sha512>::extract(Some(salt), ikm).0.as_slice().into()),
         }
+    }
+
+    fn hmac(
+        &self,
+        hash_type: HashType,
+        key: &[u8],
+        message: &[u8],
+    ) -> Result<SecretVLBytes, CryptoError> {
+        hmac::hmac(hash_type, key, message)
     }
 
     fn hkdf_expand(

--- a/traits/CHANGELOG.md
+++ b/traits/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- [#1825](https://github.com/openmls/openmls/pull/1825): Add the `hmac` method for hashing to the `OpenMlsCrypto` trait.
+
 ## 0.4.0
 - [#1760](https://github.com/openmls/openmls/pull/1760): Drop support for `XWingKemDraft2` and add support for `XWingKemDraft6`
 

--- a/traits/src/crypto.rs
+++ b/traits/src/crypto.rs
@@ -28,6 +28,13 @@ pub trait OpenMlsCrypto: Send + Sync {
         ikm: &[u8],
     ) -> Result<SecretVLBytes, CryptoError>;
 
+    fn hmac(
+        &self,
+        hash_type: HashType,
+        key: &[u8],
+        message: &[u8],
+    ) -> Result<SecretVLBytes, CryptoError>;
+
     /// HKDF expand.
     ///
     /// Returns an error if the [`HashType`] is not supported or the output length


### PR DESCRIPTION
Coses #1375.

Since `OpenMlsCrypto` is also used by `Mac` and `Secret` we also need to add the respective methods here.

Both the rust_crypto and libcrux crypto providers have been updated to implement the new trait. Although `hkdf_expand` could have been used, we opted for the explicit `hmac` implementations provided by both crates for clarity and consistency.

A separate module was created for the HMAC implementation in rust_crypto to resolve import conflicts (multiple applicable methods in the same scope).

The test_utils have also been updated to use the new hmac function.