### PR TITLE
Add `openmls_rust_crypto_hpke_ng` sibling provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,8 @@ dependencies = [
 [[package]]
 name = "hpke-ng"
 version = "0.1.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031300ec46a577e9eebbd0620a6a428d606a0084a1be0ad373888b5929fe6426"
 dependencies = [
  "aead",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +833,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +951,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -974,6 +1002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1011,6 +1040,16 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -1107,12 +1146,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1121,7 +1160,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature",
 ]
 
@@ -1141,6 +1180,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed448-goldilocks"
+version = "0.14.0-pre.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f6a69850962cce143a2872dba18284ebc9117286f5a79c6a14f0ce7c95b9f6d"
+dependencies = [
+ "elliptic-curve 0.14.0-rc.32",
+ "hash2curve",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,17 +1204,36 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf 0.12.4",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.0-rc.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda94f31325c4275e9706adecbb6f0650dee2f904c915a98e3d81adaaaa757aa"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.3",
+ "crypto-common 0.2.1",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
+ "rustcrypto-group",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -1496,6 +1567,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash2curve"
+version = "0.14.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5e38a1358dfed60ae56c6d62b2d1466853d162d9a518da0673e3670d95fd10"
+dependencies = [
+ "digest 0.11.2",
+ "elliptic-curve 0.14.0-rc.32",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1692,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.2",
+]
+
+[[package]]
+name = "hpke-ng"
+version = "0.1.0-rc.2"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "ed448-goldilocks",
+ "hkdf 0.12.4",
+ "k256",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rand_core 0.9.5",
+ "sha2 0.10.9",
+ "sha3 0.10.9",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -1750,7 +1853,9 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -2127,7 +2232,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -2777,6 +2901,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "openmls_rust_crypto_hpke_ng"
+version = "0.1.0"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "ed25519-dalek",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "hpke-ng",
+ "openmls_memory_storage",
+ "openmls_rust_crypto",
+ "openmls_traits",
+ "p256",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "rand_core 0.9.5",
+ "serde",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tls_codec",
+ "zeroize",
+]
+
+[[package]]
 name = "openmls_sqlite_storage"
 version = "0.2.0"
 dependencies = [
@@ -2826,7 +2974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "primeorder",
  "sha2 0.10.9",
 ]
@@ -2837,7 +2985,18 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct 0.2.0",
+ "elliptic-curve 0.13.8",
  "primeorder",
 ]
 
@@ -2938,8 +3097,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3027,7 +3196,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -3574,6 +3743,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
+ "subtle",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3703,10 +3893,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.0",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -3848,6 +4052,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak 0.2.0",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3933,7 +4157,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "der 0.8.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "openmls",
     "traits",
     "openmls_rust_crypto",
+    "openmls_rust_crypto_hpke_ng",
     "libcrux_crypto",
     "fuzz",
     "cli",

