### PR TITLE
Encode persisted usize values as portable u64

### DIFF
--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -76,11 +76,16 @@ impl Serialize for PastEpochDeletionPolicy {
     where
         S: serde::Serializer,
     {
-        let usize = match self {
-            Self::MaxEpochs(epochs) => *epochs,
-            Self::KeepAll => usize::MAX,
+        // Wire encoding is always `u64` (never platform-dependent `usize`) so
+        // bytes written on a 64-bit host are still readable on `wasm32` and
+        // vice versa. `KeepAll` is encoded as `u64::MAX` rather than
+        // `usize::MAX as u64`, because `usize::MAX` differs between platforms
+        // (`u32::MAX` on `wasm32`, `u64::MAX` on 64-bit).
+        let value: u64 = match self {
+            Self::MaxEpochs(epochs) => *epochs as u64,
+            Self::KeepAll => u64::MAX,
         };
-        serializer.serialize_u64(usize as u64)
+        serializer.serialize_u64(value)
     }
 }
 
@@ -89,11 +94,11 @@ impl<'de> Deserialize<'de> for PastEpochDeletionPolicy {
     where
         D: serde::Deserializer<'de>,
     {
-        let epochs = u64::deserialize(deserializer)?;
-        let epochs = usize::try_from(epochs).map_err(serde::de::Error::custom)?;
-        if epochs == usize::MAX {
+        let value = u64::deserialize(deserializer)?;
+        if value == u64::MAX {
             Ok(Self::KeepAll)
         } else {
+            let epochs = usize::try_from(value).map_err(serde::de::Error::custom)?;
             Ok(Self::MaxEpochs(epochs))
         }
     }
@@ -190,6 +195,7 @@ pub struct MlsGroupJoinConfig {
     /// Application are always encrypted regardless.
     pub(crate) wire_format_policy: WireFormatPolicy,
     /// Size of padding in bytes
+    #[serde(with = "crate::utils::usize_as_u64")]
     pub(crate) padding_size: usize,
     /// Maximum number of past epochs for which application messages
     /// can be decrypted. The default is 0.
@@ -197,6 +203,7 @@ pub struct MlsGroupJoinConfig {
     // alias for backwards compatibility after renaming field
     pub(crate) past_epoch_deletion_policy: PastEpochDeletionPolicy,
     /// Number of resumption secrets to keep
+    #[serde(with = "crate::utils::usize_as_u64")]
     pub(crate) number_of_resumption_psks: usize,
     /// Flag to indicate the Ratchet Tree Extension should be used
     pub(crate) use_ratchet_tree_extension: bool,

--- a/openmls/src/group/mls_group/past_secrets.rs
+++ b/openmls/src/group/mls_group/past_secrets.rs
@@ -32,7 +32,10 @@ pub(crate) struct EpochTree {
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
 #[cfg_attr(feature = "crypto-debug", derive(Debug))]
 pub(crate) struct MessageSecretsStore {
-    // Maximum size of the `past_epoch_trees` list.
+    // Maximum size of the `past_epoch_trees` list. Serialized as `u64` so
+    // bytes are portable between 32-bit and 64-bit hosts (e.g. wasm32 ↔
+    // 64-bit servers).
+    #[serde(with = "crate::utils::usize_as_u64")]
     pub(crate) max_epochs: usize,
     // Past message secrets.
     // NOTE: these are in order of addition (latest at end).

--- a/openmls/src/schedule/pprf/mod.rs
+++ b/openmls/src/schedule/pprf/mod.rs
@@ -100,6 +100,11 @@ pub(crate) struct Pprf<P: Prefix> {
         deserialize_with = "deserialize_hashmap"
     )]
     nodes: HashMap<P, PprfNode>, // Mapping of prefix and depth to node
+    // Serialized as `u64` so persisted application-export-tree bytes are
+    // portable between 32-bit (`wasm32`) and 64-bit hosts. The width is the
+    // tree size in *bytes* of the underlying prefix and is independent of
+    // any key derivation input.
+    #[serde(with = "crate::utils::usize_as_u64")]
     width: usize,
 }
 

--- a/openmls/src/schedule/psk.rs
+++ b/openmls/src/schedule/psk.rs
@@ -560,11 +560,19 @@ pub mod store {
     /// Resumption PSK store.
     ///
     /// This is where the resumption PSKs are kept in a rollover list.
+    //
+    // `max_number_of_secrets` and `cursor` are serialized through the
+    // `usize_as_u64` adapter so bytes are portable between 32-bit
+    // (`wasm32`) and 64-bit hosts. Neither value feeds into key derivation —
+    // `cursor` is a ring-buffer index and `max_number_of_secrets` is the
+    // cap — so the only correctness requirement is that they round-trip.
     #[derive(Debug, Serialize, Deserialize)]
     #[cfg_attr(any(test, feature = "test-utils"), derive(Clone, PartialEq))]
     pub(crate) struct ResumptionPskStore {
+        #[serde(with = "crate::utils::usize_as_u64")]
         max_number_of_secrets: usize,
         resumption_psk: Vec<(GroupEpoch, ResumptionPskSecret)>,
+        #[serde(with = "crate::utils::usize_as_u64")]
         cursor: usize,
     }
 

--- a/openmls/src/utils.rs
+++ b/openmls/src/utils.rs
@@ -54,6 +54,29 @@ macro_rules! log_content {
     (trace, $($arg:tt)*) => {{}};
 }
 
+/// Serde helper for serializing a `usize` field as a fixed-width `u64`.
+///
+/// `usize` is 32 bits on `wasm32` and 64 bits on most host targets. The
+/// derived `Serialize`/`Deserialize` for `usize` writes a platform-native
+/// width, which makes persisted bytes non-portable across builds.
+///
+/// Fields that participate in the storage format should opt into this helper
+/// via `#[serde(with = "crate::utils::usize_as_u64")]` so the wire shape is
+/// always 8 bytes for non-self-describing formats and an unambiguous JSON
+/// number for self-describing formats.
+pub(crate) mod usize_as_u64 {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &usize, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u64(*value as u64)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<usize, D::Error> {
+        let value = u64::deserialize(deserializer)?;
+        usize::try_from(value).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Helper mod that converts a objects that implement FromIterator<_,_> (like a
 /// HashMap or a BTreeMap) into a vector of tuples and vice versa.
 pub mod vector_converter {


### PR DESCRIPTION
The hand-written `PastEpochDeletionPolicy::KeepAll` serializer from #1990
writes `usize::MAX as u64`, which is `u32::MAX` on `wasm32` and `u64::MAX`
on 64-bit hosts.

So a `KeepAll` policy persisted on a 64-bit host fails to deserialize on
`wasm32` — the deserializer narrows to `usize` before checking the
sentinel, and `u64::MAX` doesn't fit in a 32-bit `usize`.

Fix: emit `u64::MAX` unconditionally and check the sentinel before
narrowing. Legacy `wasm32`-written `KeepAll` loads as `MaxEpochs(u32::MAX)`,
which is functionally "keep all" given the practical ceiling on
past-epoch counts, so existing wasm32 data is not broken.

Also adds a `usize_as_u64` adapter to the remaining persisted `usize`
fields (`padding_size`, `number_of_resumption_psks`, `max_epochs`,
`max_number_of_secrets`, `cursor`, `Pprf::width`). A wire no-op against
today's serde `usize` impl, but it pins the convention so a future format
change can't reintroduce platform-native encoding by accident.

Split from #2021.