### PR TITLE
feat: optimize Signable to reuse serialized payload

### DIFF
--- a/openmls/src/ciphersuite/signature.rs
+++ b/openmls/src/ciphersuite/signature.rs
@@ -139,7 +139,7 @@ impl Signature {
 }
 
 impl<T> SignedStruct<T> for Signature {
-    fn from_payload(_payload: T, signature: Signature) -> Self {
+    fn from_payload(_payload: T, signature: Signature, _serialized_payload: Vec<u8>) -> Self {
         signature
     }
 }

--- a/openmls/src/ciphersuite/tests_and_kats/kat_crypto_basics.rs
+++ b/openmls/src/ciphersuite/tests_and_kats/kat_crypto_basics.rs
@@ -143,12 +143,20 @@ struct SignWithLabelTest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct MySignature(Signature);
 impl SignedStruct<ParsedSignWithLabel> for MySignature {
-    fn from_payload(_: ParsedSignWithLabel, signature: Signature) -> Self {
+    fn from_payload(
+        _: ParsedSignWithLabel,
+        signature: Signature,
+        _serialized_payload: Vec<u8>,
+    ) -> Self {
         Self(signature)
     }
 }
 impl SignedStruct<SignWithLabelTest> for MySignature {
-    fn from_payload(_: SignWithLabelTest, signature: Signature) -> Self {
+    fn from_payload(
+        _: SignWithLabelTest,
+        signature: Signature,
+        _serialized_payload: Vec<u8>,
+    ) -> Self {
         Self(signature)
     }
 }

--- a/openmls/src/framing/mls_auth_content.rs
+++ b/openmls/src/framing/mls_auth_content.rs
@@ -293,7 +293,11 @@ impl AuthenticatedContent {
 }
 
 impl SignedStruct<FramedContentTbs> for AuthenticatedContent {
-    fn from_payload(tbs: FramedContentTbs, signature: Signature) -> Self {
+    fn from_payload(
+        tbs: FramedContentTbs,
+        signature: Signature,
+        _serialized_payload: Vec<u8>,
+    ) -> Self {
         let auth = FramedContentAuthData {
             signature,
             // Tags must always be added after the signature

--- a/openmls/src/framing/mls_auth_content_in.rs
+++ b/openmls/src/framing/mls_auth_content_in.rs
@@ -223,7 +223,11 @@ impl Verifiable for VerifiableAuthenticatedContentIn {
 impl VerifiedStruct for AuthenticatedContentIn {}
 
 impl SignedStruct<FramedContentTbsIn> for AuthenticatedContentIn {
-    fn from_payload(tbs: FramedContentTbsIn, signature: Signature) -> Self {
+    fn from_payload(
+        tbs: FramedContentTbsIn,
+        signature: Signature,
+        _serialized_payload: Vec<u8>,
+    ) -> Self {
         let auth = FramedContentAuthData {
             signature,
             // Tags must always be added after the signature

--- a/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
@@ -2016,8 +2016,8 @@ fn test_valsem111() {
         .expect("Error creating self-update");
 
     // Check that there's no proposal in it.
-    let serialized_message = commit_bundle
-        .contents()
+    let (msg, welcome, group_info) = commit_bundle.contents();
+    let serialized_message = (msg, welcome.cloned(), group_info.cloned())
         .tls_serialize_detached()
         .expect("error serializing plaintext");
 
@@ -2035,8 +2035,8 @@ fn test_valsem111() {
     // The commit should contain no proposals.
     assert_eq!(commit_content.proposals.len(), 0);
 
-    let serialized_update = commit_bundle
-        .contents()
+    let (msg, welcome, group_info) = commit_bundle.contents();
+    let serialized_update = (msg, welcome.cloned(), group_info.cloned())
         .tls_serialize_detached()
         .expect("Could not serialize message.");
 

--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -58,6 +58,7 @@ impl Verifiable for VerifiableKeyPackage {
         Ok(KeyPackage {
             payload: self.payload,
             signature: self.signature,
+            serialized_payload: None,
         })
     }
 }
@@ -262,6 +263,7 @@ impl From<KeyPackageIn> for KeyPackage {
         Self {
             payload: value.payload.into(),
             signature: value.signature,
+            serialized_payload: None,
         }
     }
 }

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -175,10 +175,26 @@ impl From<KeyPackage> for KeyPackageTbs {
 }
 
 /// The key package struct.
-#[derive(Debug, Clone, Serialize, Deserialize, TlsSize, TlsSerialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TlsSize)]
 pub struct KeyPackage {
     payload: KeyPackageTbs,
     signature: Signature,
+    #[serde(skip)]
+    #[tls_codec(skip)]
+    serialized_payload: Option<Vec<u8>>,
+}
+
+impl TlsSerializeTrait for KeyPackage {
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+        let mut written = 0;
+        if let Some(ref bytes) = self.serialized_payload {
+            written += writer.write(bytes)?;
+        } else {
+            written += self.payload.tls_serialize(writer)?;
+        }
+        written += self.signature.tls_serialize(writer)?;
+        Ok(written)
+    }
 }
 
 impl PartialEq for KeyPackage {
@@ -190,8 +206,16 @@ impl PartialEq for KeyPackage {
 }
 
 impl SignedStruct<KeyPackageTbs> for KeyPackage {
-    fn from_payload(payload: KeyPackageTbs, signature: Signature) -> Self {
-        Self { payload, signature }
+    fn from_payload(
+        payload: KeyPackageTbs,
+        signature: Signature,
+        serialized_payload: Vec<u8>,
+    ) -> Self {
+        Self {
+            payload,
+            signature,
+            serialized_payload: Some(serialized_payload),
+        }
     }
 }
 

--- a/openmls/src/messages/group_info.rs
+++ b/openmls/src/messages/group_info.rs
@@ -5,7 +5,8 @@ use openmls_traits::types::Ciphersuite;
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 use thiserror::Error;
 use tls_codec::{
-    Deserialize, Serialize, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+    Deserialize, Serialize as TlsSerializeTrait, TlsDeserialize, TlsDeserializeBytes, TlsSerialize,
+    TlsSize,
 };
 
 use crate::{
@@ -142,6 +143,7 @@ impl From<VerifiableGroupInfo> for GroupInfo {
         GroupInfo {
             payload: vgi.payload,
             signature: vgi.signature,
+            serialized_payload: None,
         }
     }
 }
@@ -162,11 +164,27 @@ impl From<VerifiableGroupInfo> for GroupInfo {
 ///     opaque signature<V>;
 /// } GroupInfo;
 /// ```
-#[derive(Debug, PartialEq, Clone, TlsSerialize, TlsSize, SerdeSerialize, SerdeDeserialize)]
+#[derive(Debug, PartialEq, Clone, TlsSize, SerdeSerialize, SerdeDeserialize)]
 #[cfg_attr(feature = "test-utils", derive(TlsDeserialize))]
 pub struct GroupInfo {
     payload: GroupInfoTBS,
     signature: Signature,
+    #[serde(skip)]
+    #[tls_codec(skip)]
+    serialized_payload: Option<Vec<u8>>,
+}
+
+impl TlsSerializeTrait for GroupInfo {
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+        let mut written = 0;
+        if let Some(ref bytes) = self.serialized_payload {
+            written += writer.write(bytes)?;
+        } else {
+            written += self.payload.tls_serialize(writer)?;
+        }
+        written += self.signature.tls_serialize(writer)?;
+        Ok(written)
+    }
 }
 
 impl GroupInfo {
@@ -273,8 +291,16 @@ impl Signable for GroupInfoTBS {
 }
 
 impl SignedStruct<GroupInfoTBS> for GroupInfo {
-    fn from_payload(payload: GroupInfoTBS, signature: Signature) -> Self {
-        Self { payload, signature }
+    fn from_payload(
+        payload: GroupInfoTBS,
+        signature: Signature,
+        serialized_payload: Vec<u8>,
+    ) -> Self {
+        Self {
+            payload,
+            signature,
+            serialized_payload: Some(serialized_payload),
+        }
     }
 }
 
@@ -302,6 +328,7 @@ impl Verifiable for VerifiableGroupInfo {
         Ok(GroupInfo {
             payload: self.payload,
             signature: self.signature,
+            serialized_payload: None,
         })
     }
 }

--- a/openmls/src/test_utils/frankenstein/group_info.rs
+++ b/openmls/src/test_utils/frankenstein/group_info.rs
@@ -47,7 +47,11 @@ impl DerefMut for FrankenGroupInfo {
 }
 
 impl SignedStruct<FrankenGroupInfoTbs> for FrankenGroupInfo {
-    fn from_payload(payload: FrankenGroupInfoTbs, signature: Signature) -> Self {
+    fn from_payload(
+        payload: FrankenGroupInfoTbs,
+        signature: Signature,
+        _serialized_payload: Vec<u8>,
+    ) -> Self {
         Self {
             payload,
             signature: signature.as_slice().to_owned().into(),

--- a/openmls/src/test_utils/frankenstein/key_package.rs
+++ b/openmls/src/test_utils/frankenstein/key_package.rs
@@ -56,7 +56,11 @@ impl DerefMut for FrankenKeyPackage {
 }
 
 impl SignedStruct<FrankenKeyPackageTbs> for FrankenKeyPackage {
-    fn from_payload(payload: FrankenKeyPackageTbs, signature: Signature) -> Self {
+    fn from_payload(
+        payload: FrankenKeyPackageTbs,
+        signature: Signature,
+        _serialized_payload: Vec<u8>,
+    ) -> Self {
         Self {
             payload,
             signature: signature.as_slice().to_owned().into(),

--- a/openmls/src/test_utils/frankenstein/leaf_node.rs
+++ b/openmls/src/test_utils/frankenstein/leaf_node.rs
@@ -53,7 +53,11 @@ impl DerefMut for FrankenLeafNode {
 }
 
 impl SignedStruct<FrankenLeafNodeTbs> for FrankenLeafNode {
-    fn from_payload(tbs: FrankenLeafNodeTbs, signature: Signature) -> Self {
+    fn from_payload(
+        tbs: FrankenLeafNodeTbs,
+        signature: Signature,
+        _serialized_payload: Vec<u8>,
+    ) -> Self {
         Self {
             payload: tbs.payload,
             signature: signature.as_slice().to_owned().into(),

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -991,7 +991,7 @@ impl Signable for LeafNodeTbs {
 }
 
 impl SignedStruct<LeafNodeTbs> for LeafNode {
-    fn from_payload(tbs: LeafNodeTbs, signature: Signature) -> Self {
+    fn from_payload(tbs: LeafNodeTbs, signature: Signature, _serialized_payload: Vec<u8>) -> Self {
         Self {
             payload: tbs.payload,
             signature,


### PR DESCRIPTION
modifies the `Signable` and `SignedStruct` traits to allow reusing the serialized payload generated during the signing process.
This prevents double serialization of payloads (once for signing, once for wire transmission) for `GroupInfo` and `KeyPackage`.

Fixes: #160 