### PR TITLE
chore(ci): make the CI leaner

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -8,7 +8,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   workflow_dispatch:
 
 env:
@@ -16,14 +26,7 @@ env:
 
 jobs:
   benchmarks:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   workflow_dispatch:
 
 env:
@@ -39,34 +49,20 @@ jobs:
           - aarch64-apple-ios
           # WASM
           - wasm32-unknown-unknown
-        include:
-          # Compile iOS sim on macOS
-          - os: macos-latest
-            arch: aarch64-apple-ios-sim
-        mode:
-          - debug
-          - release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # Install the required target
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.arch }}
       - uses: Swatinem/rust-cache@v2
 
-      - run: |
-          if [ ${{ matrix.mode }} == debug ]; then
-            echo "TEST_MODE=" >> $GITHUB_ENV
-          else
-            echo "TEST_MODE=--release" >> $GITHUB_ENV
-          fi
       - name: Build (wasm)
         if: matrix.arch == 'wasm32-unknown-unknown'
-        run: cargo build $TEST_MODE --verbose --target ${{ matrix.arch }} -p openmls -F js
+        run: cargo build --release --verbose --target ${{ matrix.arch }} -p openmls -F js
       - name: Build
-        if: ${{ matrix.arch != 'wasm32-unknown-unknown'  }} 
-        run: cargo build $TEST_MODE --verbose --target ${{ matrix.arch }} -p openmls
+        if: ${{ matrix.arch != 'wasm32-unknown-unknown'  }}
+        run: cargo build --release --verbose --target ${{ matrix.arch }} -p openmls
 
   # Check feature powerset
   check:
@@ -80,9 +76,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-hack
 
-      # Group all features except fork-resolution,js,extensions-draft-08
+      # Group all features except fork-resolution and extensions-draft-08
       - name: Cargo hack
         run: |
           cargo hack check --feature-powerset --no-dev-deps --verbose -p openmls \
           --group-features test-utils,crypto-debug,content-debug,backtrace,libcrux-provider,sqlite-provider \
-          --group-features extensions-draft-08,extensions-draft-08-test-dependencies
+          --group-features extensions-draft-08,extensions-draft-08-test-dependencies \
+          --group-features js,js-test

--- a/.github/workflows/build_test_sqlx_provider.yml
+++ b/.github/workflows/build_test_sqlx_provider.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build_test_workspace.yml
+++ b/.github/workflows/build_test_workspace.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   workflow_dispatch:
 
 concurrency: 
@@ -19,7 +29,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
         tests: [welcome_decode, mls_message_decode, proposal_decode]
         include:
           - tests: welcome_decode
@@ -28,7 +37,7 @@ jobs:
             runs: 50000
           - tests: proposal_decode
             runs: 50000
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   workflow_dispatch:
 
 concurrency:
@@ -19,41 +29,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
-          - { os: ubuntu-latest, target: i686-unknown-linux-gnu }
-          - { os: windows-latest, target: i686-pc-windows-msvc }
-          - { os: windows-latest, target: x86_64-pc-windows-msvc }
-          - { os: macos-latest, target: x86_64-apple-darwin }
-          - { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu }
-        mode:
-          - { name: debug, arg: "" }
-          - { name: release, arg: --release }
-        features:
-          - { name: "", arg: "" }
-          - { name: fork-resolution, arg: "-F fork-resolution" }
-          - { name: extensions-draft-08, arg: "-F extensions-draft-08,extensions-draft-08-test-dependencies" }
-    runs-on: ${{ matrix.target.os }}
-    name: ${{ matrix.target.target }} (${{ matrix.mode.name }}/${{ matrix.features.name }})
+        include:
+          # Full coverage on Linux x86_64: both modes × all feature variants.
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: debug, mode_arg: "", features_name: default, features_arg: "" }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: release, mode_arg: --release, features_name: default, features_arg: "" }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: debug, mode_arg: "", features_name: fork-resolution, features_arg: "-F fork-resolution" }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: release, mode_arg: --release, features_name: fork-resolution, features_arg: "-F fork-resolution" }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: debug, mode_arg: "", features_name: extensions-draft-08, features_arg: "-F extensions-draft-08,extensions-draft-08-test-dependencies" }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: release, mode_arg: --release, features_name: extensions-draft-08, features_arg: "-F extensions-draft-08,extensions-draft-08-test-dependencies" }
+          # Other platforms: debug + default features only.
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, mode_name: debug, mode_arg: "", features_name: default, features_arg: "" }
+          - { os: macos-latest, target: aarch64-apple-darwin, mode_name: debug, mode_arg: "", features_name: default, features_arg: "" }
+          - { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, mode_name: debug, mode_arg: "", features_name: default, features_arg: "" }
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.target }} (${{ matrix.mode_name }}/${{ matrix.features_name }})
     steps:
-      # Checkout
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: Swatinem/rust-cache@v2
-
-      # Install 32 bit toolchains
       - uses: dtolnay/rust-toolchain@stable
-        if: matrix.target.target == 'i686-pc-windows-msvc'
-        with:
-          targets: i686-pc-windows-msvc
-      - uses: dtolnay/rust-toolchain@stable
-        if: matrix.target.target == 'i686-unknown-linux-gnu'
-        with:
-          targets: i686-unknown-linux-gnu
 
       - name: Tests
-        run: cargo test ${{ matrix.mode.arg }} -p openmls --verbose --no-default-features ${{ matrix.features.arg }}
+        run: cargo test ${{ matrix.mode_arg }} -p openmls --verbose --no-default-features ${{ matrix.features_arg }}
 
   wasm:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/wasm-bench.yml
+++ b/.github/workflows/wasm-bench.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'book/**'
+      - 'LICENSE*'
+      - '.gitignore'
   workflow_dispatch:
 
 env:

--- a/README.md
+++ b/README.md
@@ -28,20 +28,19 @@ It has a safe and easy-to-use interface that hides the complexity of the underly
 OpenMLS is built and tested on the Github CI for the following rust targets.
 
 - x86_64-unknown-linux-gnu
-- i686-unknown-linux-gnu
 - x86_64-pc-windows-msvc
-- i686-pc-windows-msvc
-- x86_64-apple-darwin
+- aarch64-apple-darwin
+- aarch64-unknown-linux-gnu
 
 ### Unsupported, but built on CI
 
 The Github CI also builds (but doesn't test) the following rust targets.
 
-- aarch64-apple-darwin
-- aarch64-unknown-linux-gnu
+- i686-unknown-linux-gnu
+- i686-pc-windows-msvc
+- x86_64-apple-darwin
 - aarch64-linux-android
 - aarch64-apple-ios
-- aarch64-apple-ios-sim
 - wasm32-unknown-unknown
 - armv7-linux-androideabi
 - x86_64-linux-android


### PR DESCRIPTION
An attempt to make the CI faster with the following changes:

 - Test matrix flattened: full coverage only on Linux x86_64, single debug+default run on other platforms.
  - Dropped 32-bit targets (i686 Linux/Windows) and the iOS simulator.
  - macOS tests moved to Apple silicon (also matches the runner btw).
  - Cross-build matrix: dropped debug pass, release only.
  - Benches and fuzz: Linux-only.
  - Cargo-hack powerset: tighter grouping (js+js-test), combos dropped 129 → 17.
  - paths-ignore on compile-heavy workflows so doc-only PRs skip them.
  - README's platform list resynced to the new matrix.

We need to adjust the required tests before we can merge this.