### PR TITLE
chore: update PSK validation id comments

### DIFF
--- a/openmls/src/schedule/psk.rs
+++ b/openmls/src/schedule/psk.rs
@@ -302,6 +302,8 @@ impl PreSharedKeyId {
         // ValSem402
         match self.psk() {
             Psk::Resumption(resumption_psk) => {
+                // https://validation.openmls.tech/#valn0801
+                // https://validation.openmls.tech/#valn0802
                 if resumption_psk.usage != ResumptionPskUsage::Application {
                     return Err(PskError::UsageMismatch {
                         allowed: vec![ResumptionPskUsage::Application],
@@ -313,6 +315,7 @@ impl PreSharedKeyId {
         };
 
         // ValSem401
+        // https://validation.openmls.tech/#valn0803
         {
             let expected_nonce_length = ciphersuite.hash_length();
             let got_nonce_length = self.psk_nonce().len();
@@ -376,7 +379,6 @@ impl PreSharedKeyId {
                 Psk::External(_) => {}
             };
 
-            // https://validation.openmls.tech/#valn0803
             {
                 let expected_nonce_length = ciphersuite.hash_length();
                 let got_nonce_length = id.psk_nonce().len();


### PR DESCRIPTION
We didn't have comments for valn0801 and valn0802 (using psks with the wrong usage in a welcome), and valn0803 was in the wrong place (valn08xx are about PSKs in Welcomes, and it was in the validation of proposals). I added the comments.

How valn0801/0802 satisfy the criterion may not be obvious because the wording in the RFC is a bit weird, but basically we don't support ReInit and Branching, so we only check that it is not one of those.

I will also update the dashboard.