### PR TITLE
Remove nightly-only `cargo fmt` config settings

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,1 @@
-wrap_comments = true
 edition = "2021"
-format_code_in_doc_comments = true


### PR DESCRIPTION
This removes two config options that only apply to nightly. 

Fixes #1899 