### PR TITLE
Add feature flag for `serde` serialization backwards compatibility with `openmls` v0.8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,23 @@ jobs:
       - name: Tests
         run: cargo test ${{ matrix.mode_arg }} -p openmls --verbose --no-default-features ${{ matrix.features_arg }}
 
+  compat_tests:
+    runs-on: "ubuntu-latest"
+    defaults:
+      run:
+        working-directory: "compat_tests"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Tests
+        run: ./test.sh
+
+
+
   wasm:
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,9 @@ jobs:
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: release, mode_arg: --release, features_name: fork-resolution, features_arg: "-F fork-resolution" }
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: debug, mode_arg: "", features_name: extensions-draft-08, features_arg: "-F extensions-draft-08,extensions-draft-08-test-dependencies" }
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: release, mode_arg: --release, features_name: extensions-draft-08, features_arg: "-F extensions-draft-08,extensions-draft-08-test-dependencies" }
+          # Test the storage compatibility feature with and without extensions draft feature
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: release, mode_arg: --release, features_name: 0-8-1-storage-format, features_arg: "-F 0-8-1-storage-format" }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, mode_name: release, mode_arg: --release, features_name: 0-8-1-storage-format-extensions-draft-08, features_arg: "-F 0-8-1-storage-format,extensions-draft-08,extensions-draft-08-test-dependencies" }
           # Other platforms: debug + default features only.
           - { os: windows-latest, target: x86_64-pc-windows-msvc, mode_name: debug, mode_arg: "", features_name: default, features_arg: "" }
           - { os: macos-latest, target: aarch64-apple-darwin, mode_name: debug, mode_arg: "", features_name: default, features_arg: "" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1972](https://github.com/openmls/openmls/pull/1972): Add APIs for time-based deletion of past epoch secrets, and for setting the past epoch deletion policy for an `MlsGroup`.
 - [#2010](https://github.com/openmls/openmls/pull/2010): Added `MlsGroup::propose_self_update_with_new_signer`, a variant of `propose_self_update` that stages an `Update` proposal carrying a new signature key.
 
+### Fixed
+- [#2034](https://github.com/openmls/openmls/pull/2034): Fixes a bug where the integer storage tags for `serde` non-self-describing serializations were changed, leading to incorrect deserializations. By default, storage format compatibility with `openmls` v0.7.1 and earlier is now restored. Enabling the `0-8-1-storage-format` feature maintains storage format compatibility with `openmls` v0.8.1 (the previous `openmls` release).
+
 ### Changed
 
 - [#1980](https://github.com/openmls/openmls/pull/1980): Enrich limetime related errors returned during leaf node validation with more information

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,11 +704,11 @@ dependencies = [
  "base64",
  "ds-lib",
  "log",
- "openmls 0.8.1",
+ "openmls",
  "openmls_basic_credential",
  "openmls_memory_storage",
  "openmls_rust_crypto",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "pretty_env_logger",
  "rand_chacha 0.9.0",
  "reqwest",
@@ -1116,11 +1116,11 @@ dependencies = [
 name = "ds-lib"
 version = "0.1.0"
 dependencies = [
- "openmls 0.8.1",
+ "openmls",
  "openmls_basic_credential",
  "openmls_memory_storage",
  "openmls_rust_crypto",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "rand 0.9.4",
  "serde",
 ]
@@ -2049,10 +2049,10 @@ dependencies = [
  "clap",
  "clap_derive",
  "mls_interop_proto",
- "openmls 0.8.1",
+ "openmls",
  "openmls_basic_credential",
  "openmls_rust_crypto",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "serde",
  "serde_json",
  "tls_codec",
@@ -2595,10 +2595,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "log",
- "openmls 0.8.1",
+ "openmls",
  "openmls_basic_credential",
  "openmls_rust_crypto",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "pretty_env_logger",
  "serde",
  "serde_json",
@@ -2708,22 +2708,6 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openmls"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af47d535cef7b75806a2b5fcf81ba8e68179f5923aca9bc6a4d8d563e4f8757"
-dependencies = [
- "log",
- "openmls_traits 0.4.1",
- "rayon",
- "serde",
- "serde_bytes",
- "thiserror 2.0.18",
- "tls_codec",
- "zeroize",
-]
-
-[[package]]
-name = "openmls"
 version = "0.8.1"
 dependencies = [
  "backtrace",
@@ -2739,7 +2723,7 @@ dependencies = [
  "lazy_static",
  "log",
  "once_cell",
- "openmls 0.8.1",
+ "openmls",
  "openmls_basic_credential",
  "openmls_libcrux_crypto",
  "openmls_memory_storage",
@@ -2747,7 +2731,7 @@ dependencies = [
  "openmls_serialization_helpers",
  "openmls_sqlite_storage",
  "openmls_test",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "pretty_env_logger",
  "rand 0.9.4",
  "rayon",
@@ -2768,7 +2752,7 @@ name = "openmls-fuzz"
 version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
- "openmls 0.8.1",
+ "openmls",
 ]
 
 [[package]]
@@ -2778,10 +2762,10 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
  "js-sys",
- "openmls 0.8.1",
+ "openmls",
  "openmls_basic_credential",
  "openmls_rust_crypto",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "tls_codec",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -2792,24 +2776,13 @@ name = "openmls_basic_credential"
 version = "0.5.0"
 dependencies = [
  "ed25519-dalek",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "p256",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
  "tls_codec",
  "zeroize",
-]
-
-[[package]]
-name = "openmls_compat_tests"
-version = "0.1.0"
-dependencies = [
- "openmls 0.7.1",
- "openmls 0.8.1",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2826,7 +2799,7 @@ dependencies = [
  "libcrux-sha2",
  "libcrux-traits",
  "openmls_memory_storage",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "tls_codec",
@@ -2840,7 +2813,7 @@ dependencies = [
  "hex",
  "log",
  "openmls_memory_storage",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2859,7 +2832,7 @@ dependencies = [
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
  "openmls_memory_storage",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "p256",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -2887,7 +2860,7 @@ name = "openmls_sqlite_storage"
 version = "0.2.0"
 dependencies = [
  "log",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "refinery",
  "rusqlite",
  "serde",
@@ -2903,22 +2876,12 @@ dependencies = [
  "openmls_libcrux_crypto",
  "openmls_rust_crypto",
  "openmls_sqlite_storage",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "proc-macro2",
  "quote",
  "rstest",
  "rstest_reuse",
  "syn",
-]
-
-[[package]]
-name = "openmls_traits"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21d8877bacdbc407060df29bf59b145bb886a8fa0099b87ae8067a34b902a13"
-dependencies = [
- "serde",
- "tls_codec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,8 @@ members = [
     "openmls_test",
     "sqlite_storage",
     "serialization_helpers",
-    "compat_tests",
 ]
-exclude = ["sqlx_storage"]
+exclude = ["compat_tests", "sqlx_storage"]
 resolver = "2"
 
 # Central dependency management for some crates

--- a/compat_tests/Cargo.toml
+++ b/compat_tests/Cargo.toml
@@ -4,11 +4,25 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[features]
+compat_0_7_1 = ["dep:openmls_0_7_1"]
+compat_0_8_1 = ["dep:openmls_0_8_1", "openmls/0-8-1-storage-format"]
+compat_0_8_1_extensions = [
+    "compat_0_8_1",
+    "openmls_0_8_1/extensions-draft-08",
+    "openmls/extensions-draft-08",
+]
+
 [dependencies]
 serde = { version = "^1.0" }
 thiserror = { version = "^2.0" }
+openmls_0_7_1 = { package = "openmls", version = "=0.7.1", optional = true }
+openmls_0_8_1 = { package = "openmls", version = "=0.8.1", optional = true }
+openmls = { path = "../openmls" }
 
 [dev-dependencies]
 serde_json = "1.0"
-openmls = { path = "../openmls" }
-openmls_0_7_1 = { package = "openmls", version = "=0.7.1" }
+
+[patch.crates-io]
+openmls_libcrux_crypto = { path = "../libcrux_crypto" }
+openmls_sqlite_storage = { path = "../sqlite_storage" }

--- a/compat_tests/Cargo.toml
+++ b/compat_tests/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-serde = { workspace = true }
-thiserror = { workspace = true }
+serde = { version = "^1.0" }
+thiserror = { version = "^2.0" }
 
 [dev-dependencies]
 serde_json = "1.0"
-openmls = { workspace = true }
+openmls = { path = "../openmls" }
 openmls_0_7_1 = { package = "openmls", version = "=0.7.1" }

--- a/compat_tests/Cargo.toml
+++ b/compat_tests/Cargo.toml
@@ -23,6 +23,9 @@ openmls = { path = "../openmls" }
 [dev-dependencies]
 serde_json = "1.0"
 
+# XXX: workaround for incompatible dependencies between
+# `main` and `openmls=0.8.1` when the `extensions-draft-08`
+# feature is enabled
 [patch.crates-io]
 openmls_libcrux_crypto = { path = "../libcrux_crypto" }
 openmls_sqlite_storage = { path = "../sqlite_storage" }

--- a/compat_tests/README.md
+++ b/compat_tests/README.md
@@ -1,0 +1,11 @@
+# Compatibility tests for `openmls`
+
+This crate includes tests for compatibility with previous `openmls` versions.
+- storage format compatibility tests for `openmls=0.7.1`, `openmls=0.8.1`, and `openmls=0.8.1` with the feature `extensions-draft-08` enabled
+
+## Usage
+```
+cargo test -F compat_0_7_1
+cargo test -F compat_0_8_1
+cargo test -F compat_0_8_1_extensions
+```

--- a/compat_tests/test.sh
+++ b/compat_tests/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cargo test -F compat_0_7_1
+cargo test -F compat_0_8_1
+cargo test -F compat_0_8_1_extensions

--- a/compat_tests/tests/data/storage_tag_stability.json
+++ b/compat_tests/tests/data/storage_tag_stability.json
@@ -1,235 +1,565 @@
 {
   "credential_type": [
-    "Basic",
-    "X509",
     {
-      "Other": 20
+      "input": "Basic",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "X509",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "Grease": 0
+      },
+      "supported": [
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "Other": 20
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     }
   ],
   "extension_type": [
-    "ApplicationId",
-    "RatchetTree",
-    "RequiredCapabilities",
-    "ExternalPub",
-    "ExternalSenders",
-    "LastResort",
     {
-      "Unknown": 20
+      "input": "ApplicationId",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "RatchetTree",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "RequiredCapabilities",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "ExternalPub",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "ExternalSenders",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "LastResort",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "AppDataDictionary",
+      "supported": [
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "Grease": 0
+      },
+      "supported": [
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "Unknown": 20
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     }
   ],
   "extension": [
     {
-      "ApplicationId": {
-        "key_id": {
-          "vec": []
+      "input": {
+        "ApplicationId": {
+          "key_id": {
+            "vec": []
+          }
         }
-      }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     },
     {
-      "RatchetTree": {
-        "ratchet_tree": []
-      }
-    },
-    {
-      "RequiredCapabilities": {
-        "extension_types": [],
-        "proposal_types": [],
-        "credential_types": []
-      }
-    },
-    {
-      "ExternalPub": {
-        "external_pub": {
-          "vec": []
+      "input": {
+        "RatchetTree": {
+          "ratchet_tree": []
         }
-      }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     },
     {
-      "ExternalSenders": []
+      "input": {
+        "RequiredCapabilities": {
+          "credential_types": [],
+          "extension_types": [],
+          "proposal_types": []
+        }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     },
     {
-      "LastResort": {}
+      "input": {
+        "ExternalPub": {
+          "external_pub": {
+            "vec": []
+          }
+        }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     },
     {
-      "Unknown": [
-        7,
-        []
+      "input": {
+        "ExternalSenders": []
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "AppDataDictionary": {
+          "dictionary": {
+            "component_data": {}
+          }
+        }
+      },
+      "supported": [
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "LastResort": {}
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "Unknown": [
+          7,
+          []
+        ]
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
       ]
     }
   ],
   "proposal_type": [
-    "Add",
-    "Update",
-    "Remove",
-    "PreSharedKey",
-    "Reinit",
-    "ExternalInit",
-    "GroupContextExtensions",
-    "SelfRemove",
     {
-      "Custom": 20
+      "input": "Add",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "Update",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "Remove",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "PreSharedKey",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "Reinit",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "ExternalInit",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "GroupContextExtensions",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "SelfRemove",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "AppEphemeral",
+      "supported": [
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "AppDataUpdate",
+      "supported": [
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "Grease": 0
+      },
+      "supported": [
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "Custom": 20
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     }
   ],
   "proposal": [
     {
-      "Add": {
-        "key_package": {
-          "payload": {
-            "protocol_version": "Mls10",
-            "ciphersuite": "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
-            "init_key": {
-              "key": {
-                "vec": []
-              }
-            },
-            "leaf_node": {
-              "payload": {
-                "encryption_key": {
-                  "key": {
-                    "vec": []
+      "input": {
+        "Add": {
+          "key_package": {
+            "payload": {
+              "ciphersuite": "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
+              "extensions": {
+                "unique": []
+              },
+              "init_key": {
+                "key": {
+                  "vec": []
+                }
+              },
+              "leaf_node": {
+                "payload": {
+                  "capabilities": {
+                    "ciphersuites": [],
+                    "credentials": [],
+                    "extensions": [],
+                    "proposals": [],
+                    "versions": []
+                  },
+                  "credential": {
+                    "credential_type": "Basic",
+                    "serialized_credential_content": {
+                      "vec": []
+                    }
+                  },
+                  "encryption_key": {
+                    "key": {
+                      "vec": []
+                    }
+                  },
+                  "extensions": {
+                    "unique": []
+                  },
+                  "leaf_node_source": "Update",
+                  "signature_key": {
+                    "value": {
+                      "vec": []
+                    }
                   }
                 },
-                "signature_key": {
+                "signature": {
                   "value": {
                     "vec": []
                   }
-                },
-                "credential": {
-                  "credential_type": "Basic",
-                  "serialized_credential_content": {
-                    "vec": []
-                  }
-                },
-                "capabilities": {
-                  "versions": [],
-                  "ciphersuites": [],
-                  "extensions": [],
-                  "proposals": [],
-                  "credentials": []
-                },
-                "leaf_node_source": "Update",
-                "extensions": {
-                  "unique": []
                 }
               },
+              "protocol_version": "Mls10",
               "signature": {
                 "value": {
                   "vec": []
                 }
               }
             },
-            "extensions": {
-              "unique": []
+            "signature": {
+              "value": {
+                "vec": []
+              }
+            }
+          }
+        }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "Update": {
+          "leaf_node": {
+            "payload": {
+              "capabilities": {
+                "ciphersuites": [],
+                "credentials": [],
+                "extensions": [],
+                "proposals": [],
+                "versions": []
+              },
+              "credential": {
+                "credential_type": "Basic",
+                "serialized_credential_content": {
+                  "vec": []
+                }
+              },
+              "encryption_key": {
+                "key": {
+                  "vec": []
+                }
+              },
+              "extensions": {
+                "unique": []
+              },
+              "leaf_node_source": "Update",
+              "signature_key": {
+                "value": {
+                  "vec": []
+                }
+              }
             },
             "signature": {
               "value": {
                 "vec": []
               }
             }
-          },
-          "signature": {
-            "value": {
-              "vec": []
-            }
           }
         }
-      }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     },
     {
-      "Update": {
-        "leaf_node": {
-          "payload": {
-            "encryption_key": {
-              "key": {
-                "vec": []
-              }
-            },
-            "signature_key": {
-              "value": {
-                "vec": []
-              }
-            },
-            "credential": {
-              "credential_type": "Basic",
-              "serialized_credential_content": {
-                "vec": []
-              }
-            },
-            "capabilities": {
-              "versions": [],
-              "ciphersuites": [],
-              "extensions": [],
-              "proposals": [],
-              "credentials": []
-            },
-            "leaf_node_source": "Update",
-            "extensions": {
-              "unique": []
-            }
-          },
-          "signature": {
-            "value": {
-              "vec": []
-            }
-          }
+      "input": {
+        "Remove": {
+          "removed": 0
         }
-      }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     },
     {
-      "Remove": {
-        "removed": 0
-      }
-    },
-    {
-      "PreSharedKey": {
-        "psk": {
+      "input": {
+        "PreSharedKey": {
           "psk": {
-            "External": {
-              "psk_id": {
-                "vec": []
+            "psk": {
+              "External": {
+                "psk_id": {
+                  "vec": []
+                }
               }
+            },
+            "psk_nonce": {
+              "vec": []
+            }
+          }
+        }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "ReInit": {
+          "ciphersuite": "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
+          "extensions": {
+            "unique": []
+          },
+          "group_id": {
+            "value": {
+              "vec": []
             }
           },
-          "psk_nonce": {
+          "version": "Mls10"
+        }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "ExternalInit": {
+          "kem_output": {
             "vec": []
           }
         }
-      }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     },
     {
-      "ReInit": {
-        "group_id": {
-          "value": {
+      "input": {
+        "GroupContextExtensions": {
+          "extensions": {
+            "unique": []
+          }
+        }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "AppDataUpdate": {
+          "component_id": 0,
+          "operation": {
+            "Update": {
+              "vec": []
+            }
+          }
+        }
+      },
+      "supported": [
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": "SelfRemove",
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
+    },
+    {
+      "input": {
+        "AppEphemeral": {
+          "component_id": 0,
+          "data": {
             "vec": []
           }
-        },
-        "version": "Mls10",
-        "ciphersuite": "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
-        "extensions": {
-          "unique": []
         }
-      }
+      },
+      "supported": [
+        "OpenMls_0_8_1_Extensions"
+      ]
     },
     {
-      "ExternalInit": {
-        "kem_output": {
-          "vec": []
+      "input": {
+        "Custom": {
+          "payload": [],
+          "proposal_type": 0
         }
-      }
-    },
-    {
-      "GroupContextExtensions": {
-        "extensions": {
-          "unique": []
-        }
-      }
-    },
-    "SelfRemove",
-    {
-      "Custom": {
-        "proposal_type": 0,
-        "payload": []
-      }
+      },
+      "supported": [
+        "OpenMls_0_7_1",
+        "OpenMls_0_8_1",
+        "OpenMls_0_8_1_Extensions"
+      ]
     }
   ]
 }

--- a/compat_tests/tests/test_storage_tag_stability.rs
+++ b/compat_tests/tests/test_storage_tag_stability.rs
@@ -1,5 +1,6 @@
 //! These tests check storage tag stability for `serde` serializations of `Extension`,
 //!   `ExtensionType`, `Proposal`, `ProposalType`, and `CredentialType`.
+#![allow(dead_code)]
 
 use openmls_compat_tests::storage_tag_check::*;
 
@@ -115,4 +116,8 @@ macro_rules! compat_tests {
 }
 
 // check the storage tag stability for openmls=0.7.1 => `main`
+#[cfg(feature = "compat_0_7_1")]
 compat_tests!(test_storage_tags_0_7_1, openmls_0_7_1, openmls);
+// check the storage tag stability for openmls=0.8.1 => `main`
+#[cfg(feature = "compat_0_8_1")]
+compat_tests!(test_storage_tags_0_8_1, openmls_0_8_1, openmls);

--- a/compat_tests/tests/test_storage_tag_stability.rs
+++ b/compat_tests/tests/test_storage_tag_stability.rs
@@ -82,6 +82,7 @@ fn name(input: &serde_json::Value) -> String {
     match input {
         serde_json::Value::String(s) => s.to_string(),
         serde_json::Value::Object(map) => map.keys().next().unwrap().to_string(),
+        // NOTE: the test data does not include `serde_json::Value`s of other types
         _ => unimplemented!(),
     }
 }

--- a/compat_tests/tests/test_storage_tag_stability.rs
+++ b/compat_tests/tests/test_storage_tag_stability.rs
@@ -8,18 +8,32 @@ use std::sync::OnceLock;
 
 static TEST_DATA: OnceLock<TestData> = OnceLock::new();
 
+#[allow(nonstandard_style)]
+#[derive(PartialEq, serde::Serialize, serde::Deserialize)]
+enum SupportedVersion {
+    OpenMls_0_7_1,
+    OpenMls_0_8_1,
+    OpenMls_0_8_1_Extensions,
+}
+
 /// Partly deserialized test data.
 ///
 /// Each `serde_json::Value` is deserialized separately
 /// into two versions of a type (Before, After), and
 /// can be used to compare their values..
-#[derive(serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
 struct TestData {
-    credential_type: Vec<serde_json::Value>,
-    extension_type: Vec<serde_json::Value>,
-    extension: Vec<serde_json::Value>,
-    proposal_type: Vec<serde_json::Value>,
-    proposal: Vec<serde_json::Value>,
+    credential_type: Vec<TestCase>,
+    extension_type: Vec<TestCase>,
+    extension: Vec<TestCase>,
+    proposal_type: Vec<TestCase>,
+    proposal: Vec<TestCase>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct TestCase {
+    input: serde_json::Value,
+    supported: Vec<SupportedVersion>,
 }
 
 impl TestData {
@@ -64,19 +78,23 @@ where
 }
 
 macro_rules! test_case {
-    ($test_name:ident,$before:ty,$after:ty,$test_cases:expr) => {
+    ($test_name:ident,$before:ty,$after:ty,$test_cases:expr,$version:expr) => {
         #[test]
         fn $test_name() {
-            $test_cases.iter().for_each(|case| {
-                let migration = Migration::<$before, $after>::from_value(case);
-                migration.test_tag()
-            });
+            $test_cases
+                .iter()
+                .filter(|case| case.supported.contains(&$version))
+                .for_each(|case| {
+                    eprintln!("{}", case.input);
+                    let migration = Migration::<$before, $after>::from_value(&case.input);
+                    migration.test_tag()
+                });
         }
     };
 }
 
 macro_rules! compat_tests {
-    ($mod_name:ident, $before:tt, $after:tt) => {
+    ($mod_name:ident, $before:tt, $after:tt, $version:expr) => {
         mod $mod_name {
             use super::*;
 
@@ -84,32 +102,37 @@ macro_rules! compat_tests {
                 test_extension_type,
                 $before::prelude::ExtensionType,
                 $after::prelude::ExtensionType,
-                TestData::load().extension_type
+                TestData::load().extension_type,
+                $version
             );
             test_case!(
                 test_extension,
                 $before::prelude::Extension,
                 $after::prelude::Extension,
-                TestData::load().extension
+                TestData::load().extension,
+                $version
             );
             test_case!(
                 test_credential_type,
                 $before::prelude::CredentialType,
                 $after::prelude::CredentialType,
-                TestData::load().credential_type
+                TestData::load().credential_type,
+                $version
             );
             test_case!(
                 test_proposal_type,
                 $before::prelude::ProposalType,
                 $after::prelude::ProposalType,
-                TestData::load().proposal_type
+                TestData::load().proposal_type,
+                $version
             );
 
             test_case!(
                 test_proposal,
                 $before::prelude::Proposal,
                 $after::prelude::Proposal,
-                TestData::load().proposal
+                TestData::load().proposal,
+                $version
             );
         }
     };
@@ -117,7 +140,25 @@ macro_rules! compat_tests {
 
 // check the storage tag stability for openmls=0.7.1 => `main`
 #[cfg(feature = "compat_0_7_1")]
-compat_tests!(test_storage_tags_0_7_1, openmls_0_7_1, openmls);
+compat_tests!(
+    test_storage_tags_0_7_1,
+    openmls_0_7_1,
+    openmls,
+    SupportedVersion::OpenMls_0_7_1
+);
 // check the storage tag stability for openmls=0.8.1 => `main`
-#[cfg(feature = "compat_0_8_1")]
-compat_tests!(test_storage_tags_0_8_1, openmls_0_8_1, openmls);
+#[cfg(all(feature = "compat_0_8_1", not(feature = "compat_0_8_1_extensions")))]
+compat_tests!(
+    test_storage_tags_0_8_1,
+    openmls_0_8_1,
+    openmls,
+    SupportedVersion::OpenMls_0_8_1
+);
+// check the storage tag stability for openmls=0.8.1 => `main` with feature `extensions-draft-08`
+#[cfg(feature = "compat_0_8_1_extensions")]
+compat_tests!(
+    test_storage_tags_0_8_1,
+    openmls_0_8_1,
+    openmls,
+    SupportedVersion::OpenMls_0_8_1_Extensions
+);

--- a/compat_tests/tests/test_storage_tag_stability.rs
+++ b/compat_tests/tests/test_storage_tag_stability.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 static TEST_DATA: OnceLock<TestData> = OnceLock::new();
 
 #[allow(nonstandard_style)]
-#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(PartialEq, Debug, serde::Deserialize)]
 enum SupportedVersion {
     OpenMls_0_7_1,
     OpenMls_0_8_1,
@@ -21,7 +21,7 @@ enum SupportedVersion {
 /// Each `serde_json::Value` is deserialized separately
 /// into two versions of a type (Before, After), and
 /// can be used to compare their values..
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Deserialize)]
 struct TestData {
     credential_type: Vec<TestCase>,
     extension_type: Vec<TestCase>,
@@ -30,7 +30,7 @@ struct TestData {
     proposal: Vec<TestCase>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Deserialize)]
 struct TestCase {
     input: serde_json::Value,
     supported: Vec<SupportedVersion>,

--- a/compat_tests/tests/test_storage_tag_stability.rs
+++ b/compat_tests/tests/test_storage_tag_stability.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 static TEST_DATA: OnceLock<TestData> = OnceLock::new();
 
 #[allow(nonstandard_style)]
-#[derive(PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 enum SupportedVersion {
     OpenMls_0_7_1,
     OpenMls_0_8_1,
@@ -77,6 +77,15 @@ where
     }
 }
 
+/// Helper function to retrieve the enum variant name from the `serde_json::Value` input data
+fn name(input: &serde_json::Value) -> String {
+    match input {
+        serde_json::Value::String(s) => s.to_string(),
+        serde_json::Value::Object(map) => map.keys().next().unwrap().to_string(),
+        _ => unimplemented!(),
+    }
+}
+
 macro_rules! test_case {
     ($test_name:ident,$before:ty,$after:ty,$test_cases:expr,$version:expr) => {
         #[test]
@@ -85,9 +94,13 @@ macro_rules! test_case {
                 .iter()
                 .filter(|case| case.supported.contains(&$version))
                 .for_each(|case| {
-                    eprintln!("{}", case.input);
                     let migration = Migration::<$before, $after>::from_value(&case.input);
-                    migration.test_tag()
+                    migration.test_tag();
+                    eprintln!(
+                        "Tests succeeded for {}::{}",
+                        stringify!($before).replace(" ", ""),
+                        name(&case.input)
+                    );
                 });
         }
     };

--- a/compat_tests/tests/test_storage_tag_stability.rs
+++ b/compat_tests/tests/test_storage_tag_stability.rs
@@ -87,7 +87,7 @@ fn name(input: &serde_json::Value) -> String {
     }
 }
 
-macro_rules! test_case {
+macro_rules! generate_test_fn {
     ($test_name:ident,$before:ty,$after:ty,$test_cases:expr,$version:expr) => {
         #[test]
         fn $test_name() {
@@ -112,28 +112,28 @@ macro_rules! compat_tests {
         mod $mod_name {
             use super::*;
 
-            test_case!(
+            generate_test_fn!(
                 test_extension_type,
                 $before::prelude::ExtensionType,
                 $after::prelude::ExtensionType,
                 TestData::load().extension_type,
                 $version
             );
-            test_case!(
+            generate_test_fn!(
                 test_extension,
                 $before::prelude::Extension,
                 $after::prelude::Extension,
                 TestData::load().extension,
                 $version
             );
-            test_case!(
+            generate_test_fn!(
                 test_credential_type,
                 $before::prelude::CredentialType,
                 $after::prelude::CredentialType,
                 TestData::load().credential_type,
                 $version
             );
-            test_case!(
+            generate_test_fn!(
                 test_proposal_type,
                 $before::prelude::ProposalType,
                 $after::prelude::ProposalType,
@@ -141,7 +141,7 @@ macro_rules! compat_tests {
                 $version
             );
 
-            test_case!(
+            generate_test_fn!(
                 test_proposal,
                 $before::prelude::Proposal,
                 $after::prelude::Proposal,

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -46,6 +46,8 @@ zeroize = "1.8.1"
 serde_bytes = "0.11.17"
 
 [features]
+# enable for compatibility with openmls=0.8.1
+0-8-1-storage-format = []
 test-utils = [
     "dep:serde_json",
     "dep:itertools",

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -77,31 +77,32 @@ pub mod errors;
 /// | 0xDADA           | GREASE                   | Y | RFC XXXX |
 /// | 0xEAEA           | GREASE                   | Y | RFC XXXX |
 /// | 0xF000  - 0xFFFF | Reserved for Private Use | - | RFC XXXX |
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    openmls_serialization_helpers::Serialize,
-    openmls_serialization_helpers::Deserialize,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "0-8-1-storage-format",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(
+    not(feature = "0-8-1-storage-format"),
+    derive(
+        openmls_serialization_helpers::Serialize,
+        openmls_serialization_helpers::Deserialize,
+    )
 )]
 #[repr(u16)]
 pub enum CredentialType {
-    #[storage_tag = 0]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 0)]
     /// A [`BasicCredential`]
     Basic = 1,
-    #[storage_tag = 1]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 1)]
     /// An X.509 [`Certificate`]
     X509 = 2,
-    #[storage_tag = 2]
-    /// Another type of credential that is not in the MLS protocol spec.
-    Other(u16),
-    #[storage_tag = 3]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 3)]
     /// A GREASE credential type for ensuring extensibility.
     Grease(u16),
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 2)]
+    /// Another type of credential that is not in the MLS protocol spec.
+    Other(u16),
 }
 
 impl CredentialType {

--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -85,61 +85,61 @@ mod tests;
 /// | 0xff00  - 0xffff | Reserved for Private Use | N/A        | N/A         | RFC XXXX  |
 ///
 /// Note: OpenMLS does not provide a `Reserved` variant in [ExtensionType].
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    openmls_serialization_helpers::Serialize,
-    openmls_serialization_helpers::Deserialize,
-    Ord,
-    PartialOrd,
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[cfg_attr(
+    feature = "0-8-1-storage-format",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(
+    not(feature = "0-8-1-storage-format"),
+    derive(
+        openmls_serialization_helpers::Serialize,
+        openmls_serialization_helpers::Deserialize,
+    )
 )]
 pub enum ExtensionType {
-    #[storage_tag = 0]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 0)]
     /// The application id extension allows applications to add an explicit,
     /// application-defined identifier to a KeyPackage.
     ApplicationId,
 
-    #[storage_tag = 1]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 1)]
     /// The ratchet tree extensions provides the whole public state of the
     /// ratchet tree.
     RatchetTree,
 
-    #[storage_tag = 2]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 2)]
     /// The required capabilities extension defines the configuration of a group
     /// that imposes certain requirements on clients in the group.
     RequiredCapabilities,
 
-    #[storage_tag = 3]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 3)]
     /// To join a group via an External Commit, a new member needs a GroupInfo
     /// with an ExternalPub extension present in its extensions field.
     ExternalPub,
 
-    #[storage_tag = 4]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 4)]
     /// Group context extension that contains the credentials and signature keys
     /// of senders that are permitted to send external proposals to the group.
     ExternalSenders,
 
-    #[storage_tag = 5]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 5)]
     /// KeyPackage extension that marks a KeyPackage for use in a last resort
     /// scenario.
     LastResort,
 
-    #[storage_tag = 6]
-    /// A currently unknown extension type.
-    Unknown(u16),
+    #[cfg(feature = "extensions-draft-08")]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 8)]
+    /// AppDataDictionary extension
+    AppDataDictionary,
 
-    #[storage_tag = 7]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 7)]
     /// A GREASE extension type for ensuring extensibility.
     Grease(u16),
 
-    #[cfg(feature = "extensions-draft-08")]
-    #[storage_tag = 8]
-    /// AppDataDictionary extension
-    AppDataDictionary,
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 6)]
+    /// A currently unknown extension type.
+    Unknown(u16),
 }
 
 impl ExtensionType {
@@ -310,47 +310,51 @@ impl From<ExtensionType> for u16 {
 ///     opaque extension_data<V>;
 /// } Extension;
 /// ```
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    openmls_serialization_helpers::Serialize,
-    openmls_serialization_helpers::Deserialize,
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "0-8-1-storage-format",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(
+    not(feature = "0-8-1-storage-format"),
+    derive(
+        openmls_serialization_helpers::Serialize,
+        openmls_serialization_helpers::Deserialize,
+    )
 )]
 pub enum Extension {
-    #[storage_tag = 0]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 0)]
     /// An [`ApplicationIdExtension`]
     ApplicationId(ApplicationIdExtension),
 
-    #[storage_tag = 1]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 1)]
     /// A [`RatchetTreeExtension`]
     RatchetTree(RatchetTreeExtension),
 
-    #[storage_tag = 2]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 2)]
     /// A [`RequiredCapabilitiesExtension`]
     RequiredCapabilities(RequiredCapabilitiesExtension),
 
-    #[storage_tag = 3]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 3)]
     /// An [`ExternalPubExtension`]
     ExternalPub(ExternalPubExtension),
 
-    #[storage_tag = 4]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 4)]
     /// An [`ExternalSendersExtension`]
     ExternalSenders(ExternalSendersExtension),
 
-    #[storage_tag = 5]
-    /// A [`LastResortExtension`]
-    LastResort(LastResortExtension),
-
-    #[storage_tag = 6]
-    /// A currently unknown extension.
-    Unknown(u16, UnknownExtension),
-
-    #[storage_tag = 7]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 7)]
     /// An [`AppDataDictionaryExtension`]
     #[cfg(feature = "extensions-draft-08")]
     AppDataDictionary(AppDataDictionaryExtension),
+
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 5)]
+    /// A [`LastResortExtension`]
+    LastResort(LastResortExtension),
+
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 6)]
+    /// A currently unknown extension.
+    Unknown(u16, UnknownExtension),
 }
 
 /// A unknown/unparsed extension represented by raw bytes.

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -72,48 +72,48 @@ use crate::component::ComponentId;
 /// |:=======|:==============|:============|:==============|:==========|:=============================|
 /// | 0x0009 | app_ephemeral | Y           | N             | RFC XXXX  | draft-ietf-mls-extensions-08 |
 /// | 0x000a | self_remove   | Y           | Y             | RFC XXXX  | draft-ietf-mls-extensions-07 |
-#[derive(
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Clone,
-    Copy,
-    Debug,
-    Hash,
-    openmls_serialization_helpers::Serialize,
-    openmls_serialization_helpers::Deserialize,
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash)]
+#[cfg_attr(
+    feature = "0-8-1-storage-format",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(
+    not(feature = "0-8-1-storage-format"),
+    derive(
+        openmls_serialization_helpers::Serialize,
+        openmls_serialization_helpers::Deserialize,
+    )
 )]
 #[allow(missing_docs)]
 #[repr(u16)]
 pub enum ProposalType {
-    #[storage_tag = 0]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 0)]
     Add,
-    #[storage_tag = 1]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 1)]
     Update,
-    #[storage_tag = 2]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 2)]
     Remove,
-    #[storage_tag = 3]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 3)]
     PreSharedKey,
-    #[storage_tag = 4]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 4)]
     Reinit,
-    #[storage_tag = 5]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 5)]
     ExternalInit,
-    #[storage_tag = 6]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 6)]
     GroupContextExtensions,
     // AppAck = 7,
-    #[storage_tag = 8]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 8)]
     SelfRemove,
-    #[storage_tag = 9]
-    Custom(u16),
-    #[storage_tag = 10]
-    Grease(u16),
     #[cfg(feature = "extensions-draft-08")]
-    #[storage_tag = 11]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 11)]
     AppEphemeral,
     #[cfg(feature = "extensions-draft-08")]
-    #[storage_tag = 12]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 12)]
     AppDataUpdate,
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 10)]
+    Grease(u16),
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 9)]
+    Custom(u16),
 }
 
 impl ProposalType {
@@ -256,42 +256,47 @@ impl From<ProposalType> for u16 {
 ///     };
 /// } Proposal;
 /// ```
-#[derive(
-    Debug,
-    PartialEq,
-    Clone,
-    openmls_serialization_helpers::Serialize,
-    openmls_serialization_helpers::Deserialize,
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(
+    feature = "0-8-1-storage-format",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(
+    not(feature = "0-8-1-storage-format"),
+    derive(
+        openmls_serialization_helpers::Serialize,
+        openmls_serialization_helpers::Deserialize,
+    )
 )]
 #[allow(missing_docs)]
 pub enum Proposal {
-    #[storage_tag = 0]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 0)]
     Add(Box<AddProposal>),
-    #[storage_tag = 1]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 1)]
     Update(Box<UpdateProposal>),
-    #[storage_tag = 2]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 2)]
     Remove(Box<RemoveProposal>),
-    #[storage_tag = 3]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 3)]
     PreSharedKey(Box<PreSharedKeyProposal>),
-    #[storage_tag = 4]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 4)]
     ReInit(Box<ReInitProposal>),
-    #[storage_tag = 5]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 5)]
     ExternalInit(Box<ExternalInitProposal>),
-    #[storage_tag = 6]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 6)]
     GroupContextExtensions(Box<GroupContextExtensionProposal>),
     // AppAck = 7,
-    // A SelfRemove proposal is an empty struct.
-    #[storage_tag = 8]
-    SelfRemove,
-    #[storage_tag = 9]
-    Custom(Box<CustomProposal>),
     // # Extensions
     #[cfg(feature = "extensions-draft-08")]
-    #[storage_tag = 10]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 10)]
     AppDataUpdate(Box<AppDataUpdateProposal>),
+    // A SelfRemove proposal is an empty struct.
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 8)]
+    SelfRemove,
     #[cfg(feature = "extensions-draft-08")]
-    #[storage_tag = 11]
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 11)]
     AppEphemeral(Box<AppEphemeralProposal>),
+    #[cfg_attr(not(feature = "0-8-1-storage-format"), storage_tag = 9)]
+    Custom(Box<CustomProposal>),
 }
 
 impl Proposal {


### PR DESCRIPTION
This PR introduces a feature flag to enable storage serialization backwards compatibility with the `openmls` v0.8.1 release. This PR builds on the changes in #2034, which restore storage compatibility with `openmls` v0.7.1, but do not yet address compatibility with `openmls` v0.8.1.

The added `0-8-1-storage-format` feature flag, when enabled, ensures that the `serde` serializations for the affected types (`Extension`, `ExtensionType`, `CredentialType`, `ProposalType`, and `Proposal`) match the formats used in the released `openmls` v0.8.1.

This PR also adds storage compatibility tests for `openmls` v0.8.1, both with and without the `extensions-draft-08` feature,  to the `openmls_compat_tests` crate.
