### PR TITLE
feat: P-384, ML-DSA and general PQ ciphersuite support for RustCrypto provider

### DIFF
--- a/.github/workflows/build_test_workspace.yml
+++ b/.github/workflows/build_test_workspace.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Test workspace
         run: |
           cargo test --workspace --all-targets --exclude=openmls --exclude openmls-fuzz
-      - name: Build workspace with `extensions-draft-08` feature
+      - name: Build workspace with experimental features
         run: |
-          cargo build --workspace -F extensions-draft-08 --all-targets --exclude openmls-fuzz
-      - name: Test workspace with `extensions-draft-08` feature
+          cargo build --workspace -F extensions-draft-08,draft-ietf-mls-pq-ciphersuites --all-targets --exclude openmls-fuzz
+      - name: Test workspace with experimental features
         run: |
-          cargo test --workspace -F extensions-draft-08 --all-targets --exclude=openmls --exclude openmls-fuzz
+          cargo test --workspace -F extensions-draft-08,draft-ietf-mls-pq-ciphersuites --all-targets --exclude=openmls --exclude openmls-fuzz

--- a/.github/workflows/tests_nightly.yml
+++ b/.github/workflows/tests_nightly.yml
@@ -30,6 +30,7 @@ jobs:
           - { name: base, arg: "" }
           - { name: fork-resolution, arg: "-F fork-resolution" }
           - { name: extensions-draft-08, arg: "-F extensions-draft-08,extensions-draft-08-test-dependencies" }
+          - { name: pq-ciphersuites, arg: "-F draft-ietf-mls-pq-ciphersuites" }
     runs-on: ubuntu-latest
     name: full matrix (${{ matrix.mode.name }}/${{ matrix.features.name }})
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,11 +1492,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2833,6 +2835,7 @@ dependencies = [
  "flate2",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "hex",
  "indicatif",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,18 +237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,15 +1582,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1618,11 +1597,11 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2543,9 +2522,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3768,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,7 +967,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -986,10 +1000,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
+ "subtle",
 ]
 
 [[package]]
