### PR TITLE
Allow proposing a self update that includes a new signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [#1972](https://github.com/openmls/openmls/pull/1972): Add APIs for time-based deletion of past epoch secrets, and for setting the past epoch deletion policy for an `MlsGroup`.
+- [#2010](https://github.com/openmls/openmls/pull/2010): Added `MlsGroup::propose_self_update_with_new_signer`, a variant of `propose_self_update` that stages an `Update` proposal carrying a new signature key.
 
 ### Changed
 

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -372,6 +372,10 @@ pub enum ProposeSelfUpdateError<StorageError> {
     /// The updated leaf node does not support all group context extensions.
     #[error("The updated leaf node does not support all group context extensions.")]
     UnsupportedGroupContextExtensions,
+    /// The `leaf_node_parameters.credential_with_key` does not match
+    /// `new_signer.credential_with_key` (rotation paths only).
+    #[error("Mismatched credential_with_key between leaf_node_parameters and new_signer")]
+    InvalidLeafNodeParameters,
 }
 
 /// Commit to pending proposals error

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -376,6 +376,10 @@ pub enum ProposeSelfUpdateError<StorageError> {
     /// `new_signer.credential_with_key` (rotation paths only).
     #[error("Mismatched credential_with_key between leaf_node_parameters and new_signer")]
     InvalidLeafNodeParameters,
+    /// The `leaf_node_parameters.credential_with_key` does not match
+    /// `new_signer.credential_with_key` (rotation paths only).
+    #[error("Mismatched ciphersuite between new_signer and the group")]
+    InvalidSignerCiphersuite,
 }
 
 /// Commit to pending proposals error

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -3544,6 +3544,74 @@ fn propose_self_update_with_new_signer_mismatched_credential() {
     assert_eq!(err, ProposeSelfUpdateError::InvalidLeafNodeParameters);
 }
 
+// A `NewSignerBundle` whose `signer` uses a signature scheme that does not
+// match the group's ciphersuite is rejected with `InvalidSignerCiphersuite`
+// before any proposal is staged.
+#[openmls_test::openmls_test]
+fn propose_self_update_with_new_signer_mismatched_ciphersuite() {
+    use crate::credentials::{BasicCredential, CredentialWithKey};
+    use openmls_traits::types::SignatureScheme;
+
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let bob_party = CorePartyState::<Provider>::new("bob");
+
+    let alice_pre_group = alice_party.generate_pre_group(ciphersuite);
+    let bob_pre_group = bob_party.generate_pre_group(ciphersuite);
+
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .build();
+    let mls_group_join_config = mls_group_create_config.join_config().clone();
+
+    let group_id = GroupId::from_slice(b"test");
+    let mut group_state =
+        GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
+
+    group_state
+        .add_member(AddMemberConfig {
+            adder: "alice",
+            addees: vec![bob_pre_group],
+            join_config: mls_group_join_config.clone(),
+            tree: None,
+        })
+        .expect("Could not add member");
+
+    // Pick a signature scheme that differs from the group's ciphersuite.
+    // Ed25519 covers every non-Ed25519 ciphersuite; P-256 covers the Ed25519
+    // ones. Both schemes are supported by the rust-crypto test provider.
+    let group_scheme = ciphersuite.signature_algorithm();
+    let mismatched_scheme = if group_scheme == SignatureScheme::ED25519 {
+        SignatureScheme::ECDSA_SECP256R1_SHA256
+    } else {
+        SignatureScheme::ED25519
+    };
+
+    let [alice_group_state] = group_state.members_mut(&["alice"]);
+    let mismatched_signer = SignatureKeyPair::new(mismatched_scheme).unwrap();
+    let credential_with_key = CredentialWithKey {
+        credential: BasicCredential::new(b"alice".to_vec()).into(),
+        signature_key: mismatched_signer.to_public_vec().into(),
+    };
+
+    let new_signer = NewSignerBundle {
+        signer: &mismatched_signer,
+        credential_with_key,
+    };
+
+    let err = alice_group_state
+        .group
+        .propose_self_update_with_new_signer(
+            &alice_group_state.party.core_state.provider,
+            &alice_group_state.party.signer,
+            new_signer,
+            LeafNodeParameters::default(),
+        )
+        .unwrap_err();
+
+    assert_eq!(err, ProposeSelfUpdateError::InvalidSignerCiphersuite);
+}
+
 // Alice proposes a signer swap; Bob processes the proposal (envelope verifies
 // against Alice's OLD leaf sig key, embedded leaf verifies against the NEW sig
 // key), stores it, and commits it. After both merge, everyone's view of

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -3563,12 +3563,8 @@ fn propose_self_update_with_new_signer_roundtrip() {
     let mls_group_join_config = mls_group_create_config.join_config().clone();
 
     let group_id = GroupId::from_slice(b"test");
-    let mut group_state = GroupState::new_from_party(
-        group_id,
-        alice_pre_group,
-        mls_group_create_config,
-    )
-    .unwrap();
+    let mut group_state =
+        GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
 
     group_state
         .add_member(AddMemberConfig {
@@ -3581,7 +3577,10 @@ fn propose_self_update_with_new_signer_roundtrip() {
 
     // Alice generates a new signer + credential.
     let new_pre_group_state = alice_party.generate_pre_group(ciphersuite);
-    let new_signature_key = new_pre_group_state.credential_with_key.signature_key.clone();
+    let new_signature_key = new_pre_group_state
+        .credential_with_key
+        .signature_key
+        .clone();
 
     let new_signer_bundle = NewSignerBundle {
         signer: &new_pre_group_state.signer,
@@ -3620,10 +3619,7 @@ fn propose_self_update_with_new_signer_roundtrip() {
         };
         bob_group_state
             .group
-            .store_pending_proposal(
-                bob_group_state.party.core_state.provider.storage(),
-                *staged,
-            )
+            .store_pending_proposal(bob_group_state.party.core_state.provider.storage(), *staged)
             .expect("Bob failed to store proposal");
     }
 
@@ -3705,12 +3701,8 @@ fn propose_self_update_with_new_signer_committed_by_proposer() {
     let mls_group_join_config = mls_group_create_config.join_config().clone();
 
     let group_id = GroupId::from_slice(b"test");
-    let mut group_state = GroupState::new_from_party(
-        group_id,
-        alice_pre_group,
-        mls_group_create_config,
-    )
-    .unwrap();
+    let mut group_state =
+        GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
 
     group_state
         .add_member(AddMemberConfig {
@@ -3722,7 +3714,10 @@ fn propose_self_update_with_new_signer_committed_by_proposer() {
         .expect("Could not add member");
 
     let new_pre_group_state = alice_party.generate_pre_group(ciphersuite);
-    let new_signature_key = new_pre_group_state.credential_with_key.signature_key.clone();
+    let new_signature_key = new_pre_group_state
+        .credential_with_key
+        .signature_key
+        .clone();
 
     // Alice proposes, then Alice commits via build_with_new_signer.
     let commit = {

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -3483,3 +3483,311 @@ fn group_replacement() {
         .build()
         .expect("Bob failed to join the new group despite replace flag.");
 }
+
+// A mismatched `leaf_node_parameters.credential_with_key` vs
+// `new_signer.credential_with_key` on the propose-side yields the new
+// `InvalidLeafNodeParameters` variant.
+#[openmls_test::openmls_test]
+fn propose_self_update_with_new_signer_mismatched_credential() {
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let bob_party = CorePartyState::<Provider>::new("bob");
+
+    let alice_pre_group = alice_party.generate_pre_group(ciphersuite);
+    let old_credential_with_key = alice_pre_group.credential_with_key.clone();
+    let bob_pre_group = bob_party.generate_pre_group(ciphersuite);
+
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .build();
+    let mls_group_join_config = mls_group_create_config.join_config().clone();
+
+    let group_id = GroupId::from_slice(b"test");
+    let mut group_state =
+        GroupState::new_from_party(group_id, alice_pre_group, mls_group_create_config).unwrap();
+
+    group_state
+        .add_member(AddMemberConfig {
+            adder: "alice",
+            addees: vec![bob_pre_group],
+            join_config: mls_group_join_config.clone(),
+            tree: None,
+        })
+        .expect("Could not add member");
+
+    // Generate a new signer/credential for Alice.
+    let new_pre_group_state = alice_party.generate_pre_group(ciphersuite);
+
+    let [alice_group_state] = group_state.members_mut(&["alice"]);
+
+    // Disagreeing credentials: leaf_node_parameters pins the OLD credential
+    // while new_signer carries the NEW credential.
+    let leaf_node_parameters = LeafNodeParameters::builder()
+        .with_credential_with_key(old_credential_with_key)
+        .build();
+
+    let new_signer = NewSignerBundle {
+        signer: &new_pre_group_state.signer,
+        credential_with_key: new_pre_group_state.credential_with_key,
+    };
+
+    let err = alice_group_state
+        .group
+        .propose_self_update_with_new_signer(
+            &alice_group_state.party.core_state.provider,
+            &alice_group_state.party.signer,
+            new_signer,
+            leaf_node_parameters,
+        )
+        .unwrap_err();
+
+    assert_eq!(err, ProposeSelfUpdateError::InvalidLeafNodeParameters);
+}
+
+// Alice proposes a signer swap; Bob processes the proposal (envelope verifies
+// against Alice's OLD leaf sig key, embedded leaf verifies against the NEW sig
+// key), stores it, and commits it. After both merge, everyone's view of
+// Alice's leaf carries the NEW credential + NEW sig key.
+#[openmls_test::openmls_test]
+fn propose_self_update_with_new_signer_roundtrip() {
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let bob_party = CorePartyState::<Provider>::new("bob");
+
+    let alice_pre_group = alice_party.generate_pre_group(ciphersuite);
+    let bob_pre_group = bob_party.generate_pre_group(ciphersuite);
+
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .build();
+    let mls_group_join_config = mls_group_create_config.join_config().clone();
+
+    let group_id = GroupId::from_slice(b"test");
+    let mut group_state = GroupState::new_from_party(
+        group_id,
+        alice_pre_group,
+        mls_group_create_config,
+    )
+    .unwrap();
+
+    group_state
+        .add_member(AddMemberConfig {
+            adder: "alice",
+            addees: vec![bob_pre_group],
+            join_config: mls_group_join_config.clone(),
+            tree: None,
+        })
+        .expect("Could not add member");
+
+    // Alice generates a new signer + credential.
+    let new_pre_group_state = alice_party.generate_pre_group(ciphersuite);
+    let new_signature_key = new_pre_group_state.credential_with_key.signature_key.clone();
+
+    let new_signer_bundle = NewSignerBundle {
+        signer: &new_pre_group_state.signer,
+        credential_with_key: new_pre_group_state.credential_with_key.clone(),
+    };
+
+    // Alice proposes the swap.
+    let (proposal_msg, _proposal_ref) = {
+        let [alice_group_state] = group_state.members_mut(&["alice"]);
+        alice_group_state
+            .group
+            .propose_self_update_with_new_signer(
+                &alice_group_state.party.core_state.provider,
+                &alice_group_state.party.signer,
+                new_signer_bundle,
+                LeafNodeParameters::default(),
+            )
+            .expect("Alice failed to create proposal")
+    };
+
+    // Bob processes Alice's proposal and stores it.
+    {
+        let [bob_group_state] = group_state.members_mut(&["bob"]);
+        let processed = bob_group_state
+            .group
+            .process_message(
+                &bob_group_state.party.core_state.provider,
+                proposal_msg
+                    .clone()
+                    .into_protocol_message()
+                    .expect("proposal is a protocol message"),
+            )
+            .expect("Bob failed to process proposal (envelope/leaf signatures)");
+        let ProcessedMessageContent::ProposalMessage(staged) = processed.into_content() else {
+            panic!("expected a proposal");
+        };
+        bob_group_state
+            .group
+            .store_pending_proposal(
+                bob_group_state.party.core_state.provider.storage(),
+                *staged,
+            )
+            .expect("Bob failed to store proposal");
+    }
+
+    // Bob commits to the pending proposal.
+    let bob_commit = {
+        let [bob_group_state] = group_state.members_mut(&["bob"]);
+        let bundle = bob_group_state
+            .group
+            .commit_to_pending_proposals(
+                &bob_group_state.party.core_state.provider,
+                &bob_group_state.party.signer,
+            )
+            .expect("Bob failed to commit to pending proposals");
+        bob_group_state
+            .group
+            .merge_pending_commit(&bob_group_state.party.core_state.provider)
+            .expect("Bob failed to merge his own commit");
+        let (commit, _welcome, _gi) = bundle;
+        commit
+    };
+
+    // Alice applies Bob's commit.
+    group_state
+        .deliver_and_apply_if(bob_commit.into(), |state| {
+            state.party.core_state.name != "bob"
+        })
+        .expect("Alice failed to apply Bob's commit");
+
+    // Both parties see the NEW signature key on Alice's leaf.
+    for name in ["alice", "bob"] {
+        let [member] = group_state.members_mut(&[name]);
+        let alice_sigkey = member
+            .group
+            .members()
+            .find(|m| m.index == LeafNodeIndex::new(0))
+            .unwrap()
+            .signature_key;
+        assert_eq!(
+            alice_sigkey.as_slice(),
+            new_signature_key.as_slice(),
+            "{name} sees stale signature key for Alice",
+        );
+    }
+
+    // Alice can now sign with her new signer.
+    let [alice_group_state] = group_state.members_mut(&["alice"]);
+    let bundle = alice_group_state
+        .group
+        .self_update(
+            &alice_group_state.party.core_state.provider,
+            &new_pre_group_state.signer,
+            LeafNodeParameters::default(),
+        )
+        .expect("Alice failed to self_update with new signer");
+    group_state
+        .deliver_and_apply_if(bundle.into_commit().into(), |state| {
+            state.party.core_state.name != "alice"
+        })
+        .expect("Bob failed to apply Alice's follow-up commit");
+}
+
+// Alice proposes a signer swap and then commits the proposal herself via
+// `commit_builder().build_with_new_signer(...)`. The pending-proposal-queue +
+// `own_leaf_nodes` path must route through the NEW signer on commit, because
+// a single-signer `commit_to_pending_proposals(old_signer)` would ignore the
+// queued Update's rotation.
+#[openmls_test::openmls_test]
+fn propose_self_update_with_new_signer_committed_by_proposer() {
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let bob_party = CorePartyState::<Provider>::new("bob");
+
+    let alice_pre_group = alice_party.generate_pre_group(ciphersuite);
+    let bob_pre_group = bob_party.generate_pre_group(ciphersuite);
+
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .build();
+    let mls_group_join_config = mls_group_create_config.join_config().clone();
+
+    let group_id = GroupId::from_slice(b"test");
+    let mut group_state = GroupState::new_from_party(
+        group_id,
+        alice_pre_group,
+        mls_group_create_config,
+    )
+    .unwrap();
+
+    group_state
+        .add_member(AddMemberConfig {
+            adder: "alice",
+            addees: vec![bob_pre_group],
+            join_config: mls_group_join_config.clone(),
+            tree: None,
+        })
+        .expect("Could not add member");
+
+    let new_pre_group_state = alice_party.generate_pre_group(ciphersuite);
+    let new_signature_key = new_pre_group_state.credential_with_key.signature_key.clone();
+
+    // Alice proposes, then Alice commits via build_with_new_signer.
+    let commit = {
+        let [alice_group_state] = group_state.members_mut(&["alice"]);
+        let new_signer_bundle = NewSignerBundle {
+            signer: &new_pre_group_state.signer,
+            credential_with_key: new_pre_group_state.credential_with_key.clone(),
+        };
+        alice_group_state
+            .group
+            .propose_self_update_with_new_signer(
+                &alice_group_state.party.core_state.provider,
+                &alice_group_state.party.signer,
+                new_signer_bundle,
+                LeafNodeParameters::default(),
+            )
+            .expect("Alice failed to create proposal");
+
+        let new_signer_for_build = NewSignerBundle {
+            signer: &new_pre_group_state.signer,
+            credential_with_key: new_pre_group_state.credential_with_key.clone(),
+        };
+
+        let provider = &alice_group_state.party.core_state.provider;
+        let bundle = alice_group_state
+            .group
+            .commit_builder()
+            .consume_proposal_store(true)
+            .load_psks(provider.storage())
+            .expect("load_psks")
+            .build_with_new_signer(
+                provider.rand(),
+                provider.crypto(),
+                &alice_group_state.party.signer,
+                new_signer_for_build,
+                |_| true,
+            )
+            .expect("build_with_new_signer")
+            .stage_commit(provider)
+            .expect("stage_commit");
+        alice_group_state
+            .group
+            .merge_pending_commit(provider)
+            .expect("Alice failed to merge her commit");
+        bundle.into_commit()
+    };
+
+    group_state
+        .deliver_and_apply_if(commit.into(), |state| {
+            state.party.core_state.name != "alice"
+        })
+        .expect("Bob failed to apply Alice's self-committed rotation");
+
+    for name in ["alice", "bob"] {
+        let [member] = group_state.members_mut(&[name]);
+        let alice_sigkey = member
+            .group
+            .members()
+            .find(|m| m.index == LeafNodeIndex::new(0))
+            .unwrap()
+            .signature_key;
+        assert_eq!(
+            alice_sigkey.as_slice(),
+            new_signature_key.as_slice(),
+            "{name} sees stale signature key for Alice after self-committed rotation",
+        );
+    }
+}

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -94,7 +94,7 @@ impl MlsGroup {
     /// Creates a proposal to update the own leaf node. Optionally, a
     /// [`LeafNode`] can be provided to update the leaf node. Note that its
     /// private key must be manually added to the key store.
-    fn _create_self_update_proposal<Provider: OpenMlsProvider, S: Signer>(
+    fn create_self_update_proposal_internal<Provider: OpenMlsProvider, S: Signer>(
         &mut self,
         provider: &Provider,
         old_signer: &impl Signer,
@@ -169,14 +169,14 @@ impl MlsGroup {
         Ok(update_proposal)
     }
 
-    fn _propose_self_update<Provider: OpenMlsProvider, S: Signer>(
+    fn propose_self_update_internal<Provider: OpenMlsProvider, S: Signer>(
         &mut self,
         provider: &Provider,
         old_signer: &impl Signer,
         new_signer: Option<NewSignerBundle<'_, S>>,
         leaf_node_parameters: LeafNodeParameters,
     ) -> Result<(MlsMessageOut, ProposalRef), ProposeSelfUpdateError<Provider::StorageError>> {
-        let update_proposal = self._create_self_update_proposal(
+        let update_proposal = self.create_self_update_proposal_internal(
             provider,
             old_signer,
             new_signer,
@@ -209,7 +209,7 @@ impl MlsGroup {
         signer: &S,
         leaf_node_parameters: LeafNodeParameters,
     ) -> Result<(MlsMessageOut, ProposalRef), ProposeSelfUpdateError<Provider::StorageError>> {
-        self._propose_self_update(
+        self.propose_self_update_internal(
             provider,
             signer,
             None::<NewSignerBundle<'_, S>>,
@@ -239,6 +239,6 @@ impl MlsGroup {
         new_signer: NewSignerBundle<'_, S>,
         leaf_node_parameters: LeafNodeParameters,
     ) -> Result<(MlsMessageOut, ProposalRef), ProposeSelfUpdateError<Provider::StorageError>> {
-        self._propose_self_update(provider, old_signer, Some(new_signer), leaf_node_parameters)
+        self.propose_self_update_internal(provider, old_signer, Some(new_signer), leaf_node_parameters)
     }
 }

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -90,11 +90,11 @@ impl MlsGroup {
     /// Creates a proposal to update the own leaf node. Optionally, a
     /// [`LeafNode`] can be provided to update the leaf node. Note that its
     /// private key must be manually added to the key store.
-    fn _propose_self_update<Provider: OpenMlsProvider>(
+    fn _create_self_update_proposal<Provider: OpenMlsProvider>(
         &mut self,
         provider: &Provider,
         signer: &impl Signer,
-        leaf_node_parmeters: LeafNodeParameters,
+        leaf_node_parameters: LeafNodeParameters,
     ) -> Result<AuthenticatedContent, ProposeSelfUpdateError<Provider::StorageError>> {
         self.is_operational()?;
 
@@ -114,7 +114,7 @@ impl MlsGroup {
             signer,
             self.group_id().clone(),
             self.own_leaf_index(),
-            leaf_node_parmeters,
+            leaf_node_parameters,
         )?;
 
         // Validate that the updated leaf node supports all group context extensions

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -1,9 +1,8 @@
 use commit_builder::CommitMessageBundle;
 use errors::{ProposeSelfUpdateError, SelfUpdateError};
 use openmls_traits::{
-    signatures::{Signer, SignerError},
+    signatures::Signer,
     storage::StorageProvider as _,
-    types::SignatureScheme,
 };
 
 use crate::{credentials::NewSignerBundle, storage::OpenMlsProvider, treesync::LeafNodeParameters};
@@ -114,6 +113,10 @@ impl MlsGroup {
             .clone();
 
         if let Some(new_signer) = new_signer {
+            if self.ciphersuite().signature_algorithm() != new_signer.signer.signature_scheme() {
+                return Err(ProposeSelfUpdateError::InvalidSignerCiphersuite);
+            }
+
             // Reconcile `leaf_node_parameters.credential_with_key` with
             // `new_signer.credential_with_key`. Mirrors the commit-path logic in
             // `CommitBuilder::build_internal`.
@@ -239,6 +242,11 @@ impl MlsGroup {
         new_signer: NewSignerBundle<'_, S>,
         leaf_node_parameters: LeafNodeParameters,
     ) -> Result<(MlsMessageOut, ProposalRef), ProposeSelfUpdateError<Provider::StorageError>> {
-        self.propose_self_update_internal(provider, old_signer, Some(new_signer), leaf_node_parameters)
+        self.propose_self_update_internal(
+            provider,
+            old_signer,
+            Some(new_signer),
+            leaf_node_parameters,
+        )
     }
 }

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -1,6 +1,10 @@
 use commit_builder::CommitMessageBundle;
 use errors::{ProposeSelfUpdateError, SelfUpdateError};
-use openmls_traits::{signatures::{Signer, SignerError}, storage::StorageProvider as _, types::SignatureScheme};
+use openmls_traits::{
+    signatures::{Signer, SignerError},
+    storage::StorageProvider as _,
+    types::SignatureScheme,
+};
 
 use crate::{credentials::NewSignerBundle, storage::OpenMlsProvider, treesync::LeafNodeParameters};
 
@@ -118,8 +122,7 @@ impl MlsGroup {
                     return Err(ProposeSelfUpdateError::InvalidLeafNodeParameters);
                 }
             } else {
-                leaf_node_parameters
-                    .set_credential_with_key(new_signer.credential_with_key);
+                leaf_node_parameters.set_credential_with_key(new_signer.credential_with_key);
             }
 
             own_leaf.update(
@@ -173,7 +176,12 @@ impl MlsGroup {
         new_signer: Option<NewSignerBundle<'_, S>>,
         leaf_node_parameters: LeafNodeParameters,
     ) -> Result<(MlsMessageOut, ProposalRef), ProposeSelfUpdateError<Provider::StorageError>> {
-        let update_proposal = self._create_self_update_proposal(provider, old_signer, new_signer, leaf_node_parameters)?;
+        let update_proposal = self._create_self_update_proposal(
+            provider,
+            old_signer,
+            new_signer,
+            leaf_node_parameters,
+        )?;
         let proposal = QueuedProposal::from_authenticated_content_by_ref(
             self.ciphersuite(),
             provider.crypto(),
@@ -207,11 +215,20 @@ impl MlsGroup {
         // shares almost all logic.
         enum NoSigner {}
         impl Signer for NoSigner {
-            fn sign(&self, _payload: &[u8]) -> Result<Vec<u8>, SignerError> { unreachable!() }
-            fn signature_scheme(&self) -> SignatureScheme { unreachable!() }
+            fn sign(&self, _payload: &[u8]) -> Result<Vec<u8>, SignerError> {
+                unreachable!()
+            }
+            fn signature_scheme(&self) -> SignatureScheme {
+                unreachable!()
+            }
         }
 
-        self._propose_self_update(provider, signer, None::<NewSignerBundle<'_, NoSigner>>, leaf_node_parameters)
+        self._propose_self_update(
+            provider,
+            signer,
+            None::<NewSignerBundle<'_, NoSigner>>,
+            leaf_node_parameters,
+        )
     }
 
     /// Creates an Update proposal that rotates the sender's signature key.

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -1,9 +1,6 @@
 use commit_builder::CommitMessageBundle;
 use errors::{ProposeSelfUpdateError, SelfUpdateError};
-use openmls_traits::{
-    signatures::Signer,
-    storage::StorageProvider as _,
-};
+use openmls_traits::{signatures::Signer, storage::StorageProvider as _};
 
 use crate::{credentials::NewSignerBundle, storage::OpenMlsProvider, treesync::LeafNodeParameters};
 

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -191,4 +191,51 @@ impl MlsGroup {
         self.reset_aad();
         Ok((mls_message, proposal_ref))
     }
+
+    /// Creates a proposal to update the own leaf node. The application can
+    /// choose to update the credential, the capabilities, and the extensions by
+    /// building the [`LeafNodeParameters`].
+    pub fn propose_self_update<Provider: OpenMlsProvider>(
+        &mut self,
+        provider: &Provider,
+        signer: &impl Signer,
+        leaf_node_parameters: LeafNodeParameters,
+    ) -> Result<(MlsMessageOut, ProposalRef), ProposeSelfUpdateError<Provider::StorageError>> {
+        // This trivial type allows propose_self_update and propose_self_update_with_new_signer to share
+        // a call to _propose_self_update. NoSigner is never (and can't be) instantiated and is only
+        // pushed to the None case to satisfy types. This is preferable to copy pasting the inner impl which
+        // shares almost all logic.
+        enum NoSigner {}
+        impl Signer for NoSigner {
+            fn sign(&self, _payload: &[u8]) -> Result<Vec<u8>, SignerError> { unreachable!() }
+            fn signature_scheme(&self) -> SignatureScheme { unreachable!() }
+        }
+
+        self._propose_self_update(provider, signer, None::<NewSignerBundle<'_, NoSigner>>, leaf_node_parameters)
+    }
+
+    /// Creates an Update proposal that rotates the sender's signature key.
+    ///
+    /// In contrast to [`Self::propose_self_update`], this function allows
+    /// updating the signature public key of the sender's leaf node. The
+    /// produced MLS message's envelope is authenticated using `old_signer`
+    /// (required because the sender's current leaf in the group tree still
+    /// carries the old signature key), while the new leaf embedded in the
+    /// `UpdateProposal` is self-signed by `new_signer.signer` so that it
+    /// validates against its own `signature_key` field at the receiver.
+    ///
+    /// If `leaf_node_parameters` sets `credential_with_key`, it MUST equal
+    /// `new_signer.credential_with_key`. If it is not set the new-signer credential
+    /// is folded in automatically.
+    ///
+    /// Returns an error if there is a pending commit.
+    pub fn propose_self_update_with_new_signer<Provider: OpenMlsProvider, S: Signer>(
+        &mut self,
+        provider: &Provider,
+        old_signer: &impl Signer,
+        new_signer: NewSignerBundle<'_, S>,
+        leaf_node_parameters: LeafNodeParameters,
+    ) -> Result<(MlsMessageOut, ProposalRef), ProposeSelfUpdateError<Provider::StorageError>> {
+        self._propose_self_update(provider, old_signer, Some(new_signer), leaf_node_parameters)
+    }
 }

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -203,30 +203,16 @@ impl MlsGroup {
     /// Creates a proposal to update the own leaf node. The application can
     /// choose to update the credential, the capabilities, and the extensions by
     /// building the [`LeafNodeParameters`].
-    pub fn propose_self_update<Provider: OpenMlsProvider>(
+    pub fn propose_self_update<Provider: OpenMlsProvider, S: Signer>(
         &mut self,
         provider: &Provider,
-        signer: &impl Signer,
+        signer: &S,
         leaf_node_parameters: LeafNodeParameters,
     ) -> Result<(MlsMessageOut, ProposalRef), ProposeSelfUpdateError<Provider::StorageError>> {
-        // This trivial type allows propose_self_update and propose_self_update_with_new_signer to share
-        // a call to _propose_self_update. NoSigner is never (and can't be) instantiated and is only
-        // pushed to the None case to satisfy types. This is preferable to copy pasting the inner impl which
-        // shares almost all logic.
-        enum NoSigner {}
-        impl Signer for NoSigner {
-            fn sign(&self, _payload: &[u8]) -> Result<Vec<u8>, SignerError> {
-                unreachable!()
-            }
-            fn signature_scheme(&self) -> SignatureScheme {
-                unreachable!()
-            }
-        }
-
         self._propose_self_update(
             provider,
             signer,
-            None::<NewSignerBundle<'_, NoSigner>>,
+            None::<NewSignerBundle<'_, S>>,
             leaf_node_parameters,
         )
     }

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -1,6 +1,6 @@
 use commit_builder::CommitMessageBundle;
 use errors::{ProposeSelfUpdateError, SelfUpdateError};
-use openmls_traits::{signatures::Signer, storage::StorageProvider as _};
+use openmls_traits::{signatures::{Signer, SignerError}, storage::StorageProvider as _, types::SignatureScheme};
 
 use crate::{credentials::NewSignerBundle, storage::OpenMlsProvider, treesync::LeafNodeParameters};
 
@@ -90,11 +90,12 @@ impl MlsGroup {
     /// Creates a proposal to update the own leaf node. Optionally, a
     /// [`LeafNode`] can be provided to update the leaf node. Note that its
     /// private key must be manually added to the key store.
-    fn _create_self_update_proposal<Provider: OpenMlsProvider>(
+    fn _create_self_update_proposal<Provider: OpenMlsProvider, S: Signer>(
         &mut self,
         provider: &Provider,
-        signer: &impl Signer,
-        leaf_node_parameters: LeafNodeParameters,
+        old_signer: &impl Signer,
+        new_signer: Option<NewSignerBundle<'_, S>>,
+        mut leaf_node_parameters: LeafNodeParameters,
     ) -> Result<AuthenticatedContent, ProposeSelfUpdateError<Provider::StorageError>> {
         self.is_operational()?;
 
@@ -108,14 +109,37 @@ impl MlsGroup {
             .ok_or_else(|| LibraryError::custom("The tree is broken. Couldn't find own leaf."))?
             .clone();
 
-        own_leaf.update(
-            self.ciphersuite(),
-            provider,
-            signer,
-            self.group_id().clone(),
-            self.own_leaf_index(),
-            leaf_node_parameters,
-        )?;
+        if let Some(new_signer) = new_signer {
+            // Reconcile `leaf_node_parameters.credential_with_key` with
+            // `new_signer.credential_with_key`. Mirrors the commit-path logic in
+            // `CommitBuilder::build_internal`.
+            if let Some(ln_cred) = leaf_node_parameters.credential_with_key() {
+                if ln_cred != &new_signer.credential_with_key {
+                    return Err(ProposeSelfUpdateError::InvalidLeafNodeParameters);
+                }
+            } else {
+                leaf_node_parameters
+                    .set_credential_with_key(new_signer.credential_with_key);
+            }
+
+            own_leaf.update(
+                self.ciphersuite(),
+                provider,
+                new_signer.signer,
+                self.group_id().clone(),
+                self.own_leaf_index(),
+                leaf_node_parameters,
+            )?;
+        } else {
+            own_leaf.update(
+                self.ciphersuite(),
+                provider,
+                old_signer,
+                self.group_id().clone(),
+                self.own_leaf_index(),
+                leaf_node_parameters,
+            )?;
+        }
 
         // Validate that the updated leaf node supports all group context extensions
         // https://validation.openmls.tech/#valn0602
@@ -131,7 +155,7 @@ impl MlsGroup {
         }
 
         let update_proposal =
-            self.create_update_proposal(self.framing_parameters(), own_leaf.clone(), signer)?;
+            self.create_update_proposal(self.framing_parameters(), own_leaf.clone(), old_signer)?;
 
         provider
             .storage()
@@ -142,16 +166,14 @@ impl MlsGroup {
         Ok(update_proposal)
     }
 
-    /// Creates a proposal to update the own leaf node. The application can
-    /// choose to update the credential, the capabilities, and the extensions by
-    /// building the [`LeafNodeParameters`].
-    pub fn propose_self_update<Provider: OpenMlsProvider>(
+    fn _propose_self_update<Provider: OpenMlsProvider, S: Signer>(
         &mut self,
         provider: &Provider,
-        signer: &impl Signer,
+        old_signer: &impl Signer,
+        new_signer: Option<NewSignerBundle<'_, S>>,
         leaf_node_parameters: LeafNodeParameters,
     ) -> Result<(MlsMessageOut, ProposalRef), ProposeSelfUpdateError<Provider::StorageError>> {
-        let update_proposal = self._propose_self_update(provider, signer, leaf_node_parameters)?;
+        let update_proposal = self._create_self_update_proposal(provider, old_signer, new_signer, leaf_node_parameters)?;
         let proposal = QueuedProposal::from_authenticated_content_by_ref(
             self.ciphersuite(),
             provider.crypto(),


### PR DESCRIPTION
Resolves https://github.com/openmls/openmls/issues/2008

Adds `propose_self_update_with_new_signer`. I opted to refactor the internals of `propose_self_update` to plumb in an optional new signer. The new public function and the existing propose now defer to the same internal helper (which differs only by an optional signer).