### PR TITLE
feat: add from_components method to avoid allocations in TreeNode

### DIFF
--- a/openmls/src/binary_tree/array_representation/tree.rs
+++ b/openmls/src/binary_tree/array_representation/tree.rs
@@ -103,6 +103,36 @@ impl<L: Clone + Debug + Default, P: Clone + Debug + Default> ABinaryTree<L, P> {
         })
     }
 
+    /// Create a tree directly from separate vectors of leaf and parent nodes,
+    /// avoiding the allocations required when using `TreeNode` enum variants.
+    ///
+    /// # Arguments
+    /// * `leaf_nodes` - Vector of leaf nodes
+    /// * `parent_nodes` - Vector of parent nodes
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// * The total number of nodes exceeds `MAX_TREE_SIZE`
+    /// * The vectors don't form a valid full, left-balanced binary tree
+    pub(crate) fn from_components(
+        leaf_nodes: Vec<L>,
+        parent_nodes: Vec<P>,
+    ) -> Result<Self, ABinaryTreeError> {
+        let total_nodes = leaf_nodes.len() + parent_nodes.len();
+        if total_nodes > MAX_TREE_SIZE as usize {
+            return Err(ABinaryTreeError::OutOfRange);
+        }
+        if leaf_nodes.len() != parent_nodes.len() + 1 {
+            return Err(ABinaryTreeError::InvalidNumberOfNodes);
+        }
+        Ok(ABinaryTree {
+            leaf_nodes,
+            parent_nodes,
+            default_leaf: L::default(),
+            default_parent: P::default(),
+        })
+    }
+
     /// Obtain a reference to the data contained in the leaf node at index
     /// `leaf_index`, where the indexing corresponds to the array representation
     /// of the underlying binary tree. Returns the default value if the node

--- a/openmls/src/binary_tree/tests.rs
+++ b/openmls/src/binary_tree/tests.rs
@@ -239,3 +239,62 @@ fn diff_leaf_access() {
     let leaf_outside_of_diff = diff.leaf(LeafNodeIndex::new(3));
     assert_eq!(leaf_outside_of_diff, &0)
 }
+
+#[test]
+fn test_from_components() {
+    let leaf_nodes = vec![1u32, 2, 3, 4];
+    let parent_nodes = vec![10u32, 20, 30];
+
+    let tree = MlsBinaryTree::from_components(leaf_nodes, parent_nodes)
+        .expect("Error creating tree from components");
+
+    assert_eq!(tree.leaf_count(), 4);
+    assert_eq!(tree.parent_count(), 3);
+    assert_eq!(tree.tree_size(), TreeSize::new(7));
+
+    assert_eq!(tree.leaf_by_index(LeafNodeIndex::new(0)), &1);
+    assert_eq!(tree.leaf_by_index(LeafNodeIndex::new(1)), &2);
+    assert_eq!(tree.leaf_by_index(LeafNodeIndex::new(2)), &3);
+    assert_eq!(tree.leaf_by_index(LeafNodeIndex::new(3)), &4);
+
+    assert_eq!(tree.parent_by_index(ParentNodeIndex::new(0)), &10);
+    assert_eq!(tree.parent_by_index(ParentNodeIndex::new(1)), &20);
+    assert_eq!(tree.parent_by_index(ParentNodeIndex::new(2)), &30);
+
+    let invalid_leaf_nodes = vec![1u32, 2];
+    let invalid_parent_nodes = vec![10u32, 20];
+
+    assert_eq!(
+        MlsBinaryTree::from_components(invalid_leaf_nodes, invalid_parent_nodes)
+            .expect_err("Should fail with invalid node count"),
+        MlsBinaryTreeError::InvalidNumberOfNodes
+    );
+
+    let leaf_vec = vec![5u32, 6];
+    let parent_vec = vec![15u32];
+
+    let tree1 = MlsBinaryTree::from_components(leaf_vec.clone(), parent_vec.clone())
+        .expect("Error creating tree from components");
+
+    let tree2 = MlsBinaryTree::new(vec![
+        TreeNode::leaf(5),
+        TreeNode::parent(15),
+        TreeNode::leaf(6),
+    ])
+    .expect("Error creating tree from TreeNode");
+
+    assert_eq!(tree1.leaf_count(), tree2.leaf_count());
+    assert_eq!(tree1.parent_count(), tree2.parent_count());
+    assert_eq!(
+        tree1.leaf_by_index(LeafNodeIndex::new(0)),
+        tree2.leaf_by_index(LeafNodeIndex::new(0))
+    );
+    assert_eq!(
+        tree1.leaf_by_index(LeafNodeIndex::new(1)),
+        tree2.leaf_by_index(LeafNodeIndex::new(1))
+    );
+    assert_eq!(
+        tree1.parent_by_index(ParentNodeIndex::new(0)),
+        tree2.parent_by_index(ParentNodeIndex::new(0))
+    );
+}


### PR DESCRIPTION
- Add `ABinaryTree::from_components` method that accepts separate `Vec<L>` and `Vec<P>` to avoid intermediate Box allocations
- Refactor `TreeSync::from_ratchet_tree` to use `from_components` directly
- Add tests for the new method
- Remove unused `TreeNode` import from `treesync` module

This change eliminates unnecessary heap allocations when creating binary trees, improving performance by avoiding the creation of Vec<TreeNode> and subsequent Box unwrapping.

Fixes #1839