### PR TITLE
Disable KAT generation and reduce tests to one ciphersuite/provider by default

### DIFF
--- a/.github/workflows/tests_nightly.yml
+++ b/.github/workflows/tests_nightly.yml
@@ -1,0 +1,43 @@
+name: Nightly full-matrix tests
+
+# Runs the openmls test suite with every provider and every supported
+# ciphersuite enabled. The per-PR `tests.yml` job runs only against
+# RustCrypto and the MTI ciphersuite to keep CI fast, so this job exists
+# to catch regressions in the rest of the matrix.
+
+on:
+  schedule:
+    # 02:00 UTC every day. Cron syntax: minute hour dom month dow.
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        mode:
+          - { name: debug, arg: "" }
+          - { name: release, arg: --release }
+        features:
+          - { name: base, arg: "" }
+          - { name: fork-resolution, arg: "-F fork-resolution" }
+          - { name: extensions-draft-08, arg: "-F extensions-draft-08,extensions-draft-08-test-dependencies" }
+    runs-on: ubuntu-latest
+    name: full matrix (${{ matrix.mode.name }}/${{ matrix.features.name }})
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Tests with all providers and ciphersuites
+        run: |
+          cargo test ${{ matrix.mode.arg }} -p openmls --verbose --no-default-features \
+            -F all-ciphersuites,sqlite-provider,libcrux-provider ${{ matrix.features.arg }}

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -66,6 +66,11 @@ sqlite-provider = [
     "dep:openmls_sqlite_storage",
     "openmls_test?/sqlite-provider",
 ]
