### PR TITLE
Lock persisted enum variant indices via custom serde impls

### DIFF
--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -77,6 +77,9 @@ pub mod errors;
 /// | 0xDADA           | GREASE                   | Y | RFC XXXX |
 /// | 0xEAEA           | GREASE                   | Y | RFC XXXX |
 /// | 0xF000  - 0xFFFF | Reserved for Private Use | - | RFC XXXX |
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(u16)]
 pub enum CredentialType {
@@ -84,10 +87,13 @@ pub enum CredentialType {
     Basic = 1,
     /// An X.509 [`Certificate`]
     X509 = 2,
-    /// A GREASE credential type for ensuring extensibility.
-    Grease(u16),
     /// Another type of credential that is not in the MLS protocol spec.
     Other(u16),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    /// A GREASE credential type for ensuring extensibility.
+    Grease(u16),
 }
 
 impl CredentialType {

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -94,7 +94,7 @@ mod tests;
 // serde index shifts depending on whether the feature is enabled —
 // which silently corrupts persisted data in non-self-describing formats
 // (bincode, postcard) when consumers toggle the feature.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum ExtensionType {
     /// The application id extension allows applications to add an explicit,
     /// application-defined identifier to a KeyPackage.
@@ -132,6 +132,180 @@ pub enum ExtensionType {
     #[cfg(feature = "extensions-draft-08")]
     /// AppDataDictionary extension
     AppDataDictionary,
+}
+
+// Manual serde impls with explicit variant indices. See the comment on
+// `CredentialType` in `credentials/mod.rs` for the rationale: indices are
+// the bincode wire format and must remain stable across versions.
+const EXTENSION_TYPE_VARIANTS: &[&str] = &[
+    "ApplicationId",
+    "RatchetTree",
+    "RequiredCapabilities",
+    "ExternalPub",
+    "ExternalSenders",
+    "LastResort",
+    "Unknown",
+    "Grease",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppDataDictionary",
+];
+
+impl Serialize for ExtensionType {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::ApplicationId => {
+                serializer.serialize_unit_variant("ExtensionType", 0, "ApplicationId")
+            }
+            Self::RatchetTree => {
+                serializer.serialize_unit_variant("ExtensionType", 1, "RatchetTree")
+            }
+            Self::RequiredCapabilities => {
+                serializer.serialize_unit_variant("ExtensionType", 2, "RequiredCapabilities")
+            }
+            Self::ExternalPub => {
+                serializer.serialize_unit_variant("ExtensionType", 3, "ExternalPub")
+            }
+            Self::ExternalSenders => {
+                serializer.serialize_unit_variant("ExtensionType", 4, "ExternalSenders")
+            }
+            Self::LastResort => serializer.serialize_unit_variant("ExtensionType", 5, "LastResort"),
+            Self::Unknown(v) => {
+                serializer.serialize_newtype_variant("ExtensionType", 6, "Unknown", v)
+            }
+            Self::Grease(v) => {
+                serializer.serialize_newtype_variant("ExtensionType", 7, "Grease", v)
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppDataDictionary => {
+                serializer.serialize_unit_variant("ExtensionType", 8, "AppDataDictionary")
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtensionType {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_enum(
+            "ExtensionType",
+            EXTENSION_TYPE_VARIANTS,
+            ExtensionTypeVisitor,
+        )
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ExtensionTypeId {
+    ApplicationId,
+    RatchetTree,
+    RequiredCapabilities,
+    ExternalPub,
+    ExternalSenders,
+    LastResort,
+    Unknown,
+    Grease,
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataDictionary,
+}
+
+impl<'de> Deserialize<'de> for ExtensionTypeId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = ExtensionTypeId;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("ExtensionType variant identifier")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                match v {
+                    0 => Ok(ExtensionTypeId::ApplicationId),
+                    1 => Ok(ExtensionTypeId::RatchetTree),
+                    2 => Ok(ExtensionTypeId::RequiredCapabilities),
+                    3 => Ok(ExtensionTypeId::ExternalPub),
+                    4 => Ok(ExtensionTypeId::ExternalSenders),
+                    5 => Ok(ExtensionTypeId::LastResort),
+                    6 => Ok(ExtensionTypeId::Unknown),
+                    7 => Ok(ExtensionTypeId::Grease),
+                    #[cfg(feature = "extensions-draft-08")]
+                    8 => Ok(ExtensionTypeId::AppDataDictionary),
+                    other => Err(E::invalid_value(
+                        serde::de::Unexpected::Unsigned(other),
+                        &"valid ExtensionType variant index",
+                    )),
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "ApplicationId" => Ok(ExtensionTypeId::ApplicationId),
+                    "RatchetTree" => Ok(ExtensionTypeId::RatchetTree),
+                    "RequiredCapabilities" => Ok(ExtensionTypeId::RequiredCapabilities),
+                    "ExternalPub" => Ok(ExtensionTypeId::ExternalPub),
+                    "ExternalSenders" => Ok(ExtensionTypeId::ExternalSenders),
+                    "LastResort" => Ok(ExtensionTypeId::LastResort),
+                    "Unknown" => Ok(ExtensionTypeId::Unknown),
+                    "Grease" => Ok(ExtensionTypeId::Grease),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppDataDictionary" => Ok(ExtensionTypeId::AppDataDictionary),
+                    other => Err(E::unknown_variant(other, EXTENSION_TYPE_VARIANTS)),
+                }
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                self.visit_str(std::str::from_utf8(v).map_err(E::custom)?)
+            }
+        }
+        deserializer.deserialize_identifier(V)
+    }
+}
+
+struct ExtensionTypeVisitor;
+
+impl<'de> serde::de::Visitor<'de> for ExtensionTypeVisitor {
+    type Value = ExtensionType;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("enum ExtensionType")
+    }
+
+    fn visit_enum<A: serde::de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        use serde::de::VariantAccess;
+        let (variant, access) = data.variant::<ExtensionTypeId>()?;
+        match variant {
+            ExtensionTypeId::ApplicationId => {
+                access.unit_variant()?;
+                Ok(ExtensionType::ApplicationId)
+            }
+            ExtensionTypeId::RatchetTree => {
+                access.unit_variant()?;
+                Ok(ExtensionType::RatchetTree)
+            }
+            ExtensionTypeId::RequiredCapabilities => {
+                access.unit_variant()?;
+                Ok(ExtensionType::RequiredCapabilities)
+            }
+            ExtensionTypeId::ExternalPub => {
+                access.unit_variant()?;
+                Ok(ExtensionType::ExternalPub)
+            }
+            ExtensionTypeId::ExternalSenders => {
+                access.unit_variant()?;
+                Ok(ExtensionType::ExternalSenders)
+            }
+            ExtensionTypeId::LastResort => {
+                access.unit_variant()?;
+                Ok(ExtensionType::LastResort)
+            }
+            ExtensionTypeId::Unknown => Ok(ExtensionType::Unknown(access.newtype_variant()?)),
+            ExtensionTypeId::Grease => Ok(ExtensionType::Grease(access.newtype_variant()?)),
+            #[cfg(feature = "extensions-draft-08")]
+            ExtensionTypeId::AppDataDictionary => {
+                access.unit_variant()?;
+                Ok(ExtensionType::AppDataDictionary)
+            }
+        }
+    }
 }
 
 impl ExtensionType {
@@ -311,7 +485,7 @@ impl From<ExtensionType> for u16 {
 // serde index shifts depending on whether the feature is enabled —
 // which silently corrupts persisted data in non-self-describing formats
 // (bincode, postcard) when consumers toggle the feature.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Extension {
     /// An [`ApplicationIdExtension`]
     ApplicationId(ApplicationIdExtension),
@@ -340,6 +514,181 @@ pub enum Extension {
     /// An [`AppDataDictionaryExtension`]
     #[cfg(feature = "extensions-draft-08")]
     AppDataDictionary(AppDataDictionaryExtension),
+}
+
+// Manual serde impls with explicit variant indices. See the comment on
+// `CredentialType` in `credentials/mod.rs` for the rationale.
+const EXTENSION_VARIANTS: &[&str] = &[
+    "ApplicationId",
+    "RatchetTree",
+    "RequiredCapabilities",
+    "ExternalPub",
+    "ExternalSenders",
+    "LastResort",
+    "Unknown",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppDataDictionary",
+];
+
+impl Serialize for Extension {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeTupleVariant;
+        match self {
+            Self::ApplicationId(e) => {
+                serializer.serialize_newtype_variant("Extension", 0, "ApplicationId", e)
+            }
+            Self::RatchetTree(e) => {
+                serializer.serialize_newtype_variant("Extension", 1, "RatchetTree", e)
+            }
+            Self::RequiredCapabilities(e) => {
+                serializer.serialize_newtype_variant("Extension", 2, "RequiredCapabilities", e)
+            }
+            Self::ExternalPub(e) => {
+                serializer.serialize_newtype_variant("Extension", 3, "ExternalPub", e)
+            }
+            Self::ExternalSenders(e) => {
+                serializer.serialize_newtype_variant("Extension", 4, "ExternalSenders", e)
+            }
+            Self::LastResort(e) => {
+                serializer.serialize_newtype_variant("Extension", 5, "LastResort", e)
+            }
+            Self::Unknown(t, data) => {
+                let mut tv = serializer.serialize_tuple_variant("Extension", 6, "Unknown", 2)?;
+                tv.serialize_field(t)?;
+                tv.serialize_field(data)?;
+                tv.end()
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppDataDictionary(e) => {
+                serializer.serialize_newtype_variant("Extension", 7, "AppDataDictionary", e)
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Extension {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_enum("Extension", EXTENSION_VARIANTS, ExtensionVisitor)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ExtensionId {
+    ApplicationId,
+    RatchetTree,
+    RequiredCapabilities,
+    ExternalPub,
+    ExternalSenders,
+    LastResort,
+    Unknown,
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataDictionary,
+}
+
+impl<'de> Deserialize<'de> for ExtensionId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = ExtensionId;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("Extension variant identifier")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                match v {
+                    0 => Ok(ExtensionId::ApplicationId),
+                    1 => Ok(ExtensionId::RatchetTree),
+                    2 => Ok(ExtensionId::RequiredCapabilities),
+                    3 => Ok(ExtensionId::ExternalPub),
+                    4 => Ok(ExtensionId::ExternalSenders),
+                    5 => Ok(ExtensionId::LastResort),
+                    6 => Ok(ExtensionId::Unknown),
+                    #[cfg(feature = "extensions-draft-08")]
+                    7 => Ok(ExtensionId::AppDataDictionary),
+                    other => Err(E::invalid_value(
+                        serde::de::Unexpected::Unsigned(other),
+                        &"valid Extension variant index",
+                    )),
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "ApplicationId" => Ok(ExtensionId::ApplicationId),
+                    "RatchetTree" => Ok(ExtensionId::RatchetTree),
+                    "RequiredCapabilities" => Ok(ExtensionId::RequiredCapabilities),
+                    "ExternalPub" => Ok(ExtensionId::ExternalPub),
+                    "ExternalSenders" => Ok(ExtensionId::ExternalSenders),
+                    "LastResort" => Ok(ExtensionId::LastResort),
+                    "Unknown" => Ok(ExtensionId::Unknown),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppDataDictionary" => Ok(ExtensionId::AppDataDictionary),
+                    other => Err(E::unknown_variant(other, EXTENSION_VARIANTS)),
+                }
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                self.visit_str(std::str::from_utf8(v).map_err(E::custom)?)
+            }
+        }
+        deserializer.deserialize_identifier(V)
+    }
+}
+
+struct ExtensionVisitor;
+
+impl<'de> serde::de::Visitor<'de> for ExtensionVisitor {
+    type Value = Extension;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("enum Extension")
+    }
+
+    fn visit_enum<A: serde::de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        use serde::de::VariantAccess;
+        let (variant, access) = data.variant::<ExtensionId>()?;
+        match variant {
+            ExtensionId::ApplicationId => Ok(Extension::ApplicationId(access.newtype_variant()?)),
+            ExtensionId::RatchetTree => Ok(Extension::RatchetTree(access.newtype_variant()?)),
+            ExtensionId::RequiredCapabilities => {
+                Ok(Extension::RequiredCapabilities(access.newtype_variant()?))
+            }
+            ExtensionId::ExternalPub => Ok(Extension::ExternalPub(access.newtype_variant()?)),
+            ExtensionId::ExternalSenders => {
+                Ok(Extension::ExternalSenders(access.newtype_variant()?))
+            }
+            ExtensionId::LastResort => Ok(Extension::LastResort(access.newtype_variant()?)),
+            ExtensionId::Unknown => {
+                struct UnknownPayload;
+                impl<'de> serde::de::Visitor<'de> for UnknownPayload {
+                    type Value = (u16, UnknownExtension);
+                    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                        f.write_str("tuple (u16, UnknownExtension)")
+                    }
+                    fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                        self,
+                        mut seq: A,
+                    ) -> Result<Self::Value, A::Error> {
+                        use serde::de::Error;
+                        let t: u16 = seq
+                            .next_element()?
+                            .ok_or_else(|| Error::invalid_length(0, &self))?;
+                        let data: UnknownExtension = seq
+                            .next_element()?
+                            .ok_or_else(|| Error::invalid_length(1, &self))?;
+                        Ok((t, data))
+                    }
+                }
+                let (t, data) = access.tuple_variant(2, UnknownPayload)?;
+                Ok(Extension::Unknown(t, data))
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            ExtensionId::AppDataDictionary => {
+                Ok(Extension::AppDataDictionary(access.newtype_variant()?))
+            }
+        }
+    }
 }
 
 /// A unknown/unparsed extension represented by raw bytes.

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -85,6 +85,15 @@ mod tests;
 /// | 0xff00  - 0xffff | Reserved for Private Use | N/A        | N/A         | RFC XXXX  |
 ///
 /// Note: OpenMLS does not provide a `Reserved` variant in [ExtensionType].
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum ExtensionType {
     /// The application id extension allows applications to add an explicit,
@@ -111,15 +120,18 @@ pub enum ExtensionType {
     /// scenario.
     LastResort,
 
-    #[cfg(feature = "extensions-draft-08")]
-    /// AppDataDictionary extension
-    AppDataDictionary,
+    /// A currently unknown extension type.
+    Unknown(u16),
 
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
     /// A GREASE extension type for ensuring extensibility.
     Grease(u16),
 
-    /// A currently unknown extension type.
-    Unknown(u16),
+    #[cfg(feature = "extensions-draft-08")]
+    /// AppDataDictionary extension
+    AppDataDictionary,
 }
 
 impl ExtensionType {
@@ -290,6 +302,15 @@ impl From<ExtensionType> for u16 {
 ///     opaque extension_data<V>;
 /// } Extension;
 /// ```
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Extension {
     /// An [`ApplicationIdExtension`]
@@ -307,15 +328,18 @@ pub enum Extension {
     /// An [`ExternalSendersExtension`]
     ExternalSenders(ExternalSendersExtension),
 
-    /// An [`AppDataDictionaryExtension`]
-    #[cfg(feature = "extensions-draft-08")]
-    AppDataDictionary(AppDataDictionaryExtension),
-
     /// A [`LastResortExtension`]
     LastResort(LastResortExtension),
 
     /// A currently unknown extension.
     Unknown(u16, UnknownExtension),
+
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    /// An [`AppDataDictionaryExtension`]
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataDictionary(AppDataDictionaryExtension),
 }
 
 /// A unknown/unparsed extension represented by raw bytes.

--- a/openmls/src/group/mls_group/proposal_store.rs
+++ b/openmls/src/group/mls_group/proposal_store.rs
@@ -637,6 +637,13 @@ impl ProposalQueue {
                     // have to be checked by the application instead.
                     valid_proposals.add(queued_proposal.proposal_reference());
                 }
+                Proposal::_AppAck => {
+                    // `_AppAck` is a serde-format placeholder for the
+                    // removed `AppAck` variant; it cannot be produced via
+                    // TLS deserialization, so reaching this arm would
+                    // indicate corrupted state.
+                    unreachable!("Proposal::_AppAck cannot reach the proposal queue")
+                }
             }
         }
 

--- a/openmls/src/messages/codec.rs
+++ b/openmls/src/messages/codec.rs
@@ -35,6 +35,7 @@ impl Size for Proposal {
                 #[cfg(feature = "extensions-draft-08")]
                 Proposal::AppEphemeral(p) => p.tls_serialized_len(),
                 Proposal::Custom(p) => p.payload().tls_serialized_len(),
+                Proposal::_AppAck => 0,
             }
     }
 }