@@ -1011,6 +1039,16 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -1107,12 +1145,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1121,8 +1159,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1131,7 +1169,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -1160,7 +1198,7 @@ dependencies = [
  "group",
  "hkdf 0.12.4",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1244,6 +1282,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1497,6 +1541,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1512,11 +1565,11 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1670,6 +1723,7 @@ dependencies = [
  "hkdf 0.12.4",
  "hpke-rs-crypto",
  "k256",
+ "ml-kem",
  "p256",
  "p384",
  "rand 0.8.5",
@@ -1678,7 +1732,8 @@ dependencies = [
  "rand_core 0.6.4",
  "sha2 0.10.9",
  "subtle",
- "x25519-dalek",
+ "x-wing",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -1750,6 +1805,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
+ "ctutils",
  "typenum",
 ]
 
@@ -2131,6 +2187,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,9 +2476,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.35.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2519,6 +2595,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-dsa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67011732d2747886c7b64f2eceef9d6eb2645a0aa528a26828b949ece257285"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "shake",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "rand_core 0.10.1",
+ "sha3",
+]
+
+[[package]]
 name = "mls-ds"
 version = "0.1.0"
 dependencies = [
@@ -2550,6 +2655,17 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -2710,8 +2826,10 @@ name = "openmls_basic_credential"
 version = "0.5.0"
 dependencies = [
  "ed25519-dalek",
+ "ml-dsa",
  "openmls_traits",
  "p256",
+ "p384",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -2765,10 +2883,13 @@ dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
+ "ml-dsa",
  "openmls_memory_storage",
  "openmls_traits",
  "p256",
+ "p384",
  "rand_chacha 0.3.1",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.11.0",
@@ -2837,8 +2958,10 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2938,8 +3061,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3540,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.37.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -3704,9 +3837,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -3848,6 +3981,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.2",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +4034,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3933,8 +4097,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"
@@ -5209,15 +5389,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x-wing"
+version = "0.1.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d0d5f4d1f26b9b9e7477af1d3bef960e1d1fb64edab7912fde472a8a8432e"
+dependencies = [
+ "kem",
+ "ml-kem",
+ "rand_core 0.10.1",
+ "sha3",
+ "x25519-dalek 3.0.0-pre.6",
+]
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d5d6ff67acd3945b933e592bfa7143db4fcbb2f871754b6b9fbd7847fc5aea"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "rand_core 0.10.1",
 ]
 
 [[package]]

--- a/basic_credential/Cargo.toml
+++ b/basic_credential/Cargo.toml
@@ -17,12 +17,17 @@ serde = "1.0"
 # Rust Crypto
 ed25519-dalek = { version = "2.0", features = ["rand_core"] }
 p256 = { version = "0.13" }
+p384 = { version = "0.13" }
+ml-dsa = "0.1.0"
 rand_core = { version = "0.6", features = ["getrandom"] }
 zeroize = "1.8.2"
 
 [features]
-clonable = []   # Make the keys clonable
+clonable = [] # Make the keys clonable
 test-utils = [] # Only use for tests!
+draft-ietf-mls-pq-ciphersuites = [
+    "openmls_traits/draft-ietf-mls-pq-ciphersuites",
+]
 
 [dev-dependencies]
 serde_json = "1.0.149"

--- a/basic_credential/src/lib.rs
+++ b/basic_credential/src/lib.rs
@@ -73,11 +73,41 @@ impl Signer for SignatureKeyPair {
                 let signature: Signature = k.sign(payload);
                 Ok(signature.to_der().to_bytes().into())
             }
+            SignatureScheme::ECDSA_SECP384R1_SHA384 => {
+                let k = p384::ecdsa::SigningKey::from_bytes(self.private.as_slice().into())
+                    .map_err(|_| SignerError::SigningError)?;
+                let signature: p384::ecdsa::Signature = k.sign(payload);
+                Ok(signature.to_der().to_bytes().into())
+            }
             SignatureScheme::ED25519 => {
                 let k = ed25519_dalek::SigningKey::try_from(self.private.as_slice())
                     .map_err(|_| SignerError::SigningError)?;
                 let signature = k.sign(payload);
                 Ok(signature.to_bytes().into())
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            SignatureScheme::MLDSA65 => {
+                use ml_dsa::Signer;
+                let seed: &ml_dsa::Seed = self
+                    .private
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| SignerError::SigningError)?;
+                let k = ml_dsa::SigningKey::<ml_dsa::MlDsa65>::from_seed(seed);
+                let signature = k.sign(payload);
+                Ok(signature.encode().to_vec())
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            SignatureScheme::MLDSA87 => {
+                use ml_dsa::Signer;
+                let seed: &ml_dsa::Seed = self
+                    .private
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| SignerError::SigningError)?;
+                let k = ml_dsa::SigningKey::<ml_dsa::MlDsa87>::from_seed(seed);
+                let signature = k.sign(payload);
+                Ok(signature.encode().to_vec())
             }
             _ => Err(SignerError::SigningError),
         }
@@ -111,12 +141,33 @@ impl SignatureKeyPair {
                 key_bytes.zeroize();
                 (private, pk)
             }
+            SignatureScheme::ECDSA_SECP384R1_SHA384 => {
+                let k = p384::ecdsa::SigningKey::random(&mut OsRng);
+                let pk = k.verifying_key().to_encoded_point(false).as_bytes().into();
+                (k.to_bytes().as_slice().into(), pk)
+            }
             SignatureScheme::ED25519 => {
                 let sk = ed25519_dalek::SigningKey::generate(&mut OsRng);
                 let pk = sk.verifying_key().to_bytes().into();
                 // Use as_bytes() to avoid an unzeroed stack copy from to_bytes().
                 // sk itself implements ZeroizeOnDrop.
                 (sk.as_bytes().as_slice().into(), pk)
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            SignatureScheme::MLDSA65 => {
+                use ml_dsa::{Generate, Keypair};
+                let sk = ml_dsa::SigningKey::<ml_dsa::MlDsa65>::generate();
+                let pk = sk.verifying_key().encode().to_vec();
+                let sk = sk.to_seed().to_vec();
+                (sk.into(), pk)
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            SignatureScheme::MLDSA87 => {
+                use ml_dsa::{Generate, Keypair};
+                let sk = ml_dsa::SigningKey::<ml_dsa::MlDsa87>::generate();
+                let pk = sk.verifying_key().encode().to_vec();
+                let sk = sk.to_seed().to_vec();
+                (sk.into(), pk)
             }
             _ => return Err(CryptoError::UnsupportedSignatureScheme),
         };

--- a/libcrux_crypto/Cargo.toml
+++ b/libcrux_crypto/Cargo.toml
@@ -33,3 +33,7 @@ extensions-draft-08 = [
     "openmls_traits/extensions-draft-08",
     "openmls_memory_storage/extensions-draft-08",
 ]
+draft-ietf-mls-pq-ciphersuites = [
+    "openmls_traits/draft-ietf-mls-pq-ciphersuites",
+    "openmls_memory_storage/draft-ietf-mls-pq-ciphersuites",
+]

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -57,6 +57,7 @@ impl OpenMlsCrypto for CryptoProvider {
         vec![
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
             Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
             Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519,
             // TODO: enable
             //Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
@@ -399,7 +400,12 @@ fn hpke_kem(kem: HpkeKemType) -> hpke_rs_crypto::types::KemAlgorithm {
         HpkeKemType::DhKemP521 => hpke_rs_crypto::types::KemAlgorithm::DhKemP521,
         HpkeKemType::DhKem25519 => hpke_rs_crypto::types::KemAlgorithm::DhKem25519,
         HpkeKemType::DhKem448 => hpke_rs_crypto::types::KemAlgorithm::DhKem448,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
         HpkeKemType::XWingKemDraft6 => hpke_rs_crypto::types::KemAlgorithm::XWingDraft06,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        HpkeKemType::MlKem768 => hpke_rs_crypto::types::KemAlgorithm::MlKem768,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        HpkeKemType::MlKem1024 => hpke_rs_crypto::types::KemAlgorithm::MlKem1024,
     }
 }
 

--- a/memory_storage/Cargo.toml
+++ b/memory_storage/Cargo.toml
@@ -20,10 +20,16 @@ hex = { version = "0.4", features = ["serde"], optional = true }
 base64 = { version = "0.22", optional = true }
 
 [features]
-test-utils = ["hex", "openmls_traits/test-utils"]            # Enable test utilites
+test-utils = ["hex", "openmls_traits/test-utils"] # Enable test utilites
 persistence = ["base64"]
 extensions-draft-08 = ["openmls_traits/extensions-draft-08"]
-virtual-clients-draft = ["extensions-draft-08", "openmls_traits/virtual-clients-draft"]
+draft-ietf-mls-pq-ciphersuites = [
+    "openmls_traits/draft-ietf-mls-pq-ciphersuites",
+]
+virtual-clients-draft = [
+    "extensions-draft-08",
+    "openmls_traits/virtual-clients-draft",
+]
 
 [dev-dependencies]
 openmls_memory_storage = { path = ".", features = ["test-utils"] }

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -40,6 +40,8 @@ itertools = { version = "0.14", optional = true }
 wasm-bindgen-test = { version = "0.3.50", optional = true }
 getrandom = { version = "0.3.4", optional = true }
 getrandom_old = { package = "getrandom", version = "0.2.15", optional = true }
+# transitive depedency; only present to enable its wasm backend
+getrandom_0_4 = { package = "getrandom", version = "0.4", optional = true }
 web-time = { version = "1.1", optional = true, features = ["serde"] }
 once_cell = { version = "1.19.0", optional = true }
 zeroize = "1.8.1"
@@ -81,10 +83,12 @@ crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content
 js = [
     "dep:getrandom",
+    "dep:getrandom_0_4",
     "dep:web-time",
 
     # enable randomness source
     "getrandom/wasm_js",
+    "getrandom_0_4/wasm_js",
 ]
 
 js-test = [

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -120,6 +120,14 @@ extensions-draft-08-test-dependencies = [
     "openmls_libcrux_crypto?/extensions-draft-08",
     "openmls_memory_storage?/extensions-draft-08",
 ]
+draft-ietf-mls-pq-ciphersuites = [
+    "openmls_traits/draft-ietf-mls-pq-ciphersuites",
+    "openmls_memory_storage?/draft-ietf-mls-pq-ciphersuites",
+    "openmls_sqlite_storage?/draft-ietf-mls-pq-ciphersuites",
+    "openmls_libcrux_crypto?/draft-ietf-mls-pq-ciphersuites",
+    "openmls_rust_crypto?/draft-ietf-mls-pq-ciphersuites",
+    "openmls_basic_credential?/draft-ietf-mls-pq-ciphersuites",
+]
 # experimental feature implementing the virtual-clients draft
 # enable randomness source
 fork-resolution = []

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -127,6 +127,7 @@ draft-ietf-mls-pq-ciphersuites = [
     "openmls_libcrux_crypto?/draft-ietf-mls-pq-ciphersuites",
     "openmls_rust_crypto?/draft-ietf-mls-pq-ciphersuites",
     "openmls_basic_credential?/draft-ietf-mls-pq-ciphersuites",
+    "openmls_test?/draft-ietf-mls-pq-ciphersuites",
 ]
 # experimental feature implementing the virtual-clients draft
 # enable randomness source

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -101,7 +101,7 @@ impl Welcome {
     }
 
     /// Returns a reference to the ciphersuite in this Welcome message.
-    pub(crate) fn ciphersuite(&self) -> Ciphersuite {
+    pub fn ciphersuite(&self) -> Ciphersuite {
         self.cipher_suite
     }
 

--- a/openmls/src/schedule/pprf/mod.rs
+++ b/openmls/src/schedule/pprf/mod.rs
@@ -281,7 +281,10 @@ mod tests {
 
         let result = pprf.evaluate(crypto, ciphersuite, &index);
         assert!(result.is_ok());
-        assert_eq!(result.as_ref().unwrap().as_slice().len(), 32);
+        assert_eq!(
+            result.as_ref().unwrap().as_slice().len(),
+            ciphersuite.hash_length()
+        );
     }
 
     #[openmls_test]

--- a/openmls/src/storage/kat_storage_stability.rs
+++ b/openmls/src/storage/kat_storage_stability.rs
@@ -441,10 +441,17 @@ fn test() {
         base64::engine::GeneralPurposeConfig::new(),
     );
 
-    // load data
+    // load data — skip unknown ciphersuite keys (e.g. PQ suites when that feature is off)
     let mut data: HashMap<Ciphersuite, KatData> = {
         let file = std::fs::File::open("test_vectors/storage-stability.json").unwrap();
-        serde_json::from_reader(file).unwrap()
+        let raw: HashMap<String, KatData> = serde_json::from_reader(file).unwrap();
+        raw.into_iter()
+            .filter_map(|(k, v)| {
+                serde_json::from_value::<Ciphersuite>(serde_json::Value::String(k))
+                    .ok()
+                    .map(|cs| (cs, v))
+            })
+            .collect()
     };
 
     let KatData { group_id, storages } = data.remove(&ciphersuite).unwrap();

--- a/openmls/src/treesync/node/leaf_node/capabilities.rs
+++ b/openmls/src/treesync/node/leaf_node/capabilities.rs
@@ -388,7 +388,22 @@ pub(super) fn default_ciphersuites() -> Vec<Ciphersuite> {
         Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
         Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
         Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
         Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        Ciphersuite::MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87,
     ]
 }
 

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -14,8 +14,9 @@ openmls_traits = { workspace = true }
 openmls_memory_storage = { workspace = true }
 
 hpke = { version = "0.6.1", package = "hpke-rs", default-features = false, features = [
-    "hazmat",
-    "serialization",
+  "hazmat",
+  "serialization",
+  "experimental",
 ] }
 # Rust Crypto dependencies
 sha2 = { version = "0.11" }
@@ -24,14 +25,20 @@ chacha20poly1305 = { version = "0.10" }
 hmac = { version = "0.13" }
 ed25519-dalek = { version = "2.0", features = ["rand_core"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
+rand_core_0_10 = { package = "rand_core", version = "0.10" }
 p256 = { version = "0.13" }
+p384 = { version = "0.13" }
 hkdf = { version = "0.13" }
 rand_chacha = { version = "0.3" }
 hpke-rs-crypto = { version = "0.6.1" }
-hpke-rs-rust-crypto = { version = "0.6.1" }
+hpke-rs-rust-crypto = { version = "0.6.1", features = ["experimental"] }
 tls_codec = { workspace = true }
 thiserror = "2.0"
 serde = { version = "^1.0", features = ["derive"] }
+ml-dsa = "0.1.0"
 
 [features]
 test-utils = ["openmls_memory_storage/test-utils"]
+draft-ietf-mls-pq-ciphersuites = [
+  "openmls_traits/draft-ietf-mls-pq-ciphersuites",
+]

--- a/openmls_rust_crypto/src/lib.rs
+++ b/openmls_rust_crypto/src/lib.rs
@@ -10,6 +10,8 @@ mod provider;
 pub use provider::*;
 
 mod hmac;
+#[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+mod rand_shim;
 
 #[derive(Default, Debug)]
 #[cfg_attr(feature = "test-utils", derive(Clone))]

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -58,9 +58,12 @@ fn kem_mode(kem: HpkeKemType) -> hpke_types::KemAlgorithm {
         HpkeKemType::DhKemP521 => hpke_types::KemAlgorithm::DhKemP521,
         HpkeKemType::DhKem25519 => hpke_types::KemAlgorithm::DhKem25519,
         HpkeKemType::DhKem448 => hpke_types::KemAlgorithm::DhKem448,
-        HpkeKemType::XWingKemDraft6 => {
-            unimplemented!("XWingKemDraft6 is not supported by the RustCrypto provider.")
-        }
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        HpkeKemType::XWingKemDraft6 => hpke_types::KemAlgorithm::XWingDraft06,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        HpkeKemType::MlKem768 => hpke_types::KemAlgorithm::MlKem768,
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        HpkeKemType::MlKem1024 => hpke_types::KemAlgorithm::MlKem1024,
     }
 }
 
@@ -89,6 +92,13 @@ impl OpenMlsCrypto for RustCrypto {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
             | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
             | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => Ok(()),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256
+            | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87 => Ok(()),
             _ => Err(CryptoError::UnsupportedCiphersuite),
         }
     }
@@ -98,6 +108,20 @@ impl OpenMlsCrypto for RustCrypto {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
             Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
             Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87,
         ]
     }
 
@@ -264,6 +288,49 @@ impl OpenMlsCrypto for RustCrypto {
                 let pk = sk.verifying_key().to_bytes().into();
                 Ok((sk.to_bytes().into(), pk))
             }
+            SignatureScheme::ECDSA_SECP384R1_SHA384 => {
+                let mut rng = self
+                    .rng
+                    .write()
+                    .map_err(|_| CryptoError::InsufficientRandomness)?;
+                let k = p384::ecdsa::SigningKey::random(&mut *rng);
+                let pk = k.verifying_key().to_encoded_point(false).as_bytes().into();
+                Ok((k.to_bytes().as_slice().into(), pk))
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            SignatureScheme::MLDSA65 => {
+                use crate::rand_shim::RandCore0_10;
+                use ml_dsa::{Generate, Keypair};
+                let sk = {
+                    let mut rng = self
+                        .rng
+                        .write()
+                        .map_err(|_| CryptoError::InsufficientRandomness)?;
+                    ml_dsa::SigningKey::<ml_dsa::MlDsa65>::generate_from_rng(&mut RandCore0_10(
+                        &mut *rng,
+                    ))
+                };
+                let pk = sk.verifying_key().encode().to_vec();
+                let sk = sk.to_seed().to_vec();
+                Ok((sk, pk))
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            SignatureScheme::MLDSA87 => {
+                use crate::rand_shim::RandCore0_10;
+                use ml_dsa::{Generate, Keypair};
+                let sk = {
+                    let mut rng = self
+                        .rng
+                        .write()
+                        .map_err(|_| CryptoError::InsufficientRandomness)?;
+                    ml_dsa::SigningKey::<ml_dsa::MlDsa87>::generate_from_rng(&mut RandCore0_10(
+                        &mut *rng,
+                    ))
+                };
+                let pk = sk.verifying_key().encode().to_vec();
+                let sk = sk.to_seed().to_vec();
+                Ok((sk, pk))
+            }
             _ => Err(CryptoError::UnsupportedSignatureScheme),
         }
     }
@@ -298,6 +365,47 @@ impl OpenMlsCrypto for RustCrypto {
                 k.verify_strict(data, &ed25519_dalek::Signature::from(sig))
                     .map_err(|_| CryptoError::InvalidSignature)
             }
+            SignatureScheme::ECDSA_SECP384R1_SHA384 => {
+                let k = p384::ecdsa::VerifyingKey::from_encoded_point(
+                    &p384::EncodedPoint::from_bytes(pk)
+                        .map_err(|_| CryptoError::CryptoLibraryError)?,
+                )
+                .map_err(|_| CryptoError::CryptoLibraryError)?;
+                k.verify(
+                    data,
+                    &p384::ecdsa::Signature::from_der(signature)
+                        .map_err(|_| CryptoError::InvalidSignature)?,
+                )
+                .map_err(|_| CryptoError::InvalidSignature)
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            SignatureScheme::MLDSA65 => {
+                use ml_dsa::Verifier;
+                let encoded_key: &ml_dsa::EncodedVerifyingKey<ml_dsa::MlDsa65> =
+                    pk.try_into().map_err(|_| CryptoError::InvalidLength)?;
+                let encoded_signature: &ml_dsa::EncodedSignature<ml_dsa::MlDsa65> = signature
+                    .try_into()
+                    .map_err(|_| CryptoError::InvalidLength)?;
+                let key = ml_dsa::VerifyingKey::<ml_dsa::MlDsa65>::decode(encoded_key);
+                let signature = ml_dsa::Signature::<ml_dsa::MlDsa65>::decode(encoded_signature)
+                    .ok_or(CryptoError::InvalidSignature)?;
+                key.verify(data, &signature)
+                    .map_err(|_| CryptoError::InvalidSignature)
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            SignatureScheme::MLDSA87 => {
+                use ml_dsa::Verifier;
+                let encoded_key: &ml_dsa::EncodedVerifyingKey<ml_dsa::MlDsa87> =
+                    pk.try_into().map_err(|_| CryptoError::InvalidLength)?;
+                let encoded_signature: &ml_dsa::EncodedSignature<ml_dsa::MlDsa87> = signature
+                    .try_into()
+                    .map_err(|_| CryptoError::InvalidLength)?;
+                let key = ml_dsa::VerifyingKey::<ml_dsa::MlDsa87>::decode(encoded_key);
+                let signature = ml_dsa::Signature::<ml_dsa::MlDsa87>::decode(encoded_signature)
+                    .ok_or(CryptoError::InvalidSignature)?;
+                key.verify(data, &signature)
+                    .map_err(|_| CryptoError::InvalidSignature)
+            }
             _ => Err(CryptoError::UnsupportedSignatureScheme),
         }
     }
@@ -315,11 +423,33 @@ impl OpenMlsCrypto for RustCrypto {
                 let signature: Signature = k.sign(data);
                 Ok(signature.to_der().to_bytes().into())
             }
+            SignatureScheme::ECDSA_SECP384R1_SHA384 => {
+                let k = p384::ecdsa::SigningKey::from_bytes(key.into())
+                    .map_err(|_| CryptoError::CryptoLibraryError)?;
+                let signature: p384::ecdsa::Signature = k.sign(data);
+                Ok(signature.to_der().to_bytes().into())
+            }
             SignatureScheme::ED25519 => {
                 let k = ed25519_dalek::SigningKey::try_from(key)
                     .map_err(|_| CryptoError::CryptoLibraryError)?;
                 let signature = k.sign(data);
                 Ok(signature.to_bytes().into())
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            SignatureScheme::MLDSA65 => {
+                use ml_dsa::Signer;
+                let seed: &ml_dsa::Seed = key.try_into().map_err(|_| CryptoError::InvalidLength)?;
+                let k = ml_dsa::SigningKey::<ml_dsa::MlDsa65>::from_seed(seed);
+                let signature = k.sign(data);
+                Ok(signature.encode().to_vec())
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            SignatureScheme::MLDSA87 => {
+                use ml_dsa::Signer;
+                let seed: &ml_dsa::Seed = key.try_into().map_err(|_| CryptoError::InvalidLength)?;
+                let k = ml_dsa::SigningKey::<ml_dsa::MlDsa87>::from_seed(seed);
+                let signature = k.sign(data);
+                Ok(signature.encode().to_vec())
             }
             _ => Err(CryptoError::UnsupportedSignatureScheme),
         }

--- a/openmls_rust_crypto/src/rand_shim.rs
+++ b/openmls_rust_crypto/src/rand_shim.rs
@@ -1,0 +1,28 @@
+use std::convert::Infallible;
+
+pub(crate) struct RandCore0_10<R>(pub(crate) R);
+
+impl<R> rand_core_0_10::TryCryptoRng for RandCore0_10<R> where
+    R: rand_core::RngCore + rand_core::CryptoRng
+{
+}
+
+impl<R> rand_core_0_10::TryRng for RandCore0_10<R>
+where
+    R: rand_core::RngCore,
+{
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.0.next_u32())
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(self.0.next_u64())
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        self.0.fill_bytes(dst);
+        Ok(())
+    }
+}

--- a/openmls_test/Cargo.toml
+++ b/openmls_test/Cargo.toml
@@ -16,6 +16,11 @@ proc-macro = true
 # This needs to be enabled explicity to allow disabling on some platforms
 libcrux-provider = ["dep:openmls_libcrux_crypto"]
 sqlite-provider = ["dep:openmls_sqlite_storage"]
+draft-ietf-mls-pq-ciphersuites = [
+    "openmls_rust_crypto/draft-ietf-mls-pq-ciphersuites",
+    "openmls_libcrux_crypto?/draft-ietf-mls-pq-ciphersuites",
+    "openmls_sqlite_storage?/draft-ietf-mls-pq-ciphersuites",
+]
 
 [dependencies]
 syn = { version = "2.0", features = ["full", "visit"] }

--- a/openmls_test/src/lib.rs
+++ b/openmls_test/src/lib.rs
@@ -1,8 +1,31 @@
 use openmls_rust_crypto::OpenMlsRustCrypto;
-use openmls_traits::{crypto::OpenMlsCrypto, OpenMlsProvider};
+use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite, OpenMlsProvider};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, ItemFn};
+
+/// Limit the post-quantum ciphersuites (enabled via the `draft-ietf-mls-pq-ciphersuites` feature)
+/// to a single representative variant to keep the number of generated tests and their runtime
+/// manageable. The variant is chosen such that both the ML-KEM and the ML-DSA code paths are
+/// exercised.
+fn test_ciphersuites(supported: Vec<Ciphersuite>) -> Vec<Ciphersuite> {
+    supported
+        .into_iter()
+        .filter(|ciphersuite| match ciphersuite {
+            // RFC 9420 Ciphersuites
+            Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+            | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
+            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
+            | Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448
+            | Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521
+            | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448
+            | Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384
+            // One of the PQ Ciphersuites covering ML-KEM and ML-DSA
+            | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65 => true,
+            _ => false,
+        })
+        .collect()
+}
 
 #[proc_macro_attribute]
 pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -15,7 +38,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let rc = OpenMlsRustCrypto::default();
 
