### PR TITLE
Unit tests for serde variant indices on persisted enums

### DIFF
--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -77,6 +77,9 @@ pub mod errors;
 /// | 0xDADA           | GREASE                   | Y | RFC XXXX |
 /// | 0xEAEA           | GREASE                   | Y | RFC XXXX |
 /// | 0xF000  - 0xFFFF | Reserved for Private Use | - | RFC XXXX |
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(u16)]
 pub enum CredentialType {
@@ -84,10 +87,13 @@ pub enum CredentialType {
     Basic = 1,
     /// An X.509 [`Certificate`]
     X509 = 2,
-    /// A GREASE credential type for ensuring extensibility.
-    Grease(u16),
     /// Another type of credential that is not in the MLS protocol spec.
     Other(u16),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    /// A GREASE credential type for ensuring extensibility.
+    Grease(u16),
 }
 
 impl CredentialType {

--- a/openmls/src/credentials/tests.rs
+++ b/openmls/src/credentials/tests.rs
@@ -49,3 +49,30 @@ fn that_unknown_credential_types_are_de_serialized_correctly() {
         assert_eq!(test, got_serialized);
     }
 }
+
+/// Locks the `(variant_index, variant_name)` pair that the manual `Serialize`
+/// impl for [`CredentialType`] emits for each variant. These values are the
+/// bincode/postcard wire encoding of the enum tag and must not change without
+/// a deliberate, versioned migration of every existing persisted group.
+///
+/// When adding a new variant, append a new `check(...)` line with a fresh
+/// `variant_index` — never reuse or renumber the existing entries.
+#[test]
+fn credential_type_variant_indices() {
+    use crate::utils::variant_index_probe::probe;
+
+    fn check(value: CredentialType, expected_index: u32, expected_name: &'static str) {
+        let (idx, name) =
+            probe(&value).expect("CredentialType Serialize should call serialize_*_variant");
+        assert_eq!(
+            (idx, name),
+            (expected_index, expected_name),
+            "CredentialType::{expected_name} drifted from index {expected_index}",
+        );
+    }
+
+    check(CredentialType::Basic, 0, "Basic");
+    check(CredentialType::X509, 1, "X509");
+    check(CredentialType::Other(0), 2, "Other");
+    check(CredentialType::Grease(0), 3, "Grease");
+}

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -85,6 +85,15 @@ mod tests;
 /// | 0xff00  - 0xffff | Reserved for Private Use | N/A        | N/A         | RFC XXXX  |
 ///
 /// Note: OpenMLS does not provide a `Reserved` variant in [ExtensionType].
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum ExtensionType {
     /// The application id extension allows applications to add an explicit,
@@ -111,15 +120,18 @@ pub enum ExtensionType {
     /// scenario.
     LastResort,
 
-    #[cfg(feature = "extensions-draft-08")]
-    /// AppDataDictionary extension
-    AppDataDictionary,
+    /// A currently unknown extension type.
+    Unknown(u16),
 
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
     /// A GREASE extension type for ensuring extensibility.
     Grease(u16),
 
-    /// A currently unknown extension type.
-    Unknown(u16),
+    #[cfg(feature = "extensions-draft-08")]
+    /// AppDataDictionary extension
+    AppDataDictionary,
 }
 
 impl ExtensionType {
@@ -290,6 +302,15 @@ impl From<ExtensionType> for u16 {
 ///     opaque extension_data<V>;
 /// } Extension;
 /// ```
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Extension {
     /// An [`ApplicationIdExtension`]
@@ -307,15 +328,18 @@ pub enum Extension {
     /// An [`ExternalSendersExtension`]
     ExternalSenders(ExternalSendersExtension),
 
-    /// An [`AppDataDictionaryExtension`]
-    #[cfg(feature = "extensions-draft-08")]
-    AppDataDictionary(AppDataDictionaryExtension),
-
     /// A [`LastResortExtension`]
     LastResort(LastResortExtension),
 
     /// A currently unknown extension.
     Unknown(u16, UnknownExtension),
+
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    /// An [`AppDataDictionaryExtension`]
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataDictionary(AppDataDictionaryExtension),
 }
 
 /// A unknown/unparsed extension represented by raw bytes.

--- a/openmls/src/extensions/tests.rs
+++ b/openmls/src/extensions/tests.rs
@@ -467,3 +467,103 @@ fn app_data_dictionary_extension() {
     // check the dictionary
     assert_eq!(&dictionary, extension.dictionary());
 }
+
+/// Locks the `(variant_index, variant_name)` pair that the manual `Serialize`
+/// impl for [`ExtensionType`] emits for each variant. These values are the
+/// bincode/postcard wire encoding of the enum tag and must not change without
+/// a deliberate, versioned migration of every existing persisted group.
+///
+/// When adding a new variant, append a new `check(...)` line with a fresh
+/// `variant_index` — never reuse or renumber the existing entries.
+#[test]
+fn extension_type_variant_indices() {
+    use crate::utils::variant_index_probe::probe;
+
+    fn check(value: ExtensionType, expected_index: u32, expected_name: &'static str) {
+        let (idx, name) =
+            probe(&value).expect("ExtensionType Serialize should call serialize_*_variant");
+        assert_eq!(
+            (idx, name),
+            (expected_index, expected_name),
+            "ExtensionType::{expected_name} drifted from index {expected_index}",
+        );
+    }
+
+    check(ExtensionType::ApplicationId, 0, "ApplicationId");
+    check(ExtensionType::RatchetTree, 1, "RatchetTree");
+    check(
+        ExtensionType::RequiredCapabilities,
+        2,
+        "RequiredCapabilities",
+    );
+    check(ExtensionType::ExternalPub, 3, "ExternalPub");
+    check(ExtensionType::ExternalSenders, 4, "ExternalSenders");
+    check(ExtensionType::LastResort, 5, "LastResort");
+    check(ExtensionType::Unknown(0), 6, "Unknown");
+    check(ExtensionType::Grease(0), 7, "Grease");
+    #[cfg(feature = "extensions-draft-08")]
+    check(ExtensionType::AppDataDictionary, 8, "AppDataDictionary");
+}
+
+/// Locks the `(variant_index, variant_name)` pair for each [`Extension`]
+/// variant. See [`extension_type_variant_indices`] for the rationale and
+/// growth discipline.
+///
+/// The payloads of newtype/tuple variants are never serialized by the probe
+/// — they are constructed only to satisfy Rust's type system at the call
+/// site. Using minimal/empty payloads keeps this test independent of any
+/// other types.
+#[test]
+fn extension_variant_indices() {
+    use crate::utils::variant_index_probe::probe;
+
+    fn check(value: Extension, expected_index: u32, expected_name: &'static str) {
+        let (idx, name) =
+            probe(&value).expect("Extension Serialize should call serialize_*_variant");
+        assert_eq!(
+            (idx, name),
+            (expected_index, expected_name),
+            "Extension::{expected_name} drifted from index {expected_index}",
+        );
+    }
+
+    check(
+        Extension::ApplicationId(ApplicationIdExtension::new(&[])),
+        0,
+        "ApplicationId",
+    );
+    check(
+        Extension::RatchetTree(RatchetTreeExtension::new(
+            RatchetTreeIn::from_nodes(vec![]).into(),
+        )),
+        1,
+        "RatchetTree",
+    );
+    check(
+        Extension::RequiredCapabilities(RequiredCapabilitiesExtension::default()),
+        2,
+        "RequiredCapabilities",
+    );
+    check(
+        Extension::ExternalPub(ExternalPubExtension::new(HpkePublicKey::new(vec![]))),
+        3,
+        "ExternalPub",
+    );
+    check(Extension::ExternalSenders(vec![]), 4, "ExternalSenders");
+    check(
+        Extension::LastResort(LastResortExtension::new()),
+        5,
+        "LastResort",
+    );
+    check(
+        Extension::Unknown(0, UnknownExtension(vec![])),
+        6,
+        "Unknown",
+    );
+    #[cfg(feature = "extensions-draft-08")]
+    check(
+        Extension::AppDataDictionary(AppDataDictionaryExtension::new(AppDataDictionary::new())),
+        7,
+        "AppDataDictionary",
+    );
+}

--- a/openmls/src/group/mls_group/proposal_store.rs
+++ b/openmls/src/group/mls_group/proposal_store.rs
@@ -637,6 +637,13 @@ impl ProposalQueue {
                     // have to be checked by the application instead.
                     valid_proposals.add(queued_proposal.proposal_reference());
                 }
+                Proposal::_AppAck => {
+                    // `_AppAck` is a serde-format placeholder for the
+                    // removed `AppAck` variant; it cannot be produced via
+                    // TLS deserialization, so reaching this arm would
+                    // indicate corrupted state.
+                    unreachable!("Proposal::_AppAck cannot reach the proposal queue")
+                }
             }
         }
 

--- a/openmls/src/messages/codec.rs
+++ b/openmls/src/messages/codec.rs
@@ -35,6 +35,7 @@ impl Size for Proposal {
                 #[cfg(feature = "extensions-draft-08")]
                 Proposal::AppEphemeral(p) => p.tls_serialized_len(),
                 Proposal::Custom(p) => p.payload().tls_serialized_len(),
+                Proposal::_AppAck => 0,
             }
     }
 }
@@ -56,6 +57,12 @@ impl Serialize for Proposal {
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppEphemeral(p) => p.tls_serialize(writer),
             Proposal::Custom(p) => p.payload().tls_serialize(writer),
+            // `_AppAck` is a serde-format placeholder for the removed
+            // `AppAck` variant; the library never produces it at runtime,
+            // so TLS serialization is unreachable.
+            Proposal::_AppAck => {
+                unreachable!("Proposal::_AppAck cannot be TLS-serialized")
+            }
         }
         .map(|l| written + l)
     }
