### PR TITLE
Doc fixes

### DIFF
--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -363,7 +363,7 @@ impl MlsGroupCreateConfigBuilder {
         Ok(self)
     }
 
-    /// Finalizes the builder and retursn an `[MlsGroupCreateConfig`].
+    /// Finalizes the builder and retursn an [`MlsGroupCreateConfig`].
     pub fn build(self) -> MlsGroupCreateConfig {
         self.config
     }

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -363,7 +363,7 @@ impl MlsGroupCreateConfigBuilder {
         Ok(self)
     }
 
-    /// Finalizes the builder and retursn an [`MlsGroupCreateConfig`].
+    /// Finalizes the builder and returns an [`MlsGroupCreateConfig`].
     pub fn build(self) -> MlsGroupCreateConfig {
         self.config
     }

--- a/openmls/src/messages/group_info.rs
+++ b/openmls/src/messages/group_info.rs
@@ -180,7 +180,7 @@ impl GroupInfo {
         &self.payload.extensions
     }
 
-    /// Returns the [`GroupInfo`] extensions.
+    /// Returns the [`GroupInfo`] signature.
     pub fn signature(&self) -> &Signature {
         &self.signature
     }


### PR DESCRIPTION
This pull request contains several small fixes for the  `openmls` crate's doc comments. These include updating a broken link, a correction to the doc comment for `GroupInfo::signature()`, and and a typo fix.