### PR TITLE
Migrate to web-time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -30,7 +30,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64",
- "bitflags 2.11.0",
+ "bitflags",
  "brotli",
  "bytes",
  "bytestring",
@@ -466,12 +466,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1274,21 +1268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluvio-wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b768c170dc045fa587a8f948c91f9bcfb87f774930477c6215addf54317f137f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,21 +1295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,17 +1309,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1398,7 +1351,6 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2023,18 +1975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2710,7 +2650,6 @@ dependencies = [
  "clap",
  "criterion",
  "flate2",
- "fluvio-wasm-timer",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "hex",
@@ -2738,6 +2677,7 @@ dependencies = [
  "tls_codec",
  "wasm-bindgen",
  "wasm-bindgen-test",
+ "web-time",
  "zeroize",
 ]
 
@@ -2913,37 +2853,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3016,12 +2931,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -3220,7 +3129,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "memchr",
  "unicase",
 ]
@@ -3425,20 +3334,11 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3644,7 +3544,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3679,7 +3579,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3817,7 +3717,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4091,7 +3991,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4286,7 +4186,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",
@@ -4503,7 +4403,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -4872,7 +4772,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4895,6 +4795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -5271,7 +5172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -39,7 +39,7 @@ itertools = { version = "0.14", optional = true }
 wasm-bindgen-test = { version = "0.3.50", optional = true }
 getrandom = { version = "0.3.4", optional = true }
 getrandom_old = { package = "getrandom", version = "0.2.15", optional = true }
-fluvio-wasm-timer = { version = "0.2.5", optional = true }
+web-time = { version = "1.1", optional = true, features = ["serde"] }
 once_cell = { version = "1.19.0", optional = true }
 zeroize = "1.8.1"
 serde_bytes = "0.11.17"