--- a/openmls_rust_crypto_hpke_ng/Cargo.toml
+++ b/openmls_rust_crypto_hpke_ng/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "openmls_rust_crypto_hpke_ng"
+authors = ["OpenMLS Authors"]
+version = "0.1.0"
+edition = "2021"
+description = "A crypto backend for OpenMLS implementing openmls_traits using RustCrypto primitives, with HPKE provided by hpke-ng."
+license = "MIT"
+documentation = "https://docs.rs/openmls_rust_crypto_hpke_ng"
+repository = "https://github.com/openmls/openmls/tree/main/openmls_rust_crypto_hpke_ng"
+readme = "README.md"
+
+[dependencies]
+openmls_traits = { workspace = true }
+openmls_memory_storage = { workspace = true }
+
+# HPKE provided by hpke-ng (RFC 9180). Path dep for local development; switch
+# to a registry version once hpke-ng publishes a stable release.
+hpke-ng = { path = "../../../symbolic/hpke-ng", default-features = false, features = ["std"] }
+
+# Rust Crypto dependencies
+sha2 = { version = "0.11" }
+aes-gcm = { version = "0.10" }
+chacha20poly1305 = { version = "0.10" }
+hmac = { version = "0.13" }
+ed25519-dalek = { version = "2.0", features = ["rand_core"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
+# hpke-ng uses rand_core 0.9; bring it in alongside 0.6 (used by ed25519-dalek
+# and p256) and bridge between them via a small trait wrapper in `provider.rs`.
+rand_core_09 = { package = "rand_core", version = "0.9", default-features = false }
+p256 = { version = "0.13" }
+hkdf = { version = "0.13" }
+rand_chacha = { version = "0.3" }
+tls_codec = { workspace = true }
+thiserror = "2.0"
+serde = { version = "^1.0", features = ["derive"] }
+zeroize = { version = "1.8", features = ["derive", "alloc"] }
+
+[features]
+test-utils = ["openmls_memory_storage/test-utils"]
+
+[dev-dependencies]
+# Cross-validate against the legacy hpke-rs-backed provider so the two crates
+# stay byte-compatible at the RFC 9180 layer.
+openmls_rust_crypto = { workspace = true }

--- a/openmls_rust_crypto_hpke_ng/Cargo.toml
+++ b/openmls_rust_crypto_hpke_ng/Cargo.toml
@@ -13,9 +13,7 @@ readme = "README.md"
 openmls_traits = { workspace = true }
 openmls_memory_storage = { workspace = true }
 
-# HPKE provided by hpke-ng (RFC 9180). Path dep for local development; switch
-# to a registry version once hpke-ng publishes a stable release.
-hpke-ng = { path = "../../../symbolic/hpke-ng", default-features = false, features = ["std"] }
+hpke-ng = { default-features = false, features = ["std"] }
 
 # Rust Crypto dependencies
 sha2 = { version = "0.11" }

--- a/openmls_rust_crypto_hpke_ng/Cargo.toml
+++ b/openmls_rust_crypto_hpke_ng/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 openmls_traits = { workspace = true }
 openmls_memory_storage = { workspace = true }
 
-hpke-ng = { default-features = false, features = ["std"] }
+hpke-ng = { version = "0.1.0-rc.2", default-features = false, features = ["std"] }
 
 # Rust Crypto dependencies
 sha2 = { version = "0.11" }

--- a/openmls_rust_crypto_hpke_ng/README.md
+++ b/openmls_rust_crypto_hpke_ng/README.md
@@ -1,0 +1,16 @@
+# Rust Crypto Backend (hpke-ng)
+
+This crate implements the [OpenMLS traits](../traits/README.md) using the following Rust crates: [hkdf], [hpke-ng], [sha2], [p256], [p384], [x25519-dalek], [ed25519-dalek], [chacha20poly1305], [aes-gcm].
+
+It is a sibling of [`openmls_rust_crypto`](../openmls_rust_crypto/README.md) that swaps the HPKE dependency from [hpke-rs] to [hpke-ng]. The non-HPKE primitives (signatures, AEAD, hashes, HKDF, HMAC) match `openmls_rust_crypto` exactly, so the two crates are interchangeable as `OpenMlsProvider` implementations.
+
+[hkdf]: https://docs.rs/hkdf
+[hpke-ng]: https://github.com/symbolicsoft/hpke-ng
+[hpke-rs]: https://docs.rs/hpke-rs
+[sha2]: https://docs.rs/sha2
+[p256]: https://docs.rs/p256
+[p384]: https://docs.rs/p384
+[x25519-dalek]: https://docs.rs/x25519-dalek
+[ed25519-dalek]: https://docs.rs/ed25519-dalek
+[chacha20poly1305]: https://docs.rs/chacha20poly1305
+[aes-gcm]: https://docs.rs/aes-gcm

--- a/openmls_rust_crypto_hpke_ng/src/hmac.rs
+++ b/openmls_rust_crypto_hpke_ng/src/hmac.rs
@@ -1,0 +1,31 @@
+use hmac::{KeyInit, Mac};
+use openmls_traits::types;
+use openmls_traits::types::{CryptoError, HashType};
+use sha2::{Sha256, Sha384, Sha512};
+use tls_codec::SecretVLBytes;
+
+type HmacSha256 = hmac::Hmac<Sha256>;
+type HmacSha384 = hmac::Hmac<Sha384>;
+type HmacSha512 = hmac::Hmac<Sha512>;
+
+macro_rules! hmac_digest {
+    ($hash_t:ty, $key:ident, $message:ident) => {{
+        let mut hmac = <$hash_t>::new_from_slice($key).map_err(|_e| CryptoError::InvalidLength)?;
+        hmac.update($message);
+        #[allow(deprecated)]
+        hmac.finalize().into_bytes().as_slice().to_vec()
+    }};
+}
+
+pub(crate) fn hmac(
+    hash_type: HashType,
+    key: &[u8],
+    message: &[u8],
+) -> Result<SecretVLBytes, types::CryptoError> {
+    let digest: Vec<u8> = match hash_type {
+        HashType::Sha2_256 => hmac_digest!(HmacSha256, key, message),
+        HashType::Sha2_384 => hmac_digest!(HmacSha384, key, message),
+        HashType::Sha2_512 => hmac_digest!(HmacSha512, key, message),
+    };
+    Ok(SecretVLBytes::new(digest))
+}

--- a/openmls_rust_crypto_hpke_ng/src/lib.rs
+++ b/openmls_rust_crypto_hpke_ng/src/lib.rs
@@ -1,0 +1,39 @@
+//! # OpenMLS Default Crypto Provider (hpke-ng)
+//!
+//! This is an implementation of the [`OpenMlsProvider`] trait to use with
+//! OpenMLS, identical to [`openmls_rust_crypto`] except that HPKE is provided
+//! by [`hpke-ng`](https://github.com/symbolicsoft/hpke-ng) rather than
+//! [`hpke-rs`](https://docs.rs/hpke-rs).
+
+pub use openmls_memory_storage::{MemoryStorage, MemoryStorageError};
+use openmls_traits::OpenMlsProvider;
+
+mod provider;
+pub use provider::*;
+
+mod hmac;
+
+#[derive(Default, Debug)]
+#[cfg_attr(feature = "test-utils", derive(Clone))]
+pub struct OpenMlsRustCrypto {
+    crypto: RustCrypto,
+    key_store: MemoryStorage,
+}
+
+impl OpenMlsProvider for OpenMlsRustCrypto {
+    type CryptoProvider = RustCrypto;
+    type RandProvider = RustCrypto;
+    type StorageProvider = MemoryStorage;
+
+    fn storage(&self) -> &Self::StorageProvider {
+        &self.key_store
+    }
+
+    fn crypto(&self) -> &Self::CryptoProvider {
+        &self.crypto
+    }
+
+    fn rand(&self) -> &Self::RandProvider {
+        &self.crypto
+    }
+}

--- a/openmls_rust_crypto_hpke_ng/src/provider.rs
+++ b/openmls_rust_crypto_hpke_ng/src/provider.rs
@@ -1,0 +1,597 @@
+use std::sync::RwLock;
+
+use aes_gcm::{
+    aead::{Aead, Payload},
+    Aes128Gcm, Aes256Gcm, KeyInit,
+};
+use chacha20poly1305::ChaCha20Poly1305;
+use ed25519_dalek::Signer;
+use hkdf::Hkdf;
+use hpke_ng::{
+    Aes128Gcm as HpkeAes128Gcm, Aes256Gcm as HpkeAes256Gcm,
+    ChaCha20Poly1305 as HpkeChaCha20Poly1305, DhKemP256HkdfSha256, DhKemP384HkdfSha384,
+    DhKemP521HkdfSha512, DhKemX25519HkdfSha256, DhKemX448HkdfSha512, HkdfSha256, HkdfSha384,
+    HkdfSha512, Hpke, HpkeError, Kem,
+};
+use openmls_traits::{
+    crypto::OpenMlsCrypto,
+    random::OpenMlsRand,
+    types::{
+        self, AeadType, Ciphersuite, CryptoError, ExporterSecret, HashType, HpkeAeadType,
+        HpkeCiphertext, HpkeConfig, HpkeKdfType, HpkeKemType, HpkeKeyPair, SignatureScheme,
+    },
+};
+use p256::{
+    ecdsa::{signature::Verifier, Signature, SigningKey, VerifyingKey},
+    EncodedPoint,
+};
+use rand_core::{RngCore as _, SeedableRng as _};
+use sha2::{Digest, Sha256, Sha384, Sha512};
+use tls_codec::SecretVLBytes;
+
+use crate::hmac;
+
+#[derive(Debug)]
+pub struct RustCrypto {
+    rng: RwLock<rand_chacha::ChaCha20Rng>,
+}
+
+// For testing we want to clone.
+// But really we just create a new Rng.
+#[cfg(feature = "test-utils")]
+impl Clone for RustCrypto {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl Default for RustCrypto {
+    fn default() -> Self {
+        Self {
+            rng: RwLock::new(rand_chacha::ChaCha20Rng::from_entropy()),
+        }
+    }
+}
+
+/// Bridge from `rand_core` 0.6 to `rand_core` 0.9.
+///
+/// `rand_chacha` 0.3 (and `ed25519-dalek 2` / `p256 0.13`) speak `rand_core`
+/// 0.6 traits; `hpke-ng` requires `rand_core` 0.9. The wrapper forwards the
+/// three `RngCore` methods that 0.9 actually defines (no `try_fill_bytes`) and
+/// re-asserts `CryptoRng`.
+struct RngCompat09<'a, R: rand_core::RngCore + rand_core::CryptoRng>(&'a mut R);
+
+impl<R: rand_core::RngCore + rand_core::CryptoRng> rand_core_09::RngCore for RngCompat09<'_, R> {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+    fn fill_bytes(&mut self, dst: &mut [u8]) {
+        self.0.fill_bytes(dst);
+    }
+}
+
+impl<R: rand_core::RngCore + rand_core::CryptoRng> rand_core_09::CryptoRng for RngCompat09<'_, R> {}
+
+/// Dispatch on `(kem, kdf, aead)` to the matching `hpke-ng` `Hpke<K, F, A>`.
+///
+/// Each arm declares two type aliases — `$kem` for `K` and `$suite` for the
+/// fully-parameterized `Hpke<K, F, A>` — then evaluates `$body` with both in
+/// scope. Only the 15 KEM-KDF-AEAD combinations whose KEM/KDF SHA sizes line
+/// up are handled (these are the only ones that appear in real MLS
+/// ciphersuites). `XWingKemDraft6` mirrors `openmls_rust_crypto`'s
+/// `unimplemented!()`.
+macro_rules! dispatch_hpke {
+    ($config:expr, |$kem:ident, $suite:ident| $body:block) => {
+        match ($config.0, $config.1, $config.2) {
+            (HpkeKemType::DhKem25519, HpkeKdfType::HkdfSha256, HpkeAeadType::AesGcm128) => {
+                #[allow(dead_code)]
+                type $kem = DhKemX25519HkdfSha256;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemX25519HkdfSha256, HkdfSha256, HpkeAes128Gcm>;
+                $body
+            }
+            (HpkeKemType::DhKem25519, HpkeKdfType::HkdfSha256, HpkeAeadType::AesGcm256) => {
+                #[allow(dead_code)]
+                type $kem = DhKemX25519HkdfSha256;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemX25519HkdfSha256, HkdfSha256, HpkeAes256Gcm>;
+                $body
+            }
+            (HpkeKemType::DhKem25519, HpkeKdfType::HkdfSha256, HpkeAeadType::ChaCha20Poly1305) => {
+                #[allow(dead_code)]
+                type $kem = DhKemX25519HkdfSha256;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemX25519HkdfSha256, HkdfSha256, HpkeChaCha20Poly1305>;
+                $body
+            }
+            (HpkeKemType::DhKemP256, HpkeKdfType::HkdfSha256, HpkeAeadType::AesGcm128) => {
+                #[allow(dead_code)]
+                type $kem = DhKemP256HkdfSha256;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemP256HkdfSha256, HkdfSha256, HpkeAes128Gcm>;
+                $body
+            }
+            (HpkeKemType::DhKemP256, HpkeKdfType::HkdfSha256, HpkeAeadType::AesGcm256) => {
+                #[allow(dead_code)]
+                type $kem = DhKemP256HkdfSha256;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemP256HkdfSha256, HkdfSha256, HpkeAes256Gcm>;
+                $body
+            }
+            (HpkeKemType::DhKemP256, HpkeKdfType::HkdfSha256, HpkeAeadType::ChaCha20Poly1305) => {
+                #[allow(dead_code)]
+                type $kem = DhKemP256HkdfSha256;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemP256HkdfSha256, HkdfSha256, HpkeChaCha20Poly1305>;
+                $body
+            }
+            (HpkeKemType::DhKemP384, HpkeKdfType::HkdfSha384, HpkeAeadType::AesGcm128) => {
+                #[allow(dead_code)]
+                type $kem = DhKemP384HkdfSha384;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemP384HkdfSha384, HkdfSha384, HpkeAes128Gcm>;
+                $body
+            }
+            (HpkeKemType::DhKemP384, HpkeKdfType::HkdfSha384, HpkeAeadType::AesGcm256) => {
+                #[allow(dead_code)]
+                type $kem = DhKemP384HkdfSha384;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemP384HkdfSha384, HkdfSha384, HpkeAes256Gcm>;
+                $body
+            }
+            (HpkeKemType::DhKemP384, HpkeKdfType::HkdfSha384, HpkeAeadType::ChaCha20Poly1305) => {
+                #[allow(dead_code)]
+                type $kem = DhKemP384HkdfSha384;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemP384HkdfSha384, HkdfSha384, HpkeChaCha20Poly1305>;
+                $body
+            }
+            (HpkeKemType::DhKemP521, HpkeKdfType::HkdfSha512, HpkeAeadType::AesGcm128) => {
+                #[allow(dead_code)]
+                type $kem = DhKemP521HkdfSha512;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemP521HkdfSha512, HkdfSha512, HpkeAes128Gcm>;
+                $body
+            }
+            (HpkeKemType::DhKemP521, HpkeKdfType::HkdfSha512, HpkeAeadType::AesGcm256) => {
+                #[allow(dead_code)]
+                type $kem = DhKemP521HkdfSha512;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemP521HkdfSha512, HkdfSha512, HpkeAes256Gcm>;
+                $body
+            }
+            (HpkeKemType::DhKemP521, HpkeKdfType::HkdfSha512, HpkeAeadType::ChaCha20Poly1305) => {
+                #[allow(dead_code)]
+                type $kem = DhKemP521HkdfSha512;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemP521HkdfSha512, HkdfSha512, HpkeChaCha20Poly1305>;
+                $body
+            }
+            (HpkeKemType::DhKem448, HpkeKdfType::HkdfSha512, HpkeAeadType::AesGcm128) => {
+                #[allow(dead_code)]
+                type $kem = DhKemX448HkdfSha512;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemX448HkdfSha512, HkdfSha512, HpkeAes128Gcm>;
+                $body
+            }
+            (HpkeKemType::DhKem448, HpkeKdfType::HkdfSha512, HpkeAeadType::AesGcm256) => {
+                #[allow(dead_code)]
+                type $kem = DhKemX448HkdfSha512;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemX448HkdfSha512, HkdfSha512, HpkeAes256Gcm>;
+                $body
+            }
+            (HpkeKemType::DhKem448, HpkeKdfType::HkdfSha512, HpkeAeadType::ChaCha20Poly1305) => {
+                #[allow(dead_code)]
+                type $kem = DhKemX448HkdfSha512;
+                #[allow(dead_code)]
+                type $suite = Hpke<DhKemX448HkdfSha512, HkdfSha512, HpkeChaCha20Poly1305>;
+                $body
+            }
+            (HpkeKemType::XWingKemDraft6, _, _) => {
+                unimplemented!("XWingKemDraft6 is not supported by the RustCrypto provider.")
+            }
+            _ => Err(CryptoError::UnsupportedCiphersuite),
+        }
+    };
+}
+
+/// Mirrors the original provider's hpke-rs error mapping: only "the input was
+/// the wrong shape" is `InvalidLength`; everything else is collapsed to the
+/// generic library error.
+fn map_seal_err(e: HpkeError) -> CryptoError {
+    match e {
+        HpkeError::InvalidPublicKey
+        | HpkeError::InvalidPrivateKey
+        | HpkeError::InvalidEncappedKey => CryptoError::InvalidLength,
+        _ => CryptoError::CryptoLibraryError,
+    }
+}
+
+fn map_derive_err(e: HpkeError) -> CryptoError {
+    match e {
+        HpkeError::DeriveKeyPairError | HpkeError::InvalidPrivateKey => CryptoError::InvalidLength,
+        _ => CryptoError::CryptoLibraryError,
+    }
+}
+
+impl OpenMlsCrypto for RustCrypto {
+    fn supports(&self, ciphersuite: Ciphersuite) -> Result<(), CryptoError> {
+        match ciphersuite {
+            Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
+            | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => Ok(()),
+            _ => Err(CryptoError::UnsupportedCiphersuite),
+        }
+    }
+
+    fn supported_ciphersuites(&self) -> Vec<Ciphersuite> {
+        vec![
+            Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+            Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+            Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
+        ]
+    }
+
+    fn hkdf_extract(
+        &self,
+        hash_type: openmls_traits::types::HashType,
+        salt: &[u8],
+        ikm: &[u8],
+    ) -> Result<SecretVLBytes, openmls_traits::types::CryptoError> {
+        #[allow(deprecated)]
+        match hash_type {
+            HashType::Sha2_256 => Ok(Hkdf::<Sha256>::extract(Some(salt), ikm).0.as_slice().into()),
+            HashType::Sha2_384 => Ok(Hkdf::<Sha384>::extract(Some(salt), ikm).0.as_slice().into()),
+            HashType::Sha2_512 => Ok(Hkdf::<Sha512>::extract(Some(salt), ikm).0.as_slice().into()),
+        }
+    }
+
+    fn hmac(
+        &self,
+        hash_type: HashType,
+        key: &[u8],
+        message: &[u8],
+    ) -> Result<SecretVLBytes, CryptoError> {
+        hmac::hmac(hash_type, key, message)
+    }
+
+    fn hkdf_expand(
+        &self,
+        hash_type: openmls_traits::types::HashType,
+        prk: &[u8],
+        info: &[u8],
+        okm_len: usize,
+    ) -> Result<SecretVLBytes, openmls_traits::types::CryptoError> {
+        match hash_type {
+            HashType::Sha2_256 => {
+                let hkdf = Hkdf::<Sha256>::from_prk(prk)
+                    .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+                let mut okm = vec![0u8; okm_len];
+                hkdf.expand(info, &mut okm)
+                    .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+                Ok(okm.into())
+            }
+            HashType::Sha2_512 => {
+                let hkdf = Hkdf::<Sha512>::from_prk(prk)
+                    .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+                let mut okm = vec![0u8; okm_len];
+                hkdf.expand(info, &mut okm)
+                    .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+                Ok(okm.into())
+            }
+            HashType::Sha2_384 => {
+                let hkdf = Hkdf::<Sha384>::from_prk(prk)
+                    .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+                let mut okm = vec![0u8; okm_len];
+                hkdf.expand(info, &mut okm)
+                    .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+                Ok(okm.into())
+            }
+        }
+    }
+
+    fn hash(
+        &self,
+        hash_type: openmls_traits::types::HashType,
+        data: &[u8],
+    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        #[allow(deprecated)]
+        match hash_type {
+            HashType::Sha2_256 => Ok(Sha256::digest(data).as_slice().into()),
+            HashType::Sha2_384 => Ok(Sha384::digest(data).as_slice().into()),
+            HashType::Sha2_512 => Ok(Sha512::digest(data).as_slice().into()),
+        }
+    }
+
+    fn aead_encrypt(
+        &self,
+        alg: openmls_traits::types::AeadType,
+        key: &[u8],
+        data: &[u8],
+        nonce: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        match alg {
+            AeadType::Aes128Gcm => {
+                let aes =
+                    Aes128Gcm::new_from_slice(key).map_err(|_| CryptoError::CryptoLibraryError)?;
+                aes.encrypt(nonce.into(), Payload { msg: data, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::CryptoLibraryError)
+            }
+            AeadType::Aes256Gcm => {
+                let aes =
+                    Aes256Gcm::new_from_slice(key).map_err(|_| CryptoError::CryptoLibraryError)?;
+                aes.encrypt(nonce.into(), Payload { msg: data, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::CryptoLibraryError)
+            }
+            AeadType::ChaCha20Poly1305 => {
+                let chacha_poly = ChaCha20Poly1305::new_from_slice(key)
+                    .map_err(|_| CryptoError::CryptoLibraryError)?;
+                chacha_poly
+                    .encrypt(nonce.into(), Payload { msg: data, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::CryptoLibraryError)
+            }
+        }
+    }
+
+    fn aead_decrypt(
+        &self,
+        alg: openmls_traits::types::AeadType,
+        key: &[u8],
+        ct_tag: &[u8],
+        nonce: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        match alg {
+            AeadType::Aes128Gcm => {
+                let aes =
+                    Aes128Gcm::new_from_slice(key).map_err(|_| CryptoError::CryptoLibraryError)?;
+                aes.decrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::AeadDecryptionError)
+            }
+            AeadType::Aes256Gcm => {
+                let aes =
+                    Aes256Gcm::new_from_slice(key).map_err(|_| CryptoError::CryptoLibraryError)?;
+                aes.decrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::AeadDecryptionError)
+            }
+            AeadType::ChaCha20Poly1305 => {
+                let chacha_poly = ChaCha20Poly1305::new_from_slice(key)
+                    .map_err(|_| CryptoError::CryptoLibraryError)?;
+                chacha_poly
+                    .decrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::AeadDecryptionError)
+            }
+        }
+    }
+
+    fn signature_key_gen(
+        &self,
+        alg: openmls_traits::types::SignatureScheme,
+    ) -> Result<(Vec<u8>, Vec<u8>), openmls_traits::types::CryptoError> {
+        match alg {
+            SignatureScheme::ECDSA_SECP256R1_SHA256 => {
+                let mut rng = self
+                    .rng
+                    .write()
+                    .map_err(|_| CryptoError::InsufficientRandomness)?;
+                let k = SigningKey::random(&mut *rng);
+                let pk = k.verifying_key().to_encoded_point(false).as_bytes().into();
+                #[allow(deprecated)]
+                Ok((k.to_bytes().as_slice().into(), pk))
+            }
+            SignatureScheme::ED25519 => {
+                let mut rng = self
+                    .rng
+                    .write()
+                    .map_err(|_| CryptoError::InsufficientRandomness)?;
+                let sk = ed25519_dalek::SigningKey::generate(&mut *rng);
+                let pk = sk.verifying_key().to_bytes().into();
+                Ok((sk.to_bytes().into(), pk))
+            }
+            _ => Err(CryptoError::UnsupportedSignatureScheme),
+        }
+    }
+
+    fn verify_signature(
+        &self,
+        alg: openmls_traits::types::SignatureScheme,
+        data: &[u8],
+        pk: &[u8],
+        signature: &[u8],
+    ) -> Result<(), openmls_traits::types::CryptoError> {
+        match alg {
+            SignatureScheme::ECDSA_SECP256R1_SHA256 => {
+                let k = VerifyingKey::from_encoded_point(
+                    &EncodedPoint::from_bytes(pk).map_err(|_| CryptoError::CryptoLibraryError)?,
+                )
+                .map_err(|_| CryptoError::CryptoLibraryError)?;
+                k.verify(
+                    data,
+                    &Signature::from_der(signature).map_err(|_| CryptoError::InvalidSignature)?,
+                )
+                .map_err(|_| CryptoError::InvalidSignature)
+            }
+            SignatureScheme::ED25519 => {
+                let k = ed25519_dalek::VerifyingKey::try_from(pk)
+                    .map_err(|_| CryptoError::CryptoLibraryError)?;
+                if signature.len() != ed25519_dalek::SIGNATURE_LENGTH {
+                    return Err(CryptoError::CryptoLibraryError);
+                }
+                let mut sig = [0u8; ed25519_dalek::SIGNATURE_LENGTH];
+                sig.clone_from_slice(signature);
+                k.verify_strict(data, &ed25519_dalek::Signature::from(sig))
+                    .map_err(|_| CryptoError::InvalidSignature)
+            }
+            _ => Err(CryptoError::UnsupportedSignatureScheme),
+        }
+    }
+
+    fn sign(
+        &self,
+        alg: openmls_traits::types::SignatureScheme,
+        data: &[u8],
+        key: &[u8],
+    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        match alg {
+            SignatureScheme::ECDSA_SECP256R1_SHA256 => {
+                let k = SigningKey::from_bytes(key.into())
+                    .map_err(|_| CryptoError::CryptoLibraryError)?;
+                let signature: Signature = k.sign(data);
+                Ok(signature.to_der().to_bytes().into())
+            }
+            SignatureScheme::ED25519 => {
+                let k = ed25519_dalek::SigningKey::try_from(key)
+                    .map_err(|_| CryptoError::CryptoLibraryError)?;
+                let signature = k.sign(data);
+                Ok(signature.to_bytes().into())
+            }
+            _ => Err(CryptoError::UnsupportedSignatureScheme),
+        }
+    }
+
+    fn hpke_seal(
+        &self,
+        config: HpkeConfig,
+        pk_r: &[u8],
+        info: &[u8],
+        aad: &[u8],
+        ptxt: &[u8],
+    ) -> Result<types::HpkeCiphertext, CryptoError> {
+        let mut rng_guard = self
+            .rng
+            .write()
+            .map_err(|_| CryptoError::InsufficientRandomness)?;
+        let mut compat = RngCompat09(&mut *rng_guard);
+        dispatch_hpke!(config, |K, Suite| {
+            let pk = K::pk_from_bytes(pk_r).map_err(map_seal_err)?;
+            let (enc, ciphertext) =
+                Suite::seal_base(&mut compat, &pk, info, aad, ptxt).map_err(map_seal_err)?;
+            Ok(HpkeCiphertext {
+                kem_output: enc.as_ref().to_vec().into(),
+                ciphertext: ciphertext.into(),
+            })
+        })
+    }
+
+    fn hpke_open(
+        &self,
+        config: HpkeConfig,
+        input: &types::HpkeCiphertext,
+        sk_r: &[u8],
+        info: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        dispatch_hpke!(config, |K, Suite| {
+            let sk = K::sk_from_bytes(sk_r).map_err(|_| CryptoError::HpkeDecryptionError)?;
+            let enc = K::enc_from_bytes(input.kem_output.as_slice())
+                .map_err(|_| CryptoError::HpkeDecryptionError)?;
+            Suite::open_base(&enc, &sk, info, aad, input.ciphertext.as_slice())
+                .map_err(|_| CryptoError::HpkeDecryptionError)
+        })
+    }
+
+    fn hpke_setup_sender_and_export(
+        &self,
+        config: HpkeConfig,
+        pk_r: &[u8],
+        info: &[u8],
+        exporter_context: &[u8],
+        exporter_length: usize,
+    ) -> Result<(Vec<u8>, ExporterSecret), CryptoError> {
+        let mut rng_guard = self
+            .rng
+            .write()
+            .map_err(|_| CryptoError::InsufficientRandomness)?;
+        let mut compat = RngCompat09(&mut *rng_guard);
+        dispatch_hpke!(config, |K, Suite| {
+            let pk = K::pk_from_bytes(pk_r).map_err(|_| CryptoError::SenderSetupError)?;
+            let (enc, exporter) =
+                Suite::send_export_base(&mut compat, &pk, info, exporter_context, exporter_length)
+                    .map_err(|e| match e {
+                        HpkeError::ExportLengthExceeded => CryptoError::ExporterError,
+                        _ => CryptoError::SenderSetupError,
+                    })?;
+            Ok((enc.as_ref().to_vec(), exporter.into()))
+        })
+    }
+
+    fn hpke_setup_receiver_and_export(
+        &self,
+        config: HpkeConfig,
+        enc: &[u8],
+        sk_r: &[u8],
+        info: &[u8],
+        exporter_context: &[u8],
+        exporter_length: usize,
+    ) -> Result<ExporterSecret, CryptoError> {
+        dispatch_hpke!(config, |K, Suite| {
+            let sk = K::sk_from_bytes(sk_r).map_err(|_| CryptoError::ReceiverSetupError)?;
+            let enc = K::enc_from_bytes(enc).map_err(|_| CryptoError::ReceiverSetupError)?;
+            let exporter =
+                Suite::receiver_export_base(&enc, &sk, info, exporter_context, exporter_length)
+                    .map_err(|e| match e {
+                        HpkeError::ExportLengthExceeded => CryptoError::ExporterError,
+                        _ => CryptoError::ReceiverSetupError,
+                    })?;
+            Ok(exporter.into())
+        })
+    }
+
+    fn derive_hpke_keypair(
+        &self,
+        config: HpkeConfig,
+        ikm: &[u8],
+    ) -> Result<types::HpkeKeyPair, CryptoError> {
+        dispatch_hpke!(config, |K, Suite| {
+            // `Suite` is unused here — derivation happens on the KEM alone — but
+            // the dispatch macro always declares both aliases. Mark it consumed
+            // so `clippy::redundant_pub_crate` / `unused_type_aliases` stay
+            // quiet without needing per-arm allow attributes.
+            let _ = core::marker::PhantomData::<Suite>;
+            let (sk, pk) = K::derive_key_pair(ikm).map_err(map_derive_err)?;
+            Ok(HpkeKeyPair {
+                private: K::sk_to_bytes(&sk).as_slice().into(),
+                public: K::pk_to_bytes(&pk).as_slice().into(),
+            })
+        })
+    }
+}
+
+impl OpenMlsRand for RustCrypto {
+    type Error = RandError;
+
+    fn random_array<const N: usize>(&self) -> Result<[u8; N], Self::Error> {
+        let mut rng = self.rng.write().map_err(|_| Self::Error::LockPoisoned)?;
+        let mut out = [0u8; N];
+        rng.try_fill_bytes(&mut out)
+            .map_err(|_| Self::Error::NotEnoughRandomness)?;
+        Ok(out)
+    }
+
+    fn random_vec(&self, len: usize) -> Result<Vec<u8>, Self::Error> {
+        let mut rng = self.rng.write().map_err(|_| Self::Error::LockPoisoned)?;
+        let mut out = vec![0u8; len];
+        rng.try_fill_bytes(&mut out)
+            .map_err(|_| Self::Error::NotEnoughRandomness)?;
+        Ok(out)
+    }
+}
+
+#[derive(thiserror::Error, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum RandError {
+    #[error("Rng lock is poisoned.")]
+    LockPoisoned,
+    #[error("Unable to collect enough randomness.")]
+    NotEnoughRandomness,
+}

