### PR TITLE
Expose public information of PrivateMessage and PublicMessage through getters

### DIFF
--- a/openmls/src/framing/private_message.rs
+++ b/openmls/src/framing/private_message.rs
@@ -58,6 +58,21 @@ pub(crate) struct MlsMessageHeader {
 }
 
 impl PrivateMessage {
+    /// Returns the [`GroupId`] of the group this message was sent in
+    pub fn group_id(&self) -> &GroupId {
+        &self.group_id
+    }
+
+    /// Returns the [`GroupEpoch`] of the group this message was sent in
+    pub fn epoch(&self) -> GroupEpoch {
+        self.epoch
+    }
+
+    /// Returns the [`ContentType`] of the payload of this message
+    pub fn content_type(&self) -> ContentType {
+        self.content_type
+    }
+
     #[cfg(test)]
     pub(crate) fn new(
         group_id: GroupId,
@@ -269,11 +284,6 @@ impl PrivateMessage {
             generation,
             private_message,
         })
-    }
-
-    /// Returns the epoch of the message.
-    pub fn epoch(&self) -> GroupEpoch {
-        self.epoch
     }
 
     /// Returns `true` if this is a handshake message and `false` otherwise.

--- a/openmls/src/framing/public_message.rs
+++ b/openmls/src/framing/public_message.rs
@@ -116,6 +116,11 @@ impl PublicMessage {
         self.content.body.content_type()
     }
 
+    /// Returns the [`GroupId`] of the group the message was sent in.
+    pub fn group_id(&self) -> &GroupId {
+        &self.content.group_id
+    }
+
     /// Returns the epoch of the message.
     pub fn epoch(&self) -> GroupEpoch {
         self.content.epoch


### PR DESCRIPTION
PrivateMessage and  PublicMessage have some public fields that contain metadata about the message. This PR adds more getters for them.