-    let rc_ciphersuites = rc.crypto().supported_ciphersuites();
+    let rc_ciphersuites = test_ciphersuites(rc.crypto().supported_ciphersuites());
 
     let mut test_funs = Vec::new();
 
@@ -49,7 +72,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     #[cfg(all(feature = "sqlite-provider", not(target_arch = "wasm32",)))]
     {
-        let rc_ciphersuites = rc.crypto().supported_ciphersuites();
+        let rc_ciphersuites = test_ciphersuites(rc.crypto().supported_ciphersuites());
         for ciphersuite in rc_ciphersuites {
             let val = ciphersuite as u16;
             let ciphersuite_name = format!("{ciphersuite:?}");
@@ -136,7 +159,7 @@ pub fn openmls_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     ))]
     {
         let libcrux = openmls_libcrux_crypto::Provider::default();
-        let libcrux_ciphersuites = libcrux.crypto().supported_ciphersuites();
+        let libcrux_ciphersuites = test_ciphersuites(libcrux.crypto().supported_ciphersuites());
 
         for ciphersuite in libcrux_ciphersuites {
             let val = ciphersuite as u16;

--- a/sqlite_storage/Cargo.toml
+++ b/sqlite_storage/Cargo.toml
@@ -14,7 +14,7 @@ openmls_traits = { workspace = true }
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 log = { version = "0.4" }
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 refinery = { version = "0.9", features = ["rusqlite", "enums"] }
 
 [dev-dependencies]
@@ -22,4 +22,10 @@ serde_json = { version = "1.0" }
 
 [features]
 extensions-draft-08 = ["openmls_traits/extensions-draft-08"]
-virtual-clients-draft = ["extensions-draft-08", "openmls_traits/virtual-clients-draft"]
+draft-ietf-mls-pq-ciphersuites = [
+    "openmls_traits/draft-ietf-mls-pq-ciphersuites",
+]
+virtual-clients-draft = [
+    "extensions-draft-08",
+    "openmls_traits/virtual-clients-draft",
+]

--- a/sqlite_storage/Cargo.toml
+++ b/sqlite_storage/Cargo.toml
@@ -14,7 +14,7 @@ openmls_traits = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 log = { version = "0.4" }
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.37", features = ["bundled"] }
 refinery = { version = "0.9", features = ["rusqlite", "enums"] }
 
 [dev-dependencies]

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/traits.rs"
 default = []
 test-utils = []
 extensions-draft-08 = []
+draft-ietf-mls-pq-ciphersuites = []
 virtual-clients-draft = ["extensions-draft-08"]
 
 [dependencies]

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -103,6 +103,12 @@ pub enum SignatureScheme {
     ED25519 = 0x0807,
     /// ED448
     ED448 = 0x0808,
+    /// ML-DSA65
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLDSA65 = 0x0905,
+    /// ML-DSA87
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLDSA87 = 0x0906,
 }
 
 impl TryFrom<u16> for SignatureScheme {
@@ -115,6 +121,10 @@ impl TryFrom<u16> for SignatureScheme {
             0x0603 => Ok(SignatureScheme::ECDSA_SECP521R1_SHA512),
             0x0807 => Ok(SignatureScheme::ED25519),
             0x0808 => Ok(SignatureScheme::ED448),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x0905 => Ok(SignatureScheme::MLDSA65),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x0906 => Ok(SignatureScheme::MLDSA87),
             _ => Err(format!("Unsupported SignatureScheme: {value}")),
         }
     }
@@ -182,7 +192,16 @@ pub enum HpkeKemType {
     /// DH KEM on x448
     DhKem448 = 0x0021,
 
+    /// ML-KEM-768
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MlKem768 = 0x0041,
+
+    /// ML-KEM-1024
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MlKem1024 = 0x0042,
+
     /// XWing combiner for ML-KEM and X25519
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
     XWingKemDraft6 = 0x004D,
 }
 
@@ -398,7 +417,73 @@ pub enum Ciphersuite {
     MLS_256_DHKEMP384_AES256GCM_SHA384_P384 = 0x0007,
 
     /// X-WING KEM draft-01 | Chacha20Poly1305 | SHA2-256 | Ed25519
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
     MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 = 0x004D,
+
+    /// ML-KEM1024 | AES-GCM256 | SHA2-512 | ML-DSA87
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87 = 0x0906,
+
+    /// ML-KEM768 + X25519 (XWing) | AES-GCM128 | SHA2-256 | Ed25519
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites] TBD1 (provisional code point)
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites]: https://datatracker.ietf.org/doc/draft-ietf-mls-pq-ciphersuites
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519 = 0x004F,
+
+    /// ML-KEM768 + X25519 (XWing) | AES-GCM256 | SHA2-384 | Ed25519
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites] TBD2 (provisional code point)
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites]: https://datatracker.ietf.org/doc/draft-ietf-mls-pq-ciphersuites
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519 = 0x004E,
+
+    // TBD3, TBD4, TBD5 are currently not supported because there are no implementations for hybrid
+    // schemes MLKEM768P256 and MLKEM1024P384.
+    //
+    // MLS_128_MLKEM768P256_AES128GCM_SHA256_P256 = TBD3,
+    // MLS_128_MLKEM768P256_AES256GCM_SHA384_P256 = TBD4
+    // MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384 =TBD5,
+    //
+    /// ML-KEM768 | AES-GCM256 | SHA2-384 | EcDSA P256
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites] TBD6 (provisional code point)
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites]: https://datatracker.ietf.org/doc/draft-ietf-mls-pq-ciphersuites
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLS_128_MLKEM768_AES256GCM_SHA384_P256 = 0x0050,
+
+    /// ML-KEM1024 | AES-GCM256 | SHA2-384 | EcDSA P384
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites] TBD7 (provisional code point)
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites]: https://datatracker.ietf.org/doc/draft-ietf-mls-pq-ciphersuites
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLS_192_MLKEM1024_AES256GCM_SHA384_P384 = 0x0042,
+
+    /// ML-KEM768 | AES-GCM256 | SHA2-384 | ML-DSA65
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites] TBD8 (provisional code point)
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites]: https://datatracker.ietf.org/doc/draft-ietf-mls-pq-ciphersuites
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65 = 0x0051,
+
+    /// ML-KEM1024 | AES-GCM256 | SHA2-384 | ML-DSA87
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites] TBD9 (provisional code point)
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites]: https://datatracker.ietf.org/doc/draft-ietf-mls-pq-ciphersuites
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87 = 0x0907,
+
+    /// ML-KEM768 | AES-GCM256 | SHA2-384 | Ed25519
+    ///
+    /// A custom variant of MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519 without hybrid KEM.
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    AIR_128_MLKEM768_AES256GCM_SHA384_Ed25519 = 0xF042,
 }
 
 impl core::fmt::Display for Ciphersuite {
@@ -434,7 +519,22 @@ impl TryFrom<u16> for Ciphersuite {
             0x0005 => Ok(Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521),
             0x0006 => Ok(Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448),
             0x0007 => Ok(Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
             0x004D => Ok(Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x0042 => Ok(Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x0906 => Ok(Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x004E => Ok(Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x004F => Ok(Ciphersuite::MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x0050 => Ok(Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x0051 => Ok(Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x0907 => Ok(Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87),
             _ => Err(Self::Error::DecodingError(format!(
                 "{v} is not a valid ciphersuite value"
             ))),
@@ -491,12 +591,26 @@ impl Ciphersuite {
         match self {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
             | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
-            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-            | Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 => HashType::Sha2_256,
+            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 => {
+                HashType::Sha2_256
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519 => HashType::Sha2_256,
             Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => HashType::Sha2_384,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256
+            | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87 => HashType::Sha2_384,
             Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448
             | Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521
             | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 => HashType::Sha2_512,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87 => HashType::Sha2_512,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::AIR_128_MLKEM768_AES256GCM_SHA384_Ed25519 => HashType::Sha2_384,
         }
     }
 
@@ -505,11 +619,20 @@ impl Ciphersuite {
     pub const fn signature_algorithm(&self) -> SignatureScheme {
         match self {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-            | Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 => {
+            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 => {
+                SignatureScheme::ED25519
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519 => {
                 SignatureScheme::ED25519
             }
             Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => {
+                SignatureScheme::ECDSA_SECP256R1_SHA256
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256 => {
                 SignatureScheme::ECDSA_SECP256R1_SHA256
             }
             Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521 => {
@@ -522,6 +645,17 @@ impl Ciphersuite {
             Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => {
                 SignatureScheme::ECDSA_SECP384R1_SHA384
             }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384 => {
+                SignatureScheme::ECDSA_SECP384R1_SHA384
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87 => SignatureScheme::MLDSA87,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65 => SignatureScheme::MLDSA65,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::AIR_128_MLKEM768_AES256GCM_SHA384_Ed25519 => SignatureScheme::ED25519,
         }
     }
 
@@ -531,14 +665,28 @@ impl Ciphersuite {
         match self {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
             | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => AeadType::Aes128Gcm,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519 => AeadType::Aes128Gcm,
             Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-            | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448
-            | Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 => {
+            | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 => {
+                AeadType::ChaCha20Poly1305
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 => {
                 AeadType::ChaCha20Poly1305
             }
             Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448
             | Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521
             | Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => AeadType::Aes256Gcm,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256
+            | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87 => AeadType::Aes256Gcm,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::AIR_128_MLKEM768_AES256GCM_SHA384_Ed25519 => AeadType::Aes256Gcm,
         }
     }
 
@@ -548,14 +696,30 @@ impl Ciphersuite {
         match self {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
             | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
-            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-            | Self::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 => HpkeKdfType::HkdfSha256,
+            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 => {
+                HpkeKdfType::HkdfSha256
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Self::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519 => {
+                HpkeKdfType::HkdfSha256
+            }
             Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => HpkeKdfType::HkdfSha384,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256
+            | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87 => HpkeKdfType::HkdfSha384,
             Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448
             | Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521
             | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 => {
                 HpkeKdfType::HkdfSha512
             }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87 => HpkeKdfType::HkdfSha512,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::AIR_128_MLKEM768_AES256GCM_SHA384_Ed25519 => HpkeKdfType::HkdfSha384,
         }
     }
 
@@ -572,9 +736,21 @@ impl Ciphersuite {
             | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 => HpkeKemType::DhKem448,
             Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => HpkeKemType::DhKemP384,
             Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521 => HpkeKemType::DhKemP521,
-            Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 => {
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519 => {
                 HpkeKemType::XWingKemDraft6
             }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87 => HpkeKemType::MlKem1024,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256
+            | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65 => HpkeKemType::MlKem768,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::AIR_128_MLKEM768_AES256GCM_SHA384_Ed25519 => HpkeKemType::MlKem768,
         }
     }
 
@@ -584,16 +760,28 @@ impl Ciphersuite {
         match self {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
             | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => HpkeAeadType::AesGcm128,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768X25519_AES128GCM_SHA256_Ed25519 => HpkeAeadType::AesGcm128,
             Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-            | Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 => {
+            | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 => {
+                HpkeAeadType::ChaCha20Poly1305
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 => {
                 HpkeAeadType::ChaCha20Poly1305
             }
             Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448
             | Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384
             | Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521 => HpkeAeadType::AesGcm256,
-            Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 => {
-                HpkeAeadType::ChaCha20Poly1305
-            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM1024_AES256GCM_SHA384_P384
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87
+            | Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519
+            | Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256
+            | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65
+            | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87 => HpkeAeadType::AesGcm256,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::AIR_128_MLKEM768_AES256GCM_SHA384_Ed25519 => HpkeAeadType::AesGcm256,
         }
     }
 


### PR DESCRIPTION
Add post-quantum and P-384 ciphersuite support to the RustCrypto
provider, hidden behind the `draft-ietf-mls-pq-ciphersuites` feature
flag:

- `MLS_192_MLKEM1024_AES256GCM_SHA384_P384` (ML-KEM1024 + ECDSA P-384)
- `MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87` (ML-KEM1024 + ML-DSA87)
- the remaining PQ ciphersuites supported by RustCrypto, plus the custom
  `AIR_128_MLKEM768_AES256GCM_SHA384_Ed25519` ciphersuite

Wire ML-DSA 0.1 signing into basic_credential, propagate the feature
flag across crates, and adjust KAT/storage tests for the new
ciphersuites and ciphersuite-dependent hash lengths.

Co-authored-by: Konrad Kohbrok <konrad.kohbrok@datashrine.de>
