### PR TITLE
Also publish getters on PrivateMessageIn

### DIFF
--- a/openmls/src/framing/private_message_in.rs
+++ b/openmls/src/framing/private_message_in.rs
@@ -206,17 +206,17 @@ impl PrivateMessageIn {
     }
 
     /// Get the `group_id` in the `PrivateMessage`.
-    pub(crate) fn group_id(&self) -> &GroupId {
+    pub fn group_id(&self) -> &GroupId {
         &self.group_id
     }
 
     /// Get the `epoch` in the `PrivateMessage`.
-    pub(crate) fn epoch(&self) -> GroupEpoch {
+    pub fn epoch(&self) -> GroupEpoch {
         self.epoch
     }
 
     /// Get the `content_type` in the `PrivateMessage`.
-    pub(crate) fn content_type(&self) -> ContentType {
+    pub fn content_type(&self) -> ContentType {
         self.content_type
     }
 


### PR DESCRIPTION
More public getters.

Having these is even more useful, because it allows you to figure out which group you need to load in order to process the message and get a `PrivateMessage` in the first place.