@@ -56,6 +57,12 @@ impl Serialize for Proposal {
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppEphemeral(p) => p.tls_serialize(writer),
             Proposal::Custom(p) => p.payload().tls_serialize(writer),
+            // `_AppAck` is a serde-format placeholder for the removed
+            // `AppAck` variant; the library never produces it at runtime,
+            // so TLS serialization is unreachable.
+            Proposal::_AppAck => {
+                unreachable!("Proposal::_AppAck cannot be TLS-serialized")
+            }
         }
         .map(|l| written + l)
     }
@@ -155,6 +162,13 @@ impl Deserialize for ProposalIn {
                 let payload = Vec::<u8>::tls_deserialize(bytes)?;
                 let custom_proposal = CustomProposal::new(proposal_type.into(), payload);
                 ProposalIn::Custom(Box::new(custom_proposal))
+            }
+            ProposalType::_AppAck => {
+                // `_AppAck` is a serde-format placeholder for the removed
+                // `AppAck` variant; the TLS wire mapping `From<u16>` never
+                // constructs it (the reserved value `0x000b` is routed to
+                // `Custom`), so this arm is unreachable on the TLS wire.
+                unreachable!("ProposalType::_AppAck is not produced by TLS deserialization");
             }
         };
         Ok(proposal)

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -72,6 +72,15 @@ use crate::component::ComponentId;
 /// |:=======|:==============|:============|:==============|:==========|:=============================|
 /// | 0x0009 | app_ephemeral | Y           | N             | RFC XXXX  | draft-ietf-mls-extensions-08 |
 /// | 0x000a | self_remove   | Y           | Y             | RFC XXXX  | draft-ietf-mls-extensions-07 |
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Serialize, Deserialize, Hash)]
 #[allow(missing_docs)]
 pub enum ProposalType {
@@ -82,13 +91,23 @@ pub enum ProposalType {
     Reinit,
     ExternalInit,
     GroupContextExtensions,
+    // Placeholder for the removed `AppAck` variant. Kept (hidden) to preserve
+    // the serde variant indices of subsequent variants for non-self-describing
+    // formats. `AppAck` was never produced by the library on the wire, so no
+    // real data should round-trip through this variant.
+    #[doc(hidden)]
+    #[serde(rename = "AppAck")]
+    _AppAck,
     SelfRemove,
+    Custom(u16),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    Grease(u16),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral,
     #[cfg(feature = "extensions-draft-08")]
     AppDataUpdate,
-    Grease(u16),
-    Custom(u16),
 }
 
 impl ProposalType {
@@ -103,7 +122,10 @@ impl ProposalType {
             | ProposalType::Reinit
             | ProposalType::ExternalInit
             | ProposalType::GroupContextExtensions => true,
-            ProposalType::SelfRemove | ProposalType::Grease(_) | ProposalType::Custom(_) => false,
+            ProposalType::SelfRemove
+            | ProposalType::Grease(_)
+            | ProposalType::Custom(_)
+            | ProposalType::_AppAck => false,
             #[cfg(feature = "extensions-draft-08")]
             ProposalType::AppEphemeral | ProposalType::AppDataUpdate => false,
         }
@@ -201,6 +223,11 @@ impl From<ProposalType> for u16 {
             ProposalType::Reinit => 5,
             ProposalType::ExternalInit => 6,
             ProposalType::GroupContextExtensions => 7,
+            // The library never produces `_AppAck` on the wire; this arm
+            // exists only to keep the match exhaustive. The TLS-wire value
+            // `0x000b` was historically assigned to `AppAck` in earlier MLS
+            // drafts.
+            ProposalType::_AppAck => 0x000b,
             #[cfg(feature = "extensions-draft-08")]
             ProposalType::AppDataUpdate => 8,
             #[cfg(feature = "extensions-draft-08")]
@@ -231,6 +258,15 @@ impl From<ProposalType> for u16 {
 ///     };
 /// } Proposal;
 /// ```
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 #[repr(u16)]
@@ -242,14 +278,23 @@ pub enum Proposal {
     ReInit(Box<ReInitProposal>),
     ExternalInit(Box<ExternalInitProposal>),
     GroupContextExtensions(Box<GroupContextExtensionProposal>),
-    // # Extensions
-    #[cfg(feature = "extensions-draft-08")]
-    AppDataUpdate(Box<AppDataUpdateProposal>),
+    // Placeholder for the removed `AppAck(Box<AppAckProposal>)` variant.
+    // Kept (hidden) to preserve the serde variant indices of subsequent
+    // variants for non-self-describing formats. The library never produced
+    // `AppAck` proposals.
+    #[doc(hidden)]
+    #[serde(rename = "AppAck")]
+    _AppAck,
     // A SelfRemove proposal is an empty struct.
     SelfRemove,
+    Custom(Box<CustomProposal>),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataUpdate(Box<AppDataUpdateProposal>),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral(Box<AppEphemeralProposal>),
-    Custom(Box<CustomProposal>),
 }
 
 impl Proposal {
@@ -304,6 +349,7 @@ impl Proposal {
             Proposal::ReInit(_) => ProposalType::Reinit,
             Proposal::ExternalInit(_) => ProposalType::ExternalInit,
             Proposal::GroupContextExtensions(_) => ProposalType::GroupContextExtensions,
+            Proposal::_AppAck => ProposalType::_AppAck,
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppDataUpdate(_) => ProposalType::AppDataUpdate,
             Proposal::SelfRemove => ProposalType::SelfRemove,

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -81,7 +81,7 @@ use crate::component::ComponentId;
 // serde index shifts depending on whether the feature is enabled —
 // which silently corrupts persisted data in non-self-describing formats
 // (bincode, postcard) when consumers toggle the feature.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Serialize, Deserialize, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash)]
 #[allow(missing_docs)]
 pub enum ProposalType {
     Add,
@@ -96,7 +96,6 @@ pub enum ProposalType {
     // formats. `AppAck` was never produced by the library on the wire, so no
     // real data should round-trip through this variant.
     #[doc(hidden)]
-    #[serde(rename = "AppAck")]
     _AppAck,
     SelfRemove,
     Custom(u16),
@@ -108,6 +107,215 @@ pub enum ProposalType {
     AppEphemeral,
     #[cfg(feature = "extensions-draft-08")]
     AppDataUpdate,
+}
+
+// Manual serde impls with explicit variant indices. See the comment on
+// `CredentialType` in `credentials/mod.rs` for the rationale. The `_AppAck`
+// placeholder serializes/deserializes under the historical name "AppAck" so
+// the JSON wire format also stays stable across the removal of the variant.
+const PROPOSAL_TYPE_VARIANTS: &[&str] = &[
+    "Add",
+    "Update",
+    "Remove",
+    "PreSharedKey",
+    "Reinit",
+    "ExternalInit",
+    "GroupContextExtensions",
+    "AppAck",
+    "SelfRemove",
+    "Custom",
+    "Grease",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppEphemeral",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppDataUpdate",
+];
+
+impl Serialize for ProposalType {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Add => serializer.serialize_unit_variant("ProposalType", 0, "Add"),
+            Self::Update => serializer.serialize_unit_variant("ProposalType", 1, "Update"),
+            Self::Remove => serializer.serialize_unit_variant("ProposalType", 2, "Remove"),
+            Self::PreSharedKey => {
+                serializer.serialize_unit_variant("ProposalType", 3, "PreSharedKey")
+            }
+            Self::Reinit => serializer.serialize_unit_variant("ProposalType", 4, "Reinit"),
+            Self::ExternalInit => {
+                serializer.serialize_unit_variant("ProposalType", 5, "ExternalInit")
+            }
+            Self::GroupContextExtensions => {
+                serializer.serialize_unit_variant("ProposalType", 6, "GroupContextExtensions")
+            }
+            Self::_AppAck => serializer.serialize_unit_variant("ProposalType", 7, "AppAck"),
+            Self::SelfRemove => serializer.serialize_unit_variant("ProposalType", 8, "SelfRemove"),
+            Self::Custom(v) => serializer.serialize_newtype_variant("ProposalType", 9, "Custom", v),
+            Self::Grease(v) => {
+                serializer.serialize_newtype_variant("ProposalType", 10, "Grease", v)
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppEphemeral => {
+                serializer.serialize_unit_variant("ProposalType", 11, "AppEphemeral")
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppDataUpdate => {
+                serializer.serialize_unit_variant("ProposalType", 12, "AppDataUpdate")
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ProposalType {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_enum("ProposalType", PROPOSAL_TYPE_VARIANTS, ProposalTypeVisitor)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ProposalTypeId {
+    Add,
+    Update,
+    Remove,
+    PreSharedKey,
+    Reinit,
+    ExternalInit,
+    GroupContextExtensions,
+    AppAck,
+    SelfRemove,
+    Custom,
+    Grease,
+    #[cfg(feature = "extensions-draft-08")]
+    AppEphemeral,
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataUpdate,
+}
+
+impl<'de> Deserialize<'de> for ProposalTypeId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = ProposalTypeId;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("ProposalType variant identifier")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                match v {
+                    0 => Ok(ProposalTypeId::Add),
+                    1 => Ok(ProposalTypeId::Update),
+                    2 => Ok(ProposalTypeId::Remove),
+                    3 => Ok(ProposalTypeId::PreSharedKey),
+                    4 => Ok(ProposalTypeId::Reinit),
+                    5 => Ok(ProposalTypeId::ExternalInit),
+                    6 => Ok(ProposalTypeId::GroupContextExtensions),
+                    7 => Ok(ProposalTypeId::AppAck),
+                    8 => Ok(ProposalTypeId::SelfRemove),
+                    9 => Ok(ProposalTypeId::Custom),
+                    10 => Ok(ProposalTypeId::Grease),
+                    #[cfg(feature = "extensions-draft-08")]
+                    11 => Ok(ProposalTypeId::AppEphemeral),
+                    #[cfg(feature = "extensions-draft-08")]
+                    12 => Ok(ProposalTypeId::AppDataUpdate),
+                    other => Err(E::invalid_value(
+                        serde::de::Unexpected::Unsigned(other),
+                        &"valid ProposalType variant index",
+                    )),
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "Add" => Ok(ProposalTypeId::Add),
+                    "Update" => Ok(ProposalTypeId::Update),
+                    "Remove" => Ok(ProposalTypeId::Remove),
+                    "PreSharedKey" => Ok(ProposalTypeId::PreSharedKey),
+                    "Reinit" => Ok(ProposalTypeId::Reinit),
+                    "ExternalInit" => Ok(ProposalTypeId::ExternalInit),
+                    "GroupContextExtensions" => Ok(ProposalTypeId::GroupContextExtensions),
+                    "AppAck" => Ok(ProposalTypeId::AppAck),
+                    "SelfRemove" => Ok(ProposalTypeId::SelfRemove),
+                    "Custom" => Ok(ProposalTypeId::Custom),
+                    "Grease" => Ok(ProposalTypeId::Grease),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppEphemeral" => Ok(ProposalTypeId::AppEphemeral),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppDataUpdate" => Ok(ProposalTypeId::AppDataUpdate),
+                    other => Err(E::unknown_variant(other, PROPOSAL_TYPE_VARIANTS)),
+                }
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                self.visit_str(std::str::from_utf8(v).map_err(E::custom)?)
+            }
+        }
+        deserializer.deserialize_identifier(V)
+    }
+}
+
+struct ProposalTypeVisitor;
+
+impl<'de> serde::de::Visitor<'de> for ProposalTypeVisitor {
+    type Value = ProposalType;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("enum ProposalType")
+    }
+
+    fn visit_enum<A: serde::de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        use serde::de::VariantAccess;
+        let (variant, access) = data.variant::<ProposalTypeId>()?;
+        match variant {
+            ProposalTypeId::Add => {
+                access.unit_variant()?;
+                Ok(ProposalType::Add)
+            }
+            ProposalTypeId::Update => {
+                access.unit_variant()?;
+                Ok(ProposalType::Update)
+            }
+            ProposalTypeId::Remove => {
+                access.unit_variant()?;
+                Ok(ProposalType::Remove)
+            }
+            ProposalTypeId::PreSharedKey => {
+                access.unit_variant()?;
+                Ok(ProposalType::PreSharedKey)
+            }
+            ProposalTypeId::Reinit => {
+                access.unit_variant()?;
+                Ok(ProposalType::Reinit)
+            }
+            ProposalTypeId::ExternalInit => {
+                access.unit_variant()?;
+                Ok(ProposalType::ExternalInit)
+            }
+            ProposalTypeId::GroupContextExtensions => {
+                access.unit_variant()?;
+                Ok(ProposalType::GroupContextExtensions)
+            }
+            ProposalTypeId::AppAck => {
+                access.unit_variant()?;
+                Ok(ProposalType::_AppAck)
+            }
+            ProposalTypeId::SelfRemove => {
+                access.unit_variant()?;
+                Ok(ProposalType::SelfRemove)
+            }
+            ProposalTypeId::Custom => Ok(ProposalType::Custom(access.newtype_variant()?)),
+            ProposalTypeId::Grease => Ok(ProposalType::Grease(access.newtype_variant()?)),
+            #[cfg(feature = "extensions-draft-08")]
+            ProposalTypeId::AppEphemeral => {
+                access.unit_variant()?;
+                Ok(ProposalType::AppEphemeral)
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            ProposalTypeId::AppDataUpdate => {
+                access.unit_variant()?;
+                Ok(ProposalType::AppDataUpdate)
+            }
+        }
+    }
 }
 
 impl ProposalType {
@@ -267,7 +475,7 @@ impl From<ProposalType> for u16 {
 // serde index shifts depending on whether the feature is enabled —
 // which silently corrupts persisted data in non-self-describing formats
 // (bincode, postcard) when consumers toggle the feature.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(missing_docs)]
 #[repr(u16)]
 pub enum Proposal {
@@ -283,7 +491,6 @@ pub enum Proposal {
     // variants for non-self-describing formats. The library never produced
     // `AppAck` proposals.
     #[doc(hidden)]
-    #[serde(rename = "AppAck")]
     _AppAck,
     // A SelfRemove proposal is an empty struct.
     SelfRemove,
@@ -295,6 +502,182 @@ pub enum Proposal {
     AppDataUpdate(Box<AppDataUpdateProposal>),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral(Box<AppEphemeralProposal>),
+}
+
+// Manual serde impls with explicit variant indices. See the comment on
+// `CredentialType` in `credentials/mod.rs` for the rationale. `_AppAck`
+// serializes/deserializes under the historical name "AppAck" so the JSON
+// wire format stays stable across the removal of the variant.
+const PROPOSAL_VARIANTS: &[&str] = &[
+    "Add",
+    "Update",
+    "Remove",
+    "PreSharedKey",
+    "ReInit",
+    "ExternalInit",
+    "GroupContextExtensions",
+    "AppAck",
+    "SelfRemove",
+    "Custom",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppDataUpdate",
+    #[cfg(feature = "extensions-draft-08")]
+    "AppEphemeral",
+];
+
+impl Serialize for Proposal {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Add(p) => serializer.serialize_newtype_variant("Proposal", 0, "Add", p),
+            Self::Update(p) => serializer.serialize_newtype_variant("Proposal", 1, "Update", p),
+            Self::Remove(p) => serializer.serialize_newtype_variant("Proposal", 2, "Remove", p),
+            Self::PreSharedKey(p) => {
+                serializer.serialize_newtype_variant("Proposal", 3, "PreSharedKey", p)
+            }
+            Self::ReInit(p) => serializer.serialize_newtype_variant("Proposal", 4, "ReInit", p),
+            Self::ExternalInit(p) => {
+                serializer.serialize_newtype_variant("Proposal", 5, "ExternalInit", p)
+            }
+            Self::GroupContextExtensions(p) => {
+                serializer.serialize_newtype_variant("Proposal", 6, "GroupContextExtensions", p)
+            }
+            Self::_AppAck => serializer.serialize_unit_variant("Proposal", 7, "AppAck"),
+            Self::SelfRemove => serializer.serialize_unit_variant("Proposal", 8, "SelfRemove"),
+            Self::Custom(p) => serializer.serialize_newtype_variant("Proposal", 9, "Custom", p),
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppDataUpdate(p) => {
+                serializer.serialize_newtype_variant("Proposal", 10, "AppDataUpdate", p)
+            }
+            #[cfg(feature = "extensions-draft-08")]
+            Self::AppEphemeral(p) => {
+                serializer.serialize_newtype_variant("Proposal", 11, "AppEphemeral", p)
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Proposal {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_enum("Proposal", PROPOSAL_VARIANTS, ProposalVisitor)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ProposalId {
+    Add,
+    Update,
+    Remove,
+    PreSharedKey,
+    ReInit,
+    ExternalInit,
+    GroupContextExtensions,
+    AppAck,
+    SelfRemove,
+    Custom,
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataUpdate,
+    #[cfg(feature = "extensions-draft-08")]
+    AppEphemeral,
+}
+
+impl<'de> Deserialize<'de> for ProposalId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = ProposalId;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("Proposal variant identifier")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                match v {
+                    0 => Ok(ProposalId::Add),
+                    1 => Ok(ProposalId::Update),
+                    2 => Ok(ProposalId::Remove),
+                    3 => Ok(ProposalId::PreSharedKey),
+                    4 => Ok(ProposalId::ReInit),
+                    5 => Ok(ProposalId::ExternalInit),
+                    6 => Ok(ProposalId::GroupContextExtensions),
+                    7 => Ok(ProposalId::AppAck),
+                    8 => Ok(ProposalId::SelfRemove),
+                    9 => Ok(ProposalId::Custom),
+                    #[cfg(feature = "extensions-draft-08")]
+                    10 => Ok(ProposalId::AppDataUpdate),
+                    #[cfg(feature = "extensions-draft-08")]
+                    11 => Ok(ProposalId::AppEphemeral),
+                    other => Err(E::invalid_value(
+                        serde::de::Unexpected::Unsigned(other),
+                        &"valid Proposal variant index",
+                    )),
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "Add" => Ok(ProposalId::Add),
+                    "Update" => Ok(ProposalId::Update),
+                    "Remove" => Ok(ProposalId::Remove),
+                    "PreSharedKey" => Ok(ProposalId::PreSharedKey),
+                    "ReInit" => Ok(ProposalId::ReInit),
+                    "ExternalInit" => Ok(ProposalId::ExternalInit),
+                    "GroupContextExtensions" => Ok(ProposalId::GroupContextExtensions),
+                    "AppAck" => Ok(ProposalId::AppAck),
+                    "SelfRemove" => Ok(ProposalId::SelfRemove),
+                    "Custom" => Ok(ProposalId::Custom),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppDataUpdate" => Ok(ProposalId::AppDataUpdate),
+                    #[cfg(feature = "extensions-draft-08")]
+                    "AppEphemeral" => Ok(ProposalId::AppEphemeral),
+                    other => Err(E::unknown_variant(other, PROPOSAL_VARIANTS)),
+                }
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                self.visit_str(std::str::from_utf8(v).map_err(E::custom)?)
+            }
+        }
+        deserializer.deserialize_identifier(V)
+    }
+}
+
+struct ProposalVisitor;
+
+impl<'de> serde::de::Visitor<'de> for ProposalVisitor {
+    type Value = Proposal;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("enum Proposal")
+    }
+
+    fn visit_enum<A: serde::de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        use serde::de::VariantAccess;
+        let (variant, access) = data.variant::<ProposalId>()?;
+        match variant {
+            ProposalId::Add => Ok(Proposal::Add(access.newtype_variant()?)),
+            ProposalId::Update => Ok(Proposal::Update(access.newtype_variant()?)),
+            ProposalId::Remove => Ok(Proposal::Remove(access.newtype_variant()?)),
+            ProposalId::PreSharedKey => Ok(Proposal::PreSharedKey(access.newtype_variant()?)),
+            ProposalId::ReInit => Ok(Proposal::ReInit(access.newtype_variant()?)),
+            ProposalId::ExternalInit => Ok(Proposal::ExternalInit(access.newtype_variant()?)),
+            ProposalId::GroupContextExtensions => {
+                Ok(Proposal::GroupContextExtensions(access.newtype_variant()?))
+            }
+            ProposalId::AppAck => {
+                access.unit_variant()?;
+                Ok(Proposal::_AppAck)
+            }
+            ProposalId::SelfRemove => {
+                access.unit_variant()?;
+                Ok(Proposal::SelfRemove)
+            }
+            ProposalId::Custom => Ok(Proposal::Custom(access.newtype_variant()?)),
+            #[cfg(feature = "extensions-draft-08")]
+            ProposalId::AppDataUpdate => Ok(Proposal::AppDataUpdate(access.newtype_variant()?)),
+            #[cfg(feature = "extensions-draft-08")]
+            ProposalId::AppEphemeral => Ok(Proposal::AppEphemeral(access.newtype_variant()?)),
+        }
+    }
 }
 
 impl Proposal {

--- a/openmls/src/messages/proposals_in.rs
+++ b/openmls/src/messages/proposals_in.rs
@@ -421,6 +421,12 @@ impl From<crate::messages::proposals::Proposal> for ProposalIn {
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppEphemeral(app_ephemeral) => Self::AppEphemeral(app_ephemeral),
             Proposal::Custom(other) => Self::Custom(other),
+            Proposal::_AppAck => {
+                // `_AppAck` is a serde-format placeholder for the removed
+                // `AppAck` variant; the library never produces it at
+                // runtime, so this arm is unreachable.
+                unreachable!("Proposal::_AppAck has no corresponding ProposalIn")
+            }
         }
     }
 }


### PR DESCRIPTION
After #2023 the five enum variant indices are pinned by source-file order
alone, which is fragile: serde's derive macro assigns indices via
`iter().enumerate()`, so a future PR that inserts a variant mid-enum
silently re-breaks bincode/postcard the same way 0.7.x → 0.8.x did.

This replaces the derived `Serialize`/`Deserialize` on `CredentialType`,
`ExtensionType`, `Extension`, `ProposalType`, and `Proposal` with
hand-written impls that pin each variant's `variant_index` as a numeric
literal at the call site.

Wire bytes are byte-identical to the previous positional encoding — the
same `serialize_*_variant` calls, just with the indices spelled out — and
the compiler's exhaustiveness check on the new `Serialize` match now
forces anyone adding a variant to make a deliberate choice about its
index.

Stacked on top of #2023; the diff will include those commits until #2023
lands, head commit is the only new content. Drop this one if the size
isn't worth the safety — #2023 stands without it.

Split from #2021.