### PR TITLE
TreeSync: expose full_leaves/parents; make full_leaves provide LeafNodeIndex

### DIFF
--- a/openmls/src/group/public_group/mod.rs
+++ b/openmls/src/group/public_group/mod.rs
@@ -169,7 +169,7 @@ impl PublicGroup {
         // These checks only do those that don't need group context. We do the full
         // checks later, but do these here to fail early in case of funny business
         // https://validation.openmls.tech/#valn1407
-        treesync.full_leaves().try_for_each(|leaf_node| {
+        treesync.full_leaves().try_for_each(|(_, leaf_node)| {
             leaf_node.validate_locally()?;
 
             // Check that no two nodes share a signature key.
@@ -286,7 +286,7 @@ impl PublicGroup {
         public_group
             .treesync
             .full_leaves()
-            .try_for_each(|leaf_node| {
+            .try_for_each(|(_, leaf_node)| {
                 public_group.validate_leaf_node_inner(leaf_node, validate_lifetimes)
             })?;
 

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -152,8 +152,8 @@ impl PublicGroup {
         let mut leaves = self
             .treesync()
             .full_leaves()
-            .filter(|leaf_node| !signature_keys.contains(leaf_node.signature_key()));
-        let Some(first_leaf) = leaves.next() else {
+            .filter(|(_, leaf_node)| !signature_keys.contains(leaf_node.signature_key()));
+        let Some((_, first_leaf)) = leaves.next() else {
             return Ok(());
         };
 
@@ -165,7 +165,7 @@ impl PublicGroup {
             .iter()
             .collect::<HashSet<_>>();
         // Iterate over the remaining leaf nodes and intersect their capabilities
-        for leaf_node in leaves {
+        for (_, leaf_node) in leaves {
             let leaf_capabilities_set = leaf_node.capabilities().proposals().iter().collect();
             capabilities_intersection = capabilities_intersection
                 .intersection(&leaf_capabilities_set)
@@ -803,7 +803,7 @@ impl PublicGroup {
         }
 
         // Check that the credential type is supported by all members of the group (https://validation.openmls.tech/#valn0104).
-        if !self.treesync().full_leaves().all(|node| {
+        if !self.treesync().full_leaves().all(|(_, node)| {
             node.capabilities()
                 .contains_credential(leaf_node.credential().credential_type())
         }) {
@@ -816,7 +816,7 @@ impl PublicGroup {
         if !self
             .treesync()
             .full_leaves()
-            .all(|node| capabilities.contains_credential(node.credential().credential_type()))
+            .all(|(_, node)| capabilities.contains_credential(node.credential().credential_type()))
         {
             return Err(LeafNodeValidationError::UnsupportedCredentials);
         }
@@ -900,7 +900,7 @@ impl PublicGroup {
         &self,
         extensions: &[crate::extensions::ExtensionType],
     ) -> Result<(), LeafNodeValidationError> {
-        for leaf in self.treesync().full_leaves() {
+        for (_, leaf) in self.treesync().full_leaves() {
             leaf.check_extension_support(extensions)?;
         }
         Ok(())

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -568,14 +568,14 @@ impl TreeSync {
     }
 
     /// Returns an iterator over the (non-blank) [`LeafNode`]s in the tree.
-    pub(crate) fn full_leaves(&self) -> impl Iterator<Item = &LeafNode> {
+    pub fn full_leaves(&self) -> impl Iterator<Item = (LeafNodeIndex, &LeafNode)> {
         self.tree
             .leaves()
-            .filter_map(|(_, tsn)| tsn.node().as_ref())
+            .filter_map(|(index, tsn)| tsn.node().as_ref().map(|ln| (index, ln)))
     }
 
     /// Returns an iterator over the (non-blank) [`ParentNode`]s in the tree.
-    pub(crate) fn full_parents(&self) -> impl Iterator<Item = (ParentNodeIndex, &ParentNode)> {
+    pub fn full_parents(&self) -> impl Iterator<Item = (ParentNodeIndex, &ParentNode)> {
         self.tree
             .parents()
             .filter_map(|(index, tsn)| tsn.node().as_ref().map(|pn| (index, pn)))


### PR DESCRIPTION
In addition to exposing the methods I also made the full_leaves iterator return the LeafNodeIndex, both for consistency and because  the caller would have had a hard time getting it through other means. Changing the API means I also had to change it for internal consumers.

Closes #1939 