@@ -155,6 +162,13 @@ impl Deserialize for ProposalIn {
                 let payload = Vec::<u8>::tls_deserialize(bytes)?;
                 let custom_proposal = CustomProposal::new(proposal_type.into(), payload);
                 ProposalIn::Custom(Box::new(custom_proposal))
+            }
+            ProposalType::_AppAck => {
+                // `_AppAck` is a serde-format placeholder for the removed
+                // `AppAck` variant; the TLS wire mapping `From<u16>` never
+                // constructs it (the reserved value `0x000b` is routed to
+                // `Custom`), so this arm is unreachable on the TLS wire.
+                unreachable!("ProposalType::_AppAck is not produced by TLS deserialization");
             }
         };
         Ok(proposal)

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -72,6 +72,15 @@ use crate::component::ComponentId;
 /// |:=======|:==============|:============|:==============|:==========|:=============================|
 /// | 0x0009 | app_ephemeral | Y           | N             | RFC XXXX  | draft-ietf-mls-extensions-08 |
 /// | 0x000a | self_remove   | Y           | Y             | RFC XXXX  | draft-ietf-mls-extensions-07 |
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Serialize, Deserialize, Hash)]
 #[allow(missing_docs)]
 pub enum ProposalType {
@@ -82,13 +91,23 @@ pub enum ProposalType {
     Reinit,
     ExternalInit,
     GroupContextExtensions,
+    // Placeholder for the removed `AppAck` variant. Kept (hidden) to preserve
+    // the serde variant indices of subsequent variants for non-self-describing
+    // formats. `AppAck` was never produced by the library on the wire, so no
+    // real data should round-trip through this variant.
+    #[doc(hidden)]
+    #[serde(rename = "AppAck")]
+    _AppAck,
     SelfRemove,
+    Custom(u16),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    Grease(u16),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral,
     #[cfg(feature = "extensions-draft-08")]
     AppDataUpdate,
-    Grease(u16),
-    Custom(u16),
 }
 
 impl ProposalType {
@@ -103,7 +122,10 @@ impl ProposalType {
             | ProposalType::Reinit
             | ProposalType::ExternalInit
             | ProposalType::GroupContextExtensions => true,
-            ProposalType::SelfRemove | ProposalType::Grease(_) | ProposalType::Custom(_) => false,
+            ProposalType::SelfRemove
+            | ProposalType::Grease(_)
+            | ProposalType::Custom(_)
+            | ProposalType::_AppAck => false,
             #[cfg(feature = "extensions-draft-08")]
             ProposalType::AppEphemeral | ProposalType::AppDataUpdate => false,
         }
@@ -201,6 +223,11 @@ impl From<ProposalType> for u16 {
             ProposalType::Reinit => 5,
             ProposalType::ExternalInit => 6,
             ProposalType::GroupContextExtensions => 7,
+            // The library never produces `_AppAck` on the wire; this arm
+            // exists only to keep the match exhaustive. The TLS-wire value
+            // `0x000b` was historically assigned to `AppAck` in earlier MLS
+            // drafts.
+            ProposalType::_AppAck => 0x000b,
             #[cfg(feature = "extensions-draft-08")]
             ProposalType::AppDataUpdate => 8,
             #[cfg(feature = "extensions-draft-08")]
@@ -231,6 +258,15 @@ impl From<ProposalType> for u16 {
 ///     };
 /// } Proposal;
 /// ```
+// Variant order is part of the serde wire format for non-self-describing
+// serializers like bincode. Do not reorder existing variants; append new
+// variants at the end of the enum.
+//
+// Feature-gated variants must come last. If a non-optional variant is
+// added after a `#[cfg(feature = ...)]` variant, the new variant's
+// serde index shifts depending on whether the feature is enabled —
+// which silently corrupts persisted data in non-self-describing formats
+// (bincode, postcard) when consumers toggle the feature.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 #[repr(u16)]
@@ -242,14 +278,23 @@ pub enum Proposal {
     ReInit(Box<ReInitProposal>),
     ExternalInit(Box<ExternalInitProposal>),
     GroupContextExtensions(Box<GroupContextExtensionProposal>),
-    // # Extensions
-    #[cfg(feature = "extensions-draft-08")]
-    AppDataUpdate(Box<AppDataUpdateProposal>),
+    // Placeholder for the removed `AppAck(Box<AppAckProposal>)` variant.
+    // Kept (hidden) to preserve the serde variant indices of subsequent
+    // variants for non-self-describing formats. The library never produced
+    // `AppAck` proposals.
+    #[doc(hidden)]
+    #[serde(rename = "AppAck")]
+    _AppAck,
     // A SelfRemove proposal is an empty struct.
     SelfRemove,
+    Custom(Box<CustomProposal>),
+    // --- Variants appended after openmls-0.7.x ---
+    // New variants MUST be added below this line to preserve the serde wire
+    // format with older persisted data.
+    #[cfg(feature = "extensions-draft-08")]
+    AppDataUpdate(Box<AppDataUpdateProposal>),
     #[cfg(feature = "extensions-draft-08")]
     AppEphemeral(Box<AppEphemeralProposal>),
-    Custom(Box<CustomProposal>),
 }
 
 impl Proposal {
@@ -304,6 +349,7 @@ impl Proposal {
             Proposal::ReInit(_) => ProposalType::Reinit,
             Proposal::ExternalInit(_) => ProposalType::ExternalInit,
             Proposal::GroupContextExtensions(_) => ProposalType::GroupContextExtensions,
+            Proposal::_AppAck => ProposalType::_AppAck,
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppDataUpdate(_) => ProposalType::AppDataUpdate,
             Proposal::SelfRemove => ProposalType::SelfRemove,

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -922,7 +922,7 @@ impl CustomProposal {
 mod tests {
     use tls_codec::{Deserialize, Serialize};
 
-    use super::ProposalType;
+    use super::*;
 
     #[test]
     fn that_unknown_proposal_types_are_de_serialized_correctly() {
@@ -947,5 +947,100 @@ mod tests {
             let got_serialized = got.tls_serialize_detached().unwrap();
             assert_eq!(test, got_serialized);
         }
+    }
+
+    /// Locks the `(variant_index, variant_name)` pair that the manual
+    /// `Serialize` impl for [`ProposalType`] emits for each variant. These
+    /// values are the bincode/postcard wire encoding of the enum tag and must
+    /// not change without a deliberate, versioned migration of every existing
+    /// persisted group.
+    ///
+    /// When adding a new variant, append a new `check(...)` line with a fresh
+    /// `variant_index` — never reuse or renumber the existing entries.
+    #[test]
+    fn proposal_type_variant_indices() {
+        use crate::utils::variant_index_probe::probe;
+
+        fn check(value: ProposalType, expected_index: u32, expected_name: &'static str) {
+            let (idx, name) =
+                probe(&value).expect("ProposalType Serialize should call serialize_*_variant");
+            assert_eq!(
+                (idx, name),
+                (expected_index, expected_name),
+                "ProposalType::{expected_name} drifted from index {expected_index}",
+            );
+        }
+
+        check(ProposalType::Add, 0, "Add");
+        check(ProposalType::Update, 1, "Update");
+        check(ProposalType::Remove, 2, "Remove");
+        check(ProposalType::PreSharedKey, 3, "PreSharedKey");
+        check(ProposalType::Reinit, 4, "Reinit");
+        check(ProposalType::ExternalInit, 5, "ExternalInit");
+        check(
+            ProposalType::GroupContextExtensions,
+            6,
+            "GroupContextExtensions",
+        );
+        check(ProposalType::_AppAck, 7, "AppAck");
+        check(ProposalType::SelfRemove, 8, "SelfRemove");
+        check(ProposalType::Custom(0), 9, "Custom");
+        check(ProposalType::Grease(0), 10, "Grease");
+        #[cfg(feature = "extensions-draft-08")]
+        check(ProposalType::AppEphemeral, 11, "AppEphemeral");
+        #[cfg(feature = "extensions-draft-08")]
+        check(ProposalType::AppDataUpdate, 12, "AppDataUpdate");
+    }
+
+    /// Locks the `(variant_index, variant_name)` pair that the manual
+    /// `Serialize` impl for [`Proposal`] emits for each variant. See
+    /// [`proposal_type_variant_indices`] for the rationale.
+    ///
+    /// Variants whose payload is non-trivial to construct in a unit-test
+    /// context (those carrying `Box<…Proposal>` with cryptographic content)
+    /// are exercised indirectly via the [`ProposalType`] test: the
+    /// `Serialize` impls for `Proposal` and `ProposalType` use the same
+    /// numeric indices by construction, and the `Proposal::proposal_type()`
+    /// match keeps the two enums in lockstep. The variants exercised
+    /// directly here are the ones that historically drifted in PRs since
+    /// openmls-0.7.x (`_AppAck`, `SelfRemove`, `Custom`).
+    #[test]
+    fn proposal_variant_indices_anchor_variants() {
+        use crate::utils::variant_index_probe::probe;
+
+        fn check(value: Proposal, expected_index: u32, expected_name: &'static str) {
+            let (idx, name) =
+                probe(&value).expect("Proposal Serialize should call serialize_*_variant");
+            assert_eq!(
+                (idx, name),
+                (expected_index, expected_name),
+                "Proposal::{expected_name} drifted from index {expected_index}",
+            );
+        }
+
+        // Variants with payloads that are cheap to construct from primitives.
+        check(
+            Proposal::Remove(Box::new(RemoveProposal {
+                removed: crate::binary_tree::array_representation::LeafNodeIndex::new(0),
+            })),
+            2,
+            "Remove",
+        );
+        check(
+            Proposal::ExternalInit(Box::new(ExternalInitProposal::from(Vec::<u8>::new()))),
+            5,
+            "ExternalInit",
+        );
+
+        // Placeholders / unit variants — the historical drift points.
+        check(Proposal::_AppAck, 7, "AppAck");
+        check(Proposal::SelfRemove, 8, "SelfRemove");
+
+        // Custom — was at index 9 in 0.7.x and must remain there.
+        check(
+            Proposal::Custom(Box::new(CustomProposal::new(0x7C7C, Vec::new()))),
+            9,
+            "Custom",
+        );
     }
 }

--- a/openmls/src/messages/proposals_in.rs
+++ b/openmls/src/messages/proposals_in.rs
@@ -421,6 +421,12 @@ impl From<crate::messages::proposals::Proposal> for ProposalIn {
             #[cfg(feature = "extensions-draft-08")]
             Proposal::AppEphemeral(app_ephemeral) => Self::AppEphemeral(app_ephemeral),
             Proposal::Custom(other) => Self::Custom(other),
+            Proposal::_AppAck => {
+                // `_AppAck` is a serde-format placeholder for the removed
+                // `AppAck` variant; the library never produces it at
+                // runtime, so this arm is unreachable.
+                unreachable!("Proposal::_AppAck has no corresponding ProposalIn")
+            }
         }
     }
 }

--- a/openmls/src/utils.rs
+++ b/openmls/src/utils.rs
@@ -54,6 +54,220 @@ macro_rules! log_content {
     (trace, $($arg:tt)*) => {{}};
 }
 
+/// Test-only `serde::Serializer` that captures the `(variant_index, variant)`
+/// arguments of a `serialize_*_variant` call and returns them as the serializer
+/// `Ok` value. Used by per-enum tests to pin the bincode/postcard wire
+/// indices of persisted enums (`CredentialType`, `ExtensionType`, `Extension`,
+/// `ProposalType`, `Proposal`).
+///
+/// Every other `Serializer` method returns an error: the probe is intentionally
+/// minimal and is only meant to be driven against enum variants. Payloads of
+/// newtype / tuple variants are accepted but never recursed into, so payload
+/// types do not need to be cheaply constructible for the probe to work.
+#[cfg(test)]
+pub(crate) mod variant_index_probe {
+    use core::fmt;
+    use serde::ser::{Impossible, SerializeTupleVariant};
+    use serde::{ser, Serialize, Serializer};
+
+    pub(crate) type Captured = (u32, &'static str);
+
+    /// Serialize `value` through the probe and return the
+    /// `(variant_index, variant_name)` of the variant call it issued.
+    pub(crate) fn probe<T: Serialize>(value: &T) -> Result<Captured, ProbeError> {
+        value.serialize(IndexProbe)
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct ProbeError(pub(crate) String);
+
+    impl fmt::Display for ProbeError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+
+    impl std::error::Error for ProbeError {}
+
+    impl ser::Error for ProbeError {
+        fn custom<T: fmt::Display>(msg: T) -> Self {
+            ProbeError(msg.to_string())
+        }
+    }
+
+    pub(crate) struct IndexProbe;
+
+    fn reject<T>(method: &'static str) -> Result<T, ProbeError> {
+        Err(ProbeError(format!(
+            "IndexProbe::{method} unexpectedly called"
+        )))
+    }
+
+    impl Serializer for IndexProbe {
+        type Ok = Captured;
+        type Error = ProbeError;
+        type SerializeSeq = Impossible<Captured, ProbeError>;
+        type SerializeTuple = Impossible<Captured, ProbeError>;
+        type SerializeTupleStruct = Impossible<Captured, ProbeError>;
+        type SerializeTupleVariant = TupleVariantCapture;
+        type SerializeMap = Impossible<Captured, ProbeError>;
+        type SerializeStruct = Impossible<Captured, ProbeError>;
+        type SerializeStructVariant = Impossible<Captured, ProbeError>;
+
+        fn serialize_unit_variant(
+            self,
+            _name: &'static str,
+            variant_index: u32,
+            variant: &'static str,
+        ) -> Result<Self::Ok, Self::Error> {
+            Ok((variant_index, variant))
+        }
+
+        fn serialize_newtype_variant<T: ?Sized + Serialize>(
+            self,
+            _name: &'static str,
+            variant_index: u32,
+            variant: &'static str,
+            _value: &T,
+        ) -> Result<Self::Ok, Self::Error> {
+            Ok((variant_index, variant))
+        }
+
+        fn serialize_tuple_variant(
+            self,
+            _name: &'static str,
+            variant_index: u32,
+            variant: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+            Ok(TupleVariantCapture {
+                captured: (variant_index, variant),
+            })
+        }
+
+        // Every other Serializer method is unexpected for the probe's use
+        // case (variant-index assertion on `serde`-derived enum
+        // serialization). Stub them out with an error so a misuse fails the
+        // test loudly rather than silently producing a bogus result.
+        fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_bool")
+        }
+        fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_i8")
+        }
+        fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_i16")
+        }
+        fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_i32")
+        }
+        fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_i64")
+        }
+        fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_u8")
+        }
+        fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_u16")
+        }
+        fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_u32")
+        }
+        fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_u64")
+        }
+        fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_f32")
+        }
+        fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_f64")
+        }
+        fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_char")
+        }
+        fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_str")
+        }
+        fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_bytes")
+        }
+        fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_none")
+        }
+        fn serialize_some<T: ?Sized + Serialize>(
+            self,
+            _value: &T,
+        ) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_some")
+        }
+        fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_unit")
+        }
+        fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_unit_struct")
+        }
+        fn serialize_newtype_struct<T: ?Sized + Serialize>(
+            self,
+            _name: &'static str,
+            _value: &T,
+        ) -> Result<Self::Ok, Self::Error> {
+            reject("serialize_newtype_struct")
+        }
+        fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+            reject("serialize_seq")
+        }
+        fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+            reject("serialize_tuple")
+        }
+        fn serialize_tuple_struct(
+            self,
+            _name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+            reject("serialize_tuple_struct")
+        }
+        fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+            reject("serialize_map")
+        }
+        fn serialize_struct(
+            self,
+            _name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStruct, Self::Error> {
+            reject("serialize_struct")
+        }
+        fn serialize_struct_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            _variant: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStructVariant, Self::Error> {
+            reject("serialize_struct_variant")
+        }
+    }
+
+    pub(crate) struct TupleVariantCapture {
+        captured: Captured,
+    }
+
+    impl SerializeTupleVariant for TupleVariantCapture {
+        type Ok = Captured;
+        type Error = ProbeError;
+
+        fn serialize_field<T: ?Sized + Serialize>(
+            &mut self,
+            _value: &T,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(self.captured)
+        }
+    }
+}
+
 /// Helper mod that converts a objects that implement FromIterator<_,_> (like a
 /// HashMap or a BTreeMap) into a vector of tuples and vice versa.
 pub mod vector_converter {


### PR DESCRIPTION
Adds unit tests that pin the `(variant_index, variant_name)` pair for
every variant of `CredentialType`, `ExtensionType`, `Extension`,
`ProposalType`, and `Proposal`. The index is the bincode/postcard wire
encoding, the name is the JSON/CBOR encoding, and either drifting
silently corrupts persisted state.

The mechanism is a minimal `serde::Serializer` (`utils::variant_index_probe`)
whose `Ok` type is `(u32, &'static str)` and whose only working methods are
`serialize_*_variant`. Everything else errors, so misuse fails loudly,
and the tests don't have to construct full payloads for tagged-union
variants.

The variants that actually drifted (`_AppAck`, `SelfRemove`, `Custom`,
the `Unknown` arms) are each pinned explicitly.

Stacked on top of #2023 — works against either the derived impls from
that PR or the hand-rolled impls from #2026.

Split from #2021.