### PR TITLE
fix: skip removed members in capabilities check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#1846](https://github.com/openmls/openmls/pull/1846): Fix persistence during message processing by properly persisting the secret tree after processing private messages and improve forward secrecy within epochs.
+- [#1943](https://github.com/openmls/openmls/pull/1943): Fix a proposal validation check that erroneously requires members that are being removed in a commit to also support all proposal types used in the commit.
 
 ### Changed
 

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -148,11 +148,6 @@ impl PublicGroup {
             })
             .collect();
 
-        println!(
-            "Signature keys of removed members: {:?}",
-            signature_keys.len()
-        );
-
         // Iterate over all leaf nodes except the removed ones
         let mut leaves = self
             .treesync()
@@ -177,8 +172,6 @@ impl PublicGroup {
                 .cloned()
                 .collect();
         }
-
-        println!("Capabilities intersection: {:?}", capabilities_intersection);
 
         // Check that the types of all non-default proposals are supported by all members
         for proposal in proposal_queue.queued_proposals() {

--- a/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
+++ b/openmls/src/group/tests_and_kats/tests/capabilities_check.rs
@@ -383,16 +383,6 @@ fn valn0311_removed_member_capabilities_skipped_in_check() {
         .with_leaf_node_capabilities(capabilities.clone())
         .build();
 
-    // Verify that alice and bob support the non-default proposal type
-    for member in [&alice_pre_group, &bob_pre_group] {
-        let capabilities = member
-            .key_package_bundle
-            .key_package
-            .leaf_node()
-            .capabilities();
-        assert!(capabilities.contains_proposal(non_default_proposal_type));
-    }
-
     // Charlie only supports the basic proposal types
     let charlie_pre_group = charlie_party.generate_pre_group(ciphersuite);
 
@@ -427,30 +417,6 @@ fn valn0311_removed_member_capabilities_skipped_in_check() {
 
     let mut members = group_state.members_mut(&["alice"]);
     let alice_group_state = members.get_mut(0).unwrap();
-
-    println!(
-        "Number of members before removal: {}",
-        alice_group_state.group.members().count()
-    );
-
-    // Verify that Alice and Bob support the non-default proposal type
-    for member in alice_group_state.group.members() {
-        if member.index == LeafNodeIndex::new(2) {
-            continue;
-        }
-        let capabilities = alice_group_state
-            .group
-            .public_group()
-            .leaf(member.index)
-            .unwrap()
-            .capabilities();
-        if !capabilities.contains_proposal(non_default_proposal_type) {
-            println!(
-                "Member at index {:?} does not support the non-default proposal type",
-                member.index
-            )
-        };
-    }
 
     // Remove Charlie and at the same time commit to a proposal that charlie doesn't support
     let commit = alice_group_state


### PR DESCRIPTION
RFC 9420 says a commit is invalid if (among other things):

> It contains a Proposal with a non-default proposal type that is not supported by some members of the group that will process the Commit (i.e., members being added or removed by the Commit do not need to support the proposal type).

Our validation is currently stricter than necessary in that it also requires members removed in a commit to support all proposal types in that commit. This PR fixes that.