### PR TITLE
Don't explicitly include `openmls_sqlite_storage` in `extensions-draft-08` feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,4 +85,4 @@ jobs:
         run: |
           cargo hack check --feature-powerset --no-dev-deps --verbose -p openmls \
           --group-features test-utils,crypto-debug,content-debug,backtrace,libcrux-provider,sqlite-provider \
-          --group-features extensions-draft-08,extensions-draft-08-sqlite
+          --group-features extensions-draft-08,extensions-draft-08-test-dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,4 +84,5 @@ jobs:
       - name: Cargo hack
         run: |
           cargo hack check --feature-powerset --no-dev-deps --verbose -p openmls \
-          --group-features test-utils,crypto-debug,content-debug,backtrace,libcrux-provider,sqlite-provider
+          --group-features test-utils,crypto-debug,content-debug,backtrace,libcrux-provider,sqlite-provider \
+          --group-features extensions-draft-08,extensions-draft-08-sqlite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         features:
           - { name: "", arg: "" }
           - { name: fork-resolution, arg: "-F fork-resolution" }
-          - { name: extensions-draft-08, arg: "-F extensions-draft-08,extensions-draft-08-sqlite" }
+          - { name: extensions-draft-08, arg: "-F extensions-draft-08,extensions-draft-08-test-dependencies" }
     runs-on: ${{ matrix.target.os }}
     name: ${{ matrix.target.target }} (${{ matrix.mode.name }}/${{ matrix.features.name }})
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         features:
           - { name: "", arg: "" }
           - { name: fork-resolution, arg: "-F fork-resolution" }
-          - { name: extensions-draft-08, arg: "-F extensions-draft-08" }
+          - { name: extensions-draft-08, arg: "-F extensions-draft-08,extensions-draft-08-sqlite" }
     runs-on: ${{ matrix.target.os }}
     name: ${{ matrix.target.target }} (${{ matrix.mode.name }}/${{ matrix.features.name }})
     steps:

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -87,6 +87,11 @@ js-test = [
 extensions-draft-08 = [
     "openmls_traits/extensions-draft-08",
     "openmls_memory_storage?/extensions-draft-08",
+    # XXX: to avoid enabling the optional dependency
+    # for `openmls_sqlite_storage`, it is not
+    # explicitly included in this feature.
+    #
+    # Also see https://github.com/rust-lang/cargo/issues/10801
     #"openmls_sqlite_storage?/extensions-draft-08",
     "openmls_libcrux_crypto?/extensions-draft-08",
 ]

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -87,11 +87,11 @@ js-test = [
 extensions-draft-08 = [
     "openmls_traits/extensions-draft-08",
     "openmls_memory_storage?/extensions-draft-08",
-    # XXX: to avoid enabling the optional dependency
-    # for `openmls_sqlite_storage`, it is not
+    # XXX: to avoid enabling the `openmls_sqlite_storage` dependency
+    # when enabling this feature, this optional dependency is not
     # explicitly included in this feature.
     #
-    # Also see https://github.com/rust-lang/cargo/issues/10801
+    # See https://github.com/rust-lang/cargo/issues/10801
     #"openmls_sqlite_storage?/extensions-draft-08",
     "openmls_libcrux_crypto?/extensions-draft-08",
 ]

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -95,6 +95,10 @@ extensions-draft-08 = [
     #"openmls_sqlite_storage?/extensions-draft-08",
     "openmls_libcrux_crypto?/extensions-draft-08",
 ]
+
+extensions-draft-08-sqlite = [
+    "openmls_sqlite_storage?/extensions-draft-08",
+]
 # enable randomness source
 fork-resolution = []
 

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -86,18 +86,20 @@ js-test = [
 
 extensions-draft-08 = [
     "openmls_traits/extensions-draft-08",
-    "openmls_memory_storage?/extensions-draft-08",
     # XXX: to avoid enabling the `openmls_sqlite_storage` dependency
-    # when enabling this feature, this optional dependency is not
-    # explicitly included in this feature.
+    # when enabling this feature, the optional dependencies
+    # used for testing are not explicitly included in this feature.
     #
     # See https://github.com/rust-lang/cargo/issues/10801
-    #"openmls_sqlite_storage?/extensions-draft-08",
-    "openmls_libcrux_crypto?/extensions-draft-08",
+    # "openmls_sqlite_storage?/extensions-draft-08",
+    # "openmls_libcrux_crypto?/extensions-draft-08",
+    # "openmls_memory_storage?/extensions-draft-08",
 ]
 
-extensions-draft-08-sqlite = [
+extensions-draft-08-test-dependencies = [
     "openmls_sqlite_storage?/extensions-draft-08",
+    "openmls_libcrux_crypto?/extensions-draft-08",
+    "openmls_memory_storage?/extensions-draft-08",
 ]
 # enable randomness source
 fork-resolution = []

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -87,8 +87,9 @@ js-test = [
 extensions-draft-08 = [
     "openmls_traits/extensions-draft-08",
     # XXX: to avoid enabling the `openmls_sqlite_storage` dependency
-    # when enabling this feature, the optional dependencies
-    # used for testing are not explicitly included in this feature.
+    # and other dependencies used for testing
+    # when enabling this feature, these optional dependencies
+    # are not explicitly included in this feature.
     #
     # See https://github.com/rust-lang/cargo/issues/10801
     # "openmls_sqlite_storage?/extensions-draft-08",

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -87,7 +87,7 @@ js-test = [
 extensions-draft-08 = [
     "openmls_traits/extensions-draft-08",
     "openmls_memory_storage?/extensions-draft-08",
-    "openmls_sqlite_storage?/extensions-draft-08",
+    #"openmls_sqlite_storage?/extensions-draft-08",
     "openmls_libcrux_crypto?/extensions-draft-08",
 ]
 # enable randomness source


### PR DESCRIPTION
This PR updates the `extensions-draft-08` feature in the `openmls` library to no longer explicitly enable `openmls_sqlite_storage?/extensions-draft-08`.

This change prevents the crate's optional dependency `openmls_sqlite_storage` from being included in the lockfile when the `extensions-draft-08` feature is enabled, which could lead to unexpected version conflicts, in particular related to `libsqlite3-sys`. See https://github.com/rust-lang/cargo/issues/10801

For the `openmls` crate tests, to allow running these tests using the `openmls_sqlite_storage` provider when the `extensions-draft-08` feature is enabled, this PR also adds a new testing feature to `openmls`, for use with the `extensions-draft-08` feature. There may be a better way to allow this, though, for example potentially by reorganizing crate tests that use the `openmls_sqlite_storage` crate.