### PR TITLE
feat: allow to bypass KeyPackage/LeafNode validation

### DIFF
--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -135,6 +135,9 @@ extensions-draft-08-test-dependencies = [
 # enable randomness source
 fork-resolution = []
 
+# Enable unchecked conversions for types that need to be verified or validated.
+unchecked-conversions = []
+
 [dev-dependencies]
 criterion = { version = "^0.8", default-features = false }       # need to disable default features for wasm
 hex = { version = "0.4", features = ["serde"] }

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -525,6 +525,21 @@ where
     }
 }
 
+impl Extensions<AnyObject> {
+    /// Assume that the extensions contain the given extension type.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that the extensions are of the correct type.
+    #[cfg(feature = "unchecked-conversions")]
+    pub fn into_unchecked<T>(self) -> Extensions<T> {
+        Extensions {
+            unique: self.unique,
+            _object: PhantomData,
+        }
+    }
+}
+
 /// Can be implemented by a type to validate extensions.
 pub trait ExtensionValidator {
     /// The error returned by the validator

--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -215,13 +215,14 @@ impl KeyPackageIn {
     /// # Safety
     ///
     /// The caller must guarantee that the key package is verified.
+    #[cfg(feature = "unchecked-conversions")]
     pub fn into_unchecked(self) -> Result<KeyPackage, KeyPackageVerifyError> {
         let payload = KeyPackageTbs {
             protocol_version: self.payload.protocol_version,
             ciphersuite: self.payload.ciphersuite,
             init_key: self.payload.init_key,
             leaf_node: self.payload.leaf_node.into_unchecked(),
-            extensions: self.payload.extensions.try_into()?,
+            extensions: self.payload.extensions.into_unchecked(),
         };
         Ok(KeyPackage {
             payload,

--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -212,6 +212,8 @@ impl KeyPackageIn {
 
     /// Assume that the signature is valid and return the [`KeyPackage`].
     ///
+    /// # Safety
+    ///
     /// The caller must guarantee that the key package is verified.
     pub fn into_unchecked(self) -> Result<KeyPackage, KeyPackageVerifyError> {
         let payload = KeyPackageTbs {

--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -209,6 +209,24 @@ impl KeyPackageIn {
     pub(crate) fn version_is_supported(&self, protocol_version: ProtocolVersion) -> bool {
         self.payload.protocol_version == protocol_version
     }
+
+    /// Assume that the signature is valid and return the [`KeyPackage`].
+    ///
+    /// Use with caution, the client must guarantee that the key package is verified.
+    pub fn unwrap_verified(self) -> Result<KeyPackage, KeyPackageVerifyError> {
+        let payload = KeyPackageTbs {
+            protocol_version: self.payload.protocol_version,
+            ciphersuite: self.payload.ciphersuite,
+            init_key: self.payload.init_key,
+            leaf_node: self.payload.leaf_node.unwrap_verified(),
+            extensions: self.payload.extensions.try_into()?,
+        };
+        Ok(KeyPackage {
+            payload,
+            signature: self.signature,
+            serialized_payload: None,
+        })
+    }
 }
 
 #[cfg(any(feature = "test-utils", test))]

--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -212,13 +212,13 @@ impl KeyPackageIn {
 
     /// Assume that the signature is valid and return the [`KeyPackage`].
     ///
-    /// Use with caution, the client must guarantee that the key package is verified.
-    pub fn unwrap_verified(self) -> Result<KeyPackage, KeyPackageVerifyError> {
+    /// The caller must guarantee that the key package is verified.
+    pub fn into_unchecked(self) -> Result<KeyPackage, KeyPackageVerifyError> {
         let payload = KeyPackageTbs {
             protocol_version: self.payload.protocol_version,
             ciphersuite: self.payload.ciphersuite,
             init_key: self.payload.init_key,
-            leaf_node: self.payload.leaf_node.unwrap_verified(),
+            leaf_node: self.payload.leaf_node.into_unchecked(),
             extensions: self.payload.extensions.try_into()?,
         };
         Ok(KeyPackage {

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -594,6 +594,11 @@ impl KeyPackageBundle {
         &self.key_package
     }
 
+    /// Extract the key package from the bundle.
+    pub fn into_key_package(self) -> KeyPackage {
+        self.key_package
+    }
+
     /// Get a reference to the private init key.
     pub fn init_private_key(&self) -> &HpkePrivateKey {
         &self.private_init_key

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -791,6 +791,16 @@ impl LeafNodeIn {
     pub fn credential(&self) -> &Credential {
         &self.payload.credential
     }
+
+    /// Assume that signature is valid and return the corresponding [`LeafNode`].
+    ///
+    /// Use with caution, the client must guarantee that the leaf node is verified.
+    pub fn unwrap_verified(self) -> LeafNode {
+        LeafNode {
+            payload: self.payload,
+            signature: self.signature,
+        }
+    }
 }
 
 impl From<LeafNode> for LeafNodeIn {

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -797,6 +797,7 @@ impl LeafNodeIn {
     /// # Safety
     ///
     /// The caller must guarantee that the leaf node is verified.
+    #[cfg(feature = "unchecked-conversions")]
     pub fn into_unchecked(self) -> LeafNode {
         LeafNode {
             payload: self.payload,

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -794,8 +794,8 @@ impl LeafNodeIn {
 
     /// Assume that signature is valid and return the corresponding [`LeafNode`].
     ///
-    /// Use with caution, the client must guarantee that the leaf node is verified.
-    pub fn unwrap_verified(self) -> LeafNode {
+    /// The caller must guarantee that the leaf node is verified.
+    pub fn into_unchecked(self) -> LeafNode {
         LeafNode {
             payload: self.payload,
             signature: self.signature,

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -794,6 +794,8 @@ impl LeafNodeIn {
 
     /// Assume that signature is valid and return the corresponding [`LeafNode`].
     ///
+    /// # Safety
+    ///
     /// The caller must guarantee that the leaf node is verified.
     pub fn into_unchecked(self) -> LeafNode {
         LeafNode {


### PR DESCRIPTION
Add functions that allow unchecked conversion of `KeyPackageIn`, 
`LeafNodeIn`, `Extensions` into already verified types. Intended 
for callers that have verified the input through another path.

This feature is behind a feature flag `unchecked-conversions`.