### PR TITLE
Relax Wasm size limit

### DIFF
--- a/openmls-wasm/check-size.sh
+++ b/openmls-wasm/check-size.sh
@@ -16,7 +16,7 @@ raw_size=$(tar c pkg | wc -c)
 gzip_size=$(tar cj pkg | wc -c)
 
 raw_thresh=1700000
-gzip_thresh=500000
+gzip_thresh=550000
 
 if [ $raw_size -gt $raw_thresh ]; then
 	die "raw size is too large: $raw_size > $raw_thresh"


### PR DESCRIPTION
This relaxes the CI alert Wasm size limit. I don't think there is anything we can do about the size currently.