### PR TITLE
fix large enum variants

### DIFF
--- a/openmls/src/binary_tree/array_representation/tree.rs
+++ b/openmls/src/binary_tree/array_representation/tree.rs
@@ -23,8 +23,25 @@ where
     L: Clone + Debug + Default,
     P: Clone + Debug + Default,
 {
-    Leaf(L),
-    Parent(P),
+    Leaf(Box<L>),
+    Parent(Box<P>),
+}
+
+#[cfg(test)]
+impl<L, P> TreeNode<L, P>
+where
+    L: Clone + Debug + Default,
+    P: Clone + Debug + Default,
+{
+    /// Create a new leaf.
+    pub(crate) fn leaf(l: L) -> Self {
+        Self::Leaf(Box::new(l))
+    }
+
+    /// Create a new parent.
+    pub(crate) fn parent(p: P) -> Self {
+        Self::Parent(Box::new(p))
+    }
 }
 
 #[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq))]
@@ -63,14 +80,14 @@ impl<L: Clone + Debug + Default, P: Clone + Debug + Default> ABinaryTree<L, P> {
             match node {
                 TreeNode::Leaf(l) => {
                     if i % 2 == 0 {
-                        leaf_nodes.push(l)
+                        leaf_nodes.push(*l)
                     } else {
                         return Err(ABinaryTreeError::WrongNodeType);
                     }
                 }
                 TreeNode::Parent(p) => {
                     if i % 2 == 1 {
-                        parent_nodes.push(p)
+                        parent_nodes.push(*p)
                     } else {
                         return Err(ABinaryTreeError::WrongNodeType);
                     }

--- a/openmls/src/binary_tree/tests.rs
+++ b/openmls/src/binary_tree/tests.rs
@@ -13,13 +13,13 @@ use super::{
 #[test]
 fn test_tree_basics() {
     // Test tree creation: Wrong number of nodes.
-    let mut nodes = vec![TreeNode::Leaf(1), TreeNode::Parent(0)];
+    let mut nodes = vec![TreeNode::leaf(1), TreeNode::parent(0)];
     assert_eq!(
         MlsBinaryTree::new(nodes.clone())
             .expect_err("No error when creating a non-full binary tree."),
         MlsBinaryTreeError::InvalidNumberOfNodes
     );
-    nodes.push(TreeNode::Leaf(2));
+    nodes.push(TreeNode::leaf(2));
 
     let tree1 = MlsBinaryTree::new(nodes.clone()).expect("Error when creating tree from nodes.");
 
@@ -52,7 +52,7 @@ fn test_tree_basics() {
     );
 
     let tree3: ABinaryTree<u32, u32> =
-        MlsBinaryTree::new(vec![TreeNode::Leaf(1)]).expect("error creating 1 node binary tree.");
+        MlsBinaryTree::new(vec![TreeNode::leaf(1)]).expect("error creating 1 node binary tree.");
     let leaves3: Vec<(LeafNodeIndex, &u32)> = tree3.leaves().collect();
     assert_eq!(vec![(LeafNodeIndex::new(0), &1)], leaves3);
 }
@@ -60,9 +60,9 @@ fn test_tree_basics() {
 #[test]
 fn test_diff_merging() {
     let mut tree = MlsBinaryTree::new(vec![
-        TreeNode::Leaf(2),
-        TreeNode::Parent(0),
-        TreeNode::Leaf(4),
+        TreeNode::leaf(2),
+        TreeNode::parent(0),
+        TreeNode::leaf(4),
     ])
     .expect("Error creating tree.");
     let original_tree = tree.clone();
@@ -154,9 +154,9 @@ fn test_diff_iter() {
     let nodes = (0..101)
         .map(|i| {
             if i % 2 == 0 {
-                TreeNode::Leaf(i)
+                TreeNode::leaf(i)
             } else {
-                TreeNode::Parent(i)
+                TreeNode::parent(i)
             }
         })
         .collect();
@@ -186,9 +186,9 @@ fn test_diff_mutable_access_after_manipulation() {
     let nodes = (0..101)
         .map(|i| {
             if i % 2 == 0 {
-                TreeNode::Leaf(i)
+                TreeNode::leaf(i)
             } else {
-                TreeNode::Parent(i)
+                TreeNode::parent(i)
             }
         })
         .collect();
@@ -222,9 +222,9 @@ fn diff_leaf_access() {
         .map(|i| {
             if i % 2 == 0 {
                 // Let's add 10 so we recognize the default leaf which should be 0.
-                TreeNode::Leaf(i + 10)
+                TreeNode::leaf(i + 10)
             } else {
-                TreeNode::Parent(i + 10)
+                TreeNode::parent(i + 10)
             }
         })
         .collect();

--- a/openmls/src/framing/mls_auth_content.rs
+++ b/openmls/src/framing/mls_auth_content.rs
@@ -131,7 +131,7 @@ impl AuthenticatedContent {
         Self::new_and_sign(
             framing_parameters,
             Sender::Member(sender_leaf_index),
-            FramedContentBody::Application(application_message.into()),
+            FramedContentBody::application(application_message),
             context,
             signer,
         )
@@ -217,7 +217,7 @@ impl AuthenticatedContent {
         Self::new_and_sign(
             framing_parameters,
             sender,
-            FramedContentBody::Commit(commit),
+            FramedContentBody::commit(commit),
             context,
             signer,
         )

--- a/openmls/src/framing/mls_content.rs
+++ b/openmls/src/framing/mls_content.rs
@@ -47,7 +47,6 @@ impl From<AuthenticatedContent> for FramedContent {
 }
 
 /// ```c
-/// // draft-ietf-mls-protocol-17
 /// struct {
 ///     // ... continued from [FramedContent] ...
 ///
@@ -66,14 +65,22 @@ impl From<AuthenticatedContent> for FramedContent {
 #[repr(u8)]
 pub(crate) enum FramedContentBody {
     #[tls_codec(discriminant = 1)]
-    Application(VLBytes),
+    Application(Box<VLBytes>),
     #[tls_codec(discriminant = 2)]
     Proposal(Proposal),
     #[tls_codec(discriminant = 3)]
-    Commit(Commit),
+    Commit(Box<Commit>),
 }
 
 impl FramedContentBody {
+    pub(crate) fn commit(c: Commit) -> Self {
+        Self::Commit(Box::new(c))
+    }
+
+    pub(crate) fn application(bytes: &[u8]) -> Self {
+        Self::Application(Box::new(bytes.into()))
+    }
+
     /// Returns the [`ContentType`].
     pub(crate) fn content_type(&self) -> ContentType {
         match self {

--- a/openmls/src/framing/tests.rs
+++ b/openmls/src/framing/tests.rs
@@ -44,7 +44,7 @@ fn codec_plaintext() {
         1,
         sender,
         vec![1, 2, 3].into(),
-        FramedContentBody::Application(vec![4, 5, 6].into()),
+        FramedContentBody::application(&[4, 5, 6]),
     )
     .with_context(serialized_context.clone());
     let mut orig: PublicMessage = signature_input
@@ -96,7 +96,7 @@ fn codec_ciphertext() {
         1,
         sender,
         vec![1, 2, 3].into(),
-        FramedContentBody::Application(vec![4, 5, 6].into()),
+        FramedContentBody::application(&[4, 5, 6]),
     )
     .with_context(serialized_context);
     let plaintext = signature_input
@@ -306,7 +306,7 @@ fn create_content(
         1,
         sender,
         vec![1, 2, 3].into(),
-        FramedContentBody::Application(vec![4, 5, 6].into()),
+        FramedContentBody::application(&[4, 5, 6]),
     )
     .with_context(serialized_context);
 
@@ -369,7 +369,7 @@ fn membership_tag() {
         .is_ok());
 
     // Change the content of the plaintext message
-    public_message.set_content(FramedContentBodyIn::Application(vec![7, 8, 9].into()));
+    public_message.set_content(FramedContentBodyIn::application(&[7, 8, 9]));
 
     // Expect the signature & membership tag verification to fail
     assert!(public_message

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -225,7 +225,7 @@ impl<'a> CommitBuilder<'a, Initial, &mut MlsGroup> {
         self.stage.own_proposals.extend(
             key_packages
                 .into_iter()
-                .map(|key_package| Proposal::Add(AddProposal { key_package })),
+                .map(|key_package| Proposal::add(AddProposal { key_package })),
         );
         self
     }
@@ -236,7 +236,7 @@ impl<'a> CommitBuilder<'a, Initial, &mut MlsGroup> {
         self.stage.own_proposals.extend(
             removed
                 .into_iter()
-                .map(|removed| Proposal::Remove(RemoveProposal { removed })),
+                .map(|removed| Proposal::remove(RemoveProposal { removed })),
         );
         self
     }
@@ -246,7 +246,7 @@ impl<'a> CommitBuilder<'a, Initial, &mut MlsGroup> {
     pub fn propose_group_context_extensions(mut self, extensions: Extensions) -> Self {
         self.stage
             .own_proposals
-            .push(Proposal::GroupContextExtensions(
+            .push(Proposal::group_context_extensions(
                 GroupContextExtensionProposal::new(extensions),
             ));
         self

--- a/openmls/src/group/mls_group/commit_builder/external_commits.rs
+++ b/openmls/src/group/mls_group/commit_builder/external_commits.rs
@@ -204,7 +204,8 @@ impl ExternalCommitBuilder {
         let message_secrets_store =
             MessageSecretsStore::new_with_secret(config.max_past_epochs, message_secrets);
 
-        let external_init_proposal = Proposal::ExternalInit(ExternalInitProposal::from(kem_output));
+        let external_init_proposal =
+            Proposal::external_init(ExternalInitProposal::from(kem_output));
 
         // Authenticate the proposals as best as we can
         let serialized_context = group_context
@@ -246,7 +247,7 @@ impl ExternalCommitBuilder {
         // commit a remove proposal.
         let our_signature_key = credential_with_key.signature_key.as_slice();
         let remove_proposal = public_group.members().find_map(|member| {
-            (member.signature_key == our_signature_key).then_some(Proposal::Remove(
+            (member.signature_key == our_signature_key).then_some(Proposal::remove(
                 RemoveProposal {
                     removed: member.index,
                 },
@@ -316,9 +317,7 @@ impl ExternalCommitBuilder {
 impl<'a> CommitBuilder<'a, Initial, MlsGroup> {
     /// Adds a [`PreSharedKeyProposal`] to the proposals to be committed.
     pub fn add_psk_proposal(mut self, proposal: PreSharedKeyProposal) -> Self {
-        self.stage
-            .own_proposals
-            .push(Proposal::PreSharedKey(proposal));
+        self.stage.own_proposals.push(Proposal::psk(proposal));
         self
     }
 
@@ -330,7 +329,7 @@ impl<'a> CommitBuilder<'a, Initial, MlsGroup> {
     ) -> Self {
         self.stage
             .own_proposals
-            .extend(proposals.into_iter().map(Proposal::PreSharedKey));
+            .extend(proposals.into_iter().map(Proposal::psk));
         self
     }
 }

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -577,7 +577,7 @@ impl MlsGroup {
                 .check_extension_support(required_capabilities.extension_types())?;
         }
         let proposal = GroupContextExtensionProposal::new(extensions);
-        let proposal = Proposal::GroupContextExtensions(proposal);
+        let proposal = Proposal::GroupContextExtensions(Box::new(proposal));
         AuthenticatedContent::member_proposal(
             framing_parameters,
             self.own_leaf_index(),

--- a/openmls/src/group/mls_group/proposal.rs
+++ b/openmls/src/group/mls_group/proposal.rs
@@ -453,7 +453,7 @@ impl MlsGroup {
         let add_proposal = AddProposal {
             key_package: joiner_key_package,
         };
-        let proposal = Proposal::Add(add_proposal);
+        let proposal = Proposal::add(add_proposal);
         AuthenticatedContent::member_proposal(
             framing_parameters,
             self.own_leaf_index(),
@@ -477,7 +477,7 @@ impl MlsGroup {
         signer: &impl Signer,
     ) -> Result<AuthenticatedContent, LibraryError> {
         let update_proposal = UpdateProposal { leaf_node };
-        let proposal = Proposal::Update(update_proposal);
+        let proposal = Proposal::update(update_proposal);
         AuthenticatedContent::member_proposal(
             framing_parameters,
             self.own_leaf_index(),
@@ -501,7 +501,7 @@ impl MlsGroup {
             return Err(ValidationError::UnknownMember);
         }
         let remove_proposal = RemoveProposal { removed };
-        let proposal = Proposal::Remove(remove_proposal);
+        let proposal = Proposal::remove(remove_proposal);
         AuthenticatedContent::member_proposal(
             framing_parameters,
             self.own_leaf_index(),
@@ -542,7 +542,7 @@ impl MlsGroup {
         signer: &impl Signer,
     ) -> Result<AuthenticatedContent, LibraryError> {
         let presharedkey_proposal = PreSharedKeyProposal::new(psk);
-        let proposal = Proposal::PreSharedKey(presharedkey_proposal);
+        let proposal = Proposal::psk(presharedkey_proposal);
         AuthenticatedContent::member_proposal(
             framing_parameters,
             self.own_leaf_index(),
@@ -558,7 +558,7 @@ impl MlsGroup {
         custom_proposal: CustomProposal,
         signer: &impl Signer,
     ) -> Result<AuthenticatedContent, LibraryError> {
-        let proposal = Proposal::Custom(custom_proposal);
+        let proposal = Proposal::custom(custom_proposal);
         AuthenticatedContent::member_proposal(
             framing_parameters,
             self.own_leaf_index(),

--- a/openmls/src/group/mls_group/tests_and_kats/tests/proposals.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/proposals.rs
@@ -252,8 +252,8 @@ fn proposal_queue_order() {
     );
 
     let proposal_or_refs = vec![
-        ProposalOrRef::Proposal(proposal_add_bob1.clone()),
-        ProposalOrRef::Reference(proposal_reference_add_alice1),
+        ProposalOrRef::proposal(proposal_add_bob1.clone()),
+        ProposalOrRef::reference(proposal_reference_add_alice1),
     ];
 
     let sender = Sender::build_member(LeafNodeIndex::new(0));

--- a/openmls/src/group/mls_group/tests_and_kats/tests/proposals.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/proposals.rs
@@ -68,9 +68,9 @@ fn proposal_queue_functions(
         key_package: bob_key_package.clone(),
     };
 
-    let proposal_add_alice1 = Proposal::Add(add_proposal_alice1);
-    let proposal_add_alice2 = Proposal::Add(add_proposal_alice2);
-    let proposal_add_bob = Proposal::Add(add_proposal_bob);
+    let proposal_add_alice1 = Proposal::add(add_proposal_alice1);
+    let proposal_add_alice2 = Proposal::add(add_proposal_alice2);
+    let proposal_add_bob = Proposal::add(add_proposal_bob);
 
     // Test proposal types
     assert!(proposal_add_alice1.is_type(ProposalType::Add));
@@ -205,8 +205,8 @@ fn proposal_queue_order() {
         key_package: bob_key_package.clone(),
     };
 
-    let proposal_add_alice1 = Proposal::Add(add_proposal_alice1);
-    let proposal_add_bob1 = Proposal::Add(add_proposal_bob1);
+    let proposal_add_alice1 = Proposal::add(add_proposal_alice1);
+    let proposal_add_bob1 = Proposal::add(add_proposal_bob1);
 
     // Frame proposals in PublicMessage
     let mls_plaintext_add_alice1 = AuthenticatedContent::member_proposal(

--- a/openmls/src/group/public_group/diff/apply_proposals.rs
+++ b/openmls/src/group/public_group/diff/apply_proposals.rs
@@ -67,7 +67,7 @@ impl PublicGroupDiff<'_> {
             .next()
             .and_then(|queued_proposal| {
                 if let Proposal::ExternalInit(external_init_proposal) = queued_proposal.proposal() {
-                    Some(external_init_proposal.clone())
+                    Some(*(*external_init_proposal).clone())
                 } else {
                     None
                 }
@@ -142,7 +142,7 @@ impl PublicGroupDiff<'_> {
                 .diff
                 .add_leaf(leaf_node.clone())
                 .map_err(|_| LibraryError::custom("Tree full: cannot add more members"))?;
-            invitation_list.push((leaf_index, add_proposal.clone()))
+            invitation_list.push((leaf_index, *(*add_proposal).clone()))
         }
 
         self.diff.trim_tree();

--- a/openmls/src/group/public_group/staged_commit.rs
+++ b/openmls/src/group/public_group/staged_commit.rs
@@ -85,7 +85,7 @@ impl PublicGroup {
                 // Proposal references are only allowed if they refer to a
                 // SelfRemove proposal in our store
                 !self.proposal_store.proposals().any(|p| {
-                    p.proposal_reference() == *proposal_ref
+                    p.proposal_reference_ref() == proposal_ref.as_ref()
                         && p.proposal().is_type(ProposalType::SelfRemove)
                 })
             }) {
@@ -95,7 +95,7 @@ impl PublicGroup {
             let number_of_remove_proposals = commit
                 .proposals
                 .iter()
-                .filter(|prop| matches!(prop, ProposalOrRef::Proposal(Proposal::Remove(_))))
+                .filter(|prop| prop.as_proposal().filter(|p| p.is_remove()).is_some())
                 .count();
 
             // https://validation.openmls.tech/#valn0402

--- a/openmls/src/group/tests_and_kats/tests/commit_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/commit_validation.rs
@@ -283,7 +283,7 @@ fn test_valsem201() {
         let dave_key_package =
             generate_key_package(ciphersuite, Extensions::empty(), provider, dave_credential);
 
-        queued(Proposal::Add(AddProposal {
+        queued(Proposal::add(AddProposal {
             key_package: dave_key_package.key_package().clone(),
         }))
     };
@@ -301,10 +301,10 @@ fn test_valsem201() {
         )
         .unwrap();
         psk_id.store(provider, secret.as_slice()).unwrap();
-        queued(Proposal::PreSharedKey(PreSharedKeyProposal::new(psk_id)))
+        queued(Proposal::psk(PreSharedKeyProposal::new(psk_id)))
     };
 
-    let update_proposal = queued(Proposal::Update(UpdateProposal {
+    let update_proposal = queued(Proposal::update(UpdateProposal {
         leaf_node: alice_group
             .own_leaf()
             .expect("Unable to get own leaf")
@@ -312,13 +312,13 @@ fn test_valsem201() {
     }));
 
     let remove_proposal = || {
-        queued(Proposal::Remove(RemoveProposal {
+        queued(Proposal::remove(RemoveProposal {
             removed: charlie_group.own_leaf_index(),
         }))
     };
 
     let gce_proposal = || {
-        queued(Proposal::GroupContextExtensions(
+        queued(Proposal::group_context_extensions(
             GroupContextExtensionProposal::new(alice_group.context().extensions().clone()),
         ))
     };

--- a/openmls/src/group/tests_and_kats/tests/commit_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/commit_validation.rs
@@ -196,7 +196,7 @@ fn test_valsem200() {
 
     commit_content
         .proposals
-        .push(ProposalOrRef::Proposal(proposal));
+        .push(ProposalOrRef::proposal(proposal));
 
     plaintext.set_content(FramedContentBody::Commit(commit_content));
 

--- a/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
@@ -119,7 +119,7 @@ fn test_valsem241() {
 
         // Insert a second external init proposal into the commit.
         let second_ext_init_prop =
-            ProposalOrRef::Proposal(Proposal::ExternalInit(ExternalInitProposal::from(vec![
+            ProposalOrRef::Proposal(Proposal::external_init(ExternalInitProposal::from(vec![
                 1, 2, 3,
             ])));
 
@@ -251,13 +251,13 @@ fn test_valsem242() {
                 charlie_credential,
             );
 
-            ProposalOrRef::Proposal(Proposal::Add(AddProposal {
+            ProposalOrRef::Proposal(Proposal::add(AddProposal {
                 key_package: charlie_key_package.key_package().clone(),
             }))
         };
 
         let reinit_proposal = {
-            ProposalOrRef::Proposal(Proposal::ReInit(ReInitProposal {
+            ProposalOrRef::Proposal(Proposal::re_init(ReInitProposal {
                 group_id: alice_group.group_id().clone(),
                 version: Default::default(),
                 ciphersuite,
@@ -266,7 +266,7 @@ fn test_valsem242() {
         };
 
         let gce_proposal = {
-            ProposalOrRef::Proposal(Proposal::GroupContextExtensions(
+            ProposalOrRef::Proposal(Proposal::group_context_extensions(
                 GroupContextExtensionProposal::new(alice_group.context().extensions().clone()),
             ))
         };
@@ -350,7 +350,7 @@ fn test_valsem244() {
             bob_credential.clone(),
         );
 
-        let add_proposal = Proposal::Add(AddProposal {
+        let add_proposal = Proposal::add(AddProposal {
             key_package: bob_key_package.key_package().clone(),
         });
 

--- a/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
@@ -119,7 +119,7 @@ fn test_valsem241() {
 
         // Insert a second external init proposal into the commit.
         let second_ext_init_prop =
-            ProposalOrRef::Proposal(Proposal::external_init(ExternalInitProposal::from(vec![
+            ProposalOrRef::proposal(Proposal::external_init(ExternalInitProposal::from(vec![
                 1, 2, 3,
             ])));
 
@@ -251,13 +251,13 @@ fn test_valsem242() {
                 charlie_credential,
             );
 
-            ProposalOrRef::Proposal(Proposal::add(AddProposal {
+            ProposalOrRef::proposal(Proposal::add(AddProposal {
                 key_package: charlie_key_package.key_package().clone(),
             }))
         };
 
         let reinit_proposal = {
-            ProposalOrRef::Proposal(Proposal::re_init(ReInitProposal {
+            ProposalOrRef::proposal(Proposal::re_init(ReInitProposal {
                 group_id: alice_group.group_id().clone(),
                 version: Default::default(),
                 ciphersuite,
@@ -266,7 +266,7 @@ fn test_valsem242() {
         };
 
         let gce_proposal = {
-            ProposalOrRef::Proposal(Proposal::group_context_extensions(
+            ProposalOrRef::proposal(Proposal::group_context_extensions(
                 GroupContextExtensionProposal::new(alice_group.context().extensions().clone()),
             ))
         };
@@ -358,7 +358,7 @@ fn test_valsem244() {
             ProposalRef::from_raw_proposal(ciphersuite, provider.crypto(), &add_proposal).unwrap();
 
         // Add an Add proposal to the external commit.
-        let add_proposal_ref = ProposalOrRef::Reference(proposal_ref);
+        let add_proposal_ref = ProposalOrRef::reference(proposal_ref);
 
         commit_bad.proposals.push(add_proposal_ref);
 

--- a/openmls/src/group/tests_and_kats/tests/external_join_add_proposal.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_join_add_proposal.rs
@@ -7,7 +7,7 @@ use crate::{
     group::*,
     messages::{
         external_proposals::*,
-        proposals::{AddProposal, Proposal, ProposalType},
+        proposals::{Proposal, ProposalType},
     },
     test_utils::frankenstein::*,
     treesync::LeafNodeParameters,
@@ -165,10 +165,11 @@ fn external_join_add_proposal_should_succeed<Provider: OpenMlsProvider>() {
         match msg.into_content() {
             ProcessedMessageContent::ExternalJoinProposalMessage(proposal) => {
                 assert!(matches!(proposal.sender(), Sender::NewMemberProposal));
-                assert!(matches!(
-                    proposal.proposal(),
-                    Proposal::Add(AddProposal { key_package }) if key_package == charlie_kp.key_package()
-                ));
+                let add_proposal = match proposal.proposal() {
+                    Proposal::Add(kp) => kp,
+                    _ => unreachable!("This shouldn't be reached"),
+                };
+                assert!(add_proposal.key_package() == charlie_kp.key_package());
                 alice_group
                     .store_pending_proposal(provider.storage(), *proposal)
                     .unwrap()

--- a/openmls/src/group/tests_and_kats/tests/framing.rs
+++ b/openmls/src/group/tests_and_kats/tests/framing.rs
@@ -140,7 +140,7 @@ fn bad_padding() {
                 1,
                 sender,
                 vec![1, 2, 3].into(),
-                FramedContentBody::Application(vec![4, 5, 6].into()),
+                FramedContentBody::application(&[4, 5, 6]),
             )
             .with_context(vec![7, 8, 9]);
 

--- a/openmls/src/group/tests_and_kats/tests/framing_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/framing_validation.rs
@@ -355,7 +355,7 @@ fn test_valsem005() {
 
     let original_message = plaintext.clone();
 
-    plaintext.set_content(FramedContentBody::Application(vec![1, 2, 3].into()));
+    plaintext.set_content(FramedContentBody::application(&[1, 2, 3]));
 
     // The membership tag is checked before verifying content encryption, so we need to re-calculate it and set it
     plaintext

--- a/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
@@ -375,7 +375,7 @@ fn test_valsem101a() {
         )
         .unwrap();
 
-    let second_add_proposal = Proposal::Add(AddProposal {
+    let second_add_proposal = Proposal::add(AddProposal {
         key_package: dave_key_package.key_package().clone(),
     });
 
@@ -542,7 +542,7 @@ fn test_valsem102() {
     franken_key_package.resign(&dave_credential_with_key_and_signer.signer);
     let dave_key_package = KeyPackage::from(franken_key_package);
 
-    let second_add_proposal = Proposal::Add(AddProposal {
+    let second_add_proposal = Proposal::add(AddProposal {
         key_package: dave_key_package,
     });
 
@@ -951,7 +951,7 @@ fn test_valsem103_valsem104(ciphersuite: Ciphersuite, provider: &impl OpenMlsPro
     let dave_key_package = KeyPackage::from(franken_key_package);
 
     // Use the resulting KP to create an Add proposal.
-    let add_proposal = Proposal::Add(AddProposal {
+    let add_proposal = Proposal::add(AddProposal {
         key_package: dave_key_package,
     });
 
@@ -1212,7 +1212,7 @@ fn test_valsem105() {
         let original_plaintext = plaintext.clone();
 
         // Create a proposal from the test KPB.
-        let add_proposal = Proposal::Add(AddProposal {
+        let add_proposal = Proposal::add(AddProposal {
             key_package: test_kp,
         });
 
@@ -1511,7 +1511,7 @@ fn test_valsem107() {
         let commit_content = unwrap_specific_commit(commit_inline_remove);
 
         // And it should be the proposal to remove bob.
-        let expected = ProposalOrRef::Proposal(Proposal::Remove(RemoveProposal {
+        let expected = ProposalOrRef::Proposal(Proposal::remove(RemoveProposal {
             removed: bob_leaf_index,
         }));
 
@@ -1628,7 +1628,7 @@ fn test_valsem108() {
     let original_plaintext = plaintext.clone();
 
     // Use a random leaf index that doesn't exist to create a remove proposal.
-    let remove_proposal = Proposal::Remove(RemoveProposal {
+    let remove_proposal = Proposal::remove(RemoveProposal {
         removed: LeafNodeIndex::new(987),
     });
 
@@ -1824,7 +1824,7 @@ fn test_valsem110() {
 
     let original_plaintext = plaintext.clone();
 
-    let update_proposal = Proposal::Update(UpdateProposal {
+    let update_proposal = Proposal::update(UpdateProposal {
         leaf_node: franken_leaf_node.into(),
     });
 
@@ -1892,7 +1892,7 @@ fn test_valsem111() {
         alice_credential_with_key_and_signer.clone(),
     );
 
-    let update_proposal = Proposal::Update(UpdateProposal {
+    let update_proposal = Proposal::update(UpdateProposal {
         leaf_node: update_kp.key_package().leaf_node().clone(),
     });
 

--- a/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
@@ -1405,7 +1405,7 @@ fn test_valsem107() {
 
         // The commit should contain only one proposal.
         assert_eq!(commit_content.proposals.len(), 1);
-        commit_content
+        *commit_content
     }
 
     // Before we can test creation of (invalid) proposals, we set up a new group

--- a/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
@@ -382,7 +382,7 @@ fn test_valsem101a() {
     let verifiable_plaintext = insert_proposal_and_resign(
         provider,
         ciphersuite,
-        vec![ProposalOrRef::Proposal(second_add_proposal)],
+        vec![ProposalOrRef::proposal(second_add_proposal)],
         plaintext,
         &original_plaintext,
         &alice_group,
@@ -549,7 +549,7 @@ fn test_valsem102() {
     let verifiable_plaintext = insert_proposal_and_resign(
         provider,
         ciphersuite,
-        vec![ProposalOrRef::Proposal(second_add_proposal)],
+        vec![ProposalOrRef::proposal(second_add_proposal)],
         plaintext,
         &original_plaintext,
         &alice_group,
@@ -960,7 +960,7 @@ fn test_valsem103_valsem104(ciphersuite: Ciphersuite, provider: &impl OpenMlsPro
     let verifiable_plaintext = insert_proposal_and_resign(
         provider,
         ciphersuite,
-        vec![ProposalOrRef::Proposal(add_proposal)],
+        vec![ProposalOrRef::proposal(add_proposal)],
         plaintext,
         &original_plaintext,
         &alice_group,
@@ -1218,8 +1218,8 @@ fn test_valsem105() {
 
         for proposal_inclusion in [ProposalInclusion::ByValue, ProposalInclusion::ByReference] {
             let proposal_or_ref = match proposal_inclusion {
-                ProposalInclusion::ByValue => ProposalOrRef::Proposal(add_proposal.clone()),
-                ProposalInclusion::ByReference => ProposalOrRef::Reference(
+                ProposalInclusion::ByValue => ProposalOrRef::proposal(add_proposal.clone()),
+                ProposalInclusion::ByReference => ProposalOrRef::reference(
                     ProposalRef::from_raw_proposal(ciphersuite, provider.crypto(), &add_proposal)
                         .unwrap(),
                 ),
@@ -1487,7 +1487,7 @@ fn test_valsem107() {
                 _ => panic!(),
             };
 
-            ProposalOrRef::Reference(
+            ProposalOrRef::reference(
                 ProposalRef::from_authenticated_content_by_ref(
                     provider.crypto(),
                     ciphersuite,
@@ -1511,7 +1511,7 @@ fn test_valsem107() {
         let commit_content = unwrap_specific_commit(commit_inline_remove);
 
         // And it should be the proposal to remove bob.
-        let expected = ProposalOrRef::Proposal(Proposal::remove(RemoveProposal {
+        let expected = ProposalOrRef::proposal(Proposal::remove(RemoveProposal {
             removed: bob_leaf_index,
         }));
 
@@ -1637,7 +1637,7 @@ fn test_valsem108() {
     let verifiable_plaintext = insert_proposal_and_resign(
         provider,
         ciphersuite,
-        vec![ProposalOrRef::Proposal(remove_proposal)],
+        vec![ProposalOrRef::proposal(remove_proposal)],
         plaintext,
         &original_plaintext,
         &alice_group,
@@ -1832,7 +1832,7 @@ fn test_valsem110() {
     let verifiable_plaintext = insert_proposal_and_resign(
         provider,
         ciphersuite,
-        vec![ProposalOrRef::Proposal(update_proposal)],
+        vec![ProposalOrRef::proposal(update_proposal)],
         plaintext,
         &original_plaintext,
         &alice_group,
@@ -1943,7 +1943,7 @@ fn test_valsem111() {
     let verifiable_plaintext = insert_proposal_and_resign(
         provider,
         ciphersuite,
-        vec![ProposalOrRef::Proposal(update_proposal.clone())],
+        vec![ProposalOrRef::proposal(update_proposal.clone())],
         plaintext,
         &original_plaintext,
         &alice_group,
@@ -2011,7 +2011,7 @@ fn test_valsem111() {
     let verifiable_plaintext = insert_proposal_and_resign(
         provider,
         ciphersuite,
-        vec![ProposalOrRef::Reference(
+        vec![ProposalOrRef::reference(
             ProposalRef::from_raw_proposal(ciphersuite, provider.crypto(), &update_proposal)
                 .expect("error creating hash reference"),
         )],

--- a/openmls/src/messages/codec.rs
+++ b/openmls/src/messages/codec.rs
@@ -106,25 +106,33 @@ impl Deserialize for ProposalIn {
     {
         let proposal_type = ProposalType::tls_deserialize(bytes)?;
         let proposal = match proposal_type {
-            ProposalType::Add => ProposalIn::Add(AddProposalIn::tls_deserialize(bytes)?),
-            ProposalType::Update => ProposalIn::Update(UpdateProposalIn::tls_deserialize(bytes)?),
-            ProposalType::Remove => ProposalIn::Remove(RemoveProposal::tls_deserialize(bytes)?),
+            ProposalType::Add => ProposalIn::Add(Box::new(AddProposalIn::tls_deserialize(bytes)?)),
+            ProposalType::Update => {
+                ProposalIn::Update(Box::new(UpdateProposalIn::tls_deserialize(bytes)?))
+            }
+            ProposalType::Remove => {
+                ProposalIn::Remove(Box::new(RemoveProposal::tls_deserialize(bytes)?))
+            }
             ProposalType::PreSharedKey => {
-                ProposalIn::PreSharedKey(PreSharedKeyProposal::tls_deserialize(bytes)?)
+                ProposalIn::PreSharedKey(Box::new(PreSharedKeyProposal::tls_deserialize(bytes)?))
             }
-            ProposalType::Reinit => ProposalIn::ReInit(ReInitProposal::tls_deserialize(bytes)?),
+            ProposalType::Reinit => {
+                ProposalIn::ReInit(Box::new(ReInitProposal::tls_deserialize(bytes)?))
+            }
             ProposalType::ExternalInit => {
-                ProposalIn::ExternalInit(ExternalInitProposal::tls_deserialize(bytes)?)
+                ProposalIn::ExternalInit(Box::new(ExternalInitProposal::tls_deserialize(bytes)?))
             }
-            ProposalType::GroupContextExtensions => ProposalIn::GroupContextExtensions(
+            ProposalType::GroupContextExtensions => ProposalIn::GroupContextExtensions(Box::new(
                 GroupContextExtensionProposal::tls_deserialize(bytes)?,
-            ),
-            ProposalType::AppAck => ProposalIn::AppAck(AppAckProposal::tls_deserialize(bytes)?),
+            )),
+            ProposalType::AppAck => {
+                ProposalIn::AppAck(Box::new(AppAckProposal::tls_deserialize(bytes)?))
+            }
             ProposalType::SelfRemove => ProposalIn::SelfRemove,
             ProposalType::Custom(_) => {
                 let payload = Vec::<u8>::tls_deserialize(bytes)?;
                 let custom_proposal = CustomProposal::new(proposal_type.into(), payload);
-                ProposalIn::Custom(custom_proposal)
+                ProposalIn::Custom(Box::new(custom_proposal))
             }
         };
         Ok(proposal)

--- a/openmls/src/messages/external_proposals.rs
+++ b/openmls/src/messages/external_proposals.rs
@@ -49,7 +49,7 @@ impl JoinProposal {
         signer: &impl Signer,
     ) -> Result<MlsMessageOut, ProposeAddMemberError<Storage::Error>> {
         AuthenticatedContent::new_join_proposal(
-            Proposal::Add(AddProposal { key_package }),
+            Proposal::add(AddProposal { key_package }),
             group_id,
             epoch,
             signer,
@@ -81,7 +81,7 @@ impl ExternalProposal {
         let proposal = GroupContextExtensionProposal::new(extensions);
 
         AuthenticatedContent::new_external_proposal(
-            Proposal::GroupContextExtensions(proposal),
+            Proposal::GroupContextExtensions(Box::new(proposal)),
             group_id,
             epoch,
             signer,
@@ -109,7 +109,7 @@ impl ExternalProposal {
         sender_index: SenderExtensionIndex,
     ) -> Result<MlsMessageOut, ProposeRemoveMemberError<Provider::StorageError>> {
         AuthenticatedContent::new_external_proposal(
-            Proposal::Remove(RemoveProposal { removed }),
+            Proposal::remove(RemoveProposal { removed }),
             group_id,
             epoch,
             signer,
@@ -138,7 +138,7 @@ impl ExternalProposal {
         sender_index: SenderExtensionIndex,
     ) -> Result<MlsMessageOut, ProposeAddMemberError<Provider::StorageError>> {
         AuthenticatedContent::new_external_proposal(
-            Proposal::Add(AddProposal { key_package }),
+            Proposal::add(AddProposal { key_package }),
             group_id,
             epoch,
             signer,

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -310,6 +310,23 @@ impl Proposal {
             }
         }
     }
+
+    // Get this proposal as a `RemoveProposal`.
+    pub(crate) fn as_remove(&self) -> Option<&RemoveProposal> {
+        if let Self::Remove(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `true` if the proposal is [`Remove`].
+    ///
+    /// [`Remove`]: Proposal::Remove
+    #[must_use]
+    pub fn is_remove(&self) -> bool {
+        matches!(self, Self::Remove(..))
+    }
 }
 
 /// Add Proposal.
@@ -614,11 +631,50 @@ pub enum ProposalOrRefType {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, TlsSerialize, TlsSize)]
 #[repr(u8)]
 #[allow(missing_docs)]
-#[allow(clippy::large_enum_variant)]
 pub(crate) enum ProposalOrRef {
     #[tls_codec(discriminant = 1)]
-    Proposal(Proposal),
-    Reference(ProposalRef),
+    Proposal(Box<Proposal>),
+    Reference(Box<ProposalRef>),
+}
+
+impl ProposalOrRef {
+    /// Create a proposal by value.
+    pub(crate) fn proposal(p: Proposal) -> Self {
+        Self::Proposal(Box::new(p))
+    }
+
+    /// Create a proposal by reference.
+    pub(crate) fn reference(p: ProposalRef) -> Self {
+        Self::Reference(Box::new(p))
+    }
+
+    pub(crate) fn as_proposal(&self) -> Option<&Proposal> {
+        if let Self::Proposal(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn as_reference(&self) -> Option<&ProposalRef> {
+        if let Self::Reference(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Proposal> for ProposalOrRef {
+    fn from(value: Proposal) -> Self {
+        Self::proposal(value)
+    }
+}
+
+impl From<ProposalRef> for ProposalOrRef {
+    fn from(value: ProposalRef) -> Self {
+        Self::reference(value)
+    }
 }
 
 #[derive(Error, Debug)]

--- a/openmls/src/messages/proposals_in.rs
+++ b/openmls/src/messages/proposals_in.rs
@@ -247,11 +247,10 @@ impl UpdateProposalIn {
 )]
 #[repr(u8)]
 #[allow(missing_docs)]
-#[allow(clippy::large_enum_variant)]
 pub(crate) enum ProposalOrRefIn {
     #[tls_codec(discriminant = 1)]
-    Proposal(ProposalIn),
-    Reference(ProposalRef),
+    Proposal(Box<ProposalIn>),
+    Reference(Box<ProposalRef>),
 }
 
 impl ProposalOrRefIn {
@@ -263,9 +262,9 @@ impl ProposalOrRefIn {
         protocol_version: ProtocolVersion,
     ) -> Result<ProposalOrRef, ValidationError> {
         Ok(match self {
-            ProposalOrRefIn::Proposal(proposal_in) => ProposalOrRef::Proposal(
+            ProposalOrRefIn::Proposal(proposal_in) => ProposalOrRef::Proposal(Box::new(
                 proposal_in.validate(crypto, ciphersuite, None, protocol_version)?,
-            ),
+            )),
             ProposalOrRefIn::Reference(reference) => ProposalOrRef::Reference(reference),
         })
     }
@@ -378,7 +377,7 @@ impl From<crate::messages::proposals::Proposal> for ProposalIn {
 impl From<ProposalOrRefIn> for crate::messages::proposals::ProposalOrRef {
     fn from(proposal: ProposalOrRefIn) -> Self {
         match proposal {
-            ProposalOrRefIn::Proposal(proposal) => Self::Proposal(proposal.into()),
+            ProposalOrRefIn::Proposal(proposal) => Self::Proposal(Box::new((*proposal).into())),
             ProposalOrRefIn::Reference(reference) => Self::Reference(reference),
         }
     }
@@ -388,7 +387,7 @@ impl From<crate::messages::proposals::ProposalOrRef> for ProposalOrRefIn {
     fn from(proposal: crate::messages::proposals::ProposalOrRef) -> Self {
         match proposal {
             crate::messages::proposals::ProposalOrRef::Proposal(proposal) => {
-                Self::Proposal(proposal.into())
+                Self::Proposal(Box::new((*proposal).into()))
             }
             crate::messages::proposals::ProposalOrRef::Reference(reference) => {
                 Self::Reference(reference)

--- a/openmls/src/messages/proposals_in.rs
+++ b/openmls/src/messages/proposals_in.rs
@@ -44,25 +44,24 @@ use super::{
 ///     };
 /// } Proposal;
 /// ```
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 #[repr(u16)]
 pub enum ProposalIn {
-    Add(AddProposalIn),
-    Update(UpdateProposalIn),
-    Remove(RemoveProposal),
-    PreSharedKey(PreSharedKeyProposal),
-    ReInit(ReInitProposal),
-    ExternalInit(ExternalInitProposal),
-    GroupContextExtensions(GroupContextExtensionProposal),
+    Add(Box<AddProposalIn>),
+    Update(Box<UpdateProposalIn>),
+    Remove(Box<RemoveProposal>),
+    PreSharedKey(Box<PreSharedKeyProposal>),
+    ReInit(Box<ReInitProposal>),
+    ExternalInit(Box<ExternalInitProposal>),
+    GroupContextExtensions(Box<GroupContextExtensionProposal>),
     // # Extensions
     // TODO(#916): `AppAck` is not in draft-ietf-mls-protocol-17 but
     //             was moved to `draft-ietf-mls-extensions-00`.
-    AppAck(AppAckProposal),
+    AppAck(Box<AppAckProposal>),
     // A SelfRemove proposal is an empty struct.
     SelfRemove,
-    Custom(CustomProposal),
+    Custom(Box<CustomProposal>),
 }
 
 impl ProposalIn {
@@ -98,13 +97,19 @@ impl ProposalIn {
         protocol_version: ProtocolVersion,
     ) -> Result<Proposal, ValidationError> {
         Ok(match self {
-            ProposalIn::Add(add) => {
-                Proposal::Add(add.validate(crypto, protocol_version, ciphersuite)?)
-            }
+            ProposalIn::Add(add) => Proposal::Add(Box::new(add.validate(
+                crypto,
+                protocol_version,
+                ciphersuite,
+            )?)),
             ProposalIn::Update(update) => {
                 let sender_context =
                     sender_context.ok_or(ValidationError::CommitterIncludedOwnUpdate)?;
-                Proposal::Update(update.validate(crypto, ciphersuite, sender_context)?)
+                Proposal::Update(Box::new(update.validate(
+                    crypto,
+                    ciphersuite,
+                    sender_context,
+                )?))
             }
             ProposalIn::Remove(remove) => Proposal::Remove(remove),
             ProposalIn::PreSharedKey(psk) => Proposal::PreSharedKey(psk),
@@ -269,7 +274,7 @@ impl ProposalOrRefIn {
 // The following `From` implementation breaks abstraction layers and MUST
 // NOT be made available outside of tests or "test-utils".
 #[cfg(any(feature = "test-utils", test))]
-impl From<AddProposalIn> for crate::messages::proposals::AddProposal {
+impl From<AddProposalIn> for AddProposal {
     fn from(value: AddProposalIn) -> Self {
         Self {
             key_package: value.key_package.into(),
@@ -277,18 +282,27 @@ impl From<AddProposalIn> for crate::messages::proposals::AddProposal {
     }
 }
 
-impl From<crate::messages::proposals::AddProposal> for AddProposalIn {
-    fn from(value: crate::messages::proposals::AddProposal) -> Self {
-        Self {
+#[cfg(any(feature = "test-utils", test))]
+impl From<AddProposalIn> for Box<AddProposal> {
+    fn from(value: AddProposalIn) -> Self {
+        Box::new(AddProposal {
             key_package: value.key_package.into(),
-        }
+        })
+    }
+}
+
+impl From<AddProposal> for Box<AddProposalIn> {
+    fn from(value: AddProposal) -> Self {
+        Box::new(AddProposalIn {
+            key_package: value.key_package.into(),
+        })
     }
 }
 
 // The following `From` implementation( breaks abstraction layers and MUST
 // NOT be made available outside of tests or "test-utils".
 #[cfg(any(feature = "test-utils", test))]
-impl From<UpdateProposalIn> for crate::messages::proposals::UpdateProposal {
+impl From<UpdateProposalIn> for UpdateProposal {
     fn from(value: UpdateProposalIn) -> Self {
         Self {
             leaf_node: value.leaf_node.into(),
@@ -296,8 +310,8 @@ impl From<UpdateProposalIn> for crate::messages::proposals::UpdateProposal {
     }
 }
 
-impl From<crate::messages::proposals::UpdateProposal> for UpdateProposalIn {
-    fn from(value: crate::messages::proposals::UpdateProposal) -> Self {
+impl From<UpdateProposal> for UpdateProposalIn {
+    fn from(value: UpdateProposal) -> Self {
         Self {
             leaf_node: value.leaf_node.into(),
         }
@@ -305,11 +319,28 @@ impl From<crate::messages::proposals::UpdateProposal> for UpdateProposalIn {
 }
 
 #[cfg(any(feature = "test-utils", test))]
+impl From<UpdateProposalIn> for Box<UpdateProposal> {
+    fn from(value: UpdateProposalIn) -> Self {
+        Box::new(UpdateProposal {
+            leaf_node: value.leaf_node.into(),
+        })
+    }
+}
+
+impl From<UpdateProposal> for Box<UpdateProposalIn> {
+    fn from(value: UpdateProposal) -> Self {
+        Box::new(UpdateProposalIn {
+            leaf_node: value.leaf_node.into(),
+        })
+    }
+}
+
+#[cfg(any(feature = "test-utils", test))]
 impl From<ProposalIn> for crate::messages::proposals::Proposal {
     fn from(proposal: ProposalIn) -> Self {
         match proposal {
-            ProposalIn::Add(add) => Self::Add(add.into()),
-            ProposalIn::Update(update) => Self::Update(update.into()),
+            ProposalIn::Add(add) => Self::Add((*add).into()),
+            ProposalIn::Update(update) => Self::Update((*update).into()),
             ProposalIn::Remove(remove) => Self::Remove(remove),
             ProposalIn::PreSharedKey(psk) => Self::PreSharedKey(psk),
             ProposalIn::ReInit(reinit) => Self::ReInit(reinit),
@@ -327,8 +358,8 @@ impl From<ProposalIn> for crate::messages::proposals::Proposal {
 impl From<crate::messages::proposals::Proposal> for ProposalIn {
     fn from(proposal: crate::messages::proposals::Proposal) -> Self {
         match proposal {
-            Proposal::Add(add) => Self::Add(add.into()),
-            Proposal::Update(update) => Self::Update(update.into()),
+            Proposal::Add(add) => Self::Add((*add).into()),
+            Proposal::Update(update) => Self::Update((*update).into()),
             Proposal::Remove(remove) => Self::Remove(remove),
             Proposal::PreSharedKey(psk) => Self::PreSharedKey(psk),
             Proposal::ReInit(reinit) => Self::ReInit(reinit),

--- a/openmls/src/messages/tests/proposals.rs
+++ b/openmls/src/messages/tests/proposals.rs
@@ -18,7 +18,7 @@ fn proposals_codec() {
     let remove_proposal = RemoveProposal {
         removed: LeafNodeIndex::new(72549),
     };
-    let proposal = Proposal::Remove(remove_proposal);
+    let proposal = Proposal::remove(remove_proposal);
     let proposal_or_ref = ProposalOrRef::Proposal(proposal.clone());
     let encoded = proposal_or_ref
         .tls_serialize_detached()

--- a/openmls/src/messages/tests/proposals.rs
+++ b/openmls/src/messages/tests/proposals.rs
@@ -19,7 +19,7 @@ fn proposals_codec() {
         removed: LeafNodeIndex::new(72549),
     };
     let proposal = Proposal::remove(remove_proposal);
-    let proposal_or_ref = ProposalOrRef::Proposal(proposal.clone());
+    let proposal_or_ref = ProposalOrRef::proposal(proposal.clone());
     let encoded = proposal_or_ref
         .tls_serialize_detached()
         .expect("An unexpected error occurred.");
@@ -32,7 +32,7 @@ fn proposals_codec() {
 
     let reference = ProposalRef::from_raw_proposal(ciphersuite, provider.crypto(), &proposal)
         .expect("An unexpected error occurred.");
-    let proposal_or_ref = ProposalOrRef::Reference(reference);
+    let proposal_or_ref = ProposalOrRef::reference(reference);
     let encoded = proposal_or_ref
         .tls_serialize_detached()
         .expect("An unexpected error occurred.");

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -585,7 +585,7 @@ mod test {
         // Build a commit with a single add proposal
         let bundle = alice
             .build_commit_and_stage(move |builder| {
-                let add_proposal = Proposal::Add(AddProposal {
+                let add_proposal = Proposal::add(AddProposal {
                     key_package: bob_key_package,
                 });
 

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -221,7 +221,7 @@ fn build_handshake_messages(
         AuthenticatedContent::member_proposal(
             framing_parameters,
             sender_index,
-            Proposal::Remove(RemoveProposal {
+            Proposal::remove(RemoveProposal {
                 removed: LeafNodeIndex::new(7),
             }), // XXX: use random removed
             group.export_group_context(),

--- a/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_message_protection.rs
@@ -372,7 +372,7 @@ pub fn run_test_vector(
                 .0;
             match processed_message.content().to_owned() {
                 FramedContentBody::Commit(c) => {
-                    assert_eq!(commit, CommitIn::from(c))
+                    assert_eq!(commit, CommitIn::from(*c))
                 }
                 _ => panic!("Wrong processed message content"),
             }

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -843,7 +843,7 @@ impl TreeSyncDiff<'_> {
 
         // Get the first leaf.
         if let Some(leaf) = leaves.next() {
-            nodes.push(leaf.node().clone().map(Node::LeafNode));
+            nodes.push(leaf.node().clone().map(Node::leaf_node));
         } else {
             // The tree was empty.
             return RatchetTree::trimmed(vec![]);
@@ -868,8 +868,8 @@ impl TreeSyncDiff<'_> {
 
         // Interleave the leaves and parents.
         for (leaf, parent) in leaves.zip(parents) {
-            nodes.push(parent.node().clone().map(Node::ParentNode));
-            nodes.push(leaf.node().clone().map(Node::LeafNode));
+            nodes.push(parent.node().clone().map(Node::parent_node));
+            nodes.push(leaf.node().clone().map(Node::leaf_node));
         }
 
         RatchetTree::trimmed(nodes)

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -458,9 +458,9 @@ impl TreeSync {
                 Some(node) => TreeSyncNode::from(node).into(),
                 None => {
                     if node_index % 2 == 0 {
-                        TreeNode::Leaf(TreeSyncLeafNode::blank())
+                        TreeNode::Leaf(Box::new(TreeSyncLeafNode::blank()))
                     } else {
-                        TreeNode::Parent(TreeSyncParentNode::blank())
+                        TreeNode::Parent(Box::new(TreeSyncParentNode::blank()))
                     }
                 }
             };

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -173,7 +173,7 @@ impl RatchetTree {
                                 .into_signature_public_key_enriched(
                                     ciphersuite.signature_algorithm(),
                                 );
-                            Some(Node::LeafNode(match verifiable_leaf_node {
+                            Some(Node::leaf_node(match verifiable_leaf_node {
                                 VerifiableLeafNode::KeyPackage(leaf_node) => leaf_node
                                     .verify(crypto, &signature_key)
                                     .map_err(|_| RatchetTreeError::InvalidNodeSignature)?,
@@ -401,7 +401,7 @@ impl TreeSync {
         };
         let (leaf, encryption_key_pair) = LeafNode::new(provider, signer, new_leaf_node_params)?;
 
-        let node = Node::LeafNode(leaf);
+        let node = Node::leaf_node(leaf);
         let path_secret: PathSecret = Secret::random(ciphersuite, provider.rand())
             .map_err(LibraryError::unexpected_crypto_error)?
             .into();
@@ -607,7 +607,7 @@ impl TreeSync {
 
         // Get the first leaf.
         if let Some(leaf) = leaves.next() {
-            nodes.push(leaf.node().clone().map(Node::LeafNode));
+            nodes.push(leaf.node().clone().map(Node::leaf_node));
         } else {
             // The tree was empty.
             return RatchetTree::trimmed(vec![]);
@@ -632,8 +632,8 @@ impl TreeSync {
 
         // Interleave the leaves and parents.
         for (leaf, parent) in leaves.zip(parents) {
-            nodes.push(parent.node().clone().map(Node::ParentNode));
-            nodes.push(leaf.node().clone().map(Node::LeafNode));
+            nodes.push(parent.node().clone().map(Node::parent_node));
+            nodes.push(leaf.node().clone().map(Node::leaf_node));
         }
 
         RatchetTree::trimmed(nodes)
@@ -754,7 +754,7 @@ mod test {
         provider: &impl OpenMlsProvider,
     ) {
         let (key_package, _, _) = crate::key_packages::tests::key_package(ciphersuite, provider);
-        let node_in = NodeIn::from(Node::LeafNode(LeafNode::from(key_package)));
+        let node_in = NodeIn::from(Node::leaf_node(LeafNode::from(key_package)));
         let tests = [
             (vec![], false),
             (vec![None], false),

--- a/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
+++ b/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
@@ -16,13 +16,13 @@ fn test_free_leaf_computation() {
 
     // Build a rudimentary tree with two populated and two empty leaf nodes.
     let ratchet_tree = RatchetTree::trimmed(vec![
-        Some(Node::LeafNode(kpb_0.key_package().leaf_node().clone())), // Leaf 0
+        Some(Node::leaf_node(kpb_0.key_package().leaf_node().clone())), // Leaf 0
         None,
         None, // Leaf 1
         None,
         None, // Leaf 2
         None,
-        Some(Node::LeafNode(kpb_3.key_package().leaf_node().clone())), // Leaf 3
+        Some(Node::leaf_node(kpb_3.key_package().leaf_node().clone())), // Leaf 3
     ]);
 
     // Get the encryption key pair from the leaf.

--- a/openmls/src/treesync/treesync_node.rs
+++ b/openmls/src/treesync/treesync_node.rs
@@ -23,8 +23,8 @@ pub(crate) enum TreeSyncNode {
 impl From<Node> for TreeSyncNode {
     fn from(node: Node) -> Self {
         match node {
-            Node::LeafNode(leaf) => TreeSyncNode::Leaf(leaf.into()),
-            Node::ParentNode(parent) => TreeSyncNode::Parent(parent.into()),
+            Node::LeafNode(leaf) => TreeSyncNode::Leaf(Box::new((*leaf).into())),
+            Node::ParentNode(parent) => TreeSyncNode::Parent(Box::new((*parent).into())),
         }
     }
 }
@@ -105,7 +105,7 @@ impl From<LeafNode> for Box<TreeSyncLeafNode> {
 
 impl From<TreeSyncLeafNode> for Option<Node> {
     fn from(tsln: TreeSyncLeafNode) -> Self {
-        tsln.node.map(Node::LeafNode)
+        tsln.node.map(|n| Node::LeafNode(Box::new(n)))
     }
 }
 
@@ -193,6 +193,6 @@ impl From<ParentNode> for Box<TreeSyncParentNode> {
 
 impl From<TreeSyncParentNode> for Option<Node> {
     fn from(tspn: TreeSyncParentNode) -> Self {
-        tspn.node.map(Node::ParentNode)
+        tspn.node.map(|n| Node::ParentNode(Box::new(n)))
     }
 }

--- a/openmls/src/treesync/treesync_node.rs
+++ b/openmls/src/treesync/treesync_node.rs
@@ -14,10 +14,10 @@ use crate::{
 
 use super::{hashes::TreeHashInput, LeafNode, Node, ParentNode};
 
-#[allow(clippy::large_enum_variant)]
+/// A node in the MLS tree.
 pub(crate) enum TreeSyncNode {
-    Leaf(TreeSyncLeafNode),
-    Parent(TreeSyncParentNode),
+    Leaf(Box<TreeSyncLeafNode>),
+    Parent(Box<TreeSyncParentNode>),
 }
 
 impl From<Node> for TreeSyncNode {
@@ -32,8 +32,8 @@ impl From<Node> for TreeSyncNode {
 impl From<TreeSyncNode> for Option<Node> {
     fn from(tsn: TreeSyncNode) -> Self {
         match tsn {
-            TreeSyncNode::Leaf(leaf) => leaf.into(),
-            TreeSyncNode::Parent(parent) => parent.into(),
+            TreeSyncNode::Leaf(leaf) => (*leaf).into(),
+            TreeSyncNode::Parent(parent) => (*parent).into(),
         }
     }
 }
@@ -94,6 +94,12 @@ impl TreeSyncLeafNode {
 impl From<LeafNode> for TreeSyncLeafNode {
     fn from(node: LeafNode) -> Self {
         Self { node: Some(node) }
+    }
+}
+
+impl From<LeafNode> for Box<TreeSyncLeafNode> {
+    fn from(node: LeafNode) -> Self {
+        Box::new(TreeSyncLeafNode { node: Some(node) })
     }
 }
 
@@ -176,6 +182,12 @@ impl TreeSyncParentNode {
 impl From<ParentNode> for TreeSyncParentNode {
     fn from(node: ParentNode) -> Self {
         Self { node: Some(node) }
+    }
+}
+
+impl From<ParentNode> for Box<TreeSyncParentNode> {
+    fn from(node: ParentNode) -> Self {
+        Box::new(TreeSyncParentNode { node: Some(node) })
     }
 }
 


### PR DESCRIPTION
While working on the partial MLS draft I ran into the large enums again and again. So I fixed them. This is a pretty mechanic changes. I only had to touch logic in a few places where matching doesn't work anymore.

Fixes #1670 