### PR TITLE
refactor: improve PPRF secret handling

### DIFF
--- a/openmls/src/ciphersuite/tests_and_kats/tests.rs
+++ b/openmls/src/ciphersuite/tests_and_kats/tests.rs
@@ -83,6 +83,8 @@ fn test_hpke_seal_open() {
 #[cfg(feature = "extensions-draft-08")]
 #[openmls_test::openmls_test]
 fn test_safe_hpke_seal_open() {
+    use crate::component::ComponentId;
+
     let provider = &Provider::default();
 
     const CONTEXT: &[u8] = &[1, 2, 3];
@@ -99,7 +101,7 @@ fn test_safe_hpke_seal_open() {
         )
         .expect("error deriving hpke key pair");
 
-    const COMPONENT_ID: u16 = 1;
+    const COMPONENT_ID: ComponentId = 1;
 
     let ciphertext = hpke::safe_encrypt_with_label(
         &kp.public,

--- a/openmls/src/component.rs
+++ b/openmls/src/component.rs
@@ -55,20 +55,20 @@ impl ComponentData {
 
 /// An unknown component id in the standardized range (0x0000-0x7fff)
 #[repr(transparent)]
-pub struct UnknownComponentId(u16);
+pub struct UnknownComponentId(ComponentId);
 
 impl UnknownComponentId {
     /// Creates a new [`UnknownComponentId`]. Only returns [`Some`] if it is not covered by any of the
     /// specified ranges.
-    pub fn new(id: u16) -> Option<Self> {
-        let is_grease = (id & 0x0f0f == 0x0a0a) && (id & 0xff == (id >> 8)) && id != 0xfefe;
-        (!is_grease && matches!(id, ..0x8000)).then_some(Self(id))
+    pub fn new(id: ComponentId) -> Option<Self> {
+        let is_grease = (id & 0x0f0f == 0x0a0a) && (id & 0xff == (id >> 8)) && id != 0xfafa;
+        (!is_grease && id < 0x8000).then_some(Self(id))
     }
 }
 
 /// A component id from the private range (0x8000-0xffff)
 #[repr(transparent)]
-pub struct PrivateComponentId(u16);
+pub struct PrivateComponentId(ComponentId);
 
 impl PrivateComponentId {
     /// Creates a new [`PrivateComponentId`]. Only returns [`Some`] if it is in the range specified

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 
 #[cfg(feature = "extensions-draft-08")]
-use crate::messages::proposals_in::ProposalOrRefIn;
+use crate::{component::ComponentId, messages::proposals_in::ProposalOrRefIn};
 
 use super::{
     mls_auth_content::AuthenticatedContent,
@@ -343,7 +343,7 @@ impl ProcessedMessage {
     pub fn safe_export_secret<Crypto: OpenMlsCrypto>(
         &mut self,
         crypto: &Crypto,
-        component_id: u16,
+        component_id: ComponentId,
     ) -> Result<Vec<u8>, ProcessedMessageSafeExportSecretError> {
         if let ProcessedMessageContent::StagedCommitMessage(ref mut staged_commit) =
             &mut self.content

--- a/openmls/src/group/mls_group/exporting.rs
+++ b/openmls/src/group/mls_group/exporting.rs
@@ -1,12 +1,15 @@
 use errors::{ExportGroupInfoError, ExportSecretError};
 use openmls_traits::{crypto::OpenMlsCrypto, signatures::Signer};
 
-#[cfg(feature = "extensions-draft-08")]
-use crate::group::{PendingSafeExportSecretError, SafeExportSecretError};
 use crate::{
     ciphersuite::HpkePublicKey,
     extensions::errors::InvalidExtensionError,
     schedule::{EpochAuthenticator, ResumptionPskSecret},
+};
+#[cfg(feature = "extensions-draft-08")]
+use crate::{
+    component::ComponentId,
+    group::{PendingSafeExportSecretError, SafeExportSecretError},
 };
 
 use super::*;
@@ -51,7 +54,7 @@ impl MlsGroup {
         &mut self,
         crypto: &Crypto,
         storage: &Storage,
-        component_id: u16,
+        component_id: ComponentId,
     ) -> Result<Vec<u8>, SafeExportSecretError<Storage::Error>> {
         if !self.is_active() {
             return Err(SafeExportSecretError::GroupState(
@@ -79,7 +82,7 @@ impl MlsGroup {
         &mut self,
         crypto: &impl OpenMlsCrypto,
         storage: &Provider,
-        component_id: u16,
+        component_id: ComponentId,
     ) -> Result<Vec<u8>, PendingSafeExportSecretError<Provider::Error>> {
         let group_id = self.group_id().clone();
         let MlsGroupState::PendingCommit(ref mut group_state) = self.group_state else {

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -18,7 +18,7 @@ use crate::group::diff::PublicGroupDiff;
 use crate::group::GroupEpoch;
 use crate::prelude::{Commit, LeafNodeIndex};
 #[cfg(feature = "extensions-draft-08")]
-use crate::schedule::application_export_tree::ApplicationExportTree;
+use crate::{component::ComponentId, schedule::application_export_tree::ApplicationExportTree};
 
 use crate::treesync::errors::TreeSyncFromNodesError;
 use crate::treesync::RatchetTree;
@@ -754,7 +754,7 @@ impl StagedCommit {
     pub(crate) fn safe_export_secret(
         &mut self,
         crypto: &impl OpenMlsCrypto,
-        component_id: u16,
+        component_id: ComponentId,
     ) -> Result<Vec<u8>, StagedSafeExportSecretError> {
         let ciphersuite = self.group_context().ciphersuite();
         let StagedCommitState::GroupMember(ref mut staged_commit) = self.state else {

--- a/openmls/src/schedule/application_export_tree.rs
+++ b/openmls/src/schedule/application_export_tree.rs
@@ -3,6 +3,7 @@ use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite};
 use crate::{
     binary_tree::array_representation::TreeSize,
     ciphersuite::Secret,
+    component::ComponentId,
     schedule::{
         pprf::{Pprf, PprfError, Prefix16},
         ApplicationExportSecret,
@@ -25,7 +26,7 @@ impl ApplicationExportTree {
         &mut self,
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
-        component_id: u16,
+        component_id: ComponentId,
     ) -> Result<Secret, ApplicationExportTreeError> {
         self.evaluate(crypto, ciphersuite, &component_id)
     }

--- a/openmls/src/schedule/pprf/mod.rs
+++ b/openmls/src/schedule/pprf/mod.rs
@@ -5,15 +5,19 @@
 //! over the size of the tree. Additionally, it is designed to be efficient even
 //! for larger sizes.
 
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap, fmt, marker::PhantomData};
 
 use openmls_traits::{
     crypto::OpenMlsCrypto,
     types::{Ciphersuite, CryptoError},
 };
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::{self, Visitor},
+    ser::SerializeSeq,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use thiserror::Error;
-use zeroize::ZeroizeOnDrop;
+use zeroize::Zeroize;
 
 use crate::{
     binary_tree::array_representation::TreeSize, ciphersuite::Secret,
@@ -43,20 +47,28 @@ pub enum PprfError {
 }
 
 /// A Node in the PPRF tree that contains the node's secret.
-#[derive(Debug, Serialize, Deserialize, Clone, ZeroizeOnDrop)]
+///
+/// Implements transparent and custom serde for efficiently storing and reading secret bytes.
+#[derive(Debug, Clone)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq))]
-#[serde(transparent)]
-struct PprfNode(#[serde(with = "serde_bytes")] Vec<u8>);
+struct PprfNode(Secret);
 
-impl From<Secret> for PprfNode {
-    fn from(secret: Secret) -> Self {
-        Self(secret.as_slice().to_vec())
+impl Serialize for PprfNode {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serde_bytes::Bytes::new(self.0.as_slice()).serialize(serializer)
     }
 }
 
-impl From<PprfNode> for Secret {
-    fn from(node: PprfNode) -> Self {
-        Secret::from_slice(&node.0)
+impl<'de> Deserialize<'de> for PprfNode {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Some serialization formats do not support 0-copy deserialization of bytes, so we need to
+        // support owned bytes as well.
+        let bytes: Cow<[u8]> = serde_bytes::Deserialize::deserialize(deserializer)?;
+        let secret = Secret::from_slice(bytes.as_ref());
+        if let Cow::Owned(mut bytes) = bytes {
+            bytes.zeroize() // Zeroize owned bytes to prevent leaking secrets.
+        }
+        Ok(Self(secret))
     }
 }
 
@@ -67,9 +79,9 @@ impl PprfNode {
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
     ) -> Result<(Self, Self), CryptoError> {
-        let own_secret = Secret::from_slice(&self.0);
-        let (left_secret, right_secret) = derive_child_secrets(&own_secret, crypto, ciphersuite)?;
-        Ok((left_secret.into(), right_secret.into()))
+        let own_secret = &self.0;
+        let (left_secret, right_secret) = derive_child_secrets(own_secret, crypto, ciphersuite)?;
+        Ok((Self(left_secret), Self(right_secret)))
     }
 }
 
@@ -105,7 +117,7 @@ impl<P: Prefix> Pprf<P> {
         Pprf {
             // The width of the tree in bytes.
             width,
-            nodes: [(P::new(), PprfNode(secret.as_slice().to_vec()))].into(),
+            nodes: [(P::new(), PprfNode(secret))].into(),
         }
     }
 
@@ -115,7 +127,7 @@ impl<P: Prefix> Pprf<P> {
         Pprf {
             // The width of the tree in bytes.
             width,
-            nodes: [(P::new(), secret.into())].into(),
+            nodes: [(P::new(), PprfNode(secret))].into(),
         }
     }
 
@@ -142,7 +154,7 @@ impl<P: Prefix> Pprf<P> {
         loop {
             if let Some(node) = self.nodes.remove(&prefix) {
                 if depth == P::MAX_DEPTH {
-                    return Ok(node.into());
+                    return Ok(node.0);
                 } // already at leaf
                 current_node = node;
                 break;
@@ -175,19 +187,21 @@ impl<P: Prefix> Pprf<P> {
             prefix.push_bit(bit);
         }
 
-        Ok(current_node.into())
+        Ok(current_node.0)
     }
 }
 
-fn serialize_hashmap<'a, T, U, V, S>(v: &'a V, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_hashmap<T, U, S>(map: &HashMap<T, U>, serializer: S) -> Result<S::Ok, S::Error>
 where
     T: Serialize,
     U: Serialize,
-    &'a V: IntoIterator<Item = (T, U)> + 'a,
     S: Serializer,
 {
-    let vec = v.into_iter().collect::<Vec<_>>();
-    vec.serialize(serializer)
+    let mut seq = serializer.serialize_seq(Some(map.len()))?;
+    for (k, v) in map {
+        seq.serialize_element(&(k, v))?;
+    }
+    seq.end()
 }
 
 fn deserialize_hashmap<'de, T, U, D>(deserializer: D) -> Result<HashMap<T, U>, D::Error>
@@ -196,9 +210,36 @@ where
     U: Deserialize<'de>,
     D: Deserializer<'de>,
 {
-    Ok(Vec::<(T, U)>::deserialize(deserializer)?
-        .into_iter()
-        .collect::<HashMap<T, U>>())
+    struct TupleSeqVisitor<T, U> {
+        marker: PhantomData<(T, U)>,
+    }
+
+    impl<'de, T, U> Visitor<'de> for TupleSeqVisitor<T, U>
+    where
+        T: Eq + std::hash::Hash + Deserialize<'de>,
+        U: Deserialize<'de>,
+    {
+        type Value = HashMap<T, U>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a sequence of tuples")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::SeqAccess<'de>,
+        {
+            let mut map = HashMap::with_capacity(seq.size_hint().unwrap_or(0));
+            while let Some((k, v)) = seq.next_element::<(T, U)>()? {
+                map.insert(k, v);
+            }
+            Ok(map)
+        }
+    }
+
+    deserializer.deserialize_seq(TupleSeqVisitor {
+        marker: PhantomData,
+    })
 }
 
 #[cfg(test)]
@@ -291,5 +332,27 @@ mod tests {
 
         let result = pprf.evaluate(crypto, ciphersuite, &index);
         assert!(matches!(result, Err(PprfError::IndexOutOfBounds)));
+    }
+
+    #[openmls_test]
+    fn pprf_serialization() {
+        let provider = &Provider::default();
+        let seed: [u8; 32] = OsRng.unwrap_mut().random();
+        println!("Seed: {:?}", seed);
+        let mut rng = StdRng::from_seed(seed);
+        let root_secret = dummy_secret(&mut rng, ciphersuite);
+        let mut pprf = Pprf::<Prefix16>::new_for_test(root_secret);
+        let index = random_vec(&mut rng, Prefix16::MAX_INPUT_LEN);
+
+        let crypto = provider.crypto();
+
+        let result = pprf.evaluate(crypto, ciphersuite, &index);
+        assert!(result.is_ok());
+
+        let serialized = serde_json::to_string(&pprf).unwrap();
+        println!("Serialized: {}", serialized);
+        let deserialized: Pprf<Prefix16> = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(pprf, deserialized);
     }
 }

--- a/openmls/src/schedule/pprf/prefix.rs
+++ b/openmls/src/schedule/pprf/prefix.rs
@@ -7,7 +7,9 @@
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-pub trait Prefix: Clone + Eq + std::hash::Hash + Serialize + DeserializeOwned {
+pub(crate) trait Prefix:
+    Clone + Eq + std::hash::Hash + Serialize + DeserializeOwned
+{
     /// The maximum depth of the prefix in bits. Must be a multiple of 8.
     const MAX_DEPTH: usize;
 
@@ -39,10 +41,7 @@ impl Prefix for Prefix16 {
     }
 
     fn push_bit(&mut self, bit: bool) {
-        self.bits <<= 1;
-        if bit {
-            self.bits |= 1;
-        }
+        self.bits = self.bits << 1 | u16::from(bit);
         self.len += 1;
     }
 }

--- a/openmls/tests/book_code_app_data.rs
+++ b/openmls/tests/book_code_app_data.rs
@@ -6,13 +6,13 @@
 
 #![cfg(feature = "extensions-draft-08")]
 
-use openmls::prelude::*;
 use openmls::test_utils::single_group_test_framework::*;
+use openmls::{component::ComponentId, prelude::*};
 use openmls_test::openmls_test;
 
 // ANCHOR: component_definition
 /// Our counter component ID (in the private range 0x8000..0xffff)
-const COUNTER_COMPONENT_ID: u16 = 0xf042;
+const COUNTER_COMPONENT_ID: ComponentId = 0xf042;
 
 /// The operations that can be performed on the counter
 #[repr(u8)]


### PR DESCRIPTION
* Store `Secret` directly in `PprfNode` instead of `Vec<u8>`, avoiding
  extra heap allocation and copy on each split.
* Implement custom `Serialize`/`Deserialize` for `PprfNode` that
  zeroizes any owned byte buffer produced during deserialization and
  support zero-copy deserialization.
* Rewrite `serialize_hashmap`/`deserialize_hashmap` to use
  `serialize_seq` and a custom `Visitor`, avoiding the intermediate
  `Vec` allocation.