### PR TITLE
feat: Implement Safe AAD capabilities from extensions doc

### DIFF
--- a/openmls/src/component.rs
+++ b/openmls/src/component.rs
@@ -200,6 +200,54 @@ impl From<ComponentType> for ComponentId {
     }
 }
 
+/// A list of [`ComponentId`]s.
+///
+/// Used as the body of the `safe_aad` component in the `app_data_dictionary`
+/// extension. When present in a LeafNode it lists supported components. When
+/// present in the GroupContext it lists components whose Safe AAD must be
+/// understood by the entire group.
+///
+/// ```tls
+/// struct {
+///     ComponentID component_ids<V>;
+/// } ComponentsList;
+/// ```
+#[cfg(feature = "extensions-draft-08")]
+#[derive(
+    PartialEq,
+    Eq,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
+)]
+pub struct ComponentsList {
+    component_ids: Vec<ComponentId>,
+}
+
+#[cfg(feature = "extensions-draft-08")]
+impl ComponentsList {
+    /// Create a new [`ComponentsList`] from a vector of [`ComponentId`]s.
+    pub fn new(component_ids: Vec<ComponentId>) -> Self {
+        Self { component_ids }
+    }
+
+    /// Access the underlying ids.
+    pub fn ids(&self) -> &[ComponentId] {
+        &self.component_ids
+    }
+
+    /// Consume self and return the ids.
+    pub fn into_ids(self) -> Vec<ComponentId> {
+        self.component_ids
+    }
+}
+
 /// Label for safe encryption/decryption as defined in Section 4.2 of the MLS Extensions draft
 #[derive(Debug, TlsSerialize, TlsSize)]
 pub(crate) struct ComponentOperationLabel {

--- a/openmls/src/framing/mod.rs
+++ b/openmls/src/framing/mod.rs
@@ -66,6 +66,8 @@ pub(crate) mod private_message;
 pub(crate) mod private_message_in;
 pub(crate) mod public_message;
 pub(crate) mod public_message_in;
+#[cfg(feature = "extensions-draft-08")]
+pub(crate) mod safe_aad;
 pub(crate) mod sender;
 pub(crate) mod validation;
 pub(crate) use errors::*;
@@ -92,6 +94,8 @@ pub use private_message::*;
 pub use private_message_in::*;
 pub use public_message::*;
 pub use public_message_in::*;
+#[cfg(feature = "extensions-draft-08")]
+pub use safe_aad::{SafeAad, SafeAadError, SafeAadItem};
 pub use sender::*;
 pub use validation::*;
 

--- a/openmls/src/framing/safe_aad.rs
+++ b/openmls/src/framing/safe_aad.rs
@@ -1,0 +1,319 @@
+//! Safe Additional Authenticated Data (Safe AAD) framing.
+//!
+//! Implements the wire format and validation rules from
+//! <https://datatracker.ietf.org/doc/html/draft-ietf-mls-extensions> Section 4.9.
+//!
+//! ```tls
+//! struct {
+//!   ComponentID component_id;
+//!   opaque aad_item_data<V>;
+//! } SafeAADItem;
+//!
+//! struct {
+//!   SafeAADItem aad_items<V>;
+//! } SafeAAD;
+//! ```
+//!
+//! Items in a [`SafeAad`] are sorted in strictly-increasing order of
+//! `component_id`. Duplicates and misordering are rejected on both construction
+//! and deserialization.
+
+use serde::{Deserialize, Serialize};
+use std::io::Read;
+use tls_codec::{
+    Deserialize as TlsDeserializeTrait, DeserializeBytes as TlsDeserializeBytesTrait,
+    Serialize as TlsSerializeTrait, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize,
+    VLBytes,
+};
+
+use crate::component::ComponentId;
+
+/// Errors that can occur when building or parsing a [`SafeAad`].
+#[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
+pub enum SafeAadError {
+    /// Two items share the same [`ComponentId`].
+    #[error("duplicate component id in SafeAAD: {0}")]
+    DuplicateComponentId(ComponentId),
+    /// Items are not sorted in strictly-increasing order by [`ComponentId`].
+    #[error("SafeAAD items are not sorted by component id in increasing order")]
+    ItemsNotSortedAscending,
+    /// Encoding or decoding failure.
+    #[error("codec error: {0}")]
+    Codec(String),
+}
+
+/// A single Safe AAD entry tagged by [`ComponentId`].
+///
+/// ```tls
+/// struct {
+///   ComponentID component_id;
+///   opaque aad_item_data<V>;
+/// } SafeAADItem;
+/// ```
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsDeserializeBytes,
+    TlsSize,
+)]
+pub struct SafeAadItem {
+    component_id: ComponentId,
+    aad_item_data: VLBytes,
+}
+
+impl SafeAadItem {
+    /// Create a new [`SafeAadItem`].
+    pub fn new(component_id: ComponentId, data: Vec<u8>) -> Self {
+        Self {
+            component_id,
+            aad_item_data: data.into(),
+        }
+    }
+
+    /// The [`ComponentId`] this item is tagged with.
+    pub fn component_id(&self) -> ComponentId {
+        self.component_id
+    }
+
+    /// The bytes carried by this item.
+    pub fn data(&self) -> &[u8] {
+        self.aad_item_data.as_slice()
+    }
+}
+
+/// A Safe AAD struct as it appears at the beginning of an MLS message's
+/// `authenticated_data` field when negotiated for the group.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TlsSerialize, TlsSize)]
+pub struct SafeAad {
+    aad_items: Vec<SafeAadItem>,
+}
+
+impl SafeAad {
+    /// Build a [`SafeAad`] from a list of items.
+    ///
+    /// Returns an error if items are not sorted in strictly-increasing
+    /// [`ComponentId`] order or if any [`ComponentId`] appears more than once.
+    pub fn from_items(items: Vec<SafeAadItem>) -> Result<Self, SafeAadError> {
+        Self::validate(&items)?;
+        Ok(Self { aad_items: items })
+    }
+
+    /// Build an empty [`SafeAad`].
+    pub fn empty() -> Self {
+        Self {
+            aad_items: Vec::new(),
+        }
+    }
+
+    /// Returns all items.
+    pub fn items(&self) -> &[SafeAadItem] {
+        &self.aad_items
+    }
+
+    /// Look up the data carried for a given [`ComponentId`].
+    ///
+    /// Returns `None` if there is no item tagged with that id.
+    pub fn get(&self, component_id: ComponentId) -> Option<&[u8]> {
+        // The list is sorted by construction, so a binary search is correct
+        // and cheap.
+        self.aad_items
+            .binary_search_by_key(&component_id, SafeAadItem::component_id)
+            .ok()
+            .map(|index| self.aad_items[index].data())
+    }
+
+    /// Returns true if there are no items.
+    pub fn is_empty(&self) -> bool {
+        self.aad_items.is_empty()
+    }
+
+    /// Number of items.
+    pub fn len(&self) -> usize {
+        self.aad_items.len()
+    }
+
+    fn validate(items: &[SafeAadItem]) -> Result<(), SafeAadError> {
+        let mut previous: Option<ComponentId> = None;
+        for item in items {
+            if let Some(prev) = previous {
+                if item.component_id == prev {
+                    return Err(SafeAadError::DuplicateComponentId(item.component_id));
+                }
+                if item.component_id < prev {
+                    return Err(SafeAadError::ItemsNotSortedAscending);
+                }
+            }
+            previous = Some(item.component_id);
+        }
+        Ok(())
+    }
+}
+
+impl TlsDeserializeTrait for SafeAad {
+    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error> {
+        let aad_items = Vec::<SafeAadItem>::tls_deserialize(bytes)?;
+        SafeAad::from_items(aad_items)
+            .map_err(|err| tls_codec::Error::DecodingError(err.to_string()))
+    }
+}
+
+impl TlsDeserializeBytesTrait for SafeAad {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
+        let (aad_items, rest) = Vec::<SafeAadItem>::tls_deserialize_bytes(bytes)?;
+        let aad = SafeAad::from_items(aad_items)
+            .map_err(|err| tls_codec::Error::DecodingError(err.to_string()))?;
+        Ok((aad, rest))
+    }
+}
+
+/// Build the bytes that go into `authenticated_data` for an outgoing message
+/// when Safe AAD is required: the TLS-serialized [`SafeAad`] followed by the
+/// caller-supplied tail bytes.
+pub(crate) fn assemble_authenticated_data(
+    safe_aad: &SafeAad,
+    tail: &[u8],
+) -> Result<Vec<u8>, SafeAadError> {
+    let mut out = safe_aad
+        .tls_serialize_detached()
+        .map_err(|err| SafeAadError::Codec(err.to_string()))?;
+    out.extend_from_slice(tail);
+    Ok(out)
+}
+
+/// Parse the [`SafeAad`] prefix from `authenticated_data` bytes when Safe AAD
+/// is required for the group. Returns the parsed struct and the length of the
+/// consumed prefix.
+pub(crate) fn parse_authenticated_data_prefix(
+    bytes: &[u8],
+) -> Result<(SafeAad, usize), SafeAadError> {
+    let (parsed, remainder) = SafeAad::tls_deserialize_bytes(bytes)
+        .map_err(|err| SafeAadError::Codec(err.to_string()))?;
+    let prefix_len = bytes.len() - remainder.len();
+    Ok((parsed, prefix_len))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tls_codec::{Deserialize, Serialize};
+
+    fn item(id: ComponentId, data: &[u8]) -> SafeAadItem {
+        SafeAadItem::new(id, data.to_vec())
+    }
+
+    #[test]
+    fn roundtrip_non_empty() {
+        let safe_aad = SafeAad::from_items(vec![
+            item(1, b"first"),
+            item(7, b""),
+            item(42, b"last item bytes"),
+        ])
+        .unwrap();
+
+        let bytes = safe_aad.tls_serialize_detached().unwrap();
+        let parsed = SafeAad::tls_deserialize_exact(&bytes).unwrap();
+
+        assert_eq!(parsed, safe_aad);
+        let reserialized = parsed.tls_serialize_detached().unwrap();
+        assert_eq!(reserialized, bytes);
+    }
+
+    #[test]
+    fn empty_is_length_prefix_only() {
+        let safe_aad = SafeAad::empty();
+        let bytes = safe_aad.tls_serialize_detached().unwrap();
+
+        // The TLS encoding of a zero-length `<V>` vector is a single zero byte.
+        assert_eq!(bytes, vec![0x00]);
+
+        let parsed = SafeAad::tls_deserialize_exact(&bytes).unwrap();
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn from_items_rejects_duplicates() {
+        let err = SafeAad::from_items(vec![item(3, b"a"), item(3, b"b")]).unwrap_err();
+        assert_eq!(err, SafeAadError::DuplicateComponentId(3));
+    }
+
+    #[test]
+    fn from_items_rejects_misordered() {
+        let err = SafeAad::from_items(vec![item(9, b""), item(2, b"")]).unwrap_err();
+        assert_eq!(err, SafeAadError::ItemsNotSortedAscending);
+    }
+
+    #[test]
+    fn deserialize_rejects_misordered() {
+        // Hand-craft TLS bytes for two items that are out of order. The derived
+        // serializer would normally refuse to emit these, so we build the bytes
+        // directly from items wrapped in a plain `Vec`.
+        let raw_items: Vec<SafeAadItem> = vec![item(5, b"x"), item(1, b"y")];
+        let raw_bytes = raw_items.tls_serialize_detached().unwrap();
+
+        let err = SafeAad::tls_deserialize_exact(&raw_bytes).unwrap_err();
+        match err {
+            tls_codec::Error::DecodingError(message) => {
+                assert!(
+                    message.contains("not sorted"),
+                    "unexpected error message: {message}"
+                );
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deserialize_rejects_duplicates() {
+        let raw_items: Vec<SafeAadItem> = vec![item(4, b""), item(4, b"")];
+        let raw_bytes = raw_items.tls_serialize_detached().unwrap();
+
+        let err = SafeAad::tls_deserialize_exact(&raw_bytes).unwrap_err();
+        match err {
+            tls_codec::Error::DecodingError(message) => {
+                assert!(
+                    message.contains("duplicate"),
+                    "unexpected error message: {message}"
+                );
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn boundary_component_ids() {
+        let safe_aad = SafeAad::from_items(vec![item(0, b"min"), item(u16::MAX, b"max")]).unwrap();
+
+        let bytes = safe_aad.tls_serialize_detached().unwrap();
+        let parsed = SafeAad::tls_deserialize_exact(&bytes).unwrap();
+
+        assert_eq!(parsed.get(0), Some(b"min".as_slice()));
+        assert_eq!(parsed.get(u16::MAX), Some(b"max".as_slice()));
+    }
+
+    #[test]
+    fn get_returns_none_for_missing() {
+        let safe_aad = SafeAad::from_items(vec![item(1, b"a"), item(10, b"b")]).unwrap();
+        assert_eq!(safe_aad.get(5), None);
+        assert_eq!(safe_aad.get(1), Some(b"a".as_slice()));
+        assert_eq!(safe_aad.get(10), Some(b"b".as_slice()));
+    }
+
+    #[test]
+    fn assemble_and_parse_authenticated_data_roundtrip() {
+        let safe_aad =
+            SafeAad::from_items(vec![item(2, b"safe-aad-data"), item(8, b"more")]).unwrap();
+        let tail = b"caller tail bytes";
+
+        let combined = assemble_authenticated_data(&safe_aad, tail).unwrap();
+
+        let (parsed, prefix_len) = parse_authenticated_data_prefix(&combined).unwrap();
+        assert_eq!(parsed, safe_aad);
+        assert_eq!(&combined[prefix_len..], tail);
+    }
+}

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -36,7 +36,9 @@ use crate::{
 };
 
 #[cfg(feature = "extensions-draft-08")]
-use crate::{component::ComponentId, messages::proposals_in::ProposalOrRefIn};
+use crate::{
+    component::ComponentId, framing::safe_aad::SafeAad, messages::proposals_in::ProposalOrRefIn,
+};
 
 use super::{
     mls_auth_content::AuthenticatedContent,
@@ -282,6 +284,14 @@ pub struct ProcessedMessage {
     authenticated_data: Vec<u8>,
     content: ProcessedMessageContent,
     credential: Credential,
+    /// Parsed Safe AAD prefix, populated only when the message's GroupContext
+    /// required Safe AAD framing. `None` otherwise.
+    #[cfg(feature = "extensions-draft-08")]
+    safe_aad: Option<SafeAad>,
+    /// Length in bytes of the Safe AAD prefix at the start of
+    /// `authenticated_data`. Zero when [`Self::safe_aad`] is `None`.
+    #[cfg(feature = "extensions-draft-08")]
+    safe_aad_prefix_len: usize,
 }
 
 impl ProcessedMessage {
@@ -301,7 +311,47 @@ impl ProcessedMessage {
             authenticated_data,
             content,
             credential,
+            #[cfg(feature = "extensions-draft-08")]
+            safe_aad: None,
+            #[cfg(feature = "extensions-draft-08")]
+            safe_aad_prefix_len: 0,
         }
+    }
+
+    /// Parse the Safe AAD prefix at the start of `authenticated_data` and
+    /// attach it to this message. Callers should invoke this only when the receiving
+    /// group's GroupContext requires Safe AAD framing. Otherwise, `safe_aad`
+    /// stays `None` and `authenticated_data` is the caller-supplied bytes
+    /// untouched.
+    #[cfg(feature = "extensions-draft-08")]
+    pub(crate) fn try_attach_safe_aad(&mut self) -> Result<(), crate::framing::SafeAadError> {
+        let (safe_aad, prefix_len) =
+            crate::framing::safe_aad::parse_authenticated_data_prefix(&self.authenticated_data)?;
+        self.safe_aad = Some(safe_aad);
+        self.safe_aad_prefix_len = prefix_len;
+        Ok(())
+    }
+
+    /// Returns the parsed Safe AAD struct, or `None` if Safe AAD was not
+    /// active for the group this message belongs to.
+    #[cfg(feature = "extensions-draft-08")]
+    pub fn safe_aad(&self) -> Option<&SafeAad> {
+        self.safe_aad.as_ref()
+    }
+
+    /// Look up a Safe AAD item by [`ComponentId`].
+    #[cfg(feature = "extensions-draft-08")]
+    pub fn safe_aad_item(&self, component_id: crate::component::ComponentId) -> Option<&[u8]> {
+        self.safe_aad
+            .as_ref()
+            .and_then(|safe_aad| safe_aad.get(component_id))
+    }
+
+    /// Returns the bytes of `authenticated_data` after any Safe AAD prefix.
+    /// Equal to [`Self::aad`] when no Safe AAD prefix is present.
+    #[cfg(feature = "extensions-draft-08")]
+    pub fn tail_aad(&self) -> &[u8] {
+        &self.authenticated_data[self.safe_aad_prefix_len..]
     }
 
     /// Returns the group ID of the message.

--- a/openmls/src/group/group_context.rs
+++ b/openmls/src/group/group_context.rs
@@ -5,6 +5,8 @@ use openmls_traits::types::Ciphersuite;
 
 use super::*;
 #[cfg(feature = "extensions-draft-08")]
+use crate::component::{ComponentId, ComponentType, ComponentsList};
+#[cfg(feature = "extensions-draft-08")]
 use crate::extensions::AppDataDictionary;
 use crate::{
     error::LibraryError,
@@ -89,6 +91,44 @@ impl GroupContext {
         self.extensions
             .app_data_dictionary()
             .map(|extension| extension.dictionary())
+    }
+
+    /// Whether Safe AAD framing is active for messages in this group.
+    ///
+    /// Returns `true` exactly when the `app_data_dictionary` GroupContext
+    /// extension contains a `safe_aad` component (the value bytes are not
+    /// inspected here, an empty `ComponentsList` is still "present").
+    /// Per the Safe AAD spec section 4.9, when this is `true` the
+    /// `authenticated_data` field always starts with the `SafeAAD` struct.
+    #[cfg(feature = "extensions-draft-08")]
+    pub fn safe_aad_required(&self) -> bool {
+        let safe_aad_id = ComponentId::from(ComponentType::SafeAad);
+        self.app_data_dict()
+            .is_some_and(|dict| dict.contains(&safe_aad_id))
+    }
+
+    /// The list of [`ComponentId`]s required to be understood by every member
+    /// for Safe AAD purposes.
+    ///
+    /// Returns `Ok(None)` when the `safe_aad` component is absent from the
+    /// `app_data_dictionary` GroupContext extension, `Ok(Some(list))` when it
+    /// is present and parses cleanly (the list may be empty), and an error
+    /// when the component value fails to decode as a `ComponentsList`.
+    #[cfg(feature = "extensions-draft-08")]
+    pub fn safe_aad_required_components(
+        &self,
+    ) -> Result<Option<Vec<ComponentId>>, crate::framing::SafeAadError> {
+        let safe_aad_id = ComponentId::from(ComponentType::SafeAad);
+        let Some(dict) = self.app_data_dict() else {
+            return Ok(None);
+        };
+        let Some(raw) = dict.get(&safe_aad_id) else {
+            return Ok(None);
+        };
+        use tls_codec::Deserialize as _;
+        let list = ComponentsList::tls_deserialize_exact(raw)
+            .map_err(|err| crate::framing::SafeAadError::Codec(err.to_string()))?;
+        Ok(Some(list.into_ids()))
     }
 
     /// Create the `GroupContext` needed upon creation of a new group.

--- a/openmls/src/group/mls_group/application.rs
+++ b/openmls/src/group/mls_group/application.rs
@@ -69,9 +69,10 @@ impl MlsGroup {
             return Err(MlsGroupStateError::PendingProposal.into());
         }
 
+        let aad = self.outgoing_authenticated_data()?;
         let authenticated_content = AuthenticatedContent::new_application(
             self.own_leaf_index(),
-            &self.aad,
+            &aad,
             message,
             self.context(),
             signer,

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -183,6 +183,8 @@ impl MlsGroupBuilder {
             mls_group_config: mls_group_create_config.join_config.clone(),
             own_leaf_nodes: vec![],
             aad: vec![],
+            #[cfg(feature = "extensions-draft-08")]
+            safe_aad: crate::framing::SafeAad::empty(),
             group_state: MlsGroupState::Operational,
             public_group,
             group_epoch_secrets,

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -673,12 +673,32 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, LoadedPsks, G> {
             path: path_computation_result.encrypted_path,
         };
 
-        let framing_parameters =
-            if let Some(ExternalCommitInfo { aad, .. }) = &cur_stage.external_commit_info {
-                FramingParameters::new(aad, WireFormat::PublicMessage)
-            } else {
-                group.framing_parameters()
+        let (outgoing_aad, wire_format): (Vec<u8>, WireFormat) =
+            match &cur_stage.external_commit_info {
+                None => (
+                    group.outgoing_authenticated_data()?,
+                    group.outgoing_wire_format(),
+                ),
+                Some(ExternalCommitInfo { aad, .. }) => {
+                    // The spec requires the SafeAAD prefix even with zero items
+                    // when the target GroupContext has `safe_aad` present, so a
+                    // bare `aad` would be rejected by SafeAAD-aware receivers.
+                    #[cfg(feature = "extensions-draft-08")]
+                    let aad_bytes = if group.context().safe_aad_required() {
+                        crate::framing::safe_aad::assemble_authenticated_data(
+                            &crate::framing::SafeAad::empty(),
+                            aad,
+                        )
+                        .map_err(|_| LibraryError::custom("SafeAad serialization failed"))?
+                    } else {
+                        aad.clone()
+                    };
+                    #[cfg(not(feature = "extensions-draft-08"))]
+                    let aad_bytes = aad.clone();
+                    (aad_bytes, WireFormat::PublicMessage)
+                }
             };
+        let framing_parameters = FramingParameters::new(&outgoing_aad, wire_format);
 
         // Build AuthenticatedContent
         let mut authenticated_content = AuthenticatedContent::commit(

--- a/openmls/src/group/mls_group/commit_builder/external_commits.rs
+++ b/openmls/src/group/mls_group/commit_builder/external_commits.rs
@@ -284,6 +284,8 @@ impl ExternalCommitBuilder {
             mls_group_config: config,
             own_leaf_nodes: vec![],
             aad: vec![],
+            #[cfg(feature = "extensions-draft-08")]
+            safe_aad: crate::framing::SafeAad::empty(),
             group_state: MlsGroupState::Operational,
             public_group,
             group_epoch_secrets,

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -561,6 +561,8 @@ impl StagedWelcome {
             mls_group_config: self.mls_group_config,
             own_leaf_nodes: vec![],
             aad: vec![],
+            #[cfg(feature = "extensions-draft-08")]
+            safe_aad: crate::framing::SafeAad::empty(),
             group_state: MlsGroupState::Operational,
             public_group: self.public_group,
             group_epoch_secrets: self.group_epoch_secrets,

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -141,6 +141,12 @@ pub enum PublicProcessMessageError {
     /// The proposal is invalid for the Sender of type [External](crate::prelude::Sender::External)
     #[error("The proposal is invalid for the Sender of type External")]
     UnsupportedProposalType,
+
+    /// The group's GroupContext requires Safe AAD framing, but the message's
+    /// `authenticated_data` did not start with a well-formed `SafeAad`.
+    #[cfg(feature = "extensions-draft-08")]
+    #[error("malformed SafeAAD prefix in authenticated_data")]
+    MalformedSafeAad,
 }
 
 /// Process message error
@@ -178,6 +184,12 @@ pub enum ProcessMessageError<StorageError> {
     #[cfg(feature = "extensions-draft-08")]
     #[error("Use `_with_app_data_update` functions for handling AppDataUpdate proposals")]
     FoundAppDataUpdateProposal,
+
+    /// The group's GroupContext requires Safe AAD framing, but the message's
+    /// `authenticated_data` did not start with a well-formed `SafeAad`.
+    #[cfg(feature = "extensions-draft-08")]
+    #[error("malformed SafeAAD prefix in authenticated_data")]
+    MalformedSafeAad,
 }
 
 /// Create message error

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -233,8 +233,10 @@ impl MlsGroup {
         self.is_operational()?;
 
         let removed = self.own_leaf_index();
+        let aad = self.outgoing_authenticated_data()?;
+        let framing_parameters = FramingParameters::new(&aad, self.outgoing_wire_format());
         let remove_proposal = self
-            .create_remove_proposal(self.framing_parameters(), removed, signer)
+            .create_remove_proposal(framing_parameters, removed, signer)
             .map_err(|_| LibraryError::custom("Creating a self removal should not fail"))?;
 
         let ciphersuite = self.ciphersuite();
@@ -283,8 +285,8 @@ impl MlsGroup {
         ) {
             return Err(LeaveGroupError::CannotSelfRemoveWithPureCiphertext);
         }
-        let self_remove_proposal =
-            self.create_self_remove_proposal(self.framing_parameters().aad(), signer)?;
+        let aad = self.outgoing_authenticated_data()?;
+        let self_remove_proposal = self.create_self_remove_proposal(&aad, signer)?;
 
         let ciphersuite = self.ciphersuite();
         let queued_self_remove_proposal = QueuedProposal::from_authenticated_content_by_ref(

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -251,6 +251,11 @@ pub struct MlsGroup {
     // is ephemeral and will be reset by every API call that successfully
     // returns an [`MlsMessageOut`].
     aad: Vec<u8>,
+    // Safe AAD items to attach to the next outgoing message. Ephemeral, reset
+    // alongside `aad`. Only consulted when the group's GroupContext requires
+    // Safe AAD framing.
+    #[cfg(feature = "extensions-draft-08")]
+    safe_aad: SafeAad,
     // A variable that indicates the state of the group. See [`MlsGroupState`]
     // for more information.
     group_state: MlsGroupState,
@@ -290,6 +295,28 @@ impl MlsGroup {
     /// message.
     pub fn aad(&self) -> &[u8] {
         &self.aad
+    }
+
+    /// Stage Safe AAD items for the next outgoing message. Items must be
+    /// sorted by [`ComponentId`] in strictly-increasing order and contain no
+    /// duplicates; otherwise the call fails and the previously staged items
+    /// are left untouched.
+    ///
+    /// Ephemeral, like [`Self::set_aad`]: cleared whenever an outgoing message
+    /// is produced.
+    ///
+    /// [`ComponentId`]: crate::component::ComponentId
+    #[cfg(feature = "extensions-draft-08")]
+    pub fn set_safe_aad(&mut self, items: Vec<SafeAadItem>) -> Result<(), SafeAadError> {
+        self.safe_aad = SafeAad::from_items(items)?;
+        Ok(())
+    }
+
+    /// Returns the currently staged Safe AAD items for the next outgoing
+    /// message.
+    #[cfg(feature = "extensions-draft-08")]
+    pub fn safe_aad_items(&self) -> &[SafeAadItem] {
+        self.safe_aad.items()
     }
 
     // === Advanced functions ===
@@ -456,6 +483,8 @@ impl MlsGroup {
                 mls_group_config: mls_group_config?,
                 own_leaf_nodes,
                 aad: vec![],
+                #[cfg(feature = "extensions-draft-08")]
+                safe_aad: SafeAad::empty(),
                 group_state: group_state?,
                 #[cfg(feature = "extensions-draft-08")]
                 application_export_tree,
@@ -666,12 +695,38 @@ impl MlsGroup {
         Ok(msg)
     }
 
-    /// Group framing parameters
-    pub(crate) fn framing_parameters(&self) -> FramingParameters<'_> {
-        FramingParameters::new(
-            &self.aad,
-            self.mls_group_config.wire_format_policy().outgoing(),
-        )
+    /// Outgoing wire format derived from the group's configured policy.
+    pub(crate) fn outgoing_wire_format(&self) -> WireFormat {
+        self.mls_group_config.wire_format_policy().outgoing().into()
+    }
+
+    /// Owned `authenticated_data` bytes for the next outgoing message, taking
+    /// the GroupContext's Safe AAD requirement into account.
+    ///
+    /// Callers borrow the returned buffer into a [`FramingParameters`] for the
+    /// duration of message construction.
+    pub(crate) fn outgoing_authenticated_data(&self) -> Result<Vec<u8>, LibraryError> {
+        #[cfg(feature = "extensions-draft-08")]
+        {
+            self.assembled_authenticated_data()
+        }
+        #[cfg(not(feature = "extensions-draft-08"))]
+        {
+            Ok(self.aad.clone())
+        }
+    }
+
+    /// Build the bytes that go into `authenticated_data` for the next outgoing
+    /// message. When the GroupContext requires Safe AAD framing, the result is
+    /// the TLS serialization of the staged [`SafeAad`] followed by the bytes of
+    /// `self.aad`. Otherwise, the result is `self.aad` unchanged.
+    #[cfg(feature = "extensions-draft-08")]
+    pub(crate) fn assembled_authenticated_data(&self) -> Result<Vec<u8>, LibraryError> {
+        if !self.context().safe_aad_required() {
+            return Ok(self.aad.clone());
+        }
+        crate::framing::safe_aad::assemble_authenticated_data(&self.safe_aad, &self.aad)
+            .map_err(|_| LibraryError::custom("SafeAad serialization failed"))
     }
 
     /// Delete all past epoch secrets.
@@ -712,10 +767,14 @@ impl MlsGroup {
         self.public_group.version()
     }
 
-    /// Resets the AAD.
+    /// Resets the AAD, including any staged Safe AAD items.
     #[inline]
     pub(crate) fn reset_aad(&mut self) {
         self.aad.clear();
+        #[cfg(feature = "extensions-draft-08")]
+        {
+            self.safe_aad = SafeAad::empty();
+        }
     }
 
     /// Returns a reference to the public group.

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -364,18 +364,26 @@ impl MlsGroup {
         let (content, credential) =
             unverified_message.verify(self.ciphersuite(), provider.crypto(), self.version())?;
 
-        match content.sender() {
+        #[cfg_attr(not(feature = "extensions-draft-08"), allow(unused_mut))]
+        let mut processed = match content.sender() {
             Sender::Member(_) | Sender::NewMemberProposal | Sender::NewMemberCommit => self
                 .process_internal_authenticated_content_with_app_data_updates(
                     provider,
                     content,
                     credential,
                     app_data_dict_updates,
-                ),
+                )?,
             Sender::External(_) => {
-                self.process_external_authenticated_content(provider, content, credential)
+                self.process_external_authenticated_content(provider, content, credential)?
             }
+        };
+        #[cfg(feature = "extensions-draft-08")]
+        if self.context().safe_aad_required() {
+            processed
+                .try_attach_safe_aad()
+                .map_err(|_| ProcessMessageError::MalformedSafeAad)?;
         }
+        Ok(processed)
     }
 
     /// This processing function does most of the semantic verifications.
@@ -418,14 +426,22 @@ impl MlsGroup {
         let (content, credential) =
             unverified_message.verify(self.ciphersuite(), provider.crypto(), self.version())?;
 
-        match content.sender() {
+        #[cfg_attr(not(feature = "extensions-draft-08"), allow(unused_mut))]
+        let mut processed = match content.sender() {
             Sender::Member(_) | Sender::NewMemberProposal | Sender::NewMemberCommit => {
-                self.process_internal_authenticated_content(provider, content, credential)
+                self.process_internal_authenticated_content(provider, content, credential)?
             }
             Sender::External(_) => {
-                self.process_external_authenticated_content(provider, content, credential)
+                self.process_external_authenticated_content(provider, content, credential)?
             }
+        };
+        #[cfg(feature = "extensions-draft-08")]
+        if self.context().safe_aad_required() {
+            processed
+                .try_attach_safe_aad()
+                .map_err(|_| ProcessMessageError::MalformedSafeAad)?;
         }
+        Ok(processed)
     }
 
     /// This processing function does most of the semantic verifications.

--- a/openmls/src/group/mls_group/proposal.rs
+++ b/openmls/src/group/mls_group/proposal.rs
@@ -92,7 +92,9 @@ macro_rules! impl_propose_fun {
         ) -> Result<(MlsMessageOut, ProposalRef), ProposalError<Provider::StorageError>> {
             self.is_operational()?;
 
-            let proposal = self.$group_fun(self.framing_parameters(), value, signer)?;
+            let aad = self.outgoing_authenticated_data()?;
+            let framing_parameters = FramingParameters::new(&aad, self.outgoing_wire_format());
+            let proposal = self.$group_fun(framing_parameters, value, signer)?;
 
             let queued_proposal = QueuedProposal::from_authenticated_content(
                 self.ciphersuite(),
@@ -275,8 +277,10 @@ impl MlsGroup {
     ) -> Result<(MlsMessageOut, ProposalRef), ProposeAddMemberError<Provider::StorageError>> {
         self.is_operational()?;
 
+        let aad = self.outgoing_authenticated_data()?;
+        let framing_parameters = FramingParameters::new(&aad, self.outgoing_wire_format());
         let add_proposal = self
-            .create_add_proposal(self.framing_parameters(), key_package.clone(), signer)
+            .create_add_proposal(framing_parameters, key_package.clone(), signer)
             .map_err(|e| match e {
                 CreateAddProposalError::LibraryError(e) => e.into(),
                 CreateAddProposalError::LeafNodeValidation(error) => {
@@ -315,8 +319,10 @@ impl MlsGroup {
     {
         self.is_operational()?;
 
+        let aad = self.outgoing_authenticated_data()?;
+        let framing_parameters = FramingParameters::new(&aad, self.outgoing_wire_format());
         let remove_proposal = self
-            .create_remove_proposal(self.framing_parameters(), member, signer)
+            .create_remove_proposal(framing_parameters, member, signer)
             .map_err(|_| ProposeRemoveMemberError::UnknownMember)?;
 
         let proposal = QueuedProposal::from_authenticated_content_by_ref(
@@ -400,8 +406,10 @@ impl MlsGroup {
     ) -> Result<(MlsMessageOut, ProposalRef), ProposalError<Provider::StorageError>> {
         self.is_operational()?;
 
+        let aad = self.outgoing_authenticated_data()?;
+        let framing_parameters = FramingParameters::new(&aad, self.outgoing_wire_format());
         let proposal = self.create_group_context_ext_proposal::<Provider>(
-            self.framing_parameters(),
+            framing_parameters,
             extensions,
             signer,
         )?;
@@ -470,8 +478,10 @@ impl MlsGroup {
     ) -> Result<(MlsMessageOut, ProposalRef), ProposalError<Provider::StorageError>> {
         self.is_operational()?;
 
+        let aad = self.outgoing_authenticated_data()?;
+        let framing_parameters = FramingParameters::new(&aad, self.outgoing_wire_format());
         let proposal = self.create_app_data_update_proposal(
-            self.framing_parameters(),
+            framing_parameters,
             component_id,
             operation,
             signer,

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -157,8 +157,10 @@ impl MlsGroup {
             return Err(ProposeSelfUpdateError::UnsupportedGroupContextExtensions);
         }
 
+        let aad = self.outgoing_authenticated_data()?;
+        let framing_parameters = FramingParameters::new(&aad, self.outgoing_wire_format());
         let update_proposal =
-            self.create_update_proposal(self.framing_parameters(), own_leaf.clone(), old_signer)?;
+            self.create_update_proposal(framing_parameters, own_leaf.clone(), old_signer)?;
 
         provider
             .storage()

--- a/openmls/src/group/public_group/process.rs
+++ b/openmls/src/group/public_group/process.rs
@@ -227,14 +227,22 @@ impl PublicGroup {
         let (content, credential) =
             unverified_message.verify(self.ciphersuite(), crypto, self.version())?;
 
-        match content.sender() {
+        #[cfg_attr(not(feature = "extensions-draft-08"), allow(unused_mut))]
+        let mut processed = match content.sender() {
             Sender::Member(_) | Sender::NewMemberCommit | Sender::NewMemberProposal => {
-                self.process_internal_authenticated_content(crypto, content, credential)
+                self.process_internal_authenticated_content(crypto, content, credential)?
             }
             Sender::External(_) => {
-                self.process_external_authenticated_content(crypto, content, credential)
+                self.process_external_authenticated_content(crypto, content, credential)?
             }
+        };
+        #[cfg(feature = "extensions-draft-08")]
+        if self.group_context().safe_aad_required() {
+            processed
+                .try_attach_safe_aad()
+                .map_err(|_| PublicProcessMessageError::MalformedSafeAad)?;
         }
+        Ok(processed)
     }
 
     /// This processing function does most of the semantic verifications.
@@ -277,18 +285,26 @@ impl PublicGroup {
         let (content, credential) =
             unverified_message.verify(self.ciphersuite(), crypto, self.version())?;
 
-        match content.sender() {
+        #[cfg_attr(not(feature = "extensions-draft-08"), allow(unused_mut))]
+        let mut processed = match content.sender() {
             Sender::Member(_) | Sender::NewMemberCommit | Sender::NewMemberProposal => self
                 .process_internal_authenticated_content_with_app_data_updates(
                     crypto,
                     content,
                     credential,
                     app_data_dict_updates,
-                ),
+                )?,
             Sender::External(_) => {
-                self.process_external_authenticated_content(crypto, content, credential)
+                self.process_external_authenticated_content(crypto, content, credential)?
             }
+        };
+        #[cfg(feature = "extensions-draft-08")]
+        if self.group_context().safe_aad_required() {
+            processed
+                .try_attach_safe_aad()
+                .map_err(|_| PublicProcessMessageError::MalformedSafeAad)?;
         }
+        Ok(processed)
     }
 
     fn process_internal_authenticated_content(

--- a/openmls/src/group/tests_and_kats/tests/mod.rs
+++ b/openmls/src/group/tests_and_kats/tests/mod.rs
@@ -3,6 +3,8 @@
 mod aad;
 #[cfg(feature = "extensions-draft-08")]
 mod app_data_update_proposal_validation;
+#[cfg(feature = "extensions-draft-08")]
+mod safe_aad;
 
 mod capabilities_check;
 mod commit_validation;

--- a/openmls/src/group/tests_and_kats/tests/safe_aad.rs
+++ b/openmls/src/group/tests_and_kats/tests/safe_aad.rs
@@ -325,14 +325,19 @@ fn safe_aad_rejects_malformed_inbound() {
         .unwrap();
 
     // Decompose the original into its franken form, replace authenticated_data
-    // with bytes that can never decode as a SafeAad (a too-large VL prefix),
-    // and re-sign so the signature verification does not short-circuit before
-    // Safe AAD parsing.
+    // with bytes that decode as a SafeAad with two SafeAadItems sharing the
+    // same component_id (which the SafeAad invariant rejects), and re-sign so
+    // signature verification does not short-circuit before Safe AAD parsing.
+    //
+    // Wire bytes:
+    //   0x06                 outer Vec<SafeAadItem> length: 6 bytes follow
+    //   0x00 0x01 0x00       SafeAadItem #1: component_id=1, aad_item_data len=0
+    //   0x00 0x01 0x00       SafeAadItem #2: component_id=1 (duplicate), len=0
     let frankenstein::FrankenMlsMessage {
         version,
         body:
             frankenstein::FrankenMlsMessageBody::PublicMessage(frankenstein::FrankenPublicMessage {
-                content: mut content,
+                mut content,
                 ..
             }),
     } = frankenstein::FrankenMlsMessage::from(update_prop)
@@ -340,7 +345,7 @@ fn safe_aad_rejects_malformed_inbound() {
         panic!("expected public message");
     };
 
-    content.authenticated_data = VLBytes::from(vec![0xffu8, 0xff, 0xff, 0xff]);
+    content.authenticated_data = VLBytes::from(vec![0x06, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00]);
 
     let group_context = alice_group.export_group_context().clone();
     let secrets = alice_group.message_secrets();

--- a/openmls/src/group/tests_and_kats/tests/safe_aad.rs
+++ b/openmls/src/group/tests_and_kats/tests/safe_aad.rs
@@ -1,0 +1,376 @@
+//! Integration tests for Safe AAD framing.
+
+use tls_codec::{Deserialize as _, Serialize as _, VLBytes};
+
+use crate::{
+    component::{ComponentId, ComponentType, ComponentsList},
+    extensions::{
+        AppDataDictionary, AppDataDictionaryExtension, Extension, ExtensionType, Extensions,
+    },
+    framing::*,
+    group::{
+        tests_and_kats::utils::{generate_credential_with_key, CredentialWithKeyAndSigner},
+        *,
+    },
+    key_packages::{KeyPackage, KeyPackageBundle},
+    test_utils::frankenstein,
+    treesync::{node::leaf_node::Capabilities, LeafNodeParameters},
+};
+
+fn app_data_dictionary_with_safe_aad(required_ids: Vec<ComponentId>) -> Extensions<GroupContext> {
+    let mut dictionary = AppDataDictionary::new();
+    let safe_aad_id = ComponentId::from(ComponentType::SafeAad);
+    let body = ComponentsList::new(required_ids)
+        .tls_serialize_detached()
+        .expect("serializing ComponentsList must succeed");
+    let _ = dictionary.insert(safe_aad_id, body);
+    let extension = Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary));
+    Extensions::single(extension).expect("one app_data_dictionary extension is valid")
+}
+
+/// Build a leaf-node capability set advertising `AppDataDictionary` support,
+/// which the SafeAAD-enabled groups in these tests require for adds and
+/// self-updates to pass the GroupContext-extension capability check.
+fn safe_aad_capabilities() -> Capabilities {
+    Capabilities::new(
+        None,
+        None,
+        Some(&[ExtensionType::AppDataDictionary]),
+        None,
+        None,
+    )
+}
+
+fn key_package_with_app_data_dictionary_support<Provider: crate::storage::OpenMlsProvider>(
+    ciphersuite: openmls_traits::types::Ciphersuite,
+    provider: &Provider,
+    credential_with_keys: CredentialWithKeyAndSigner,
+) -> KeyPackageBundle {
+    KeyPackage::builder()
+        .leaf_node_capabilities(safe_aad_capabilities())
+        .build(
+            ciphersuite,
+            provider,
+            &credential_with_keys.signer,
+            credential_with_keys.credential_with_key,
+        )
+        .expect("building Bob's KeyPackage must succeed")
+}
+
+fn create_group_pair<Provider: crate::storage::OpenMlsProvider>(
+    ciphersuite: openmls_traits::types::Ciphersuite,
+    alice_provider: &Provider,
+    bob_provider: &Provider,
+    wire_format_policy: WireFormatPolicy,
+    safe_aad_required: bool,
+) -> (MlsGroup, MlsGroup, CredentialWithKeyAndSigner) {
+    let group_id = GroupId::random(alice_provider.rand());
+
+    let alice_credential = generate_credential_with_key(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+    let bob_credential = generate_credential_with_key(
+        "Bob".into(),
+        ciphersuite.signature_algorithm(),
+        bob_provider,
+    );
+
+    let bob_key_package = key_package_with_app_data_dictionary_support(
+        ciphersuite,
+        bob_provider,
+        bob_credential.clone(),
+    );
+
+    let builder = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .wire_format_policy(wire_format_policy)
+        .capabilities(safe_aad_capabilities());
+
+    let mls_group_create_config = if safe_aad_required {
+        builder
+            .with_group_context_extensions(app_data_dictionary_with_safe_aad(vec![]))
+            .build()
+    } else {
+        builder.build()
+    };
+
+    let mut alice_group = MlsGroup::new_with_group_id(
+        alice_provider,
+        &alice_credential.signer,
+        &mls_group_create_config,
+        group_id,
+        alice_credential.credential_with_key.clone(),
+    )
+    .expect("creating group");
+
+    let (_commit, welcome_out, _group_info) = alice_group
+        .add_members(
+            alice_provider,
+            &alice_credential.signer,
+            core::slice::from_ref(bob_key_package.key_package()),
+        )
+        .expect("add member");
+    alice_group
+        .merge_pending_commit(alice_provider)
+        .expect("merge pending commit");
+
+    let welcome: MlsMessageIn = welcome_out.into();
+    let welcome = welcome.into_welcome().expect("welcome message");
+    let bob_group = StagedWelcome::new_from_welcome(
+        bob_provider,
+        mls_group_create_config.join_config(),
+        welcome,
+        Some(alice_group.export_ratchet_tree().into()),
+    )
+    .expect("staged welcome")
+    .into_group(bob_provider)
+    .expect("group from staged welcome");
+
+    (alice_group, bob_group, alice_credential)
+}
+
+#[openmls_test::openmls_test]
+fn safe_aad_roundtrip_private_message() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+    let (mut alice_group, mut bob_group, alice_credential) = create_group_pair(
+        ciphersuite,
+        alice_provider,
+        bob_provider,
+        PURE_CIPHERTEXT_WIRE_FORMAT_POLICY,
+        true,
+    );
+
+    assert!(alice_group.context().safe_aad_required());
+    assert_eq!(
+        alice_group
+            .context()
+            .safe_aad_required_components()
+            .expect("required components must decode"),
+        Some(Vec::new())
+    );
+
+    let items = vec![
+        SafeAadItem::new(0, b"zero".to_vec()),
+        SafeAadItem::new(42, b"the answer".to_vec()),
+        SafeAadItem::new(u16::MAX, b"max".to_vec()),
+    ];
+    alice_group.set_safe_aad(items.clone()).unwrap();
+    let tail = b"alice-tail".to_vec();
+    alice_group.set_aad(tail.clone());
+
+    let msg: MlsMessageIn = alice_group
+        .create_message(alice_provider, &alice_credential.signer, b"hello bob")
+        .expect("create message")
+        .into();
+
+    assert!(alice_group.safe_aad_items().is_empty());
+    assert!(alice_group.aad().is_empty());
+
+    let processed = bob_group
+        .process_message(bob_provider, msg.into_protocol_message().unwrap())
+        .expect("process should succeed");
+
+    let safe_aad = processed.safe_aad().expect("Safe AAD should be present");
+    assert_eq!(safe_aad.items(), items.as_slice());
+    assert_eq!(processed.tail_aad(), tail.as_slice());
+    assert_eq!(processed.safe_aad_item(0), Some(b"zero".as_slice()));
+    assert_eq!(processed.safe_aad_item(42), Some(b"the answer".as_slice()));
+    assert_eq!(processed.safe_aad_item(u16::MAX), Some(b"max".as_slice()));
+    assert_eq!(processed.safe_aad_item(7), None);
+    assert!(processed.aad().ends_with(&tail));
+    assert!(processed.aad().len() > tail.len());
+}
+
+#[openmls_test::openmls_test]
+fn safe_aad_roundtrip_public_message_proposal() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+    let (mut alice_group, mut bob_group, alice_credential) = create_group_pair(
+        ciphersuite,
+        alice_provider,
+        bob_provider,
+        PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+        true,
+    );
+
+    let items = vec![SafeAadItem::new(5, b"proposal-aad".to_vec())];
+    alice_group.set_safe_aad(items.clone()).unwrap();
+    let tail = b"proposal-tail".to_vec();
+    alice_group.set_aad(tail.clone());
+
+    let (proposal_out, _proposal_ref) = alice_group
+        .propose_self_update(
+            alice_provider,
+            &alice_credential.signer,
+            LeafNodeParameters::default(),
+        )
+        .expect("propose self update");
+
+    let proposal_in: MlsMessageIn = proposal_out.into();
+    let processed = bob_group
+        .process_message(bob_provider, proposal_in.into_protocol_message().unwrap())
+        .expect("process proposal");
+
+    let safe_aad = processed.safe_aad().expect("Safe AAD present");
+    assert_eq!(safe_aad.items(), items.as_slice());
+    assert_eq!(processed.tail_aad(), tail.as_slice());
+}
+
+#[openmls_test::openmls_test]
+fn safe_aad_absent_when_not_required() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+    let (mut alice_group, mut bob_group, alice_credential) = create_group_pair(
+        ciphersuite,
+        alice_provider,
+        bob_provider,
+        PURE_CIPHERTEXT_WIRE_FORMAT_POLICY,
+        false,
+    );
+
+    assert!(!alice_group.context().safe_aad_required());
+    assert_eq!(
+        alice_group
+            .context()
+            .safe_aad_required_components()
+            .expect("required components must decode"),
+        None
+    );
+
+    let payload = b"caller-aad-only".to_vec();
+    alice_group.set_aad(payload.clone());
+    let msg: MlsMessageIn = alice_group
+        .create_message(alice_provider, &alice_credential.signer, b"hello")
+        .expect("create")
+        .into();
+    let processed = bob_group
+        .process_message(bob_provider, msg.into_protocol_message().unwrap())
+        .expect("process");
+
+    assert!(processed.safe_aad().is_none());
+    assert_eq!(processed.tail_aad(), payload.as_slice());
+    assert_eq!(processed.aad(), payload.as_slice());
+}
+
+#[openmls_test::openmls_test]
+fn safe_aad_set_rejects_invalid_items() {
+    let alice_provider = &Provider::default();
+    let group_id = GroupId::random(alice_provider.rand());
+    let alice_credential = generate_credential_with_key(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    let mls_group_create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .capabilities(safe_aad_capabilities())
+        .with_group_context_extensions(app_data_dictionary_with_safe_aad(vec![]))
+        .build();
+
+    let mut alice_group = MlsGroup::new_with_group_id(
+        alice_provider,
+        &alice_credential.signer,
+        &mls_group_create_config,
+        group_id,
+        alice_credential.credential_with_key.clone(),
+    )
+    .unwrap();
+
+    let err = alice_group
+        .set_safe_aad(vec![
+            SafeAadItem::new(5, b"a".to_vec()),
+            SafeAadItem::new(2, b"b".to_vec()),
+        ])
+        .unwrap_err();
+    assert_eq!(err, SafeAadError::ItemsNotSortedAscending);
+
+    let err = alice_group
+        .set_safe_aad(vec![
+            SafeAadItem::new(4, b"a".to_vec()),
+            SafeAadItem::new(4, b"b".to_vec()),
+        ])
+        .unwrap_err();
+    assert_eq!(err, SafeAadError::DuplicateComponentId(4));
+
+    assert!(alice_group.safe_aad_items().is_empty());
+}
+
+#[openmls_test::openmls_test]
+fn safe_aad_rejects_malformed_inbound() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+    let (mut alice_group, mut bob_group, alice_credential) = create_group_pair(
+        ciphersuite,
+        alice_provider,
+        bob_provider,
+        PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+        true,
+    );
+
+    let (update_prop, _proposal_ref) = alice_group
+        .propose_self_update(
+            alice_provider,
+            &alice_credential.signer,
+            LeafNodeParameters::default(),
+        )
+        .unwrap();
+    // Discard the pending proposal: we won't be sending the original.
+    alice_group
+        .clear_pending_proposals(alice_provider.storage())
+        .unwrap();
+
+    // Decompose the original into its franken form, replace authenticated_data
+    // with bytes that can never decode as a SafeAad (a too-large VL prefix),
+    // and re-sign so the signature verification does not short-circuit before
+    // Safe AAD parsing.
+    let frankenstein::FrankenMlsMessage {
+        version,
+        body:
+            frankenstein::FrankenMlsMessageBody::PublicMessage(frankenstein::FrankenPublicMessage {
+                content: mut content,
+                ..
+            }),
+    } = frankenstein::FrankenMlsMessage::from(update_prop)
+    else {
+        panic!("expected public message");
+    };
+
+    content.authenticated_data = VLBytes::from(vec![0xffu8, 0xff, 0xff, 0xff]);
+
+    let group_context = alice_group.export_group_context().clone();
+    let secrets = alice_group.message_secrets();
+    let membership_key = secrets.membership_key().as_slice();
+
+    let franken_message = frankenstein::FrankenMlsMessage {
+        version,
+        body: frankenstein::FrankenMlsMessageBody::PublicMessage(
+            frankenstein::FrankenPublicMessage::auth(
+                alice_provider,
+                ciphersuite,
+                &alice_credential.signer,
+                content,
+                Some(&group_context.into()),
+                Some(membership_key),
+                None,
+            ),
+        ),
+    };
+
+    let tampered =
+        MlsMessageIn::tls_deserialize_exact(franken_message.tls_serialize_detached().unwrap())
+            .unwrap();
+
+    let err = bob_group
+        .process_message(bob_provider, tampered.into_protocol_message().unwrap())
+        .expect_err("malformed SafeAad must be rejected");
+
+    assert!(
+        matches!(err, ProcessMessageError::MalformedSafeAad),
+        "unexpected error: {err:#?}"
+    );
+}


### PR DESCRIPTION
This PR implements the Safe AAD functionality as defined in the extensions draft: https://datatracker.ietf.org/doc/draft-ietf-mls-extensions/09/

This PR should be reviewable commit-by-commit.