### PR TITLE
Improve Lifetime log message

### DIFF
--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -696,7 +696,10 @@ impl PublicGroup {
         {
             if let Some(lifetime) = leaf_node.life_time() {
                 if !lifetime.is_valid() {
-                    log::warn!("offending lifetime: {lifetime:?}");
+                    log::warn!(
+                        "offending lifetime: {lifetime:?} for leaf node with {credential:?}",
+                        credential = leaf_node.credential()
+                    );
                     return Err(LeafNodeValidationError::Lifetime(LifetimeError::NotCurrent));
                 }
             }


### PR DESCRIPTION
In the log message for an invalid lifetime, include the Credential, so that the relevant leaf node can be identified.

See #1815