### PR TITLE
`From<KeyPackage>` implementation for `AddProposal`

### DIFF
--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -380,6 +380,12 @@ impl AddProposal {
     }
 }
 
+impl From<KeyPackage> for AddProposal {
+    fn from(key_package: KeyPackage) -> AddProposal {
+        AddProposal { key_package }
+    }
+}
+
 /// Update Proposal.
 ///
 /// An Update proposal is a similar mechanism to [`AddProposal`] with the


### PR DESCRIPTION
This pull request implements `From<KeyPackage>` for the `AddProposal` type, to allow initializing it directly from a `KeyPackage`. 

The `AddProposal` instantiated in this way can then be provided to the `CommitBuilder` as part of a list of  proposals of different types, as an alternative to using the [CommitBuilder::propose_adds()](https://github.com/openmls/openmls/blob/addb82875e7d635fd816948d52fe398b499cf6c6/openmls/src/group/mls_group/commit_builder.rs#L243-L252) API.