### PR TITLE
feat: derive serde Serialize and Deserialize for MlsMessageOut

### DIFF
--- a/openmls/src/framing/message_out.rs
+++ b/openmls/src/framing/message_out.rs
@@ -21,7 +21,7 @@ use crate::messages::group_info::VerifiableGroupInfo;
 
 /// An [`MlsMessageOut`] is typically returned from an [`MlsGroup`] function and
 /// meant to be serialized and sent to the DS.
-#[derive(Debug, Clone, PartialEq, TlsSerialize, TlsSize)]
+#[derive(Debug, Clone, PartialEq, TlsSerialize, TlsSize, serde::Serialize, serde::Deserialize)]
 pub struct MlsMessageOut {
     pub(crate) version: ProtocolVersion,
     pub(crate) body: MlsMessageBodyOut,
@@ -54,7 +54,7 @@ pub struct MlsMessageOut {
 ///     }
 /// } MLSMessage;
 /// ```
-#[derive(Debug, PartialEq, Clone, TlsSerialize, TlsSize)]
+#[derive(Debug, PartialEq, Clone, TlsSerialize, TlsSize, serde::Serialize, serde::Deserialize)]
 #[repr(u16)]
 pub enum MlsMessageBodyOut {
     /// Plaintext message

--- a/openmls/src/framing/private_message.rs
+++ b/openmls/src/framing/private_message.rs
@@ -26,7 +26,9 @@ use super::*;
 ///     opaque ciphertext<V>;
 /// } PrivateMessage;
 /// ```
-#[derive(Debug, PartialEq, Eq, Clone, TlsSerialize, TlsSize)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, TlsSerialize, TlsSize, serde::Serialize, serde::Deserialize,
+)]
 pub struct PrivateMessage {
     pub(crate) group_id: GroupId,
     pub(crate) epoch: GroupEpoch,

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -59,7 +59,16 @@ use self::{proposals::*, proposals_in::ProposalOrRefIn};
 /// } Welcome;
 /// ```
 #[derive(
-    Clone, Debug, Eq, PartialEq, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 pub struct Welcome {
     cipher_suite: Ciphersuite,
@@ -117,7 +126,16 @@ impl Welcome {
 ///
 /// This is part of a [`Welcome`] message. It can be used to correlate the correct secrets with each new member.
 #[derive(
-    Clone, Debug, Eq, PartialEq, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSerialize,
+    TlsSize,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 pub struct EncryptedGroupSecrets {
     /// Key package reference of the new member


### PR DESCRIPTION
Being able to serialize and deserialize MlsMessageOut is handy if one wants to store a message for later retry.