### PR TITLE
update the `rusqlite` version used in `openmls_sqlite_storage`

### DIFF
--- a/.github/workflows/build_test_sqlx_provider.yml
+++ b/.github/workflows/build_test_sqlx_provider.yml
@@ -1,0 +1,44 @@
+name: Build & test sqlx storage provider crate
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            sqlx_storage -> target
+      - name: Build openmls_sqlx_storage
+        run: |
+          cargo build --manifest-path sqlx_storage/Cargo.toml
+      - name: Test openmls_sqlx_storage
+        run: |
+          cargo test --manifest-path sqlx_storage/Cargo.toml
+      - name: Build openmls_sqlx_storage with `extensions-draft-08` feature
+        run: |
+          cargo build -F extensions-draft-08 --manifest-path sqlx_storage/Cargo.toml
+      - name: Test openmls_sqlx_storage with `extensions-draft-08` feature
+        run: |
+          cargo test -F extensions-draft-08 --manifest-path sqlx_storage/Cargo.toml

--- a/.github/workflows/build_test_workspace.yml
+++ b/.github/workflows/build_test_workspace.yml
@@ -33,11 +33,23 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            sqlx_storage -> target
       - name: Build workspace
-        run: cargo build --workspace --all-targets --exclude openmls-fuzz
+        run: |
+          cargo build --workspace --all-targets --exclude openmls-fuzz
+          cargo build --manifest-path sqlx_storage/Cargo.toml
       - name: Test workspace
-        run: cargo test --workspace --all-targets --exclude=openmls --exclude openmls-fuzz
+        run: |
+          cargo test --workspace --all-targets --exclude=openmls --exclude openmls-fuzz
+          cargo test --manifest-path sqlx_storage/Cargo.toml
       - name: Build workspace with `extensions-draft-08` feature
-        run: cargo build --workspace -F extensions-draft-08 --all-targets --exclude openmls-fuzz
+        run: |
+          cargo build --workspace -F extensions-draft-08 --all-targets --exclude openmls-fuzz
+          cargo build -F extensions-draft-08 --manifest-path sqlx_storage/Cargo.toml
       - name: Test workspace with `extensions-draft-08` feature
-        run: cargo test --workspace -F extensions-draft-08 --all-targets --exclude=openmls --exclude openmls-fuzz
+        run: |
+          cargo test --workspace -F extensions-draft-08 --all-targets --exclude=openmls --exclude openmls-fuzz
+          cargo test -F extensions-draft-08 --manifest-path sqlx_storage/Cargo.toml

--- a/.github/workflows/build_test_workspace.yml
+++ b/.github/workflows/build_test_workspace.yml
@@ -36,20 +36,15 @@ jobs:
         with:
           workspaces: |
             . -> target
-            sqlx_storage -> target
       - name: Build workspace
         run: |
           cargo build --workspace --all-targets --exclude openmls-fuzz
-          cargo build --manifest-path sqlx_storage/Cargo.toml
       - name: Test workspace
         run: |
           cargo test --workspace --all-targets --exclude=openmls --exclude openmls-fuzz
-          cargo test --manifest-path sqlx_storage/Cargo.toml
       - name: Build workspace with `extensions-draft-08` feature
         run: |
           cargo build --workspace -F extensions-draft-08 --all-targets --exclude openmls-fuzz
-          cargo build -F extensions-draft-08 --manifest-path sqlx_storage/Cargo.toml
       - name: Test workspace with `extensions-draft-08` feature
         run: |
           cargo test --workspace -F extensions-draft-08 --all-targets --exclude=openmls --exclude openmls-fuzz
-          cargo test -F extensions-draft-08 --manifest-path sqlx_storage/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,14 @@ members = [
     "cli",
     "interop_client",
     "memory_storage",
-    "sqlite_storage",
-    "sqlx_storage",
     "delivery-service/ds",
     "delivery-service/ds-lib",
     "basic_credential",
     "openmls-wasm",
     "openmls_test",
+    "sqlite_storage",
 ]
+exclude = ["sqlx_storage"]
 resolver = "2"
 
 # Central dependency management for some crates

--- a/sqlite_storage/Cargo.toml
+++ b/sqlite_storage/Cargo.toml
@@ -14,7 +14,7 @@ openmls_traits = { workspace = true }
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 log = { version = "0.4" }
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.37", features = ["bundled"] }
 refinery = { version = "0.9", features = ["rusqlite", "enums"] }
 
 [dev-dependencies]

--- a/sqlx_storage/Cargo.toml
+++ b/sqlx_storage/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/openmls/openmls/tree/main/sqlx_storage"
 readme = "README.md"
 
 [dependencies]
-openmls_traits = { workspace = true }
+openmls_traits = { path = "../traits/" }
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 sqlx = { version = "0.8.6", features = ["sqlite", "migrate", "runtime-tokio"] }


### PR DESCRIPTION
This pull request updates the `rusqlite` version in `openmls_sqlite_storage` to `0.37`.

It also moves the `openmls_sqlx_storage` crate out of the workspace. This allows `openmls_sqlite_storage` to use a version of `libsqlite3-sys` that does not need to be compatible with that required in `openmls_sqlx_storage`

Lastly, the workspace tests on CI now test the `openmls_sqlx_storage` crate separately.

A note on the `rusqlite` version: `rusqlite` versions higher than `0.37` are not yet compatible with the latest version of `refinery` used in the `openmls_sqlite_storage` crate.

Resolves #1904 