### PR TITLE
perf: Avoid storing the whole group state after decryption

### DIFF
--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -87,7 +87,9 @@ impl MlsGroup {
 
         // Persist the group state if the secret tree was modified to ensure forward secrecy
         if will_modify_secret_tree {
-            self.store(provider.storage())
+            provider
+                .storage()
+                .write_message_secrets(self.group_id(), &self.message_secrets_store)
                 .map_err(ProcessMessageError::StorageError)?;
         }
 

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -85,7 +85,7 @@ impl MlsGroup {
             leaf_node_keypairs,
         )?;
 
-        // Persist the group state if the secret tree was modified to ensure forward secrecy
+        // Persist the secret tree if it was modified to ensure forward secrecy
         if will_modify_secret_tree {
             provider
                 .storage()


### PR DESCRIPTION
Small follow-up to #1846. Instead of storing the whole group state after decrypting a message, it only stores the message_secrets_store.