@@ -70,7 +70,7 @@ crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
 js = [
     "dep:getrandom",
-    "dep:fluvio-wasm-timer",
+    "dep:web-time",
 
     # enable randomness source
     "getrandom/wasm_js",
@@ -129,6 +129,9 @@ openmls = { path = ".", features = [
 
 [target.'cfg(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows")))'.dev-dependencies]
 openmls = { path = ".", features = ["test-utils"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+web-time = "1.1"
 
 [[bench]]
 name = "benchmark"

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -27,6 +27,11 @@
 //!     .build();
 //! ```
 
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::SystemTime;
+#[cfg(target_arch = "wasm32")]
+use web_time::SystemTime;
+
 use super::*;
 use crate::{
     extensions::Extensions,
@@ -119,7 +124,7 @@ pub struct PastEpochDeletion {
 /// A duration or timestamp before which to delete past epoch secrets.
 pub(crate) enum PastEpochDeletionTimeConfig {
     OlderThanDuration(std::time::Duration),
-    BeforeTimestamp(std::time::SystemTime),
+    BeforeTimestamp(SystemTime),
     DeleteAllWithoutTimestamp,
 }
 
@@ -133,7 +138,7 @@ impl PastEpochDeletion {
     }
 
     /// Delete all past epoch secrets before a provided timestamp.
-    pub fn before_timestamp(timestamp: std::time::SystemTime) -> Self {
+    pub fn before_timestamp(timestamp: SystemTime) -> Self {
         Self {
             config: Some(PastEpochDeletionTimeConfig::BeforeTimestamp(timestamp)),
             max_past_epochs: None,

--- a/openmls/src/group/mls_group/past_secrets.rs
+++ b/openmls/src/group/mls_group/past_secrets.rs
@@ -1,12 +1,17 @@
 use std::collections::{HashMap, VecDeque};
 
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::SystemTime;
+#[cfg(target_arch = "wasm32")]
+use web_time::SystemTime;
+
 use crate::schedule::message_secrets::MessageSecrets;
 
 use super::*;
 
 impl EpochTree {
     #[cfg(test)]
-    pub(crate) fn timestamp(&self) -> Option<std::time::SystemTime> {
+    pub(crate) fn timestamp(&self) -> Option<SystemTime> {
         self.message_secrets.timestamp()
     }
 }
@@ -72,7 +77,7 @@ impl MessageSecretsStore {
         Self {
             max_epochs,
             past_epoch_trees: VecDeque::new(),
-            message_secrets: message_secrets.with_timestamp(std::time::SystemTime::now()),
+            message_secrets: message_secrets.with_timestamp(SystemTime::now()),
         }
     }
 
@@ -97,7 +102,7 @@ impl MessageSecretsStore {
         &mut self,
         message_secrets: MessageSecrets,
     ) -> MessageSecrets {
-        let mut message_secrets = message_secrets.with_timestamp(std::time::SystemTime::now());
+        let mut message_secrets = message_secrets.with_timestamp(SystemTime::now());
         std::mem::swap(&mut self.message_secrets, &mut message_secrets);
 
         message_secrets
@@ -226,7 +231,7 @@ impl MessageSecretsStore {
     fn delete_past_epoch_secrets_older_than_duration(&mut self, duration: std::time::Duration) {
         // first, compare to the timestamp of the current message secrets
         if let Some(added_at) = self.message_secrets.timestamp() {
-            if let Ok(elapsed) = std::time::SystemTime::now().duration_since(added_at) {
+            if let Ok(elapsed) = SystemTime::now().duration_since(added_at) {
                 if elapsed > duration {
                     // delete all
                     self.past_epoch_trees.clear();
@@ -246,7 +251,7 @@ impl MessageSecretsStore {
                     return false;
                 };
 
-                let Ok(elapsed) = std::time::SystemTime::now().duration_since(added_at) else {
+                let Ok(elapsed) = SystemTime::now().duration_since(added_at) else {
                     return false;
                 };
 
@@ -263,7 +268,7 @@ impl MessageSecretsStore {
         }
     }
 
-    fn delete_past_epoch_secrets_before_timestamp(&mut self, cutoff: std::time::SystemTime) {
+    fn delete_past_epoch_secrets_before_timestamp(&mut self, cutoff: SystemTime) {
         // first, compare to timestamp of the current message secrets
         if let Some(added_at) = self.message_secrets.timestamp() {
             if added_at < cutoff {

--- a/openmls/src/group/mls_group/tests_and_kats/tests/past_secrets.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/past_secrets.rs
@@ -30,6 +30,11 @@ use crate::{
 };
 use std::time::Duration;
 
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::{Instant, SystemTime};
+#[cfg(target_arch = "wasm32")]
+use web_time::{Instant, SystemTime};
+
 const INTERVAL: Duration = Duration::from_millis(100);
 
 /// Helper function to set up an MlsGroup configured with the provided past epoch deletion policy
@@ -108,7 +113,7 @@ fn max_epochs_with_duration<Provider: crate::storage::OpenMlsProvider>(
     let (alice_provider, alice_signer, mut alice_group) =
         setup::<Provider>(ciphersuite, policy.clone());
 
-    let start = std::time::Instant::now();
+    let start = Instant::now();
 
     // apply and merge commits to advance the group epoch
     apply_and_merge_commits(4, &alice_provider, &alice_signer, &mut alice_group, policy);
@@ -152,7 +157,7 @@ fn max_epochs_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>()
 
     // === Test the `delete_past_epoch_secrets()` API with a timestamp ===
 
-    let start = std::time::SystemTime::now();
+    let start = SystemTime::now();
 
     // apply and merge commits to advance the group epoch
     apply_and_merge_commits(4, &alice_provider, &alice_signer, &mut alice_group, policy);
@@ -189,7 +194,7 @@ fn max_epochs_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>()
     alice_group
         .delete_past_epoch_secrets(
             &alice_provider,
-            PastEpochDeletion::before_timestamp(std::time::SystemTime::now()),
+            PastEpochDeletion::before_timestamp(SystemTime::now()),
         )
         .expect("error deleting past epoch secrets");
     // assert all past secrets deleted
@@ -222,7 +227,7 @@ fn keep_all_policy_with_duration<Provider: crate::storage::OpenMlsProvider>(
     let (alice_provider, alice_signer, mut alice_group) =
         setup::<Provider>(ciphersuite, policy.clone());
 
-    let start = std::time::Instant::now();
+    let start = Instant::now();
 
     // apply and merge commits to advance the group epoch
     apply_and_merge_commits(4, &alice_provider, &alice_signer, &mut alice_group, policy);
@@ -275,8 +280,7 @@ fn keep_all_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>(
     alice_group
         .delete_past_epoch_secrets(
             &alice_provider,
-            PastEpochDeletion::before_timestamp(std::time::SystemTime::UNIX_EPOCH)
-                .max_past_epochs(5),
+            PastEpochDeletion::before_timestamp(SystemTime::UNIX_EPOCH).max_past_epochs(5),
         )
         .expect("error deleting past epoch secrets");
     // assert no past secrets deleted
@@ -289,8 +293,7 @@ fn keep_all_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>(
     alice_group
         .delete_past_epoch_secrets(
             &alice_provider,
-            PastEpochDeletion::before_timestamp(std::time::SystemTime::UNIX_EPOCH)
-                .max_past_epochs(3),
+            PastEpochDeletion::before_timestamp(SystemTime::UNIX_EPOCH).max_past_epochs(3),
         )
         .expect("error deleting past epoch secrets");
     // assert no past secrets deleted
@@ -303,8 +306,7 @@ fn keep_all_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>(
     alice_group
         .delete_past_epoch_secrets(
             &alice_provider,
-            PastEpochDeletion::before_timestamp(std::time::SystemTime::UNIX_EPOCH)
-                .max_past_epochs(1),
+            PastEpochDeletion::before_timestamp(SystemTime::UNIX_EPOCH).max_past_epochs(1),
         )
         .expect("error deleting past epoch secrets");
     // assert one past secret was kept
@@ -317,7 +319,7 @@ fn keep_all_policy_with_timestamp<Provider: crate::storage::OpenMlsProvider>(
     alice_group
         .delete_past_epoch_secrets(
             &alice_provider,
-            PastEpochDeletion::before_timestamp(std::time::SystemTime::now()),
+            PastEpochDeletion::before_timestamp(SystemTime::now()),
         )
         .expect("error deleting past epoch secrets");
     // assert all past secrets deleted
@@ -382,7 +384,7 @@ fn delete_all<Provider: crate::storage::OpenMlsProvider>() {
 fn setup_tree_store_with_timestamps<Provider: OpenMlsProvider>(
     ciphersuite: Ciphersuite,
     provider: &Provider,
-    entries: &[Option<std::time::SystemTime>],
+    entries: &[Option<SystemTime>],
 ) -> MessageSecretsStore {
     // Create a store
     let mut message_secrets_store = MessageSecretsStore::new_with_secret(
@@ -585,15 +587,13 @@ fn test_secret_tree_store_migration_next_epoch_timestamp() {
     );
 
     // test deletion of all message secrets before the timestamp
-    message_secrets_store.delete_past_epoch_secrets(PastEpochDeletion::before_timestamp(
-        std::time::SystemTime::UNIX_EPOCH,
-    ));
+    message_secrets_store
+        .delete_past_epoch_secrets(PastEpochDeletion::before_timestamp(SystemTime::UNIX_EPOCH));
     assert_eq!(message_secrets_store.num_past_epoch_trees(), 2);
 
     // test deletion of all message secrets before the timestamp
-    message_secrets_store.delete_past_epoch_secrets(PastEpochDeletion::before_timestamp(
-        std::time::SystemTime::now(),
-    ));
+    message_secrets_store
+        .delete_past_epoch_secrets(PastEpochDeletion::before_timestamp(SystemTime::now()));
     assert_eq!(message_secrets_store.num_past_epoch_trees(), 0);
 }
 
@@ -634,7 +634,7 @@ fn test_secret_tree_store_migration_next_epoch_duration() {
 fn test_secret_tree_store_mixed_delete_by_timestamp() {
     let provider = &Provider::default();
 
-    let timestamp_before = std::time::SystemTime::now();
+    let timestamp_before = SystemTime::now();
 
     // Set up a secret tree store with mixed Some and None timestamps
     // NOTE: For completeness, this sequence of epoch tree timestamps is tested.
@@ -643,13 +643,13 @@ fn test_secret_tree_store_mixed_delete_by_timestamp() {
         ciphersuite,
         provider,
         &[
-            None,                                    //0
-            Some(std::time::SystemTime::UNIX_EPOCH), //1
-            None,                                    //2
-            Some(std::time::SystemTime::UNIX_EPOCH), //3
-            None,                                    //4
-            Some(std::time::SystemTime::now()),      //5
-            None,                                    //6
+            None,                         //0
+            Some(SystemTime::UNIX_EPOCH), //1
+            None,                         //2
+            Some(SystemTime::UNIX_EPOCH), //3
+            None,                         //4
+            Some(SystemTime::now()),      //5
+            None,                         //6
         ],
     );
 
@@ -679,13 +679,13 @@ fn test_secret_tree_store_mixed_delete_by_duration() {
         ciphersuite,
         provider,
         &[
-            None,                                    //0
-            Some(std::time::SystemTime::UNIX_EPOCH), //1
-            None,                                    //2
-            Some(std::time::SystemTime::UNIX_EPOCH), //3
-            None,                                    //4
-            Some(std::time::SystemTime::now()),      //5
-            None,                                    //6
+            None,                         //0
+            Some(SystemTime::UNIX_EPOCH), //1
+            None,                         //2
+            Some(SystemTime::UNIX_EPOCH), //3
+            None,                         //4
+            Some(SystemTime::now()),      //5
+            None,                         //6
         ],
     );
 
@@ -717,7 +717,7 @@ fn test_secret_tree_store() {
     message_secrets_store.add_past_epoch_tree(
         0,
         MessageSecrets::random(ciphersuite, provider.rand(), LeafNodeIndex::new(0))
-            .with_timestamp(std::time::SystemTime::now()),
+            .with_timestamp(SystemTime::now()),
         Vec::new(),
     );
 
@@ -729,7 +729,7 @@ fn test_secret_tree_store() {
         message_secrets_store.add_past_epoch_tree(
             i,
             MessageSecrets::random(ciphersuite, provider.rand(), LeafNodeIndex::new(0))
-                .with_timestamp(std::time::SystemTime::now()),
+                .with_timestamp(SystemTime::now()),
             Vec::new(),
         );
     }
@@ -759,7 +759,7 @@ fn test_empty_secret_tree_store() {
     message_secrets_store.add_past_epoch_tree(
         0,
         MessageSecrets::random(ciphersuite, provider.rand(), LeafNodeIndex::new(0))
-            .with_timestamp(std::time::SystemTime::now()),
+            .with_timestamp(SystemTime::now()),
         Vec::new(),
     );
 

--- a/openmls/src/key_packages/lifetime.rs
+++ b/openmls/src/key_packages/lifetime.rs
@@ -1,7 +1,7 @@
-#[cfg(target_arch = "wasm32")]
-use fluvio_wasm_timer::{SystemTime, UNIX_EPOCH};
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(target_arch = "wasm32")]
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
@@ -137,10 +137,10 @@ impl Default for Lifetime {
 #[cfg(test)]
 mod tests {
     use core::time::Duration;
-    #[cfg(target_arch = "wasm32")]
-    use fluvio_wasm_timer::SystemTime;
     #[cfg(not(target_arch = "wasm32"))]
     use std::time::SystemTime;
+    #[cfg(target_arch = "wasm32")]
+    use web_time::SystemTime;
 
     use tls_codec::{Deserialize, Serialize};
 

--- a/openmls/src/schedule/message_secrets.rs
+++ b/openmls/src/schedule/message_secrets.rs
@@ -1,5 +1,10 @@
 //! This module defines the [`MessageSecrets`] struct that can be used for message decryption & verification
 
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::SystemTime;
+#[cfg(target_arch = "wasm32")]
+use web_time::SystemTime;
+
 use super::*;
 
 /// Combined message secrets that need to be stored for later decryption/verification
@@ -16,7 +21,7 @@ pub(crate) struct MessageSecrets {
     /// `None` if no timestamp is available
     /// NOTE: SystemTime is not guaranteed to be monotonic.
     #[serde(default)]
-    added_at: Option<std::time::SystemTime>,
+    added_at: Option<SystemTime>,
 }
 
 #[cfg(not(feature = "crypto-debug"))]
@@ -77,14 +82,11 @@ impl MessageSecrets {
         &mut self.secret_tree
     }
 
-    pub(crate) fn timestamp(&self) -> Option<std::time::SystemTime> {
+    pub(crate) fn timestamp(&self) -> Option<SystemTime> {
         self.added_at
     }
 
-    pub(crate) fn with_timestamp(
-        self,
-        timestamp: impl Into<Option<std::time::SystemTime>>,
-    ) -> Self {
+    pub(crate) fn with_timestamp(self, timestamp: impl Into<Option<SystemTime>>) -> Self {
         Self {
             added_at: timestamp.into(),
             ..self

--- a/openmls/tests/book_code_past_epoch.rs
+++ b/openmls/tests/book_code_past_epoch.rs
@@ -1,4 +1,9 @@
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::SystemTime;
+#[cfg(target_arch = "wasm32")]
+use web_time::SystemTime;
 
 use openmls::prelude::*;
 use openmls::test_utils::single_group_test_framework::*;


### PR DESCRIPTION
This avoids panics from

/library/std/src/sys/time/unsupported.rs:35:9:
      time not implemented on this platform

and fixes https://rustsec.org/advisories/RUSTSEC-2024-0384 that `cargo deny check advisories` warns about.