### PR TITLE
update hpke and libcrux dependencies

### DIFF
--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/openmls/openmls/tree/main/openmls_libcrux_crypt
 readme = "../README.md"
 
 [dependencies]
-libcrux-aead = { version = "0.0.6" }
-libcrux-ed25519 = { version = "0.0.6", features = ["rand"] }
+libcrux-aead = { version = "0.0.7" }
+libcrux-ed25519 = { version = "0.0.7", features = ["rand"] }
 libcrux-hkdf = { version = "0.0.6" }
 libcrux-sha2 = { version = "0.0.6" }
 libcrux-hmac = { version = "0.0.6" }
@@ -24,9 +24,9 @@ rand = "0.9"
 tls_codec.workspace = true
 rand_chacha = "0.9"
 
-hpke-rs = { version = "0.6.0", features = ["hazmat", "serialization"] }
-hpke-rs-crypto = { version = "0.6.0" }
-hpke-rs-libcrux = { version = "0.6.0" }
+hpke-rs = { version = "0.6.1", features = ["hazmat", "serialization"] }
+hpke-rs-crypto = { version = "0.6.1" }
+hpke-rs-libcrux = { version = "0.6.1" }
 
 [features]
 extensions-draft-08 = [

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 openmls_traits = { workspace = true }
 openmls_memory_storage = { workspace = true }
 
-hpke = { version = "0.6.0", package = "hpke-rs", default-features = false, features = [
+hpke = { version = "0.6.1", package = "hpke-rs", default-features = false, features = [
     "hazmat",
     "serialization",
 ] }
@@ -27,8 +27,8 @@ p256 = { version = "0.13" }
 hkdf = { version = "0.12" }
 rand = "0.8"
 rand_chacha = { version = "0.3" }
-hpke-rs-crypto = { version = "0.6.0" }
-hpke-rs-rust-crypto = { version = "0.6.0" }
+hpke-rs-crypto = { version = "0.6.1" }
+hpke-rs-rust-crypto = { version = "0.6.1" }
 tls_codec = { workspace = true }
 thiserror = "2.0"
 serde = { version = "^1.0", features = ["derive"] }


### PR DESCRIPTION
This fixes the rust crypto provider by moving the unstable pq ciphersuites behind a feature flag.