+# Expand every `#[openmls_test]` over all ciphersuites supported by each
+# enabled provider. Without this feature, each provider emits a single
+# test per source function using the MTI ciphersuite. Opt in for nightly
+# CI or release validation.
+all-ciphersuites = ["openmls_test?/all-ciphersuites"]
 crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
 js = [
@@ -119,16 +124,13 @@ base64 = "0.22.1"
 flate2 = "1.0"
 indicatif = "0.18.3"
 
-# Disable for wasm32 and Win32
-[target.'cfg(not(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows"))))'.dev-dependencies]
-openmls = { path = ".", features = [
-    "test-utils",
-    "sqlite-provider",
-    "libcrux-provider",
-] }
-
-[target.'cfg(any(target_arch = "wasm32", all(target_arch = "x86", target_os = "windows")))'.dev-dependencies]
-openmls = { path = ".", features = ["test-utils"] }
+# Default test build is rustcrypto-only and MTI-ciphersuite-only.
+# Enable `sqlite-provider`, `libcrux-provider`, and/or `all-ciphersuites`
+# explicitly (for example on a nightly CI run) to exercise more of the
+# matrix.
+[dev-dependencies.openmls]
+path = "."
+features = ["test-utils"]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 web-time = "1.1"
@@ -136,6 +138,9 @@ web-time = "1.1"
 [[bench]]
 name = "benchmark"
 harness = false
+# Uses the libcrux provider directly, so skip the build when that
+# provider is not enabled (e.g. on the default test build).
+required-features = ["libcrux-provider"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -71,6 +71,9 @@ sqlite-provider = [
 # test per source function using the MTI ciphersuite. Opt in for nightly
 # CI or release validation.
 all-ciphersuites = ["openmls_test?/all-ciphersuites"]
+# Compile the KAT regenerators. Opt in when refreshing the bundled JSON test
+# vectors.
+generate-kats = []
 crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
 js = [

--- a/openmls/src/binary_tree/array_representation/kat_treemath.rs
+++ b/openmls/src/binary_tree/array_representation/kat_treemath.rs
@@ -33,7 +33,7 @@
 //! * `sibling[i]` is the node index of the sibling of the node with index `i`
 //!   in a tree with `n_leaves` leaves
 
-#[cfg(test)]
+#[cfg(all(test, feature = "generate-kats"))]
 use crate::test_utils::*;
 
 use super::treemath::*;
@@ -113,6 +113,7 @@ pub fn generate_test_vector(n_leaves: u32) -> TreeMathTestVector {
     test_vector
 }
 
+#[cfg(feature = "generate-kats")]
 #[test]
 fn write_test_vectors() {
     let mut tests = Vec::new();

--- a/openmls/src/group/mls_group/past_secrets.rs
+++ b/openmls/src/group/mls_group/past_secrets.rs
@@ -10,7 +10,7 @@ use crate::schedule::message_secrets::MessageSecrets;
 use super::*;
 
 impl EpochTree {
-    #[cfg(test)]
+    #[cfg(all(test, feature = "sqlite-provider", feature = "libcrux-provider"))]
     pub(crate) fn timestamp(&self) -> Option<SystemTime> {
         self.message_secrets.timestamp()
     }
@@ -328,7 +328,7 @@ impl MessageSecretsStore {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "sqlite-provider", feature = "libcrux-provider"))]
     /// Helper function for testing, to iterate over all past epoch secrets
     pub(crate) fn iter_past_epoch_trees(&self) -> impl Iterator<Item = &EpochTree> {
         self.past_epoch_trees.iter()

--- a/openmls/src/group/mls_group/tests_and_kats/kats/passive_client.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/kats/passive_client.rs
@@ -1,3 +1,9 @@
+// Several imports below are used only by `generate_test_vector` and its
+// helpers, which are gated behind the `generate-kats` feature. Keep the
+// imports unconditional so the writer keeps working, and silence the
+// resulting warnings when the feature is off.
+#![cfg_attr(not(feature = "generate-kats"), allow(unused_imports))]
+
 use log::{debug, info, warn};
 use openmls_traits::{crypto::OpenMlsCrypto, storage::StorageProvider, OpenMlsProvider};
 use serde::{self, Deserialize, Serialize};
@@ -24,7 +30,9 @@ const TEST_VECTORS_PATH_READ: &[&str] = &[
     "test_vectors/passive-client-random.json",
     "test_vectors/passive-client-handling-commit.json",
 ];
+#[cfg(feature = "generate-kats")]
 const TEST_VECTOR_PATH_WRITE: &[&str] = &["test_vectors/passive-client-welcome-new.json"];
+#[cfg(feature = "generate-kats")]
 const NUM_TESTS: usize = 25;
 
 /// ```json
@@ -181,6 +189,7 @@ pub fn run_test_vector(test_vector: PassiveClientWelcomeTestVector) {
     }
 }
 
+#[cfg(feature = "generate-kats")]
 #[test]
 fn test_write_vectors() {
     crate::skip_validation::checks::leaf_node_lifetime::handle().with_disabled(|| {
@@ -328,6 +337,7 @@ impl PassiveClient {
     }
 }
 
+#[cfg(feature = "generate-kats")]
 pub fn generate_test_vector(ciphersuite: Ciphersuite) -> PassiveClientWelcomeTestVector {
     let group_config = MlsGroupCreateConfig::builder()
         .ciphersuite(ciphersuite)
@@ -507,6 +517,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> PassiveClientWelcomeTes
 
 // -------------------------------------------------------------------------------------------------
 
+#[cfg(feature = "generate-kats")]
 fn propose_add(
     cipher_suite: Ciphersuite,
     provider: &OpenMlsRustCrypto,
@@ -533,6 +544,7 @@ fn propose_add(
     TestProposal(mls_message_out_proposal.tls_serialize_detached().unwrap())
 }
 
+#[cfg(feature = "generate-kats")]
 fn propose_remove(
     provider: &OpenMlsRustCrypto,
     candidate: &GroupCandidate,
@@ -552,6 +564,7 @@ fn propose_remove(
     TestProposal(mls_message_out_proposal.tls_serialize_detached().unwrap())
 }
 
+#[cfg(feature = "generate-kats")]
 fn commit(provider: &OpenMlsRustCrypto, creator: &GroupCandidate, group: &mut MlsGroup) -> Vec<u8> {
     let (mls_message_out_commit, _, _) = group
         .commit_to_pending_proposals(provider, &creator.signature_keypair)
@@ -561,6 +574,7 @@ fn commit(provider: &OpenMlsRustCrypto, creator: &GroupCandidate, group: &mut Ml
     mls_message_out_commit.tls_serialize_detached().unwrap()
 }
 
+#[cfg(feature = "generate-kats")]
 fn update_inline(
     provider: &OpenMlsRustCrypto,
     candidate: &GroupCandidate,

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mod.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mod.rs
@@ -4,6 +4,9 @@ mod commit_builder_leaf_node_validation;
 mod external_init;
 mod mls_group;
 mod past_secrets;
+// Pulls in `openmls_sqlite_storage` and `openmls_libcrux_crypto`
+// directly, so it is only compiled when both providers are enabled.
+#[cfg(all(feature = "sqlite-provider", feature = "libcrux-provider"))]
 mod past_secrets_storage_compatibility;
 mod proposals;
 mod secret_tree_persistence;

--- a/openmls/src/group/mod.rs
+++ b/openmls/src/group/mod.rs
@@ -12,7 +12,7 @@ use openmls_traits::random::OpenMlsRand;
 
 #[cfg(test)]
 use crate::ciphersuite::*;
-#[cfg(test)]
+#[cfg(all(test, feature = "generate-kats"))]
 use crate::utils::*;
 
 // Crate

--- a/openmls/src/group/tests_and_kats/kats/messages.rs
+++ b/openmls/src/group/tests_and_kats/kats/messages.rs
@@ -4,6 +4,12 @@
 //! See <https://github.com/mlswg/mls-implementations/blob/master/test-vectors.md>
 //! for more description on the test vectors.
 
+// Several imports below are used only by `generate_test_vector`, which is
+// gated behind the `generate-kats` feature. Keep the imports unconditional
+// so the writer keeps working, and silence the resulting warnings when the
+// feature is off.
+#![cfg_attr(not(feature = "generate-kats"), allow(unused_imports))]
+
 use frankenstein::{FrankenFramedContentBody, FrankenPublicMessage};
 use openmls_traits::{random::OpenMlsRand, types::SignatureScheme, OpenMlsProvider};
 use serde::{self, Deserialize, Serialize};
@@ -116,6 +122,7 @@ pub struct MessagesTestVector {
     private_message: Vec<u8>,
 }
 
+#[cfg(feature = "generate-kats")]
 pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     let provider = OpenMlsRustCrypto::default();
 
@@ -313,6 +320,7 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     }
 }
 
+#[cfg(feature = "generate-kats")]
 #[test]
 fn write_test_vectors_msg() {
     use openmls_traits::crypto::OpenMlsCrypto;

--- a/openmls/src/group/tests_and_kats/kats/transcript_hashes.rs
+++ b/openmls/src/group/tests_and_kats/kats/transcript_hashes.rs
@@ -3,6 +3,12 @@
 //! See <https://github.com/mlswg/mls-implementations/blob/master/test-vectors.md>
 //! for more description on the test vectors.
 
+// Several imports below are used only by `generate_test_vector`, which is
+// gated behind the `generate-kats` feature. Keep the imports unconditional
+// so the writer keeps working, and silence the resulting warnings when the
+// feature is off.
+#![cfg_attr(not(feature = "generate-kats"), allow(unused_imports))]
+
 use openmls_traits::{crypto::OpenMlsCrypto, random::OpenMlsRand, OpenMlsProvider};
 use serde::{self, Deserialize, Serialize};
 use tls_codec::{Deserialize as TlsDeserializeTrait, Serialize as TlsSerializeTrait};
@@ -22,7 +28,9 @@ use crate::{
 };
 
 const TEST_VECTOR_PATH_READ: &str = "test_vectors/transcript-hashes.json";
+#[cfg(feature = "generate-kats")]
 const TEST_VECTOR_PATH_WRITE: &str = "test_vectors/transcript-hashes-new.json";
+#[cfg(feature = "generate-kats")]
 const NUM_TESTS: usize = 100;
 
 /// ```json
@@ -139,6 +147,7 @@ pub fn run_test_vector(test_vector: TranscriptTestVector) {
 
 // -------------------------------------------------------------------------------------------------
 
+#[cfg(feature = "generate-kats")]
 #[test]
 fn write_test_vectors() {
     let mut tests = Vec::new();
@@ -157,6 +166,7 @@ fn write_test_vectors() {
     write(TEST_VECTOR_PATH_WRITE, &tests);
 }
 
+#[cfg(feature = "generate-kats")]
 pub fn generate_test_vector(ciphersuite: Ciphersuite) -> TranscriptTestVector {
     let provider = OpenMlsRustCrypto::default();
 

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tls_codec::{Deserialize as TlsDeserializeTrait, Serialize as TlsSerializeTrait, *};
 
-#[cfg(test)]
+#[cfg(all(test, feature = "generate-kats"))]
 use crate::schedule::psk::{ExternalPsk, Psk};
 use crate::{
     ciphersuite::{hash_ref::KeyPackageRef, *},
@@ -30,7 +30,7 @@ use crate::{
     },
     versions::ProtocolVersion,
 };
-#[cfg(test)]
+#[cfg(all(test, feature = "generate-kats"))]
 use openmls_traits::random::OpenMlsRand;
 
 pub(crate) mod codec;
@@ -510,7 +510,7 @@ impl GroupSecrets {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "generate-kats"))]
 impl GroupSecrets {
     pub fn random_encoded(
         ciphersuite: Ciphersuite,

--- a/openmls/src/schedule/tests_and_kats/kats/key_schedule.rs
+++ b/openmls/src/schedule/tests_and_kats/kats/key_schedule.rs
@@ -10,7 +10,7 @@ use openmls_traits::{random::OpenMlsRand, types::HpkeKeyPair, OpenMlsProvider};
 use serde::{self, Deserialize, Serialize};
 use tls_codec::Serialize as TlsSerializeTrait;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "generate-kats"))]
 use crate::test_utils::write;
 use crate::{
     ciphersuite::*,
@@ -248,6 +248,7 @@ pub fn generate_test_vector(
     }
 }
 
+#[cfg(feature = "generate-kats")]
 #[test]
 fn write_test_vectors() {
     const NUM_EPOCHS: u64 = 2;

--- a/openmls/src/storage/kat_storage_stability.rs
+++ b/openmls/src/storage/kat_storage_stability.rs
@@ -340,15 +340,17 @@ fn generate_kats() {
     helper_generate_kat::<Provider>(ciphersuite);
 }
 
-#[test]
-#[ignore]
-#[cfg(not(all(
-    feature = "libcrux-provider",
-    not(any(
-        target_arch = "wasm32",
-        all(target_arch = "x86", target_os = "windows")
+#[cfg(all(
+    feature = "generate-kats",
+    not(all(
+        feature = "libcrux-provider",
+        not(any(
+            target_arch = "wasm32",
+            all(target_arch = "x86", target_os = "windows")
+        ))
     ))
-)))]
+))]
+#[test]
 fn write_kats() {
     // setup
     let rustcrypto_provider = openmls_rust_crypto::OpenMlsRustCrypto::default();
@@ -371,15 +373,15 @@ fn write_kats() {
     helper_write_kats(kat_data);
 }
 
-#[test]
-#[ignore]
 #[cfg(all(
+    feature = "generate-kats",
     feature = "libcrux-provider",
     not(any(
         target_arch = "wasm32",
         all(target_arch = "x86", target_os = "windows")
     ))
 ))]
+#[test]
 fn write_kats() {
     // setup
     let libcrux_provider = openmls_libcrux_crypto::Provider::default();
@@ -411,6 +413,7 @@ fn write_kats() {
     helper_write_kats(kat_data);
 }
 
+#[cfg(feature = "generate-kats")]
 fn helper_write_kats(kat_data: Vec<(Ciphersuite, GroupId, Vec<Vec<u8>>)>) {
     let base64_engine = base64::engine::GeneralPurpose::new(
         &base64::alphabet::URL_SAFE,

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -444,6 +444,7 @@ pub fn generate_test_vector(
     }
 }
 
+#[cfg(feature = "generate-kats")]
 #[test]
 fn write_test_vectors() {
     use openmls_traits::prelude::*;

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -302,7 +302,7 @@ impl LeafNode {
     ///
     /// This function can be used when generating an update. In most other cases
     /// a leaf node should be generated as part of a new [`KeyPackage`].
-    #[cfg(test)]
+    #[cfg(all(test, feature = "generate-kats"))]
     pub(crate) fn generate_update<Provider: OpenMlsProvider>(
         ciphersuite: Ciphersuite,
         credential_with_key: CredentialWithKey,
@@ -993,7 +993,7 @@ impl SignedStruct<LeafNodeTbs> for LeafNode {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "generate-kats"))]
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum LeafNodeGenerationError<StorageError> {
     /// See [`LibraryError`] for more details.

--- a/openmls/src/treesync/tests_and_kats/tests.rs
+++ b/openmls/src/treesync/tests_and_kats/tests.rs
@@ -5,7 +5,6 @@ use crate::{
     },
     key_packages::KeyPackage,
     prelude::*,
-    storage::OpenMlsProvider,
 };
 
 mod test_diff;

--- a/openmls_test/Cargo.toml
+++ b/openmls_test/Cargo.toml
@@ -16,6 +16,11 @@ proc-macro = true
 # This needs to be enabled explicity to allow disabling on some platforms
 libcrux-provider = ["dep:openmls_libcrux_crypto"]
 sqlite-provider = ["dep:openmls_sqlite_storage"]
+# When set, every `#[openmls_test]` expands to one test per supported
+# ciphersuite of each enabled provider. When unset (the default), each
+# enabled provider emits a single test using the mandatory-to-implement
+# ciphersuite MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519.
+all-ciphersuites = []
 
 [dependencies]
 syn = { version = "2.0", features = ["full", "visit"] }

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -159,8 +159,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     ))]
     {
         let libcrux = openmls_libcrux_crypto::Provider::default();
-        let libcrux_ciphersuites =
-            filter_ciphersuites(libcrux.crypto().supported_ciphersuites());
+        let libcrux_ciphersuites = filter_ciphersuites(libcrux.crypto().supported_ciphersuites());
 
         for ciphersuite in libcrux_ciphersuites {
             let val = ciphersuite as u16;

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -15,7 +15,7 @@ const MTI_CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_
 /// With the feature enabled, every supported ciphersuite is emitted, which
 /// matches the historical behaviour and is intended for on-demand runs
 /// (nightly CI, release validation).
-fn expansion_ciphersuites(provider_supported: Vec<Ciphersuite>) -> Vec<Ciphersuite> {
+fn filter_ciphersuites(provider_supported: Vec<Ciphersuite>) -> Vec<Ciphersuite> {
     if cfg!(feature = "all-ciphersuites") {
         provider_supported
     } else if provider_supported.contains(&MTI_CIPHERSUITE) {
@@ -38,7 +38,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let rc = OpenMlsRustCrypto::default();
 
-    let rc_ciphersuites = expansion_ciphersuites(rc.crypto().supported_ciphersuites());
+    let rc_ciphersuites = filter_ciphersuites(rc.crypto().supported_ciphersuites());
 
     let mut test_funs = Vec::new();
 
@@ -72,7 +72,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     #[cfg(all(feature = "sqlite-provider", not(target_arch = "wasm32",)))]
     {
-        let rc_ciphersuites = expansion_ciphersuites(rc.crypto().supported_ciphersuites());
+        let rc_ciphersuites = filter_ciphersuites(rc.crypto().supported_ciphersuites());
         for ciphersuite in rc_ciphersuites {
             let val = ciphersuite as u16;
             let ciphersuite_name = format!("{ciphersuite:?}");
@@ -160,7 +160,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     {
         let libcrux = openmls_libcrux_crypto::Provider::default();
         let libcrux_ciphersuites =
-            expansion_ciphersuites(libcrux.crypto().supported_ciphersuites());
+            filter_ciphersuites(libcrux.crypto().supported_ciphersuites());
 
         for ciphersuite in libcrux_ciphersuites {
             let val = ciphersuite as u16;

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -1,8 +1,32 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
-use openmls_traits::{crypto::OpenMlsCrypto, OpenMlsProvider};
+use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite, OpenMlsProvider};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, ItemFn};
+
+/// Mandatory-to-implement ciphersuite per RFC 9420.
+/// Used as the sole default when the `all-ciphersuites` feature is off.
+const MTI_CIPHERSUITE: Ciphersuite =
+    Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+/// Returns the ciphersuites a provider's tests should be expanded over.
+///
+/// Without the `all-ciphersuites` feature, this collapses to the MTI
+/// ciphersuite so each `#[openmls_test]` produces one test per provider.
+/// With the feature enabled, every supported ciphersuite is emitted, which
+/// matches the historical behaviour and is intended for on-demand runs
+/// (nightly CI, release validation).
+fn expansion_ciphersuites(provider_supported: Vec<Ciphersuite>) -> Vec<Ciphersuite> {
+    if cfg!(feature = "all-ciphersuites") {
+        provider_supported
+    } else if provider_supported.contains(&MTI_CIPHERSUITE) {
+        vec![MTI_CIPHERSUITE]
+    } else {
+        // The provider does not advertise the MTI ciphersuite. Emit no
+        // tests for it rather than silently using something else.
+        Vec::new()
+    }
+}
 
 #[proc_macro_attribute]
 pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -15,7 +39,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let rc = OpenMlsRustCrypto::default();
 
-    let rc_ciphersuites = rc.crypto().supported_ciphersuites();
+    let rc_ciphersuites = expansion_ciphersuites(rc.crypto().supported_ciphersuites());
 
     let mut test_funs = Vec::new();
 
@@ -49,7 +73,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     #[cfg(all(feature = "sqlite-provider", not(target_arch = "wasm32",)))]
     {
-        let rc_ciphersuites = rc.crypto().supported_ciphersuites();
+        let rc_ciphersuites = expansion_ciphersuites(rc.crypto().supported_ciphersuites());
         for ciphersuite in rc_ciphersuites {
             let val = ciphersuite as u16;
             let ciphersuite_name = format!("{ciphersuite:?}");
@@ -136,7 +160,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     ))]
     {
         let libcrux = openmls_libcrux_crypto::Provider::default();
-        let libcrux_ciphersuites = libcrux.crypto().supported_ciphersuites();
+        let libcrux_ciphersuites = expansion_ciphersuites(libcrux.crypto().supported_ciphersuites());
 
         for ciphersuite in libcrux_ciphersuites {
             let val = ciphersuite as u16;

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -6,8 +6,7 @@ use syn::{parse_macro_input, ItemFn};
 
 /// Mandatory-to-implement ciphersuite per RFC 9420.
 /// Used as the sole default when the `all-ciphersuites` feature is off.
-const MTI_CIPHERSUITE: Ciphersuite =
-    Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+const MTI_CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
 /// Returns the ciphersuites a provider's tests should be expanded over.
 ///
@@ -160,7 +159,8 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     ))]
     {
         let libcrux = openmls_libcrux_crypto::Provider::default();
-        let libcrux_ciphersuites = expansion_ciphersuites(libcrux.crypto().supported_ciphersuites());
+        let libcrux_ciphersuites =
+            expansion_ciphersuites(libcrux.crypto().supported_ciphersuites());
 
         for ciphersuite in libcrux_ciphersuites {
             let val = ciphersuite as u16;


### PR DESCRIPTION
- Run tests with only the MTI ciphersuite and the rustcrypto provider (add a PQ ciphersuite when #1994 is merged)
- Introduce new `all-ciphersuites` feature flag that causes tests to run with all ciphersuites enabled
- Remove kat generation from test runs, hide them behind feature flag
- Introduce new nightly CI job that runs tests with all ciphersuites and all providers enabled