--- a/openmls_rust_crypto_hpke_ng/tests/cross_compat.rs
+++ b/openmls_rust_crypto_hpke_ng/tests/cross_compat.rs
@@ -1,0 +1,152 @@
+//! Cross-compatibility tests: the hpke-ng-backed provider must agree with the
+//! hpke-rs-backed `openmls_rust_crypto` on every observable HPKE output. If
+//! they ever drift, two MLS endpoints running different providers would fail
+//! to interoperate.
+//!
+//! What this checks (per OpenMLS-supported ciphersuite):
+//!  * `derive_hpke_keypair`: same IKM ⇒ same `(private, public)` bytes.
+//!  * Cross-direction seal/open: a ciphertext produced by one provider is
+//!    decrypted correctly by the other.
+
+use openmls_rust_crypto::RustCrypto as Legacy;
+use openmls_rust_crypto_hpke_ng::RustCrypto as Ng;
+use openmls_traits::{
+    crypto::OpenMlsCrypto,
+    types::{HpkeAeadType, HpkeConfig, HpkeKdfType, HpkeKemType},
+};
+
+type ConfigParts = (HpkeKemType, HpkeKdfType, HpkeAeadType);
+
+fn config_parts() -> [(&'static str, ConfigParts); 3] {
+    [
+        (
+            "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
+            (
+                HpkeKemType::DhKem25519,
+                HpkeKdfType::HkdfSha256,
+                HpkeAeadType::AesGcm128,
+            ),
+        ),
+        (
+            "MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519",
+            (
+                HpkeKemType::DhKem25519,
+                HpkeKdfType::HkdfSha256,
+                HpkeAeadType::ChaCha20Poly1305,
+            ),
+        ),
+        (
+            "MLS_128_DHKEMP256_AES128GCM_SHA256_P256",
+            (
+                HpkeKemType::DhKemP256,
+                HpkeKdfType::HkdfSha256,
+                HpkeAeadType::AesGcm128,
+            ),
+        ),
+    ]
+}
+
+fn cfg(parts: ConfigParts) -> HpkeConfig {
+    HpkeConfig(parts.0, parts.1, parts.2)
+}
+
+#[test]
+fn derive_hpke_keypair_byte_identical_across_providers() {
+    let legacy = Legacy::default();
+    let ng = Ng::default();
+    let ikm = b"shared keying material across provider implementations";
+    for (name, parts) in config_parts() {
+        let legacy_kp = legacy.derive_hpke_keypair(cfg(parts), ikm).expect(name);
+        let ng_kp = ng.derive_hpke_keypair(cfg(parts), ikm).expect(name);
+        assert_eq!(legacy_kp.public, ng_kp.public, "{name}: pk diverges");
+        assert_eq!(
+            &*legacy_kp.private,
+            &*ng_kp.private,
+            "{name}: sk diverges"
+        );
+    }
+}
+
+#[test]
+fn ng_seal_legacy_open() {
+    let legacy = Legacy::default();
+    let ng = Ng::default();
+    let info = b"mls 1.0 cross-compat";
+    let aad = b"associated authenticated data";
+    let pt = b"hello from hpke-ng";
+    for (name, parts) in config_parts() {
+        let kp = ng
+            .derive_hpke_keypair(cfg(parts), b"32-byte minimum keying material xx")
+            .expect(name);
+        let ct = ng
+            .hpke_seal(cfg(parts), &kp.public, info, aad, pt)
+            .expect(name);
+        let recovered = legacy
+            .hpke_open(cfg(parts), &ct, &kp.private, info, aad)
+            .expect(name);
+        assert_eq!(recovered, pt, "{name}: legacy.open(ng.seal) mismatch");
+    }
+}
+
+#[test]
+fn legacy_seal_ng_open() {
+    let legacy = Legacy::default();
+    let ng = Ng::default();
+    let info = b"mls 1.0 cross-compat";
+    let aad = b"associated authenticated data";
+    let pt = b"hello from hpke-rs";
+    for (name, parts) in config_parts() {
+        let kp = legacy
+            .derive_hpke_keypair(cfg(parts), b"32-byte minimum keying material xx")
+            .expect(name);
+        let ct = legacy
+            .hpke_seal(cfg(parts), &kp.public, info, aad, pt)
+            .expect(name);
+        let recovered = ng
+            .hpke_open(cfg(parts), &ct, &kp.private, info, aad)
+            .expect(name);
+        assert_eq!(recovered, pt, "{name}: ng.open(legacy.seal) mismatch");
+    }
+}
+
+#[test]
+fn cross_provider_exporter_secrets_match() {
+    // Sender on legacy + receiver on ng (and vice versa) should derive the same
+    // exporter secret. This catches drift in the HPKE key schedule that the
+    // bare seal/open round-trip might miss when the AEAD masks an off-by-one.
+    let legacy = Legacy::default();
+    let ng = Ng::default();
+    let exp_ctx = b"cross-compat exporter";
+    let exp_len = 32usize;
+    for (name, parts) in config_parts() {
+        let kp = legacy
+            .derive_hpke_keypair(cfg(parts), b"32-byte minimum keying material xx")
+            .expect(name);
+
+        // Legacy sender, ng receiver.
+        let (enc, sender_secret) = legacy
+            .hpke_setup_sender_and_export(cfg(parts), &kp.public, b"info", exp_ctx, exp_len)
+            .expect(name);
+        let receiver_secret = ng
+            .hpke_setup_receiver_and_export(cfg(parts), &enc, &kp.private, b"info", exp_ctx, exp_len)
+            .expect(name);
+        assert_eq!(
+            &*sender_secret,
+            &*receiver_secret,
+            "{name}: ng.recv ≠ legacy.send"
+        );
+
+        // ng sender, legacy receiver.
+        let (enc, sender_secret) = ng
+            .hpke_setup_sender_and_export(cfg(parts), &kp.public, b"info", exp_ctx, exp_len)
+            .expect(name);
+        let receiver_secret = legacy
+            .hpke_setup_receiver_and_export(cfg(parts), &enc, &kp.private, b"info", exp_ctx, exp_len)
+            .expect(name);
+        assert_eq!(
+            &*sender_secret,
+            &*receiver_secret,
+            "{name}: legacy.recv ≠ ng.send"
+        );
+    }
+}

--- a/openmls_rust_crypto_hpke_ng/tests/hpke.rs
+++ b/openmls_rust_crypto_hpke_ng/tests/hpke.rs
@@ -1,0 +1,195 @@
+//! Integration tests for the hpke-ng-backed RustCrypto provider.
+//!
+//! Exercises the HPKE methods OpenMLS calls through `OpenMlsCrypto`:
+//! `derive_hpke_keypair`, `hpke_seal`/`hpke_open` (seal/open round-trip),
+//! and `hpke_setup_sender_and_export`/`hpke_setup_receiver_and_export`
+//! (sender/receiver export agreement). All three OpenMLS-supported
+//! ciphersuites are covered.
+
+use openmls_rust_crypto_hpke_ng::RustCrypto;
+use openmls_traits::{
+    crypto::OpenMlsCrypto,
+    types::{Ciphersuite, HpkeAeadType, HpkeConfig, HpkeKdfType, HpkeKemType},
+};
+
+// `HpkeConfig` is not `Copy`, so each test rebuilds it from the Copy parts.
+type ConfigParts = (HpkeKemType, HpkeKdfType, HpkeAeadType);
+
+fn config_parts() -> [(&'static str, ConfigParts); 3] {
+    [
+        (
+            "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
+            (
+                HpkeKemType::DhKem25519,
+                HpkeKdfType::HkdfSha256,
+                HpkeAeadType::AesGcm128,
+            ),
+        ),
+        (
+            "MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519",
+            (
+                HpkeKemType::DhKem25519,
+                HpkeKdfType::HkdfSha256,
+                HpkeAeadType::ChaCha20Poly1305,
+            ),
+        ),
+        (
+            "MLS_128_DHKEMP256_AES128GCM_SHA256_P256",
+            (
+                HpkeKemType::DhKemP256,
+                HpkeKdfType::HkdfSha256,
+                HpkeAeadType::AesGcm128,
+            ),
+        ),
+    ]
+}
+
+fn cfg(parts: ConfigParts) -> HpkeConfig {
+    HpkeConfig(parts.0, parts.1, parts.2)
+}
+
+#[test]
+fn supported_ciphersuites_match_legacy_provider() {
+    let crypto = RustCrypto::default();
+    let supported = crypto.supported_ciphersuites();
+    assert_eq!(supported.len(), 3);
+    assert!(supported.contains(&Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519));
+    assert!(supported.contains(&Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519));
+    assert!(supported.contains(&Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256));
+}
+
+#[test]
+fn derive_hpke_keypair_is_deterministic() {
+    let crypto = RustCrypto::default();
+    for (name, parts) in config_parts() {
+        let ikm = b"test ikm bytes for derive_hpke_keypair";
+        let kp1 = crypto.derive_hpke_keypair(cfg(parts), ikm).expect(name);
+        let kp2 = crypto.derive_hpke_keypair(cfg(parts), ikm).expect(name);
+        assert_eq!(kp1.public, kp2.public, "{name}: pk diverges");
+        assert_eq!(&*kp1.private, &*kp2.private, "{name}: sk diverges");
+    }
+}
+
+#[test]
+fn seal_open_roundtrips_for_each_supported_ciphersuite() {
+    let crypto = RustCrypto::default();
+    let info = b"mls 1.0 test info";
+    let aad = b"associated authenticated data";
+    let pt = b"plaintext payload that needs sealing";
+    for (name, parts) in config_parts() {
+        let ikm = b"32-byte minimum keying material xx";
+        let kp = crypto.derive_hpke_keypair(cfg(parts), ikm).expect(name);
+
+        let ct = crypto
+            .hpke_seal(cfg(parts), &kp.public, info, aad, pt)
+            .expect(name);
+        let recovered = crypto
+            .hpke_open(cfg(parts), &ct, &kp.private, info, aad)
+            .expect(name);
+        assert_eq!(recovered, pt, "{name}: open ≠ seal");
+    }
+}
+
+#[test]
+fn open_rejects_tampered_ciphertext() {
+    let crypto = RustCrypto::default();
+    for (name, parts) in config_parts() {
+        let kp = crypto
+            .derive_hpke_keypair(cfg(parts), b"32-byte minimum keying material xx")
+            .expect(name);
+        let mut ct = crypto
+            .hpke_seal(cfg(parts), &kp.public, b"info", b"aad", b"hi")
+            .expect(name);
+        // Flip a bit in the AEAD output. The MAC tag check must reject.
+        let mut bytes: Vec<u8> = ct.ciphertext.as_slice().to_vec();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0x01;
+        ct.ciphertext = bytes.into();
+        let result = crypto.hpke_open(cfg(parts), &ct, &kp.private, b"info", b"aad");
+        assert!(result.is_err(), "{name}: tampered ciphertext was accepted");
+    }
+}
+
+#[test]
+fn sender_and_receiver_exports_match() {
+    let crypto = RustCrypto::default();
+    let exporter_context = b"mls exporter context";
+    let exporter_length = 32usize;
+    for (name, parts) in config_parts() {
+        let kp = crypto
+            .derive_hpke_keypair(cfg(parts), b"32-byte minimum keying material xx")
+            .expect(name);
+
+        let (enc, sender_secret) = crypto
+            .hpke_setup_sender_and_export(
+                cfg(parts),
+                &kp.public,
+                b"info",
+                exporter_context,
+                exporter_length,
+            )
+            .expect(name);
+
+        let receiver_secret = crypto
+            .hpke_setup_receiver_and_export(
+                cfg(parts),
+                &enc,
+                &kp.private,
+                b"info",
+                exporter_context,
+                exporter_length,
+            )
+            .expect(name);
+
+        assert_eq!(
+            &*sender_secret,
+            &*receiver_secret,
+            "{name}: exporter secrets diverge"
+        );
+        assert_eq!(
+            sender_secret.len(),
+            exporter_length,
+            "{name}: exporter length wrong"
+        );
+    }
+}
+
+#[test]
+fn fresh_seal_outputs_differ() {
+    // The randomness path runs through `RngCompat09`. If the bridge produced
+    // duplicate bytes, two consecutive `hpke_seal` calls with the same inputs
+    // would emit identical ciphertexts (the ephemeral DH key is sampled fresh
+    // each time). This catches a wrapper that, e.g., short-circuits `fill_bytes`.
+    let crypto = RustCrypto::default();
+    let parts = (
+        HpkeKemType::DhKem25519,
+        HpkeKdfType::HkdfSha256,
+        HpkeAeadType::AesGcm128,
+    );
+    let kp = crypto
+        .derive_hpke_keypair(cfg(parts), b"32-byte minimum keying material xx")
+        .unwrap();
+    let ct1 = crypto
+        .hpke_seal(cfg(parts), &kp.public, b"info", b"aad", b"hello")
+        .unwrap();
+    let ct2 = crypto
+        .hpke_seal(cfg(parts), &kp.public, b"info", b"aad", b"hello")
+        .unwrap();
+    assert_ne!(ct1.kem_output, ct2.kem_output);
+    assert_ne!(ct1.ciphertext, ct2.ciphertext);
+}
+
+#[test]
+fn unsupported_kem_kdf_pairing_returns_error() {
+    let crypto = RustCrypto::default();
+    // P-384 KEM with SHA-256 KDF is not a natural HPKE pairing and is not a
+    // valid MLS ciphersuite. The dispatch's wildcard arm must turn that into
+    // `UnsupportedCiphersuite` rather than panic.
+    let parts = (
+        HpkeKemType::DhKemP384,
+        HpkeKdfType::HkdfSha256,
+        HpkeAeadType::AesGcm128,
+    );
+    let result = crypto.hpke_seal(cfg(parts), &[0u8; 65], b"info", b"aad", b"pt");
+    assert!(result.is_err());
+}


### PR DESCRIPTION
This PR adds a new workspace crate, `openmls_rust_crypto_hpke_ng`, that mirrors `openmls_rust_crypto` exactly except its HPKE primitives come from [hpke-ng](https://github.com/symbolicsoft/hpke-ng) instead of [hpke-rs](https://docs.rs/hpke-rs). Non-HPKE primitives (signatures, AEAD, hashes, HKDF, HMAC) are unchanged byte-for-byte. The existing `openmls_rust_crypto` crate is not modified. Downstream users opt in by changing their dependency.

The two providers are byte-compatible at the RFC 9180 layer (verified by cross-tests included in this PR), so the choice between them is a property of the crate you depend on, not a wire-format incompatibility.

## Why hpke-ng

[hpke-ng](https://github.com/symbolicsoft/hpke-ng) is a from-scratch RFC 9180 implementation that we at Symbolic Software have released alongside [a detailed comparison](https://symbolic.software/blog/2026-05-08-hpke-ng/) with hpke-rs. Three reasons it's worth offering as a provider option:

### 1. Concrete security issues in hpke-rs

hpke-rs has a history of severe security vulnerabilities:

- [RUSTSEC-2026-0071](https://rustsec.org/advisories/RUSTSEC-2026-0071.html): Nonce Reuse in HPKE Context
- [RUSTSEC-2026-0070](https://rustsec.org/advisories/RUSTSEC-2026-0070.html): Panic When Opening or Sealing on Export-Only Context

In addition, hpke-rs took more than a month to publish adequate security advisories for the above vulnerabilities, raising serious questions regarding the security posture and maintenance discipline of the dependency.

### 2. Compile-time safety instead of runtime errors

hpke-ng dispatches on ciphersuite via type parameters (`Hpke<K, F, A>` is `PhantomData`-only), where hpke-rs dispatches via runtime enums. Four categories of bugs that fail at runtime in hpke-rs become **compile errors** in hpke-ng:

| Bug class | hpke-rs | hpke-ng |
| --- | --- | --- |
| Auth-mode call on a KEM that doesn't support auth (e.g., X-Wing) | runtime `Error::UnsupportedKemOperation` | trait bound `K: AuthKem` fails to resolve |
| Invalid AEAD selection for sealing | runtime `HpkeError::InvalidConfig` | `seal_base` not in scope |
| KEM-mismatched key bytes | runtime mismatch error | type mismatch |
| Base-mode call with a PSK argument | runtime `HpkeError::UnnecessaryPsk` | no PSK parameter exists in the signature |

For OpenMLS specifically, this matters because the runtime dispatch in `openmls_rust_crypto` is the layer where the provider could silently accept a malformed `HpkeConfig` and only error deep in the crypto path. With hpke-ng, malformed configs that aren't a real ciphersuite are caught by the dispatch macro itself.

### 3. Performance and footprint

From the [published benchmarks](https://symbolic.software/blog/2026-05-08-hpke-ng/):

- **encap (X25519):** 29.88 µs vs 38.09 µs (−22 %)
- **decap (X25519):** 29.31 µs vs 36.96 µs (−21 %)
- **single-shot open, 64 B payload:** 33.87 µs vs 38.26 µs (−12 %)
- **`sizeof(Context<K,F,A>)`:** 80 B vs 400 B (−80 %)
- **stripped binary:** 392 KB vs 561 KB (−30 %)

At payload sizes where the AEAD primitive dominates (≥16 KiB), the two libraries converge — both hit the wall-clock cost of the underlying primitive. Speedups are concentrated where they matter for MLS: handshake commit/processing where small HPKE messages dominate.

## Verification

| Suite | Result |
| --- | --- |
| hpke-ng `cargo test --all-features --lib` (with `sk_to_bytes` additions) | **75 / 75 pass** |
| `cargo test -p openmls_rust_crypto_hpke_ng` direct tests | **7 / 7 pass** |
| `cargo test -p openmls_rust_crypto_hpke_ng --test cross_compat` | **4 / 4 pass** |
| `cargo test --workspace` | **all green** |
| `cargo clippy --workspace --all-targets` | clean |
| `cargo build --release -p openmls_rust_crypto_hpke_ng` | clean |

The cross-compat suite is the most load-bearing check: it asserts that

- `derive_hpke_keypair` produces **byte-identical** `(private, public)` outputs for the same IKM under both providers (so persisted keys interoperate),
- a ciphertext produced by hpke-ng's `hpke_seal` opens correctly under hpke-rs's `hpke_open`,
- a ciphertext produced by hpke-rs's `hpke_seal` opens correctly under hpke-ng's `hpke_open`,
- exporter secrets agree in both cross-provider directions.

This means deploying hpke-ng in one MLS endpoint and hpke-rs in another causes no wire-format issue. Adopters can migrate at their own pace.
