### PR TITLE
Stabilize serde variant indices for persisted enums

### DIFF
--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -77,6 +77,9 @@ pub mod errors;
 /// | 0xDADA           | GREASE                   | Y | RFC XXXX |
 /// | 0xEAEA           | GREASE                   | Y | RFC XXXX |
 /// | 0xF000  - 0xFFFF | Reserved for Private Use | - | RFC XXXX |
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(u16)]
 pub enum CredentialType {
@@ -84,10 +87,13 @@ pub enum CredentialType {
     Basic = 1,
     /// An X.509 [`Certificate`]
     X509 = 2,
-    /// A GREASE credential type for ensuring extensibility.
-    Grease(u16),
     /// Another type of credential that is not in the MLS protocol spec.
     Other(u16),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    /// A GREASE credential type for ensuring extensibility.
+    Grease(u16),
 }
 
 impl CredentialType {

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -85,6 +85,15 @@ mod tests;
 /// | 0xff00  - 0xffff | Reserved for Private Use | N/A        | N/A         | RFC XXXX  |
 ///
 /// Note: OpenMLS does not provide a `Reserved` variant in [ExtensionType].
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum ExtensionType {
     /// The application id extension allows applications to add an explicit,
@@ -111,15 +120,18 @@ pub enum ExtensionType {
     /// scenario.
     LastResort,
 
-    #[cfg(feature = "extensions-draft-08")]
-    /// AppDataDictionary extension
-    AppDataDictionary,
+    /// A currently unknown extension type.
+    Unknown(u16),
 
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
     /// A GREASE extension type for ensuring extensibility.
     Grease(u16),
 
-    /// A currently unknown extension type.
-    Unknown(u16),
+    #[cfg(feature = "extensions-draft-08")]
+    /// AppDataDictionary extension
+    AppDataDictionary,
 }
 
 impl ExtensionType {
@@ -290,6 +302,15 @@ impl From<ExtensionType> for u16 {
 ///     opaque extension_data<V>;
 /// } Extension;
 /// ```
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Extension {
     /// An [`ApplicationIdExtension`]
@@ -307,15 +328,18 @@ pub enum Extension {
     /// An [`ExternalSendersExtension`]
     ExternalSenders(ExternalSendersExtension),
 
-    /// An [`AppDataDictionaryExtension`]
-    #[cfg(feature = "extensions-draft-08")]
-    AppDataDictionary(AppDataDictionaryExtension),
-
     /// A [`LastResortExtension`]
     LastResort(LastResortExtension),
 
     /// A currently unknown extension.
     Unknown(u16, UnknownExtension),
+
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    /// An [`AppDataDictionaryExtension`]
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataDictionary(AppDataDictionaryExtension),
 }
 
 /// A unknown/unparsed extension represented by raw bytes.

--- a/openmls/src/group/mls_group/proposal_store.rs
+++ b/openmls/src/group/mls_group/proposal_store.rs
@@ -637,6 +637,13 @@ impl ProposalQueue {
                     // have to be checked by the application instead.
                     valid_proposals.add(queued_proposal.proposal_reference());
                 }
+                Proposal::_AppAck => {
+                    // `_AppAck` is a serde-format placeholder for the
+                    // removed `AppAck` variant; it cannot be produced via
+                    // TLS deserialization, so reaching this arm would
+                    // indicate corrupted state.
+                    unreachable!("Proposal::_AppAck cannot reach the proposal queue")
+                }
             }
         }
 

--- a/openmls/src/messages/codec.rs
+++ b/openmls/src/messages/codec.rs
@@ -35,6 +35,7 @@ impl Size for Proposal {
                 #[cfg(feature = "extensions-draft-08")]
                 Proposal::AppEphemeral(p) => p.tls_serialized_len(),
                 Proposal::Custom(p) => p.payload().tls_serialized_len(),
+                Proposal::_AppAck => 0,
             }
     }
 }
@@ -56,6 +57,12 @@ impl Serialize for Proposal {
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppEphemeral(p) => p.tls_serialize(writer),
             Proposal::Custom(p) => p.payload().tls_serialize(writer),
+            // `_AppAck` is a serde-format placeholder for the removed
+            // `AppAck` variant; the library never produces it at runtime,
+            // so TLS serialization is unreachable.
+            Proposal::_AppAck => {
+                unreachable!("Proposal::_AppAck cannot be TLS-serialized")
+            }
         }
         .map(|l| written + l)
     }
@@ -155,6 +162,13 @@ impl Deserialize for ProposalIn {
                 let payload = Vec::<u8>::tls_deserialize(bytes)?;
                 let custom_proposal = CustomProposal::new(proposal_type.into(), payload);
                 ProposalIn::Custom(Box::new(custom_proposal))
+            }
+            ProposalType::_AppAck => {
+                // `_AppAck` is a serde-format placeholder for the removed
+                // `AppAck` variant; the TLS wire mapping `From<u16>` never
+                // constructs it (the reserved value `0x000b` is routed to
+                // `Custom`), so this arm is unreachable on the TLS wire.
+                unreachable!("ProposalType::_AppAck is not produced by TLS deserialization");
             }
         };
         Ok(proposal)

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -72,6 +72,15 @@ use crate::component::ComponentId;
 /// |:=======|:==============|:============|:==============|:==========|:=============================|
 /// | 0x0009 | app_ephemeral | Y           | N             | RFC XXXX  | draft-ietf-mls-extensions-08 |
 /// | 0x000a | self_remove   | Y           | Y             | RFC XXXX  | draft-ietf-mls-extensions-07 |
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Serialize, Deserialize, Hash)]
 #[allow(missing_docs)]
 pub enum ProposalType {
@@ -82,13 +91,23 @@ pub enum ProposalType {
     Reinit,
     ExternalInit,
     GroupContextExtensions,
+    // Placeholder for the removed `AppAck` variant. Kept (hidden) to preserve
+    // the serde variant indices of subsequent variants for non-self-describing
+    // formats. `AppAck` was never produced by the library on the wire, so no
+    // real data should round-trip through this variant.
+    #[doc(hidden)]
+    #[serde(rename = "AppAck")]
+    _AppAck,
     SelfRemove,
+    Custom(u16),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    Grease(u16),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral,
     #[cfg(feature = "extensions-draft-08")]
     AppDataUpdate,
-    Grease(u16),
-    Custom(u16),
 }
 
 impl ProposalType {
@@ -103,7 +122,10 @@ impl ProposalType {
             | ProposalType::Reinit
             | ProposalType::ExternalInit
             | ProposalType::GroupContextExtensions => true,
-            ProposalType::SelfRemove | ProposalType::Grease(_) | ProposalType::Custom(_) => false,
+            ProposalType::SelfRemove
+            | ProposalType::Grease(_)
+            | ProposalType::Custom(_)
+            | ProposalType::_AppAck => false,
             #[cfg(feature = "extensions-draft-08")]
             ProposalType::AppEphemeral | ProposalType::AppDataUpdate => false,
         }
@@ -201,6 +223,11 @@ impl From<ProposalType> for u16 {
             ProposalType::Reinit => 5,
             ProposalType::ExternalInit => 6,
             ProposalType::GroupContextExtensions => 7,
+            // The library never produces `_AppAck` on the wire; this arm
+            // exists only to keep the match exhaustive. The TLS-wire value
+            // `0x000b` was historically assigned to `AppAck` in earlier MLS
+            // drafts.
+            ProposalType::_AppAck => 0x000b,
             #[cfg(feature = "extensions-draft-08")]
             ProposalType::AppDataUpdate => 8,
             #[cfg(feature = "extensions-draft-08")]
@@ -231,6 +258,15 @@ impl From<ProposalType> for u16 {
 ///     };
 /// } Proposal;
 /// ```
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 #[repr(u16)]
@@ -242,14 +278,23 @@ pub enum Proposal {
     ReInit(Box<ReInitProposal>),
     ExternalInit(Box<ExternalInitProposal>),
     GroupContextExtensions(Box<GroupContextExtensionProposal>),
-    // # Extensions
-    #[cfg(feature = "extensions-draft-08")]
-    AppDataUpdate(Box<AppDataUpdateProposal>),
+    // Placeholder for the removed `AppAck(Box<AppAckProposal>)` variant.
+    // Kept (hidden) to preserve the serde variant indices of subsequent
+    // variants for non-self-describing formats. The library never produced
+    // `AppAck` proposals.
+    #[doc(hidden)]
+    #[serde(rename = "AppAck")]
+    _AppAck,
     // A SelfRemove proposal is an empty struct.
     SelfRemove,
+    Custom(Box<CustomProposal>),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataUpdate(Box<AppDataUpdateProposal>),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral(Box<AppEphemeralProposal>),
-    Custom(Box<CustomProposal>),
 }
 
 impl Proposal {
@@ -304,6 +349,7 @@ impl Proposal {
             Proposal::ReInit(_) => ProposalType::Reinit,
             Proposal::ExternalInit(_) => ProposalType::ExternalInit,
             Proposal::GroupContextExtensions(_) => ProposalType::GroupContextExtensions,
+            Proposal::_AppAck => ProposalType::_AppAck,
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppDataUpdate(_) => ProposalType::AppDataUpdate,
             Proposal::SelfRemove => ProposalType::SelfRemove,

--- a/openmls/src/messages/proposals_in.rs
+++ b/openmls/src/messages/proposals_in.rs
@@ -421,6 +421,12 @@ impl From<crate::messages::proposals::Proposal> for ProposalIn {
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppEphemeral(app_ephemeral) => Self::AppEphemeral(app_ephemeral),
             Proposal::Custom(other) => Self::Custom(other),
+            Proposal::_AppAck => {
+                // `_AppAck` is a serde-format placeholder for the removed
+                // `AppAck` variant; the library never produces it at
+                // runtime, so this arm is unreachable.
+                unreachable!("Proposal::_AppAck has no corresponding ProposalIn")
+            }
         }
     }
 }


### PR DESCRIPTION
bincode and postcard encode enum variant tags as positional u32s, so when
variants get inserted mid-declaration the index of every following variant
shifts and persisted data silently decodes as the wrong variant.

Since 0.7.x, `ProposalType`/`Proposal`, `Extension`/`ExtensionType`, and
`CredentialType` have all had variants added (`Grease`, `AppEphemeral`,
`AppDataUpdate`, `AppDataDictionary`) — and `AppAck` removed from
`Proposal`/`ProposalType` — in positions that shift the indices.

This PR restores the 0.7.x order, appends every new variant to the end,
and replaces the removed `AppAck` with a hidden `_AppAck` unit placeholder
at its original index 7. JSON/CBOR variant names, the TLS wire format,
and the public API are all unchanged.

The four enums with feature-gated variants also get a note in the
existing variant-order comment: new non-optional variants must not be
added after a `#[cfg(feature = ...)]` variant, because toggling the
feature would otherwise shift every following index and silently corrupt
persisted data.

This means that for non human-readable serde implementations that after a
non-optional variant is added that enabling the feature would be a breaking
change for consumers of the library.

#### On the `_AppAck` placeholder

Open to discussion. The placeholder is doing two jobs: it occupies index 7
(which no real persisted data hits — openmls never produced `AppAck`) and,
more importantly, it keeps `SelfRemove` at index 8 and `Custom` at index 9,
which 0.7.x bincode/postcard data *does* hit. Without the placeholder,
persisted `Custom(N: u16)` silently decodes as `Grease(N)` on
`ProposalType`, and persisted `SelfRemove` either fails or silently
corrupts on `Proposal`.

The cost is that exhaustive matches on `Proposal`/`ProposalType` in
external code need an `_AppAck` arm. If a tidier alternative is preferred,
marking these enums `#[non_exhaustive]` as a one-time API change would
let the placeholder be dropped and the variant deleted cleanly — happy
to take that direction.

This can go away by using #2026 for the serde impls which wouldn't break 0.8 users.

Split from #2021.