### PR TITLE
fix(external-commit): persist initial group state in finalize(); add regression test

### DIFF
--- a/openmls/src/group/mls_group/commit_builder/external_commits.rs
+++ b/openmls/src/group/mls_group/commit_builder/external_commits.rs
@@ -369,6 +369,12 @@ impl CommitBuilder<'_, super::Complete, MlsGroup> {
             group.mls_group_config.wire_format_policy = wire_format_policy;
         }
 
+        // Persist the initial group state before entering PendingCommit.
+        // Per documentation, store() should be called by constructors only.
+        group
+            .store(provider.storage())
+            .map_err(ExternalCommitBuilderFinalizeError::StorageError)?;
+
         // Set the current group state to [`MlsGroupState::PendingCommit`],
         // storing the current [`StagedCommit`] from the commit results
         group.group_state = MlsGroupState::PendingCommit(Box::new(PendingCommitState::Member(

--- a/openmls/src/group/tests_and_kats/tests/external_commit_persistence_bug.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_commit_persistence_bug.rs
@@ -1,0 +1,111 @@
+//! Test to reproduce the persistence bug in External Commits
+//! This test verifies that own_leaf_index and join_group_config are correctly persisted
+//! after an external commit.
+
+use crate::group::{
+    tests_and_kats::utils::generate_credential_with_key, MlsGroup, MlsGroupCreateConfig,
+    PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+};
+
+// Test to reproduce the external commit persistence bug
+#[openmls_test::openmls_test]
+fn test_external_commit_persistence_bug() {
+    // Separate providers for Alice and Bob (distinct storage spaces)
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    // Generate credentials
+    let alice_credential = generate_credential_with_key(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    let bob_credential = generate_credential_with_key(
+        "Bob".into(),
+        ciphersuite.signature_algorithm(),
+        bob_provider,
+    );
+
+    // Group configuration
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(ciphersuite)
+        .build();
+
+    // Alice creates a group
+    let mut alice_group = MlsGroup::new(
+        alice_provider,
+        &alice_credential.signer,
+        &mls_group_create_config,
+        alice_credential.credential_with_key.clone(),
+    )
+    .unwrap();
+
+    // Get group information for the external commit
+    let verifiable_group_info = alice_group
+        .export_group_info(alice_provider.crypto(), &alice_credential.signer, false)
+        .unwrap()
+        .into_verifiable_group_info()
+        .unwrap();
+    let tree_option = alice_group.export_ratchet_tree();
+
+    // Bob performs an external commit
+    let (bob_group, _public_message_commit) = MlsGroup::external_commit_builder()
+        .with_config(alice_group.configuration().clone())
+        .with_ratchet_tree(tree_option.into())
+        .build_group(
+            bob_provider,
+            verifiable_group_info,
+            bob_credential.credential_with_key.clone(),
+        )
+        .unwrap()
+        .load_psks(bob_provider.storage())
+        .unwrap()
+        .build(
+            bob_provider.rand(),
+            bob_provider.crypto(),
+            &bob_credential.signer,
+            |_| true,
+        )
+        .unwrap()
+        .finalize(bob_provider)
+        .unwrap();
+
+    // Verify that Bob has a valid own_leaf_index (it must be >= 0)
+    let _idx = bob_group.own_leaf_index();
+
+    // Save the group ID and Bob's index
+    let group_id = bob_group.group_id().clone();
+    let expected_own_leaf_index = bob_group.own_leaf_index();
+    let expected_join_config = bob_group.configuration().clone();
+
+    // Simulate memory loss (drop the group)
+    drop(bob_group);
+
+    // Attempt to reload the group from storage
+    let reloaded_group = MlsGroup::load(bob_provider.storage(), &group_id);
+
+    // The group should be reloadable
+    assert!(reloaded_group.is_ok(), "Group should be loadable after external commit");
+    let reloaded_group = reloaded_group.unwrap();
+    assert!(reloaded_group.is_some(), "Group should exist in storage");
+
+    let reloaded_group = reloaded_group.unwrap();
+
+    // Verify that own_leaf_index is properly persisted
+    assert_eq!(
+        reloaded_group.own_leaf_index(),
+        expected_own_leaf_index,
+        "own_leaf_index should be persisted and match the original value"
+    );
+
+    // Verify that the group configuration is properly persisted
+    assert_eq!(
+        reloaded_group.configuration(),
+        &expected_join_config,
+        "join_group_config should be persisted and match the original value"
+    );
+
+    println!("✅ Test passed: External commit persistence works correctly");
+}

--- a/openmls/src/group/tests_and_kats/tests/mod.rs
+++ b/openmls/src/group/tests_and_kats/tests/mod.rs
@@ -7,6 +7,7 @@ mod encoding;
 mod external_add_proposal;
 mod external_commit;
 mod external_commit_builder;
+mod external_commit_persistence_bug;
 mod external_commit_validation;
 mod external_group_context_extensions_proposal;
 mod external_join_add_proposal;


### PR DESCRIPTION
Linked issue
- Ref: #1801

Summary
- Persist the initial `MlsGroup` state when joining via External Commit by calling
  `group.store(provider.storage())` in `external_commit_builder::finalize()` before entering `PendingCommit`.
- Add a regression test with two providers to ensure the group is reloadable from storage after `finalize()`.

Motivation & context
- After #1801 refactoring, the initial `store()` call was no longer present in the External Commit path.
- Since an External Commit implies creating a group, that initial state must be persisted once so `MlsGroup::load()` can succeed.

Design / Approach
- `external_commit_builder::finalize()` now calls `group.store(provider.storage())` before setting `PendingCommit` and merging.
- No changes to wire or on-disk formats; behavior aligns with the documented contract that `store()` is used by constructors.

Alternatives considered
- Persist in `merge_commit()` (GroupMember path): rejected to follow the documentation (“store() only from constructors”) and avoid mixing construction and merge responsibilities.

Backwards compatibility
- No breaking changes; no format changes; aligns persistence with expected semantics.

Tests & verification
- New regression test: `external_commit_persistence_bug`:
  - Uses two providers (Alice/Bob) with distinct storages.
  - Fails without the fix (group not reloadable from Bob's storage).
  - Passes with the fix across variants.

Reproduction
```bash
CARGO_ENCODED_RUSTFLAGS= cargo test -p openmls \
  --target aarch64-apple-darwin \
  --no-default-features --features test-utils \
  -- external_commit_persistence_bug --nocapture
```

Potential side-effects / risks
- Minimal. One additional storage write during `finalize()` (constructor phase) for External Commit. No changes to merge-time writes.

Documentation
- Matches the intended contract: initial state persisted by constructor-like code paths.

Checklist
- [x] Small, focused changeset
- [x] Issue linked
- [x] Tests added and passing
- [x] No public API or format changes
- [x] Commit message in imperative mood; clear rationale