### PR TITLE
Virtual clients: More efficient PPRF

### DIFF
--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -1066,14 +1066,13 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
     }
 
     #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_emulation_epoch_state<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
+    fn delete_vc_emulation_state<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
         &self,
         epoch_id: &EpochId,
     ) -> Result<(), Self::Error> {
-        self.delete::<CURRENT_VERSION>(
-            VC_EMULATION_EPOCH_STATE_LABEL,
-            &serde_json::to_vec(epoch_id).unwrap(),
-        )
+        let serialized_epoch_id = serde_json::to_vec(epoch_id).unwrap();
+        self.delete::<CURRENT_VERSION>(VC_EMULATION_EPOCH_STATE_LABEL, &serialized_epoch_id)?;
+        self.delete::<CURRENT_VERSION>(VC_OPERATION_TREE_LABEL, &serialized_epoch_id)
     }
 
     #[cfg(feature = "virtual-clients-draft")]
@@ -1149,17 +1148,6 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
             return Ok(None);
         };
         Ok(serde_json::from_slice(value).unwrap())
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_operation_tree<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<(), Self::Error> {
-        self.delete::<CURRENT_VERSION>(
-            VC_OPERATION_TREE_LABEL,
-            &serde_json::to_vec(epoch_id).unwrap(),
-        )
     }
 }
 

--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -262,9 +262,9 @@ const APPLICATION_EXPORT_TREE_LABEL: &[u8] = b"ApplicationExportTree";
 #[cfg(feature = "virtual-clients-draft")]
 const VC_EMULATION_EPOCH_STATE_LABEL: &[u8] = b"VcEmulationEpochState";
 #[cfg(feature = "virtual-clients-draft")]
-const VC_PPRF_LABEL: &[u8] = b"VcPprf";
-#[cfg(feature = "virtual-clients-draft")]
 const VC_EMULATION_BINDING_LABEL: &[u8] = b"VcEmulationBinding";
+#[cfg(feature = "virtual-clients-draft")]
+const VC_OPERATION_TREE_LABEL: &[u8] = b"VcOperationTree";
 const INTERIM_TRANSCRIPT_HASH_LABEL: &[u8] = b"InterimTranscriptHash";
 const CONFIRMATION_TAG_LABEL: &[u8] = b"ConfirmationTag";
 
@@ -1077,46 +1077,6 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
     }
 
     #[cfg(feature = "virtual-clients-draft")]
-    fn write_vc_pprf<
-        EpochId: traits::VcEpochId<CURRENT_VERSION>,
-        VcPprf: traits::VcPprf<CURRENT_VERSION>,
-    >(
-        &self,
-        epoch_id: &EpochId,
-        vc_pprf: &VcPprf,
-    ) -> Result<(), Self::Error> {
-        self.write::<CURRENT_VERSION>(
-            VC_PPRF_LABEL,
-            &serde_json::to_vec(epoch_id).unwrap(),
-            serde_json::to_vec(vc_pprf).unwrap(),
-        )
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
-    fn vc_pprf<
-        EpochId: traits::VcEpochId<CURRENT_VERSION>,
-        VcPprf: traits::VcPprf<CURRENT_VERSION>,
-    >(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<Option<VcPprf>, Self::Error> {
-        let values = self.values.read().unwrap();
-        let key = build_key::<CURRENT_VERSION, &EpochId>(VC_PPRF_LABEL, epoch_id);
-        let Some(value) = values.get(&key) else {
-            return Ok(None);
-        };
-        Ok(serde_json::from_slice(value).unwrap())
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_pprf<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<(), Self::Error> {
-        self.delete::<CURRENT_VERSION>(VC_PPRF_LABEL, &serde_json::to_vec(epoch_id).unwrap())
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
     fn write_vc_emulation_bindings<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         VcEmulationBindings: traits::VcEmulationBindings<CURRENT_VERSION>,
@@ -1156,6 +1116,49 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         self.delete::<CURRENT_VERSION>(
             VC_EMULATION_BINDING_LABEL,
             &serde_json::to_vec(group_id).unwrap(),
+        )
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn write_vc_operation_tree<
+        EpochId: traits::VcEpochId<CURRENT_VERSION>,
+        VcOperationTree: traits::VcOperationTree<CURRENT_VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+        vc_operation_tree: &VcOperationTree,
+    ) -> Result<(), Self::Error> {
+        self.write::<CURRENT_VERSION>(
+            VC_OPERATION_TREE_LABEL,
+            &serde_json::to_vec(epoch_id).unwrap(),
+            serde_json::to_vec(vc_operation_tree).unwrap(),
+        )
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn vc_operation_tree<
+        EpochId: traits::VcEpochId<CURRENT_VERSION>,
+        VcOperationTree: traits::VcOperationTree<CURRENT_VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<Option<VcOperationTree>, Self::Error> {
+        let values = self.values.read().unwrap();
+        let key = build_key::<CURRENT_VERSION, &EpochId>(VC_OPERATION_TREE_LABEL, epoch_id);
+        let Some(value) = values.get(&key) else {
+            return Ok(None);
+        };
+        Ok(serde_json::from_slice(value).unwrap())
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn delete_vc_operation_tree<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<(), Self::Error> {
+        self.delete::<CURRENT_VERSION>(
+            VC_OPERATION_TREE_LABEL,
+            &serde_json::to_vec(epoch_id).unwrap(),
         )
     }
 }

--- a/memory_storage/src/test_store.rs
+++ b/memory_storage/src/test_store.rs
@@ -587,7 +587,7 @@ impl StorageProvider<V_TEST> for MemoryStorage {
     }
 
     #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_emulation_epoch_state<EpochId: traits::VcEpochId<V_TEST>>(
+    fn delete_vc_emulation_state<EpochId: traits::VcEpochId<V_TEST>>(
         &self,
         _epoch_id: &EpochId,
     ) -> Result<(), Self::Error> {
@@ -645,14 +645,6 @@ impl StorageProvider<V_TEST> for MemoryStorage {
         &self,
         _epoch_id: &EpochId,
     ) -> Result<Option<VcOperationTree>, Self::Error> {
-        todo!()
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_operation_tree<EpochId: traits::VcEpochId<V_TEST>>(
-        &self,
-        _epoch_id: &EpochId,
-    ) -> Result<(), Self::Error> {
         todo!()
     }
 }

--- a/memory_storage/src/test_store.rs
+++ b/memory_storage/src/test_store.rs
@@ -595,31 +595,6 @@ impl StorageProvider<V_TEST> for MemoryStorage {
     }
 
     #[cfg(feature = "virtual-clients-draft")]
-    fn write_vc_pprf<EpochId: traits::VcEpochId<V_TEST>, VcPprf: traits::VcPprf<V_TEST>>(
-        &self,
-        _epoch_id: &EpochId,
-        _vc_pprf: &VcPprf,
-    ) -> Result<(), Self::Error> {
-        todo!()
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
-    fn vc_pprf<EpochId: traits::VcEpochId<V_TEST>, VcPprf: traits::VcPprf<V_TEST>>(
-        &self,
-        _epoch_id: &EpochId,
-    ) -> Result<Option<VcPprf>, Self::Error> {
-        todo!()
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_pprf<EpochId: traits::VcEpochId<V_TEST>>(
-        &self,
-        _epoch_id: &EpochId,
-    ) -> Result<(), Self::Error> {
-        todo!()
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
     fn write_vc_emulation_bindings<
         GroupId: traits::GroupId<V_TEST>,
         VcEmulationBindings: traits::VcEmulationBindings<V_TEST>,
@@ -646,6 +621,37 @@ impl StorageProvider<V_TEST> for MemoryStorage {
     fn delete_vc_emulation_bindings<GroupId: traits::GroupId<V_TEST>>(
         &self,
         _group_id: &GroupId,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn write_vc_operation_tree<
+        EpochId: traits::VcEpochId<V_TEST>,
+        VcOperationTree: traits::VcOperationTree<V_TEST>,
+    >(
+        &self,
+        _epoch_id: &EpochId,
+        _vc_operation_tree: &VcOperationTree,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn vc_operation_tree<
+        EpochId: traits::VcEpochId<V_TEST>,
+        VcOperationTree: traits::VcOperationTree<V_TEST>,
+    >(
+        &self,
+        _epoch_id: &EpochId,
+    ) -> Result<Option<VcOperationTree>, Self::Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn delete_vc_operation_tree<EpochId: traits::VcEpochId<V_TEST>>(
+        &self,
+        _epoch_id: &EpochId,
     ) -> Result<(), Self::Error> {
         todo!()
     }

--- a/memory_storage/tests/vc_operation_tree.rs
+++ b/memory_storage/tests/vc_operation_tree.rs
@@ -48,8 +48,8 @@ fn operation_tree_read_write_delete() {
     let read: Option<TestOperationTree> = storage.vc_operation_tree(&other_epoch_id).unwrap();
     assert_eq!(read, None);
 
-    // Delete and read None.
-    storage.delete_vc_operation_tree(&epoch_id).unwrap();
+    // Deleting the emulation state removes the operation tree too.
+    storage.delete_vc_emulation_state(&epoch_id).unwrap();
     let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
     assert_eq!(read, None);
 }

--- a/memory_storage/tests/vc_operation_tree.rs
+++ b/memory_storage/tests/vc_operation_tree.rs
@@ -1,0 +1,55 @@
+#![cfg(feature = "virtual-clients-draft")]
+
+use openmls_memory_storage::MemoryStorage;
+use openmls_traits::storage::{
+    traits::{self},
+    Entity, Key, StorageProvider, CURRENT_VERSION,
+};
+use serde::{Deserialize, Serialize};
+
+// Test types
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestEpochId(Vec<u8>);
+impl traits::VcEpochId<CURRENT_VERSION> for TestEpochId {}
+impl Key<CURRENT_VERSION> for TestEpochId {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestOperationTree(Vec<u8>);
+impl traits::VcOperationTree<CURRENT_VERSION> for TestOperationTree {}
+impl Entity<CURRENT_VERSION> for TestOperationTree {}
+
+/// Write, read back, overwrite, and delete an operation secret tree.
+#[test]
+fn operation_tree_read_write_delete() {
+    let storage = MemoryStorage::default();
+    let epoch_id = TestEpochId(b"TestEpochId".to_vec());
+
+    // Nothing is stored initially.
+    let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert_eq!(read, None);
+
+    // Write and read back.
+    let tree = TestOperationTree(b"TestOperationTree".to_vec());
+    storage.write_vc_operation_tree(&epoch_id, &tree).unwrap();
+    let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert_eq!(read, Some(tree));
+
+    // A second write replaces the stored tree (write-back after a ratchet
+    // advance).
+    let advanced_tree = TestOperationTree(b"AdvancedOperationTree".to_vec());
+    storage
+        .write_vc_operation_tree(&epoch_id, &advanced_tree)
+        .unwrap();
+    let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert_eq!(read, Some(advanced_tree));
+
+    // A different epoch id reads nothing.
+    let other_epoch_id = TestEpochId(b"OtherEpochId".to_vec());
+    let read: Option<TestOperationTree> = storage.vc_operation_tree(&other_epoch_id).unwrap();
+    assert_eq!(read, None);
+
+    // Delete and read None.
+    storage.delete_vc_operation_tree(&epoch_id).unwrap();
+    let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert_eq!(read, None);
+}

--- a/openmls/src/components/mod.rs
+++ b/openmls/src/components/mod.rs
@@ -3,3 +3,9 @@
 /// the receiver re-derives.
 #[cfg(feature = "virtual-clients-draft")]
 pub mod vc_derivation_info;
+
+/// Virtual Client Operation Secret Tree (mls-virtual-clients draft): a
+/// per-emulation-epoch secret tree whose leaves expand into one operation
+/// ratchet per operation type.
+#[cfg(feature = "virtual-clients-draft")]
+pub mod vc_operation_tree;

--- a/openmls/src/components/vc_derivation_info.rs
+++ b/openmls/src/components/vc_derivation_info.rs
@@ -1,6 +1,5 @@
 use openmls_traits::{
     crypto::OpenMlsCrypto,
-    random::OpenMlsRand,
     types::{Ciphersuite, CryptoError},
 };
 use serde::{Deserialize, Serialize};
@@ -11,70 +10,45 @@ use crate::{
     binary_tree::{array_representation::TreeSize, LeafNodeIndex},
     ciphersuite::Secret,
     messages::PathSecret,
-    schedule::pprf::{Pprf, PprfError, Prefix256},
     treesync::node::encryption_keys::EncryptionKeyPair,
 };
 
 /// Component ID under which the virtual-clients derivation info is carried in
 /// the leaf node's `app_data_dictionary` extension.
 ///
-/// `0x000D` is a placeholder until the IETF draft is assigned an IANA value.
-pub const VC_COMPONENT_ID: u16 = 0x000D;
+/// `0x0006` is the value the draft suggests for IANA registration, which is
+/// still pending.
+pub const VC_COMPONENT_ID: u16 = 0x0006;
 
-// Operation-secret child labels. Each child is derived from the per-commit
-// operation secret produced by evaluating the per-epoch PPRF on the per-commit
-// input. Only `Encryption Key` and `Path Generation` are wired up at the
-// moment; the remaining ones are reserved so that `key_package` / `application`
-// derivation can be added without churning the constants.
+// Operation-secret child labels. Each child is derived from the per-operation
+// secret produced by the per-epoch operation secret tree. Only
+// `Encryption Key` and `Path Generation` are wired up at the moment, which is
+// all the `leaf_node` commit path needs. The spec also defines
+// `Signature Key` and `Init Key` children. Those, together with the
+// `key_package` and `application` operation paths that consume them, are
+// deferred to a follow-up PR.
 const ENCRYPTION_KEY_LABEL: &str = "Encryption Key";
 const PATH_GENERATION_LABEL: &str = "Path Generation";
 
+/// `ExpandWithLabel` label for the [`DerivationInfoTbe`] AEAD key derived
+/// from the per-epoch [`EpochEncryptionKey`].
+const DERIVATION_INFO_KEY_LABEL: &str = "key";
+/// `ExpandWithLabel` label for the [`DerivationInfoTbe`] AEAD nonce derived
+/// from the per-epoch [`EpochEncryptionKey`].
+const DERIVATION_INFO_NONCE_LABEL: &str = "nonce";
+
 const EPOCH_ID_LABEL: &str = "Epoch ID";
 const EPOCH_ENCRYPTION_KEY_LABEL: &str = "Encryption Key";
-const EPOCH_SECRET_LABEL: &str = "Base Secret";
+const EPOCH_BASE_SECRET_LABEL: &str = "Base Secret";
 /// `DeriveSecret` label for [`ReuseGuardSecret`].
 const REUSE_GUARD_LABEL: &str = "Reuse Guard";
+/// `DeriveSecret` label for [`GenerationIdSecret`].
+const GENERATION_ID_LABEL: &str = "Generation ID Secret";
 /// `ExpandWithLabel` label for the 16-byte FF1 PRP key derived from a
 /// [`ReuseGuardSecret`] (mls-virtual-clients draft, Reuse Guard section).
 const REUSE_GUARD_PRP_KEY_LABEL: &str = "reuse guard";
 /// FF1 PRP key length in bytes (AES-128).
 const PRP_KEY_LEN: usize = 16;
-
-/// PPRF instance keyed on a 32-byte input. One of these is registered per
-/// emulation-group epoch by
-/// [`MlsGroup::register_vc_emulation_epoch`](crate::group::MlsGroup::register_vc_emulation_epoch).
-pub(crate) type VcPprf = Pprf<Prefix256>;
-
-/// Per-commit virtual-clients material that the application supplies to
-/// [`CommitBuilder::vc_emulation`] when sending a commit on a virtual-clients
-/// group.
-///
-/// The PPRF, per-epoch AEAD key, and the registering client's
-/// emulation-group leaf index live in the storage provider — the
-/// application registers them once per emulation epoch via
-/// [`MlsGroup::register_vc_emulation_epoch`], which sources the
-/// per-emulation-epoch root secret from the emulation group's
-/// `safe_export_secret(VC_COMPONENT_ID)`. When creating a commit, the
-/// application supplies just the `epoch_id`; the library hashes
-/// `(stored leaf_index, fresh random)` to produce the PPRF input,
-/// evaluates the PPRF, and persists the punctured state.
-///
-/// The leaf carrying a VC commit must declare
-/// [`ExtensionType::AppDataDictionary`](crate::extensions::ExtensionType::AppDataDictionary)
-/// in its capabilities and must include an `AppComponents` entry (component
-/// id `1`) listing [`VC_COMPONENT_ID`] in its `AppDataDictionary` extension;
-/// otherwise the sender pre-check rejects the commit with
-/// `VirtualClientsError::AppDataDictionaryNotSupported` or
-/// `VirtualClientsError::VcComponentNotListed`.
-///
-/// [`CommitBuilder::vc_emulation`]: crate::group::CommitBuilder::vc_emulation
-/// [`MlsGroup::register_vc_emulation_epoch`]: crate::group::MlsGroup::register_vc_emulation_epoch
-#[derive(Debug)]
-pub struct VcEmulation {
-    /// Identifier of the emulation epoch whose registered PPRF + AEAD key
-    /// the library should use for this commit.
-    pub epoch_id: EpochId,
-}
 
 /// Errors that can occur while processing virtual-clients derivation info.
 #[derive(Error, Debug, PartialEq, Clone)]
@@ -82,16 +56,14 @@ pub enum VirtualClientsError {
     /// The derivation-info bytes failed to deserialize.
     #[error("Failed to deserialize derivation info.")]
     DerivationInfoMalformed,
-    /// AEAD decryption of the encrypted epoch info failed (wrong key,
+    /// AEAD decryption of the encrypted derivation info failed (wrong key,
     /// tampered ciphertext, or mismatched AAD).
-    #[error("Failed to decrypt epoch info.")]
-    EpochInfoDecryptionFailed,
-    /// No virtual-clients epoch encryption key was registered for this epoch.
-    #[error("No virtual-clients epoch encryption key for this epoch.")]
-    MissingEpochEncryptionKey,
-    /// No virtual-clients PPRF was registered for this epoch.
-    #[error("No virtual-clients PPRF for this epoch.")]
-    MissingPprf,
+    #[error("Failed to decrypt derivation info.")]
+    DerivationInfoDecryptionFailed,
+    /// No virtual-clients operation secret tree was registered for this
+    /// epoch.
+    #[error("No virtual-clients operation secret tree for this epoch.")]
+    MissingOperationTree,
     /// No virtual-clients `EmulationEpochState` was registered for this
     /// epoch, or it has been deleted.
     #[error("No virtual-clients emulation-epoch state for this epoch.")]
@@ -104,10 +76,6 @@ pub enum VirtualClientsError {
     /// from the path secret.
     #[error("Leaf encryption key from path does not match the derived key.")]
     EncryptionKeyMismatch,
-    /// PPRF evaluation failed (e.g. the input was already punctured or
-    /// out of bounds).
-    #[error("PPRF evaluation failed: {0}")]
-    PprfError(#[from] PprfError),
     /// A cryptographic operation failed during virtual-clients processing.
     #[error("Cryptographic operation failed.")]
     CryptoError(#[from] CryptoError),
@@ -121,12 +89,9 @@ pub enum VirtualClientsError {
         /// The required number of bytes in the hash output.
         expected_length: usize,
     },
-    /// Random byte generation failed.
-    #[error("Random byte generation failed.")]
-    RandError,
     /// TLS encoding/decoding of a virtual-clients structure failed. Covers
     /// both serialization on the sender side and deserialization of the
-    /// decrypted `EpochInfoTbe` on the receiver side.
+    /// decrypted `DerivationInfoTbe` on the receiver side.
     #[error("TLS codec error: {0}")]
     Tls(#[from] tls_codec::Error),
     /// The leaf carrying (or about to carry) a VC derivation-info entry
@@ -138,6 +103,25 @@ pub enum VirtualClientsError {
     /// [`VC_COMPONENT_ID`].
     #[error("Leaf's AppComponents entry does not list the virtual-clients component id.")]
     VcComponentNotListed,
+    /// The requested leaf index lies outside the operation secret tree.
+    #[error("Leaf index is outside the operation secret tree.")]
+    IndexOutOfBounds,
+    /// The operation secret for the requested generation was already derived
+    /// and deleted for forward secrecy.
+    #[error("The operation secret for this generation was already consumed.")]
+    OperationGenerationConsumed,
+    /// The requested operation generation lies too far beyond the current
+    /// ratchet head (see `MAXIMUM_FORWARD_DISTANCE` in the operation secret
+    /// tree).
+    #[error("The requested operation generation is too far beyond the ratchet head.")]
+    OperationGenerationTooDistant,
+    /// An operation ratchet has reached the maximum generation.
+    #[error("Operation ratchet generation has reached `u32::MAX`.")]
+    OperationRatchetTooLong,
+    /// An unrecoverable error has occurred due to a bug in the
+    /// implementation.
+    #[error("An unrecoverable error has occurred due to a bug in the implementation.")]
+    LibraryError,
 }
 
 /// Per-emulation-epoch root secret. Sourced internally by
@@ -173,29 +157,28 @@ impl EmulatorEpochSecret {
         Ok(EpochId(secret.as_slice().to_vec()))
     }
 
+    /// Derive the per-epoch [`EpochEncryptionKey`]. The key is a KDF
+    /// secret (the per-leaf AEAD key and nonce are expanded from it), so
+    /// it is derived at the KDF's hash length.
     pub(crate) fn derive_epoch_encryption_key(
         &self,
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
     ) -> Result<EpochEncryptionKey, VirtualClientsError> {
-        let secret = self.0.kdf_expand_label(
-            crypto,
-            ciphersuite,
-            EPOCH_ENCRYPTION_KEY_LABEL,
-            &[],
-            ciphersuite.aead_key_length(),
-        )?;
+        let secret = self
+            .0
+            .derive_secret(crypto, ciphersuite, EPOCH_ENCRYPTION_KEY_LABEL)?;
         Ok(EpochEncryptionKey(secret))
     }
 
-    pub(crate) fn derive_epoch_secret(
+    pub(crate) fn derive_epoch_base_secret(
         &self,
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
     ) -> Result<Secret, VirtualClientsError> {
         Ok(self
             .0
-            .derive_secret(crypto, ciphersuite, EPOCH_SECRET_LABEL)?)
+            .derive_secret(crypto, ciphersuite, EPOCH_BASE_SECRET_LABEL)?)
     }
 
     /// Derive the per-emulation-epoch [`ReuseGuardSecret`].
@@ -208,6 +191,18 @@ impl EmulatorEpochSecret {
             .0
             .derive_secret(crypto, ciphersuite, REUSE_GUARD_LABEL)?;
         Ok(ReuseGuardSecret(secret))
+    }
+
+    /// Derive the per-emulation-epoch [`GenerationIdSecret`].
+    pub(crate) fn derive_generation_id_secret(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+    ) -> Result<GenerationIdSecret, VirtualClientsError> {
+        let secret = self
+            .0
+            .derive_secret(crypto, ciphersuite, GENERATION_ID_LABEL)?;
+        Ok(GenerationIdSecret(secret))
     }
 }
 
@@ -232,7 +227,7 @@ impl ReuseGuardSecret {
         Self(secret)
     }
 
-    /// Derive the 16-byte FF1 PRP key for a single private message:
+    /// Derive the 16-byte FF1 PRP key for a single application message:
     ///
     /// ```text
     /// prp_key = ExpandWithLabel(reuse_guard_secret, "reuse guard",
@@ -263,47 +258,105 @@ impl ReuseGuardSecret {
     }
 }
 
-/// Build the per-emulation-epoch [`VcPprf`] root from the emulator epoch
-/// secret. Used by [`MlsGroup::register_vc_emulation_epoch`] together with
-/// the derived [`EpochId`] / [`EpochEncryptionKey`].
+/// Per-emulation-epoch secret used to derive generation IDs for DS
+/// collision detection (mls-virtual-clients draft, "Coordinating ratchet
+/// generations with the DS" section). Derived from [`EmulatorEpochSecret`]
+/// via [`EmulatorEpochSecret::derive_generation_id_secret`].
 ///
-/// The PPRF tree's logical capacity is `2^256` (set by `Prefix256`'s
-/// depth). `TreeSize` is informational metadata stored alongside the
-/// root and is capped at `u32`; the actual input space is determined by
-/// the prefix, not by `width`, so we pass a safely representable
-/// placeholder.
-///
-/// [`MlsGroup::register_vc_emulation_epoch`]: crate::group::MlsGroup::register_vc_emulation_epoch
-pub(crate) fn build_vc_pprf(epoch_secret: Secret) -> VcPprf {
-    VcPprf::new_with_size(epoch_secret, TreeSize::from_leaf_count(u16::MAX as u32))
+/// Derived and persisted now so the per-epoch state is complete, but not yet
+/// consumed: the `generation_id` derivation and its `PrivateMessageContext`
+/// input land in a follow-up PR. It is stored here so older emulation epochs
+/// remain usable once that path exists.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct GenerationIdSecret(Secret);
+
+impl std::fmt::Debug for GenerationIdSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GenerationIdSecret")
+            .field("secret", &"<redacted>")
+            .finish()
+    }
 }
 
+/// The virtual-clients derivation info carried in the leaf node's
+/// `app_data_dictionary` extension under [`VC_COMPONENT_ID`]
+/// (mls-virtual-clients draft):
+///
+/// ```text
+/// struct {
+///   opaque epoch_id<V>;
+///   opaque ciphertext<V>;
+/// } DerivationInfo
+/// ```
+///
+/// `ciphertext` is the AEAD-wrapped [`DerivationInfoTbe`], encrypted in the
+/// emulation group's ciphersuite with key and nonce derived from the
+/// per-epoch [`EpochEncryptionKey`] and the carrying leaf's serialized
+/// `encryption_key`, with `epoch_id` as AAD.
 #[derive(Debug, TlsSize, TlsSerialize, TlsDeserializeBytes)]
 pub(crate) struct DerivationInfo {
     epoch_id: EpochId,
-    ciphertext: EncryptedEpochInfo,
+    ciphertext: Vec<u8>,
 }
 
 impl DerivationInfo {
-    pub(crate) fn new(epoch_id: EpochId, ciphertext: EncryptedEpochInfo) -> Self {
-        Self {
+    /// Encrypt `tbe` under the per-epoch AEAD key, binding it to the leaf
+    /// that carries the resulting derivation info via the leaf's serialized
+    /// `encryption_key` (the key/nonce derivation context) and to
+    /// `epoch_id` (the AAD).
+    pub(crate) fn encrypt(
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        key: &EpochEncryptionKey,
+        epoch_id: EpochId,
+        leaf_encryption_key: &[u8],
+        tbe: &DerivationInfoTbe,
+    ) -> Result<Self, VirtualClientsError> {
+        let (aead_key, aead_nonce) =
+            key.derive_key_nonce(crypto, ciphersuite, leaf_encryption_key)?;
+        let payload = tbe.tls_serialize_detached()?;
+        let ciphertext = crypto.aead_encrypt(
+            ciphersuite.aead_algorithm(),
+            aead_key.as_slice(),
+            payload.as_slice(),
+            aead_nonce.as_slice(),
+            epoch_id.0.as_slice(),
+        )?;
+        Ok(Self {
             epoch_id,
             ciphertext,
-        }
+        })
     }
 
     pub(crate) fn epoch_id(&self) -> &EpochId {
         &self.epoch_id
     }
 
+    /// Decrypt the wrapped [`DerivationInfoTbe`]. `leaf_encryption_key` is
+    /// the serialized `encryption_key` of the leaf node that carries this
+    /// derivation info.
     pub(crate) fn decrypt(
         &self,
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
         key: &EpochEncryptionKey,
-    ) -> Result<EpochInfoTbe, VirtualClientsError> {
-        self.ciphertext
-            .decrypt(crypto, ciphersuite, key, &self.epoch_id)
+        leaf_encryption_key: &[u8],
+    ) -> Result<DerivationInfoTbe, VirtualClientsError> {
+        let (aead_key, aead_nonce) =
+            key.derive_key_nonce(crypto, ciphersuite, leaf_encryption_key)?;
+        let plaintext = crypto
+            .aead_decrypt(
+                ciphersuite.aead_algorithm(),
+                aead_key.as_slice(),
+                self.ciphertext.as_slice(),
+                aead_nonce.as_slice(),
+                self.epoch_id.0.as_slice(),
+            )
+            .map_err(|e| {
+                log::error!("vc: aead decrypt derivation info failed: {e:?}");
+                VirtualClientsError::DerivationInfoDecryptionFailed
+            })?;
+        Ok(DerivationInfoTbe::tls_deserialize_exact_bytes(&plaintext)?)
     }
 }
 
@@ -363,12 +416,22 @@ impl VcEmulationBindings {
     }
 }
 
-/// AEAD key used by the sender to wrap the [`EpochInfoTbe`] in the leaf's
-/// `app_data_dictionary` entry, and by the receiver to unwrap it. Its
-/// length is exactly [`Ciphersuite::aead_key_length`] for the emulation
-/// group's ciphersuite. Derived from the emulation group's
-/// `safe_export_secret(VC_COMPONENT_ID)` by
-/// [`MlsGroup::register_vc_emulation_epoch`].
+/// Per-epoch secret from which the sender derives the AEAD key and nonce
+/// that wrap the [`DerivationInfoTbe`] in the leaf's `app_data_dictionary`
+/// entry, and the receiver the same pair to unwrap it:
+///
+/// ```text
+/// derivation_info_key = ExpandWithLabel(epoch_encryption_key, "key",
+///                                       encryption_key, AEAD.Nk)
+/// derivation_info_nonce = ExpandWithLabel(epoch_encryption_key, "nonce",
+///                                         encryption_key, AEAD.Nn)
+/// ```
+///
+/// where `encryption_key` is the serialized `encryption_key` field of the
+/// LeafNode carrying the derivation info. Every operation produces a fresh
+/// leaf encryption key, so each wrap uses a distinct key-nonce pair.
+/// Derived from the emulation group's `safe_export_secret(VC_COMPONENT_ID)`
+/// by [`MlsGroup::register_vc_emulation_epoch`].
 ///
 /// [`MlsGroup::register_vc_emulation_epoch`]: crate::group::MlsGroup::register_vc_emulation_epoch
 #[derive(Serialize, Deserialize)]
@@ -382,22 +445,53 @@ impl std::fmt::Debug for EpochEncryptionKey {
     }
 }
 
+impl EpochEncryptionKey {
+    /// Derive the AEAD key and nonce for one [`DerivationInfoTbe`] wrap,
+    /// using the serialized `encryption_key` of the carrying leaf as the
+    /// `ExpandWithLabel` context.
+    fn derive_key_nonce(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        leaf_encryption_key: &[u8],
+    ) -> Result<(Secret, Secret), VirtualClientsError> {
+        let key = self.0.kdf_expand_label(
+            crypto,
+            ciphersuite,
+            DERIVATION_INFO_KEY_LABEL,
+            leaf_encryption_key,
+            ciphersuite.aead_key_length(),
+        )?;
+        let nonce = self.0.kdf_expand_label(
+            crypto,
+            ciphersuite,
+            DERIVATION_INFO_NONCE_LABEL,
+            leaf_encryption_key,
+            ciphersuite.aead_nonce_length(),
+        )?;
+        Ok((key, nonce))
+    }
+}
+
 /// Per-emulation-epoch state persisted by
-/// [`MlsGroup::register_vc_emulation_epoch`] alongside the per-epoch PPRF,
-/// keyed by [`EpochId`]. Bundles everything the library needs to emit a VC
-/// commit for this epoch and to XOR private-message nonces with
-/// deterministic reuse guards.
+/// [`MlsGroup::register_vc_emulation_epoch`] alongside the per-epoch
+/// operation secret tree, keyed by [`EpochId`]. Bundles everything the
+/// library needs to emit a VC commit for this epoch and to XOR application
+/// message nonces with deterministic reuse guards.
 ///
 /// [`MlsGroup::register_vc_emulation_epoch`]:
 ///     crate::group::MlsGroup::register_vc_emulation_epoch
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EmulationEpochState {
     /// The registering client's leaf index in the emulation group at
-    /// registration time. Hashed into `EpochInfoTbe` and used as the
+    /// registration time. Sent in `DerivationInfoTbe` and used as the
     /// sender's `leaf_index_e` in the reuse-guard derivation.
     pub(crate) leaf_index: LeafNodeIndex,
     pub(crate) epoch_encryption_key: EpochEncryptionKey,
     pub(crate) reuse_guard_secret: ReuseGuardSecret,
+    /// Stored now but not yet read. The generation-ID derivation that
+    /// consumes it is deferred to a follow-up PR (see [`GenerationIdSecret`]).
+    pub(crate) generation_id_secret: GenerationIdSecret,
     /// Number of leaves `N_e` in the emulation group at registration time.
     pub(crate) emulation_group_size: TreeSize,
     /// Ciphersuite of the emulation group at registration time. Used by
@@ -410,6 +504,7 @@ impl EmulationEpochState {
         leaf_index: LeafNodeIndex,
         epoch_encryption_key: EpochEncryptionKey,
         reuse_guard_secret: ReuseGuardSecret,
+        generation_id_secret: GenerationIdSecret,
         emulation_group_size: TreeSize,
         emulation_ciphersuite: Ciphersuite,
     ) -> Self {
@@ -417,6 +512,7 @@ impl EmulationEpochState {
             leaf_index,
             epoch_encryption_key,
             reuse_guard_secret,
+            generation_id_secret,
             emulation_group_size,
             emulation_ciphersuite,
         }
@@ -444,11 +540,23 @@ impl EmulationEpochState {
     }
 }
 
-/// Per-commit secret produced by evaluating the per-epoch PPRF on the
-/// per-commit hash input. Sender and receiver derive the same value by
-/// evaluating the same registered PPRF on the same input.
+/// Per-operation secret from which the material for a single virtual-clients
+/// operation (commit path, key package, application message) is derived.
+/// Produced by the per-epoch Virtual Client Operation Secret Tree
+/// ([`OperationSecretTree`]). Sender and receiver derive the same value
+/// from the same per-epoch state.
+///
+/// [`OperationSecretTree`]: crate::components::vc_operation_tree::OperationSecretTree
 #[derive(Serialize, Deserialize)]
-pub(crate) struct OperationSecret(Secret);
+pub struct OperationSecret(Secret);
+
+impl std::fmt::Debug for OperationSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OperationSecret")
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
 
 impl From<Secret> for OperationSecret {
     fn from(secret: Secret) -> Self {
@@ -457,6 +565,12 @@ impl From<Secret> for OperationSecret {
 }
 
 impl OperationSecret {
+    /// Test-only accessor for comparing derived operation secrets.
+    #[cfg(test)]
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
     pub(crate) fn derive_encryption_key_secret(
         &self,
         crypto: &impl OpenMlsCrypto,
@@ -502,193 +616,136 @@ impl From<PathGenerationSecret> for PathSecret {
     }
 }
 
-#[derive(Debug, TlsSize, TlsSerialize, TlsDeserializeBytes)]
-pub(crate) struct EncryptedEpochInfo {
-    nonce: Vec<u8>,
-    ciphertext: Vec<u8>,
-}
-
-impl EncryptedEpochInfo {
-    pub fn decrypt(
-        &self,
-        crypto: &impl OpenMlsCrypto,
-        ciphersuite: Ciphersuite,
-        key: &EpochEncryptionKey,
-        epoch_id: &EpochId,
-    ) -> Result<EpochInfoTbe, VirtualClientsError> {
-        let plaintext = crypto
-            .aead_decrypt(
-                ciphersuite.aead_algorithm(),
-                key.0.as_slice(),
-                self.ciphertext.as_slice(),
-                self.nonce.as_slice(),
-                epoch_id.0.as_slice(),
-            )
-            .map_err(|e| {
-                log::error!("vc: aead decrypt epoch info failed: {e:?}");
-                VirtualClientsError::EpochInfoDecryptionFailed
-            })?;
-        Ok(EpochInfoTbe::tls_deserialize_exact_bytes(&plaintext)?)
-    }
-}
-
-/// What virtual-clients operation this per-commit input is being derived
-/// for, per draft PR #11. Mixed into the PPRF input via TLS-serialized
-/// [`EpochInfoTbe`] so that secrets derived for different operations
-/// cannot collide even if the other fields happen to match.
+/// What virtual-clients operation a per-operation secret is being derived
+/// for (mls-virtual-clients draft `VirtualClientOperationType`). Mixed into
+/// the `OperationContext` of every operation-secret derivation so that
+/// secrets derived for different operations cannot collide even if the other
+/// fields happen to match.
+///
+/// The operation type does not travel on the wire. Receivers infer it from
+/// the carrying LeafNode's `leaf_node_source`: `key_package` maps to
+/// [`KeyPackage`](Self::KeyPackage), `update` and `commit` map to
+/// [`LeafNode`](Self::LeafNode).
 ///
 /// Only `LeafNode` is wired into a sender path today (see `apply_vc_emulation`
-/// in the commit builder); `KeyPackage` and `Application` are reserved
-/// variants that future code paths will emit.
+/// in the commit builder). `KeyPackage` and `Application` are reserved
+/// variants that a follow-up PR will emit, once the KeyPackage and
+/// application-message operation paths exist.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, TlsSize, TlsSerialize, TlsDeserializeBytes)]
 #[repr(u8)]
-pub(crate) enum VirtualClientOperationType {
-    LeafNode = 1,
-    #[allow(dead_code)] // reserved
-    KeyPackage = 2,
-    #[allow(dead_code)] // reserved
+pub enum VirtualClientOperationType {
+    /// Derivation of KeyPackage material for the virtual client.
+    KeyPackage = 1,
+    /// Derivation of LeafNode material for the virtual client (e.g. the
+    /// leaf carried by a commit).
+    LeafNode = 2,
+    /// Derivation of application-message material for the virtual client.
     Application = 3,
 }
 
-/// Per-commit AEAD plaintext attached to the leaf via the VC component.
-/// Per the spec, the same struct is hashed (under the emulation group's
-/// ciphersuite) to produce the PPRF input. See [`pprf_input`].
+/// AEAD plaintext attached to the leaf via the VC component
+/// (mls-virtual-clients draft):
+///
+/// ```text
+/// struct {
+///   uint32 leaf_index;
+///   uint32 generation;
+/// } DerivationInfoTBE
+/// ```
 ///
 /// `leaf_index` is the *emulation*-group leaf index of the sending virtual
 /// client, *not* the leaf index in the group that carries this commit.
+/// `generation` is the operation-ratchet generation the sender consumed for
+/// this operation.
 #[derive(Debug, PartialEq, Eq, TlsSize, TlsSerialize, TlsDeserializeBytes)]
-pub(crate) struct EpochInfoTbe {
-    pub operation_type: VirtualClientOperationType,
+pub(crate) struct DerivationInfoTbe {
     pub leaf_index: LeafNodeIndex,
-    pub random: Vec<u8>,
-}
-
-impl EpochInfoTbe {
-    pub fn encrypt(
-        &self,
-        crypto: &impl OpenMlsCrypto,
-        rand: &impl OpenMlsRand,
-        ciphersuite: Ciphersuite,
-        key: &EpochEncryptionKey,
-        epoch_id: &EpochId,
-    ) -> Result<EncryptedEpochInfo, VirtualClientsError> {
-        let nonce = rand
-            .random_vec(ciphersuite.aead_nonce_length())
-            .map_err(|e| {
-                log::error!("vc: aead nonce randomness failed: {e:?}");
-                VirtualClientsError::RandError
-            })?;
-        let payload = self.tls_serialize_detached()?;
-        let ciphertext = crypto.aead_encrypt(
-            ciphersuite.aead_algorithm(),
-            key.0.as_slice(),
-            payload.as_slice(),
-            nonce.as_slice(),
-            epoch_id.0.as_slice(),
-        )?;
-        Ok(EncryptedEpochInfo { nonce, ciphertext })
-    }
-}
-
-/// Compute the 32-byte PPRF input as `Hash(tls_serialize(epoch_info))`,
-/// truncating to 32 bytes when the ciphersuite's hash is wider (the
-/// PPRF's `Prefix256` indexes into the first 256 bits).
-pub(crate) fn pprf_input(
-    crypto: &impl OpenMlsCrypto,
-    ciphersuite: Ciphersuite,
-    epoch_info: &EpochInfoTbe,
-) -> Result<[u8; Prefix256::PPRF_INPUT_LEN], VirtualClientsError> {
-    let serialized = epoch_info.tls_serialize_detached()?;
-    let hash = crypto.hash(ciphersuite.hash_algorithm(), &serialized)?;
-    if hash.len() < Prefix256::PPRF_INPUT_LEN {
-        log::error!(
-            "vc: pprf input hash too short: got {} bytes, need {}",
-            hash.len(),
-            Prefix256::PPRF_INPUT_LEN
-        );
-        return Err(VirtualClientsError::HashOutputLengthMismatch {
-            actual_length: hash.len(),
-            expected_length: Prefix256::PPRF_INPUT_LEN,
-        });
-    }
-    let mut input = [0u8; Prefix256::PPRF_INPUT_LEN];
-    input.copy_from_slice(&hash[..Prefix256::PPRF_INPUT_LEN]);
-    Ok(input)
+    pub generation: u32,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use openmls_rust_crypto::OpenMlsRustCrypto;
-    use openmls_traits::OpenMlsProvider;
+    use openmls_traits::{random::OpenMlsRand, OpenMlsProvider};
 
-    /// Round-trip an `EpochInfoTbe` through `encrypt` ↔ `decrypt`. Catches
-    /// any disagreement between the two methods on the AAD/key/nonce layout
-    /// and any silent regression in the AEAD wrapping.
-    #[test]
-    fn epoch_info_tbe_roundtrip() {
-        let provider = OpenMlsRustCrypto::default();
-        let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+    fn setup_key_and_epoch_id(provider: &OpenMlsRustCrypto) -> (EpochEncryptionKey, EpochId) {
         let emulator = EmulatorEpochSecret::new(
             &provider
                 .rand()
-                .random_vec(ciphersuite.hash_length())
+                .random_vec(CIPHERSUITE.hash_length())
                 .expect("randomness"),
         );
         let key = emulator
-            .derive_epoch_encryption_key(provider.crypto(), ciphersuite)
+            .derive_epoch_encryption_key(provider.crypto(), CIPHERSUITE)
             .expect("derive ek");
         let epoch_id = emulator
-            .derive_epoch_id(provider.crypto(), ciphersuite)
+            .derive_epoch_id(provider.crypto(), CIPHERSUITE)
             .expect("derive epoch id");
-        let original = EpochInfoTbe {
-            operation_type: VirtualClientOperationType::LeafNode,
+        (key, epoch_id)
+    }
+
+    /// Round-trip a `DerivationInfoTbe` through `encrypt` and `decrypt`.
+    /// Catches any disagreement between the two methods on the derived
+    /// key/nonce, the AAD, or the TLS layout of the plaintext.
+    #[test]
+    fn derivation_info_tbe_roundtrip() {
+        let provider = OpenMlsRustCrypto::default();
+        let (key, epoch_id) = setup_key_and_epoch_id(&provider);
+        let leaf_encryption_key = provider.rand().random_vec(32).expect("randomness");
+        let original = DerivationInfoTbe {
             leaf_index: LeafNodeIndex::new(7),
-            random: provider.rand().random_vec(32).expect("randomness"),
+            generation: 3,
         };
-        let encrypted = original
-            .encrypt(
-                provider.crypto(),
-                provider.rand(),
-                ciphersuite,
-                &key,
-                &epoch_id,
-            )
-            .expect("encrypt");
-        let decrypted = encrypted
-            .decrypt(provider.crypto(), ciphersuite, &key, &epoch_id)
+        let derivation_info = DerivationInfo::encrypt(
+            provider.crypto(),
+            CIPHERSUITE,
+            &key,
+            epoch_id.clone(),
+            &leaf_encryption_key,
+            &original,
+        )
+        .expect("encrypt");
+        assert_eq!(derivation_info.epoch_id(), &epoch_id);
+        let decrypted = derivation_info
+            .decrypt(provider.crypto(), CIPHERSUITE, &key, &leaf_encryption_key)
             .expect("decrypt");
         assert_eq!(original, decrypted);
     }
 
-    /// Two `EpochInfoTbe`s with identical `(leaf_index, random)` but
-    /// different `operation_type` must produce different PPRF inputs;
-    /// otherwise, sharing a PPRF across operation contexts would be
-    /// unsafe.
+    /// Decryption must fail when the leaf encryption key used as the
+    /// key/nonce derivation context does not match the one used for
+    /// encryption. This is what binds the derivation info to the leaf
+    /// that carries it.
     #[test]
-    fn pprf_input_changes_with_operation_type() {
+    fn decryption_fails_with_wrong_leaf_encryption_key() {
         let provider = OpenMlsRustCrypto::default();
-        let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-        let leaf_node = EpochInfoTbe {
-            operation_type: VirtualClientOperationType::LeafNode,
-            leaf_index: LeafNodeIndex::new(3),
-            random: vec![0xAA; 32],
+        let (key, epoch_id) = setup_key_and_epoch_id(&provider);
+        let leaf_encryption_key = provider.rand().random_vec(32).expect("randomness");
+        let tbe = DerivationInfoTbe {
+            leaf_index: LeafNodeIndex::new(1),
+            generation: 0,
         };
-        let key_package = EpochInfoTbe {
-            operation_type: VirtualClientOperationType::KeyPackage,
-            leaf_index: LeafNodeIndex::new(3),
-            random: vec![0xAA; 32],
-        };
-        let application = EpochInfoTbe {
-            operation_type: VirtualClientOperationType::Application,
-            leaf_index: LeafNodeIndex::new(3),
-            random: vec![0xAA; 32],
-        };
-        let in_leaf = pprf_input(provider.crypto(), ciphersuite, &leaf_node).unwrap();
-        let in_kp = pprf_input(provider.crypto(), ciphersuite, &key_package).unwrap();
-        let in_app = pprf_input(provider.crypto(), ciphersuite, &application).unwrap();
-        assert_ne!(in_leaf, in_kp);
-        assert_ne!(in_leaf, in_app);
-        assert_ne!(in_kp, in_app);
+        let derivation_info = DerivationInfo::encrypt(
+            provider.crypto(),
+            CIPHERSUITE,
+            &key,
+            epoch_id,
+            &leaf_encryption_key,
+            &tbe,
+        )
+        .expect("encrypt");
+        let other_leaf_encryption_key = provider.rand().random_vec(32).expect("randomness");
+        let err = derivation_info
+            .decrypt(
+                provider.crypto(),
+                CIPHERSUITE,
+                &key,
+                &other_leaf_encryption_key,
+            )
+            .expect_err("decryption with the wrong context must fail");
+        assert_eq!(err, VirtualClientsError::DerivationInfoDecryptionFailed);
     }
 }

--- a/openmls/src/components/vc_derivation_info.rs
+++ b/openmls/src/components/vc_derivation_info.rs
@@ -4,7 +4,9 @@ use openmls_traits::{
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tls_codec::{DeserializeBytes, Serialize as _, TlsDeserializeBytes, TlsSerialize, TlsSize};
+use tls_codec::{
+    DeserializeBytes, Serialize as _, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes,
+};
 
 use crate::{
     binary_tree::{array_representation::TreeSize, LeafNodeIndex},
@@ -154,7 +156,7 @@ impl EmulatorEpochSecret {
         ciphersuite: Ciphersuite,
     ) -> Result<EpochId, VirtualClientsError> {
         let secret = self.0.derive_secret(crypto, ciphersuite, EPOCH_ID_LABEL)?;
-        Ok(EpochId(secret.as_slice().to_vec()))
+        Ok(EpochId(secret.as_slice().to_vec().into()))
     }
 
     /// Derive the per-epoch [`EpochEncryptionKey`]. The key is a KDF
@@ -296,7 +298,7 @@ impl std::fmt::Debug for GenerationIdSecret {
 #[derive(Debug, TlsSize, TlsSerialize, TlsDeserializeBytes)]
 pub(crate) struct DerivationInfo {
     epoch_id: EpochId,
-    ciphertext: Vec<u8>,
+    ciphertext: VLBytes,
 }
 
 impl DerivationInfo {
@@ -324,7 +326,7 @@ impl DerivationInfo {
         )?;
         Ok(Self {
             epoch_id,
-            ciphertext,
+            ciphertext: ciphertext.into(),
         })
     }
 
@@ -369,7 +371,7 @@ impl DerivationInfo {
 #[derive(
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
 )]
-pub struct EpochId(Vec<u8>);
+pub struct EpochId(VLBytes);
 
 /// Per-higher-level-group record of which emulation-group epoch produced the
 /// virtual-client LeafNode that was active at each recent epoch of that

--- a/openmls/src/components/vc_operation_tree.rs
+++ b/openmls/src/components/vc_operation_tree.rs
@@ -31,7 +31,7 @@ use std::collections::BTreeMap;
 
 use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite};
 use serde::{Deserialize, Serialize};
-use tls_codec::{Serialize as _, TlsSerialize, TlsSize};
+use tls_codec::{Serialize as _, TlsSerialize, TlsSize, VLBytes};
 
 use crate::{
     binary_tree::{
@@ -178,7 +178,7 @@ impl OperationSecretTree {
             leaf_index,
             generation,
             operation_type,
-            operation_context: operation_context.to_vec(),
+            operation_context: operation_context.to_vec().into(),
         };
         // `operation_generation_secret` is dropped when this function
         // returns, deleting it as required by the spec.
@@ -548,7 +548,7 @@ struct OperationContext {
     leaf_index: LeafNodeIndex,
     generation: u32,
     operation_type: VirtualClientOperationType,
-    operation_context: Vec<u8>,
+    operation_context: VLBytes,
 }
 
 impl OperationContext {

--- a/openmls/src/components/vc_operation_tree.rs
+++ b/openmls/src/components/vc_operation_tree.rs
@@ -160,7 +160,7 @@ impl OperationSecretTree {
     /// consumed generation and reuses key material, the reuse the draft
     /// forbids. See the type-level `# Concurrency` note.
     #[allow(clippy::too_many_arguments)]
-    pub fn derive_operation_secret(
+    pub(crate) fn derive_operation_secret(
         &mut self,
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,
@@ -199,7 +199,7 @@ impl OperationSecretTree {
     /// observed on the wire. Allocating from a stale copy, or persisting
     /// late, lets two operations share a generation and reuse key material,
     /// the reuse the draft forbids. See the type-level `# Concurrency` note.
-    pub fn next_operation_secret(
+    pub(crate) fn next_operation_secret(
         &mut self,
         crypto: &impl OpenMlsCrypto,
         ciphersuite: Ciphersuite,

--- a/openmls/src/components/vc_operation_tree.rs
+++ b/openmls/src/components/vc_operation_tree.rs
@@ -1,0 +1,1092 @@
+//! Virtual Client Operation Secret Tree (mls-virtual-clients draft).
+//!
+//! A tree of secrets with the same structure as the RFC 9420 secret tree
+//! (Section 9): it has the same set of nodes and edges as the emulation
+//! group's ratchet tree at the corresponding epoch, parent-to-child node
+//! derivation uses the same `"tree"` label with `"left"` / `"right"`
+//! context, and each leaf is expanded once it is first used. It differs
+//! from the RFC 9420 secret tree in two ways: the root is the
+//! per-emulation-epoch `epoch_base_secret` rather than a secret derived
+//! from `encryption_secret`, and each leaf expands into one operation
+//! ratchet per [`VirtualClientOperationType`] instead of a handshake and an
+//! application sender ratchet.
+//!
+//! Each ratchet hands out one [`OperationSecret`] per generation, bound to
+//! the spec's `OperationContext`
+//! `(epoch_id, leaf_index, generation, operation_type, operation_context)`.
+//!
+//! Forward secrecy mirrors the RFC 9420 secret tree: parent node secrets
+//! are deleted once their children are derived, a leaf secret is deleted as
+//! soon as the initial ratchet secrets for all operation types have been
+//! derived, and ratchet heads plus generation secrets are deleted as soon
+//! as the operation secret of a generation has been derived. Deriving for a
+//! generation ahead of the ratchet head retains only the
+//! context-independent `operation_generation_secret` of each skipped
+//! generation, since the final operation secret also binds the (then still
+//! unknown) operation context. The retained entry is deleted when the
+//! operation for that generation arrives. Retention is bounded by
+//! [`MAXIMUM_FORWARD_DISTANCE`] and [`OUT_OF_ORDER_TOLERANCE`].
+
+use std::collections::BTreeMap;
+
+use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite};
+use serde::{Deserialize, Serialize};
+use tls_codec::{Serialize as _, TlsSerialize, TlsSize};
+
+use crate::{
+    binary_tree::{
+        array_representation::{
+            direct_path, left, right, root, ParentNodeIndex, TreeNodeIndex, TreeSize,
+        },
+        LeafNodeIndex,
+    },
+    ciphersuite::Secret,
+    components::vc_derivation_info::{
+        EpochId, OperationSecret, VirtualClientOperationType, VirtualClientsError,
+    },
+    tree::secret_tree::derive_child_secrets,
+    utils::vector_converter,
+};
+
+/// `ExpandWithLabel` label for the initial operation ratchet secret of each
+/// operation type, expanded from a leaf secret.
+const OPERATION_RATCHET_INIT_LABEL: &str = "vc operation init";
+/// `DeriveSecret` label for the per-generation `operation_generation_secret`.
+const OPERATION_GENERATION_LABEL: &str = "VC Operation Secret";
+/// `DeriveSecret` label for advancing an operation ratchet to the next
+/// generation.
+const OPERATION_RATCHET_ADVANCE_LABEL: &str = "VC Operation Ratchet";
+/// `ExpandWithLabel` label for the final operation secret, expanded from an
+/// `operation_generation_secret` with the TLS-serialized [`OperationContext`].
+const OPERATION_SECRET_LABEL: &str = "vc operation";
+
+/// How far beyond the current ratchet head a requested generation may lie.
+/// Requests further out fail with
+/// [`VirtualClientsError::OperationGenerationTooDistant`], which also stops a
+/// malicious sibling from forcing up to `u32::MAX` KDF steps through a
+/// fabricated `generation` in a commit's `DerivationInfo`.
+///
+/// Operation ratchets advance once per virtual-client operation rather than
+/// once per message, so legitimate gaps stay small: commits within one
+/// higher-level group are DS-ordered, but one tree spans all higher-level
+/// groups of the virtual client, so operations from different groups can be
+/// processed out of allocation order, and DS-rejected commits leave burned
+/// generations that receivers skip. This bound and
+/// [`OUT_OF_ORDER_TOLERANCE`] can become configurable later alongside the
+/// planned emulation-group configuration.
+const MAXIMUM_FORWARD_DISTANCE: u32 = 1024;
+
+/// How many skipped `operation_generation_secret`s a ratchet retains.
+/// Skipping past more than this many unconsumed generations evicts the oldest
+/// retained entries first, after which they fail with
+/// [`VirtualClientsError::OperationGenerationConsumed`]. The draft says
+/// implementations SHOULD bound how many skipped generations they retain,
+/// since every retained secret weakens forward secrecy within the emulation
+/// epoch. See [`MAXIMUM_FORWARD_DISTANCE`] for why legitimate gaps stay
+/// small and for the plan to make both bounds configurable.
+const OUT_OF_ORDER_TOLERANCE: usize = 32;
+
+/// Per-emulation-epoch Virtual Client Operation Secret Tree.
+///
+/// Rooted at the epoch's `epoch_base_secret` and shaped like the emulation
+/// group's ratchet tree at the corresponding epoch (sized by the leaf
+/// count, including blank leaves). Node secrets and per-leaf operation
+/// ratchets are derived lazily on first use, and consumed material is deleted
+/// as it is used (see the module documentation for the forward-secrecy
+/// rules).
+///
+/// # Concurrency
+///
+/// One tree is shared by all higher-level groups the virtual client is a
+/// member of. Every derivation mutates it, so a load-derive-store cycle
+/// against the storage provider must be atomic per emulation epoch.
+/// Applications that process messages for multiple higher-level groups in
+/// parallel must serialize these cycles. Two concurrent cycles on separate
+/// copies of the tree can allocate the same generation for two different
+/// operations (the key reuse the draft forbids) and last-write-wins
+/// persistence loses the other copy's punctured nodes and retained skipped
+/// generations.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OperationSecretTree {
+    leaf_nodes: Vec<Option<Secret>>,
+    parent_nodes: Vec<Option<Secret>>,
+    operation_ratchets: Vec<Option<LeafOperationRatchets>>,
+    size: TreeSize,
+}
+
+impl OperationSecretTree {
+    /// Create a tree rooted at `epoch_base_secret` with the given `size`.
+    /// The inner node secrets and the operation ratchets only get derived
+    /// when operation secrets are requested.
+    ///
+    /// `Secret` and `TreeSize` are crate-internal, so unlike the derivation
+    /// methods this constructor cannot be `pub`.
+    pub(crate) fn new(epoch_base_secret: Secret, size: TreeSize) -> Self {
+        let leaf_count = size.leaf_count() as usize;
+        let mut tree = Self {
+            leaf_nodes: std::iter::repeat_with(|| None).take(leaf_count).collect(),
+            parent_nodes: std::iter::repeat_with(|| None).take(leaf_count).collect(),
+            operation_ratchets: std::iter::repeat_with(|| None).take(leaf_count).collect(),
+            size,
+        };
+        // Set the epoch base secret in the root node. We ignore the Result
+        // here, since we rely on the tree math to be correct, i.e.
+        // root(size) < size.
+        let _ = tree.set_node(root(size), Some(epoch_base_secret));
+        tree
+    }
+
+    /// Derive the operation secret for the given coordinates, advancing the
+    /// per-leaf, per-operation-type ratchet as necessary.
+    ///
+    /// Deriving for a generation ahead of the ratchet head advances the head
+    /// past it while retaining the context-independent generation secrets of
+    /// the skipped generations (at most [`OUT_OF_ORDER_TOLERANCE`], oldest
+    /// evicted first), so the corresponding operations can still be processed
+    /// when they arrive. Asking for a generation whose operation secret was
+    /// already derived or evicted fails with
+    /// [`VirtualClientsError::OperationGenerationConsumed`], a generation
+    /// more than [`MAXIMUM_FORWARD_DISTANCE`] beyond the head fails with
+    /// [`VirtualClientsError::OperationGenerationTooDistant`], and a leaf
+    /// index outside the tree fails with
+    /// [`VirtualClientsError::IndexOutOfBounds`].
+    ///
+    /// # Warning
+    ///
+    /// This mutates the tree: it advances and punctures ratchets. The caller
+    /// MUST persist the mutated tree before any other cycle reads it, as a
+    /// single atomic load-derive-store per emulation epoch. Deriving against
+    /// a stale copy, or not persisting before the next derive, re-serves a
+    /// consumed generation and reuses key material, the reuse the draft
+    /// forbids. See the type-level `# Concurrency` note.
+    #[allow(clippy::too_many_arguments)]
+    pub fn derive_operation_secret(
+        &mut self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        epoch_id: &EpochId,
+        leaf_index: LeafNodeIndex,
+        operation_type: VirtualClientOperationType,
+        generation: u32,
+        operation_context: &[u8],
+    ) -> Result<OperationSecret, VirtualClientsError> {
+        let ratchet = self.ratchet_mut(crypto, ciphersuite, leaf_index, operation_type)?;
+        let operation_generation_secret =
+            ratchet.generation_secret(crypto, ciphersuite, generation)?;
+        let context = OperationContext {
+            epoch_id: epoch_id.clone(),
+            leaf_index,
+            generation,
+            operation_type,
+            operation_context: operation_context.to_vec(),
+        };
+        // `operation_generation_secret` is dropped when this function
+        // returns, deleting it as required by the spec.
+        context.expand_operation_secret(crypto, ciphersuite, &operation_generation_secret)
+    }
+
+    /// Advance the caller's own ratchet for `operation_type` at
+    /// `own_leaf_index` and return the generation it was at together with the
+    /// operation secret for that generation. Use this when sending an
+    /// operation. Receivers re-derive the same secret positionally via
+    /// [`OperationSecretTree::derive_operation_secret`].
+    ///
+    /// # Warning
+    ///
+    /// This mutates the tree: it advances the own ratchet by one generation.
+    /// The caller MUST persist the mutated tree in the same atomic
+    /// load-derive-store cycle, before the allocated generation can be
+    /// observed on the wire. Allocating from a stale copy, or persisting
+    /// late, lets two operations share a generation and reuse key material,
+    /// the reuse the draft forbids. See the type-level `# Concurrency` note.
+    pub fn next_operation_secret(
+        &mut self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        epoch_id: &EpochId,
+        own_leaf_index: LeafNodeIndex,
+        operation_type: VirtualClientOperationType,
+        operation_context: &[u8],
+    ) -> Result<(u32, OperationSecret), VirtualClientsError> {
+        let generation = self
+            .ratchet_mut(crypto, ciphersuite, own_leaf_index, operation_type)?
+            .head_generation();
+        let operation_secret = self.derive_operation_secret(
+            crypto,
+            ciphersuite,
+            epoch_id,
+            own_leaf_index,
+            operation_type,
+            generation,
+            operation_context,
+        )?;
+        Ok((generation, operation_secret))
+    }
+
+    /// Return the ratchet for `(leaf_index, operation_type)`, initializing
+    /// the leaf's operation ratchets first if necessary.
+    fn ratchet_mut(
+        &mut self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        leaf_index: LeafNodeIndex,
+        operation_type: VirtualClientOperationType,
+    ) -> Result<&mut OperationRatchet, VirtualClientsError> {
+        if leaf_index.u32() >= self.size.leaf_count() {
+            log::error!("vc: leaf index is larger than the operation secret tree size.");
+            return Err(VirtualClientsError::IndexOutOfBounds);
+        }
+        if self
+            .operation_ratchets
+            .get(leaf_index.usize())
+            .ok_or(VirtualClientsError::IndexOutOfBounds)?
+            .is_none()
+        {
+            self.initialize_leaf_ratchets(crypto, ciphersuite, leaf_index)?;
+        }
+        let ratchets = self
+            .operation_ratchets
+            .get_mut(leaf_index.usize())
+            .and_then(|ratchets| ratchets.as_mut())
+            // We just initialized the ratchets, so this should not happen.
+            .ok_or(VirtualClientsError::LibraryError)?;
+        Ok(ratchets.ratchet_mut(operation_type))
+    }
+
+    /// Derive the node secrets down to `leaf_index`, expand the leaf secret
+    /// into one initial ratchet secret per operation type and delete it.
+    fn initialize_leaf_ratchets(
+        &mut self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        leaf_index: LeafNodeIndex,
+    ) -> Result<(), VirtualClientsError> {
+        // If we don't have a secret in the leaf node, we derive it from the
+        // closest populated ancestor.
+        if self.get_node(leaf_index.into())?.is_none() {
+            // Collect empty nodes in the direct path until a non-empty node
+            // is found.
+            let mut empty_nodes: Vec<ParentNodeIndex> = Vec::new();
+            for parent_node in direct_path(leaf_index, self.size) {
+                empty_nodes.push(parent_node);
+                if self.get_node(parent_node.into())?.is_some() {
+                    break;
+                }
+            }
+            // Derive the secrets down all the way to the leaf node, deleting
+            // each parent secret once its children are populated.
+            empty_nodes.reverse();
+            for parent_node in empty_nodes {
+                self.derive_down(crypto, ciphersuite, parent_node)?;
+            }
+        }
+
+        // Take the leaf secret out of the tree: the spec requires deleting
+        // it as soon as the initial ratchet secrets for all operation types
+        // have been derived. `initialize` consumes and drops it.
+        let leaf_secret = self
+            .leaf_nodes
+            .get_mut(leaf_index.usize())
+            .ok_or(VirtualClientsError::IndexOutOfBounds)?
+            .take()
+            // We just derived all necessary nodes, so this should not happen.
+            .ok_or(VirtualClientsError::LibraryError)?;
+        let ratchets = LeafOperationRatchets::initialize(crypto, ciphersuite, leaf_secret)?;
+        *self
+            .operation_ratchets
+            .get_mut(leaf_index.usize())
+            .ok_or(VirtualClientsError::IndexOutOfBounds)? = Some(ratchets);
+        Ok(())
+    }
+
+    /// Derive the secrets for the child nodes of a parent node, deleting the
+    /// parent node's secret.
+    fn derive_down(
+        &mut self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        parent_index: ParentNodeIndex,
+    ) -> Result<(), VirtualClientsError> {
+        let parent_secret = self
+            .parent_nodes
+            .get_mut(parent_index.usize())
+            .ok_or(VirtualClientsError::IndexOutOfBounds)?
+            // Taking the secret deletes the parent node.
+            .take()
+            // This function only gets called top to bottom, so this should
+            // not happen.
+            .ok_or(VirtualClientsError::LibraryError)?;
+        let (left_secret, right_secret) =
+            derive_child_secrets(&parent_secret, crypto, ciphersuite)?;
+        self.set_node(left(parent_index), Some(left_secret))?;
+        self.set_node(right(parent_index), Some(right_secret))?;
+        Ok(())
+    }
+
+    fn get_node(&self, index: TreeNodeIndex) -> Result<Option<&Secret>, VirtualClientsError> {
+        match index {
+            TreeNodeIndex::Leaf(leaf_index) => Ok(self
+                .leaf_nodes
+                .get(leaf_index.usize())
+                .ok_or(VirtualClientsError::IndexOutOfBounds)?
+                .as_ref()),
+            TreeNodeIndex::Parent(parent_index) => Ok(self
+                .parent_nodes
+                .get(parent_index.usize())
+                .ok_or(VirtualClientsError::IndexOutOfBounds)?
+                .as_ref()),
+        }
+    }
+
+    fn set_node(
+        &mut self,
+        index: TreeNodeIndex,
+        secret: Option<Secret>,
+    ) -> Result<(), VirtualClientsError> {
+        match index {
+            TreeNodeIndex::Leaf(leaf_index) => {
+                *self
+                    .leaf_nodes
+                    .get_mut(leaf_index.usize())
+                    .ok_or(VirtualClientsError::IndexOutOfBounds)? = secret;
+            }
+            TreeNodeIndex::Parent(parent_index) => {
+                *self
+                    .parent_nodes
+                    .get_mut(parent_index.usize())
+                    .ok_or(VirtualClientsError::IndexOutOfBounds)? = secret;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The per-operation-type ratchets expanded from one leaf secret, one per
+/// non-reserved [`VirtualClientOperationType`].
+#[derive(Debug, Serialize, Deserialize)]
+struct LeafOperationRatchets {
+    key_package: OperationRatchet,
+    leaf_node: OperationRatchet,
+    application: OperationRatchet,
+}
+
+impl LeafOperationRatchets {
+    /// Expand `leaf_secret` into the initial ratchet secret for every
+    /// non-reserved operation type:
+    ///
+    /// ```text
+    /// operation_ratchet_secret[operation_type][0] =
+    ///   ExpandWithLabel(leaf_secret, "vc operation init", operation_type, Kdf.Nh)
+    /// ```
+    ///
+    /// where `operation_type` is the TLS-encoded
+    /// [`VirtualClientOperationType`] value. `leaf_secret` is consumed and
+    /// dropped here, per the spec requirement to delete it as soon as the
+    /// initial ratchet secrets for all operation types have been derived.
+    fn initialize(
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        leaf_secret: Secret,
+    ) -> Result<Self, VirtualClientsError> {
+        let initial_ratchet_secret =
+            |operation_type: VirtualClientOperationType| -> Result<Secret, VirtualClientsError> {
+                let context = operation_type.tls_serialize_detached()?;
+                Ok(leaf_secret.kdf_expand_label(
+                    crypto,
+                    ciphersuite,
+                    OPERATION_RATCHET_INIT_LABEL,
+                    &context,
+                    ciphersuite.hash_length(),
+                )?)
+            };
+        Ok(Self {
+            key_package: OperationRatchet::new(initial_ratchet_secret(
+                VirtualClientOperationType::KeyPackage,
+            )?),
+            leaf_node: OperationRatchet::new(initial_ratchet_secret(
+                VirtualClientOperationType::LeafNode,
+            )?),
+            application: OperationRatchet::new(initial_ratchet_secret(
+                VirtualClientOperationType::Application,
+            )?),
+        })
+    }
+
+    fn ratchet_mut(&mut self, operation_type: VirtualClientOperationType) -> &mut OperationRatchet {
+        match operation_type {
+            VirtualClientOperationType::KeyPackage => &mut self.key_package,
+            VirtualClientOperationType::LeafNode => &mut self.leaf_node,
+            VirtualClientOperationType::Application => &mut self.application,
+        }
+    }
+}
+
+/// A single operation ratchet: the current ratchet head plus the
+/// context-independent `operation_generation_secret`s retained for
+/// generations that were skipped over.
+#[derive(Debug, Serialize, Deserialize)]
+struct OperationRatchet {
+    /// The `operation_ratchet_secret` for `next_generation`.
+    ratchet_secret: Secret,
+    next_generation: u32,
+    /// Retained `operation_generation_secret`s of skipped generations,
+    /// deleted when the operation for the generation arrives. A generation
+    /// below `next_generation` without an entry here was already consumed.
+    #[serde(with = "vector_converter")]
+    retained_generation_secrets: BTreeMap<u32, Secret>,
+}
+
+impl OperationRatchet {
+    fn new(initial_ratchet_secret: Secret) -> Self {
+        Self {
+            ratchet_secret: initial_ratchet_secret,
+            next_generation: 0,
+            retained_generation_secrets: BTreeMap::new(),
+        }
+    }
+
+    /// The generation the ratchet head is currently at, i.e. the generation
+    /// the next own operation would use.
+    fn head_generation(&self) -> u32 {
+        self.next_generation
+    }
+
+    /// Return the `operation_generation_secret` for `generation`, advancing
+    /// the ratchet head past it if necessary. Skipped generations retain
+    /// their generation secret, keeping at most [`OUT_OF_ORDER_TOLERANCE`]
+    /// entries by evicting the oldest first. Asking for a generation that was
+    /// already consumed or evicted fails with
+    /// [`VirtualClientsError::OperationGenerationConsumed`], and a generation
+    /// more than [`MAXIMUM_FORWARD_DISTANCE`] beyond the head fails with
+    /// [`VirtualClientsError::OperationGenerationTooDistant`] without
+    /// advancing the head.
+    fn generation_secret(
+        &mut self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        generation: u32,
+    ) -> Result<Secret, VirtualClientsError> {
+        if generation < self.next_generation {
+            // Removing the entry deletes the retained secret once the caller
+            // drops it.
+            return self
+                .retained_generation_secrets
+                .remove(&generation)
+                .ok_or(VirtualClientsError::OperationGenerationConsumed);
+        }
+        if self.next_generation < u32::MAX - MAXIMUM_FORWARD_DISTANCE
+            && generation > self.next_generation + MAXIMUM_FORWARD_DISTANCE
+        {
+            log::error!(
+                "vc: requested operation generation {generation} is more than \
+                 {MAXIMUM_FORWARD_DISTANCE} beyond the ratchet head {}.",
+                self.next_generation
+            );
+            return Err(VirtualClientsError::OperationGenerationTooDistant);
+        }
+        while self.next_generation < generation {
+            let skipped_generation = self.next_generation;
+            let skipped_secret = self.advance(crypto, ciphersuite)?;
+            self.retained_generation_secrets
+                .insert(skipped_generation, skipped_secret);
+        }
+        // Evict the oldest retained entries first, dropping their secrets.
+        while self.retained_generation_secrets.len() > OUT_OF_ORDER_TOLERANCE {
+            self.retained_generation_secrets.pop_first();
+        }
+        self.advance(crypto, ciphersuite)
+    }
+
+    /// One ratchet step:
+    ///
+    /// ```text
+    /// operation_generation_secret =
+    ///   DeriveSecret(operation_ratchet_secret, "VC Operation Secret")
+    /// next_operation_ratchet_secret =
+    ///   DeriveSecret(operation_ratchet_secret, "VC Operation Ratchet")
+    /// ```
+    ///
+    /// Returns the `operation_generation_secret` for the head generation and
+    /// advances the head, deleting the consumed `operation_ratchet_secret`.
+    fn advance(
+        &mut self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+    ) -> Result<Secret, VirtualClientsError> {
+        if self.next_generation == u32::MAX {
+            return Err(VirtualClientsError::OperationRatchetTooLong);
+        }
+        let operation_generation_secret =
+            self.ratchet_secret
+                .derive_secret(crypto, ciphersuite, OPERATION_GENERATION_LABEL)?;
+        // Overwriting the head deletes the consumed ratchet secret.
+        self.ratchet_secret = self.ratchet_secret.derive_secret(
+            crypto,
+            ciphersuite,
+            OPERATION_RATCHET_ADVANCE_LABEL,
+        )?;
+        self.next_generation += 1;
+        Ok(operation_generation_secret)
+    }
+}
+
+/// Context bound into each operation secret (mls-virtual-clients draft
+/// `OperationContext`):
+///
+/// ```text
+/// struct {
+///   opaque epoch_id<V>;
+///   uint32 leaf_index;
+///   uint32 generation;
+///   VirtualClientOperationType operation_type;
+///   opaque operation_context<V>;
+/// } OperationContext
+/// ```
+#[derive(Debug, TlsSize, TlsSerialize)]
+struct OperationContext {
+    epoch_id: EpochId,
+    leaf_index: LeafNodeIndex,
+    generation: u32,
+    operation_type: VirtualClientOperationType,
+    operation_context: Vec<u8>,
+}
+
+impl OperationContext {
+    /// Expand the final operation secret:
+    ///
+    /// ```text
+    /// operation_secret =
+    ///   ExpandWithLabel(operation_generation_secret, "vc operation",
+    ///                   OperationContext, Kdf.Nh)
+    /// ```
+    fn expand_operation_secret(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        operation_generation_secret: &Secret,
+    ) -> Result<OperationSecret, VirtualClientsError> {
+        let context = self.tls_serialize_detached()?;
+        let operation_secret = operation_generation_secret.kdf_expand_label(
+            crypto,
+            ciphersuite,
+            OPERATION_SECRET_LABEL,
+            &context,
+            ciphersuite.hash_length(),
+        )?;
+        Ok(OperationSecret::from(operation_secret))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openmls_rust_crypto::OpenMlsRustCrypto;
+    use openmls_traits::{random::OpenMlsRand, OpenMlsProvider};
+
+    use super::*;
+    use crate::components::vc_derivation_info::EmulatorEpochSecret;
+
+    const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+    /// Build two trees from the same `epoch_base_secret` (one sender-side,
+    /// one receiver-side instance), going through the real per-epoch
+    /// derivation chain.
+    fn setup(
+        leaf_count: u32,
+    ) -> (
+        OpenMlsRustCrypto,
+        EpochId,
+        OperationSecretTree,
+        OperationSecretTree,
+    ) {
+        let provider = OpenMlsRustCrypto::default();
+        let emulator = EmulatorEpochSecret::new(
+            &provider
+                .rand()
+                .random_vec(CIPHERSUITE.hash_length())
+                .expect("randomness"),
+        );
+        let epoch_id = emulator
+            .derive_epoch_id(provider.crypto(), CIPHERSUITE)
+            .expect("derive epoch id");
+        let epoch_base_secret = emulator
+            .derive_epoch_base_secret(provider.crypto(), CIPHERSUITE)
+            .expect("derive epoch base secret");
+        let size = TreeSize::from_leaf_count(leaf_count);
+        let tree_a = OperationSecretTree::new(epoch_base_secret.clone(), size);
+        let tree_b = OperationSecretTree::new(epoch_base_secret, size);
+        (provider, epoch_id, tree_a, tree_b)
+    }
+
+    /// Two instances built from the same `epoch_base_secret` and size must
+    /// agree on the operation secret for the same coordinates and context,
+    /// regardless of the order in which they derive.
+    #[test]
+    fn cross_instance_agreement() {
+        let (provider, epoch_id, mut tree_a, mut tree_b) = setup(8);
+        let secret_a = tree_a
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                LeafNodeIndex::new(2),
+                VirtualClientOperationType::LeafNode,
+                3,
+                b"commit context",
+            )
+            .expect("derive on tree a");
+        // Tree b derives generations 0..=3 in order before reaching the same
+        // coordinates.
+        for generation in 0..3 {
+            tree_b
+                .derive_operation_secret(
+                    provider.crypto(),
+                    CIPHERSUITE,
+                    &epoch_id,
+                    LeafNodeIndex::new(2),
+                    VirtualClientOperationType::LeafNode,
+                    generation,
+                    b"earlier context",
+                )
+                .expect("derive earlier generation on tree b");
+        }
+        let secret_b = tree_b
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                LeafNodeIndex::new(2),
+                VirtualClientOperationType::LeafNode,
+                3,
+                b"commit context",
+            )
+            .expect("derive on tree b");
+        assert_eq!(secret_a.as_slice(), secret_b.as_slice());
+    }
+
+    /// Different generations, leaves, operation types, and contexts must all
+    /// yield different operation secrets.
+    #[test]
+    fn coordinates_and_context_bind_the_secret() {
+        let (provider, epoch_id, mut tree_a, mut tree_b) = setup(8);
+        let derive = |tree: &mut OperationSecretTree,
+                      leaf: u32,
+                      operation_type: VirtualClientOperationType,
+                      generation: u32,
+                      context: &[u8]| {
+            tree.derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                LeafNodeIndex::new(leaf),
+                operation_type,
+                generation,
+                context,
+            )
+            .expect("derive operation secret")
+        };
+        let leaf_node = VirtualClientOperationType::LeafNode;
+        let baseline = derive(&mut tree_a, 0, leaf_node, 0, b"ctx");
+        let other_generation = derive(&mut tree_a, 0, leaf_node, 1, b"ctx");
+        let other_leaf = derive(&mut tree_a, 1, leaf_node, 0, b"ctx");
+        let other_type = derive(
+            &mut tree_a,
+            0,
+            VirtualClientOperationType::KeyPackage,
+            0,
+            b"ctx",
+        );
+        // Same coordinates as the baseline, but a different context. Derived
+        // on the second instance because the baseline consumed generation 0.
+        let other_context = derive(&mut tree_b, 0, leaf_node, 0, b"other ctx");
+        let secrets = [
+            baseline.as_slice(),
+            other_generation.as_slice(),
+            other_leaf.as_slice(),
+            other_type.as_slice(),
+            other_context.as_slice(),
+        ];
+        for (i, secret) in secrets.iter().enumerate() {
+            for other in &secrets[i + 1..] {
+                assert_ne!(secret, other);
+            }
+        }
+    }
+
+    /// Skipping ahead retains the skipped generations: deriving generation 5
+    /// first, generations 0 through 4 each still succeed exactly once, and
+    /// re-asking for any consumed generation fails. Skipped derivations match
+    /// an instance that derives in order.
+    #[test]
+    fn out_of_order_derivation_and_consumption() {
+        let (provider, epoch_id, mut tree_a, mut tree_b) = setup(4);
+        let leaf = LeafNodeIndex::new(0);
+        let operation_type = VirtualClientOperationType::Application;
+        let context_for = |generation: u32| format!("operation {generation}").into_bytes();
+        let in_order: Vec<_> = (0..=5)
+            .map(|generation| {
+                tree_b
+                    .derive_operation_secret(
+                        provider.crypto(),
+                        CIPHERSUITE,
+                        &epoch_id,
+                        leaf,
+                        operation_type,
+                        generation,
+                        &context_for(generation),
+                    )
+                    .expect("in-order derivation")
+            })
+            .collect();
+
+        // Generation 5 first, skipping 0..=4.
+        let skipped_ahead = tree_a
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                5,
+                &context_for(5),
+            )
+            .expect("derive generation 5");
+        assert_eq!(skipped_ahead.as_slice(), in_order[5].as_slice());
+
+        // Generations 0 through 4 still succeed exactly once.
+        for generation in 0..5 {
+            let retained = tree_a
+                .derive_operation_secret(
+                    provider.crypto(),
+                    CIPHERSUITE,
+                    &epoch_id,
+                    leaf,
+                    operation_type,
+                    generation,
+                    &context_for(generation),
+                )
+                .expect("derive retained generation");
+            assert_eq!(
+                retained.as_slice(),
+                in_order[generation as usize].as_slice()
+            );
+        }
+
+        // Re-asking for any consumed generation fails, including generation 5.
+        for generation in 0..=5 {
+            let err = tree_a
+                .derive_operation_secret(
+                    provider.crypto(),
+                    CIPHERSUITE,
+                    &epoch_id,
+                    leaf,
+                    operation_type,
+                    generation,
+                    &context_for(generation),
+                )
+                .expect_err("consumed generation must fail");
+            assert_eq!(err, VirtualClientsError::OperationGenerationConsumed);
+        }
+
+        // A leaf index outside the tree is rejected.
+        let out_of_bounds = LeafNodeIndex::new(TreeSize::from_leaf_count(4).leaf_count());
+        let err = tree_a
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                out_of_bounds,
+                operation_type,
+                0,
+                b"ctx",
+            )
+            .expect_err("out-of-bounds leaf index must fail");
+        assert_eq!(err, VirtualClientsError::IndexOutOfBounds);
+    }
+
+    /// The "next own operation" method yields sequential generations whose
+    /// secrets match what a second instance derives positionally.
+    #[test]
+    fn next_operation_secret_advances_sequentially() {
+        let (provider, epoch_id, mut tree_a, mut tree_b) = setup(4);
+        let leaf = LeafNodeIndex::new(1);
+        let operation_type = VirtualClientOperationType::KeyPackage;
+        for expected_generation in 0..3 {
+            let context = format!("key package {expected_generation}").into_bytes();
+            let (generation, own_secret) = tree_a
+                .next_operation_secret(
+                    provider.crypto(),
+                    CIPHERSUITE,
+                    &epoch_id,
+                    leaf,
+                    operation_type,
+                    &context,
+                )
+                .expect("next operation secret");
+            assert_eq!(generation, expected_generation);
+            let positional = tree_b
+                .derive_operation_secret(
+                    provider.crypto(),
+                    CIPHERSUITE,
+                    &epoch_id,
+                    leaf,
+                    operation_type,
+                    generation,
+                    &context,
+                )
+                .expect("positional derivation");
+            assert_eq!(own_secret.as_slice(), positional.as_slice());
+        }
+    }
+
+    /// A serde round-trip of a tree mid-state (some generations consumed,
+    /// some skipped) preserves behavior: the round-tripped tree still serves
+    /// retained skipped generations, still refuses consumed ones, and
+    /// continues at the right head generation.
+    #[test]
+    fn serde_roundtrip_preserves_ratchet_state() {
+        let (provider, epoch_id, mut tree_a, mut tree_b) = setup(4);
+        let leaf = LeafNodeIndex::new(2);
+        let operation_type = VirtualClientOperationType::LeafNode;
+        // Skip ahead to generation 4 (retaining 0..=3), then consume
+        // generation 1 from the retained entries.
+        tree_a
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                4,
+                b"four",
+            )
+            .expect("derive generation 4");
+        tree_a
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                1,
+                b"one",
+            )
+            .expect("derive retained generation 1");
+
+        let serialized = serde_json::to_vec(&tree_a).expect("serialize tree");
+        let mut restored: OperationSecretTree =
+            serde_json::from_slice(&serialized).expect("deserialize tree");
+
+        // A retained skipped generation is still served and agrees with a
+        // second instance.
+        let restored_secret = restored
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                2,
+                b"two",
+            )
+            .expect("derive retained generation after round-trip");
+        let positional = tree_b
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                2,
+                b"two",
+            )
+            .expect("positional derivation");
+        assert_eq!(restored_secret.as_slice(), positional.as_slice());
+
+        // Consumed generations are still refused.
+        for (generation, context) in [(1, b"one".as_slice()), (4, b"four".as_slice())] {
+            let err = restored
+                .derive_operation_secret(
+                    provider.crypto(),
+                    CIPHERSUITE,
+                    &epoch_id,
+                    leaf,
+                    operation_type,
+                    generation,
+                    context,
+                )
+                .expect_err("consumed generation must fail after round-trip");
+            assert_eq!(err, VirtualClientsError::OperationGenerationConsumed);
+        }
+
+        // The ratchet head continues right after the skipped-ahead
+        // generation.
+        let (generation, _secret) = restored
+            .next_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                b"five",
+            )
+            .expect("next operation secret after round-trip");
+        assert_eq!(generation, 5);
+    }
+
+    /// A generation more than [`MAXIMUM_FORWARD_DISTANCE`] beyond the head is
+    /// rejected without advancing the head: the next own operation still
+    /// allocates generation 0.
+    #[test]
+    fn forward_distance_bound_rejects_without_advancing() {
+        let (provider, epoch_id, mut tree_a, _tree_b) = setup(4);
+        let leaf = LeafNodeIndex::new(0);
+        let operation_type = VirtualClientOperationType::LeafNode;
+        let err = tree_a
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                MAXIMUM_FORWARD_DISTANCE + 1,
+                b"ctx",
+            )
+            .expect_err("generation beyond the forward distance must fail");
+        assert_eq!(err, VirtualClientsError::OperationGenerationTooDistant);
+
+        // The head is unchanged: the next in-window derivation is still
+        // generation 0.
+        let (generation, _secret) = tree_a
+            .next_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                b"ctx",
+            )
+            .expect("next operation secret after rejected request");
+        assert_eq!(generation, 0);
+    }
+
+    /// A generation exactly at the forward-distance limit succeeds.
+    #[test]
+    fn forward_distance_boundary_succeeds() {
+        let (provider, epoch_id, mut tree_a, _tree_b) = setup(4);
+        let leaf = LeafNodeIndex::new(0);
+        let operation_type = VirtualClientOperationType::LeafNode;
+        tree_a
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                MAXIMUM_FORWARD_DISTANCE,
+                b"ctx",
+            )
+            .expect("generation at the forward-distance limit must succeed");
+        // The head sits right behind the consumed generation.
+        let (generation, _secret) = tree_a
+            .next_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                b"ctx",
+            )
+            .expect("next operation secret after skipping to the limit");
+        assert_eq!(generation, MAXIMUM_FORWARD_DISTANCE + 1);
+    }
+
+    /// Skipping more unconsumed generations than [`OUT_OF_ORDER_TOLERANCE`]
+    /// evicts the oldest retained entries first: the evicted generation fails
+    /// as consumed, while the oldest generation still within the window is
+    /// served exactly once and agrees with an in-order instance.
+    #[test]
+    fn skipping_beyond_tolerance_evicts_oldest() {
+        let (provider, epoch_id, mut tree_a, mut tree_b) = setup(4);
+        let leaf = LeafNodeIndex::new(0);
+        let operation_type = VirtualClientOperationType::Application;
+        let tolerance = OUT_OF_ORDER_TOLERANCE as u32;
+        // Skipping 0..=tolerance retains one entry more than the tolerance,
+        // evicting generation 0.
+        let skip_to = tolerance + 1;
+        tree_a
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                skip_to,
+                b"ctx",
+            )
+            .expect("skipping derivation");
+
+        // The evicted generation 0 reports as consumed.
+        let err = tree_a
+            .derive_operation_secret(
+                provider.crypto(),
+                CIPHERSUITE,
+                &epoch_id,
+                leaf,
+                operation_type,
+                0,
+                b"ctx",
+            )
+            .expect_err("evicted generation must fail");
+        assert_eq!(err, VirtualClientsError::OperationGenerationConsumed);
+
+        // Reference values from an instance that derives strictly in order.
+        let mut in_order = Vec::new();
+        for generation in 0..=tolerance {
+            let secret = tree_b
+                .derive_operation_secret(
+                    provider.crypto(),
+                    CIPHERSUITE,
+                    &epoch_id,
+                    leaf,
+                    operation_type,
+                    generation,
+                    b"ctx",
+                )
+                .expect("in-order derivation");
+            in_order.push(secret);
+        }
+
+        // The oldest and newest generations within the window are still
+        // served, agree with the in-order instance, and are served exactly
+        // once.
+        for generation in [1, tolerance] {
+            let retained = tree_a
+                .derive_operation_secret(
+                    provider.crypto(),
+                    CIPHERSUITE,
+                    &epoch_id,
+                    leaf,
+                    operation_type,
+                    generation,
+                    b"ctx",
+                )
+                .expect("retained generation within the window");
+            assert_eq!(
+                retained.as_slice(),
+                in_order[generation as usize].as_slice()
+            );
+            let err = tree_a
+                .derive_operation_secret(
+                    provider.crypto(),
+                    CIPHERSUITE,
+                    &epoch_id,
+                    leaf,
+                    operation_type,
+                    generation,
+                    b"ctx",
+                )
+                .expect_err("second request for the same generation must fail");
+            assert_eq!(err, VirtualClientsError::OperationGenerationConsumed);
+        }
+    }
+}

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -183,6 +183,14 @@ impl DecryptedMessage {
         })
     }
 
+    /// Recovered sender emulation-group leaf index, if the message came
+    /// from a sibling emulator client.
+    #[cfg(feature = "virtual-clients-draft")]
+    #[allow(dead_code)]
+    pub(crate) fn emulator_sender_leaf_index(&self) -> Option<LeafNodeIndex> {
+        self.emulator_sender_leaf_index
+    }
+
     /// Gets the correct credential from the message depending on the sender type.
     ///
     /// The closure argument is used to look up the credential and signature key. If the epoch of
@@ -409,7 +417,7 @@ impl ProcessedMessage {
     }
 
     /// Returns the sender's leaf index in the emulation group when this
-    /// message is a private message from a sibling emulator client.
+    /// message is an application message from a sibling emulator client.
     #[cfg(feature = "virtual-clients-draft")]
     pub fn emulator_sender_leaf_index(&self) -> Option<LeafNodeIndex> {
         self.emulator_sender_leaf_index

--- a/openmls/src/group/mls_group/application.rs
+++ b/openmls/src/group/mls_group/application.rs
@@ -26,19 +26,8 @@ impl MlsGroup {
         signer: &impl Signer,
         message: &[u8],
     ) -> Result<MlsMessageOut, CreateMessageError> {
-        self.check_can_create_message()?;
-        let (_, output) = self
-            .create_message_internal(provider, signer, message)
-            .map_err(|e| match e {
-                MessageEncryptionError::LibraryError(e) => e,
-                // We know the application message is wellformed and we have
-                // the key material of the current epoch
-                MessageEncryptionError::WrongWireFormat
-                | MessageEncryptionError::SecretTreeError(_)
-                | MessageEncryptionError::StorageError(_) => {
-                    LibraryError::custom("Malformed plaintext")
-                }
-            })?;
+        let (_, output) =
+            self.create_message_internal::<_, CreateMessageError>(provider, signer, message)?;
         Ok(output)
     }
 
@@ -56,31 +45,63 @@ impl MlsGroup {
         signer: &impl Signer,
         message: &[u8],
     ) -> Result<MlsMessageOut, CreateMessageError<Provider::StorageError>> {
-        let (generation, output) = self.create_unconfirmed_message(provider, signer, message)?;
+        let (generation, output) = self.create_message_internal(provider, signer, message)?;
         self.confirm_message(provider.storage(), generation)?;
         Ok(output)
     }
 
-    /// Checks the group state preconditions for creating an application
-    /// message.
-    fn check_can_create_message(&self) -> Result<(), MlsGroupStateError> {
+    #[cfg(not(feature = "virtual-clients-draft"))]
+    fn create_message_internal<Provider: OpenMlsProvider, E>(
+        &mut self,
+        provider: &Provider,
+        signer: &impl Signer,
+        message: &[u8],
+    ) -> Result<(u32, MlsMessageOut), E>
+    where
+        E: From<LibraryError> + From<MlsGroupStateError>,
+    {
         if !self.is_active() {
-            return Err(MlsGroupStateError::UseAfterEviction);
+            return Err(MlsGroupStateError::UseAfterEviction.into());
         }
         if !self.proposal_store().is_empty() {
-            return Err(MlsGroupStateError::PendingProposal);
+            return Err(MlsGroupStateError::PendingProposal.into());
         }
-        Ok(())
+
+        let aad = self.outgoing_authenticated_data()?;
+        let authenticated_content = AuthenticatedContent::new_application(
+            self.own_leaf_index(),
+            &aad,
+            message,
+            self.context(),
+            signer,
+        )?;
+        let EncryptionOutput {
+            generation,
+            private_message,
+        } = self
+            .encrypt(authenticated_content, provider)
+            // We know the application message is wellformed and we have the key material of the current epoch
+            .map_err(|_| LibraryError::custom("Malformed plaintext"))?;
+
+        let output = MlsMessageOut::from_private_message(private_message, self.version());
+        self.reset_aad();
+        Ok((generation, output))
     }
 
-    /// Builds and encrypts an application message. Callers must run
-    /// [`Self::check_can_create_message`] first.
+    #[cfg(feature = "virtual-clients-draft")]
     fn create_message_internal<Provider: OpenMlsProvider>(
         &mut self,
         provider: &Provider,
         signer: &impl Signer,
         message: &[u8],
-    ) -> Result<(u32, MlsMessageOut), MessageEncryptionError<Provider::StorageError>> {
+    ) -> Result<(u32, MlsMessageOut), CreateMessageError<Provider::StorageError>> {
+        if !self.is_active() {
+            return Err(MlsGroupStateError::UseAfterEviction.into());
+        }
+        if !self.proposal_store().is_empty() {
+            return Err(MlsGroupStateError::PendingProposal.into());
+        }
+
         let aad = self.outgoing_authenticated_data()?;
         let authenticated_content = AuthenticatedContent::new_application(
             self.own_leaf_index(),
@@ -115,8 +136,7 @@ impl MlsGroup {
         signer: &impl Signer,
         message: &[u8],
     ) -> Result<(u32, MlsMessageOut), CreateMessageError<Provider::StorageError>> {
-        self.check_can_create_message()?;
-        Ok(self.create_message_internal(provider, signer, message)?)
+        self.create_message_internal(provider, signer, message)
     }
 
     /// Confirms that a message has been successfully sent without a generation

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -38,10 +38,10 @@ use crate::{
 #[cfg(feature = "virtual-clients-draft")]
 use crate::{
     components::vc_derivation_info::{
-        pprf_input, DerivationInfo, EmulationEpochState, EpochEncryptionKey, EpochId, EpochInfoTbe,
-        OperationSecret, VcEmulation, VcPprf, VirtualClientOperationType, VirtualClientsError,
-        VC_COMPONENT_ID,
+        DerivationInfo, DerivationInfoTbe, EmulationEpochState, EpochEncryptionKey, EpochId,
+        OperationSecret, VirtualClientOperationType, VirtualClientsError, VC_COMPONENT_ID,
     },
+    components::vc_operation_tree::OperationSecretTree,
     extensions::{AppDataDictionary, AppDataDictionaryExtension},
     treesync::node::leaf_node::LeafNode,
 };
@@ -52,17 +52,24 @@ use crate::{
     schedule::application_export_tree::ApplicationExportTree,
 };
 
-/// Per-commit virtual-clients state loaded from the storage provider in
-/// `load_psks`, kept around through `build` (which punctures the PPRF) and
-/// `stage_commit` (which writes the punctured state back).
+/// Per-commit virtual-clients state allocated by
+/// [`CommitBuilder::vc_emulation`] and consumed by `build`.
+///
+/// `vc_emulation` advances the own `LeafNode` operation ratchet by one
+/// generation and immediately persists the advanced tree, before the commit
+/// message exists. A builder that is discarded after the setter therefore
+/// burns a generation, as does a commit the DS rejects. That is harmless:
+/// sibling ratchets skip over a burned generation, retaining the skipped
+/// generation secrets inside their copy of the operation secret tree.
 #[cfg(feature = "virtual-clients-draft")]
 #[derive(Debug)]
 struct VcLoaded {
     epoch_id: EpochId,
     emulation_leaf_index: LeafNodeIndex,
-    pprf: VcPprf,
     epoch_encryption_key: EpochEncryptionKey,
     emulation_ciphersuite: openmls_traits::types::Ciphersuite,
+    generation: u32,
+    operation_secret: OperationSecret,
 }
 
 pub(crate) mod external_commits;
@@ -104,15 +111,6 @@ pub struct Initial {
     /// Whether or not to clear the proposal queue of the group when staging the commit. Needs to
     /// be done when we include the commits that have already been queued.
     consume_proposal_store: bool,
-
-    /// Per-commit virtual-clients material supplied by the application.
-    /// When `Some`, the commit's path secret and leaf encryption keypair
-    /// are derived from `operation_secret` (so a sibling virtual client
-    /// can rederive them), the `DerivationInfo` blob is embedded in the
-    /// new leaf's `app_data_dictionary` extension, and the per-commit
-    /// secrets are persisted at `stage_commit` time.
-    #[cfg(feature = "virtual-clients-draft")]
-    vc_emulation: Option<VcEmulation>,
 }
 
 impl Default for Initial {
@@ -123,8 +121,6 @@ impl Default for Initial {
             leaf_node_parameters: LeafNodeParameters::default(),
             own_proposals: vec![],
             external_commit_info: None,
-            #[cfg(feature = "virtual-clients-draft")]
-            vc_emulation: None,
         }
     }
 }
@@ -146,12 +142,6 @@ pub struct LoadedPsks {
 
     #[cfg(feature = "extensions-draft-08")]
     app_data_dictionary_updates: Option<AppDataUpdates>,
-
-    /// Per-emulation-epoch PPRF + AEAD key loaded from the storage
-    /// provider when the caller opted in via `vc_emulation`. The PPRF is
-    /// punctured during `build` and persisted by `stage_commit`.
-    #[cfg(feature = "virtual-clients-draft")]
-    vc_loaded: Option<VcLoaded>,
 }
 
 /// This stage is after we validated the data, ready for staging and exporting the messages
@@ -160,18 +150,6 @@ pub struct Complete {
     result: CreateCommitResult,
     // Only for external commits
     original_wire_format_policy: Option<WireFormatPolicy>,
-    /// Punctured PPRF state to persist back to storage on `stage_commit`,
-    /// keyed on `epoch_id`. `None` when virtual-clients was not opted into
-    /// for this commit.
-    #[cfg(feature = "virtual-clients-draft")]
-    vc_punctured: Option<VcPunctured>,
-}
-
-#[cfg(feature = "virtual-clients-draft")]
-#[derive(Debug)]
-struct VcPunctured {
-    epoch_id: EpochId,
-    pprf: VcPprf,
 }
 
 /// The [`CommitBuilder`] is used to easily and dynamically build commit messages.
@@ -220,6 +198,12 @@ pub struct CommitBuilder<'a, T, G: BorrowMut<MlsGroup> = &'a mut MlsGroup> {
     /// The current stage
     stage: T,
 
+    /// Virtual-clients material allocated by [`Self::vc_emulation`] and
+    /// consumed by `build`. Lives on the builder rather than on a stage
+    /// struct so the stage transitions can carry it through unchanged.
+    #[cfg(feature = "virtual-clients-draft")]
+    vc_loaded: Option<VcLoaded>,
+
     pd: PhantomData<&'a ()>,
 }
 
@@ -249,6 +233,8 @@ impl<'a, T, G: BorrowMut<MlsGroup>> CommitBuilder<'a, T, G> {
         let Self {
             group,
             stage,
+            #[cfg(feature = "virtual-clients-draft")]
+            vc_loaded,
             pd: PhantomData,
         } = self;
 
@@ -259,6 +245,8 @@ impl<'a, T, G: BorrowMut<MlsGroup>> CommitBuilder<'a, T, G> {
             CommitBuilder {
                 group,
                 stage,
+                #[cfg(feature = "virtual-clients-draft")]
+                vc_loaded,
                 pd: PhantomData,
             },
         )
@@ -351,6 +339,8 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
         CommitBuilder {
             group,
             stage,
+            #[cfg(feature = "virtual-clients-draft")]
+            vc_loaded: None,
             pd: PhantomData,
         }
     }
@@ -364,22 +354,25 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
 
     /// Opt this commit into the virtual-clients-draft sender flow.
     ///
-    /// The application supplies a [`VcEmulation`] referencing an
-    /// already-registered emulation epoch (see
-    /// [`MlsGroup::register_vc_emulation_epoch`]). When set, building this
-    /// commit will:
+    /// The application supplies the [`EpochId`] of an already-registered
+    /// emulation epoch (see
+    /// [`MlsGroup::register_vc_emulation_epoch`]). This method loads the
+    /// per-epoch operation secret tree and AEAD key from the storage
+    /// provider, advances the own `LeafNode` operation ratchet by one
+    /// generation, and immediately persists the advanced tree. `build`
+    /// then:
     ///
-    /// - load the per-epoch [`VcPprf`](crate::components::vc_derivation_info)
-    ///   and AEAD key from the storage provider;
-    /// - draw fresh per-commit randomness, evaluate (and puncture) the
-    ///   PPRF on the resulting input to produce the per-commit
-    ///   `OperationSecret`, and persist the punctured state at
-    ///   `stage_commit` time;
-    /// - derive the path secret and the new leaf's encryption keypair
-    ///   from that `OperationSecret`, so a sibling virtual client can
-    ///   rederive them on the receiver side;
-    /// - embed an encrypted `DerivationInfo` blob under [`VC_COMPONENT_ID`]
+    /// - derives the path secret and the new leaf's encryption keypair
+    ///   from the allocated `OperationSecret`, so a sibling virtual
+    ///   client can rederive them on the receiver side, and
+    /// - embeds an encrypted `DerivationInfo` blob under [`VC_COMPONENT_ID`]
     ///   in the new leaf's `app_data_dictionary` extension.
+    ///
+    /// Because the ratchet advance is persisted here, a builder that is
+    /// discarded after this call burns a generation. The same happens when
+    /// the DS rejects the commit. That is harmless because sibling ratchets
+    /// skip over a burned generation, retaining the skipped generation
+    /// secrets inside their copy of the operation secret tree.
     ///
     /// The application is responsible for ensuring the new leaf:
     ///
@@ -390,17 +383,74 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
     /// If those preconditions are not met the build fails with
     /// `VirtualClientsError::AppDataDictionaryNotSupported` or
     /// `VirtualClientsError::VcComponentNotListed` (wrapped in
-    /// [`CreateCommitError::VirtualClientsError`]) before any randomness
-    /// is drawn.
+    /// [`CreateCommitError::VirtualClientsError`]). The generation
+    /// allocated here stays burned in that case, which is harmless for the
+    /// reason above.
+    ///
+    /// Fails with `VirtualClientsError::MissingEmulationEpochState` or
+    /// `VirtualClientsError::MissingOperationTree` if the epoch was never
+    /// registered. Neither the state nor the tree is instantiated on the
+    /// fly, since that could diverge from a sibling virtual client's
+    /// already-advanced ratchets.
     ///
     /// Implies that a self-update takes place: the commit will always have
     /// a path even if no other proposals are queued.
     ///
     /// [`MlsGroup::register_vc_emulation_epoch`]: crate::group::MlsGroup::register_vc_emulation_epoch
     #[cfg(feature = "virtual-clients-draft")]
-    pub fn vc_emulation(mut self, emulation: VcEmulation) -> Self {
-        self.stage.vc_emulation = Some(emulation);
-        self
+    pub fn vc_emulation<Crypto: OpenMlsCrypto, Storage: StorageProvider>(
+        mut self,
+        crypto: &Crypto,
+        storage: &Storage,
+        epoch_id: EpochId,
+    ) -> Result<Self, CreateCommitError> {
+        let state: EmulationEpochState = storage
+            .vc_emulation_epoch_state(&epoch_id)
+            .map_err(|e| {
+                log::error!("vc: load emulation epoch state in vc_emulation failed: {e:?}");
+                CreateCommitError::VirtualClientsError(VirtualClientsError::StorageError)
+            })?
+            .ok_or(VirtualClientsError::MissingEmulationEpochState)?;
+        let mut operation_tree: OperationSecretTree = storage
+            .vc_operation_tree(&epoch_id)
+            .map_err(|e| {
+                log::error!("vc: load operation tree in vc_emulation failed: {e:?}");
+                CreateCommitError::VirtualClientsError(VirtualClientsError::StorageError)
+            })?
+            .ok_or(VirtualClientsError::MissingOperationTree)?;
+        let (emulation_leaf_index, epoch_encryption_key, emulation_ciphersuite) =
+            state.into_parts();
+
+        // Update-path leaf-node derivations are the only operation type
+        // wired up so far. KeyPackage / Application will get their own
+        // allocation entry points when emitted. The operation context for
+        // LeafNode operations is the higher-level group's id.
+        let (generation, operation_secret) = operation_tree.next_operation_secret(
+            crypto,
+            emulation_ciphersuite,
+            &epoch_id,
+            emulation_leaf_index,
+            VirtualClientOperationType::LeafNode,
+            self.group.borrow().group_id().as_slice(),
+        )?;
+        // Persist the advanced tree right away, so the allocation can never
+        // be observed on the wire before it is persisted.
+        storage
+            .write_vc_operation_tree(&epoch_id, &operation_tree)
+            .map_err(|e| {
+                log::error!("vc: persist advanced operation tree failed: {e:?}");
+                CreateCommitError::VirtualClientsError(VirtualClientsError::StorageError)
+            })?;
+
+        self.vc_loaded = Some(VcLoaded {
+            epoch_id,
+            emulation_leaf_index,
+            epoch_encryption_key,
+            emulation_ciphersuite,
+            generation,
+            operation_secret,
+        });
+        Ok(self)
     }
 
     /// Loads the PSKs for the PskProposals marked for inclusion and moves on to the next phase.
@@ -444,42 +494,6 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
             other_extensions: vec![],
         };
 
-        // When the caller opted into virtual-clients for this commit, load
-        // the per-emulation-epoch PPRF + state (AEAD key + the registering
-        // client's emulation-group leaf index) from storage now — both
-        // must already be registered via
-        // `MlsGroup::register_vc_emulation_epoch`. Refusing to instantiate
-        // either on the fly avoids accidentally diverging from a sibling
-        // virtual client's already-advanced PPRF.
-        #[cfg(feature = "virtual-clients-draft")]
-        let vc_loaded = if let Some(emulation) = &self.stage.vc_emulation {
-            let pprf: VcPprf = storage
-                .vc_pprf(&emulation.epoch_id)
-                .map_err(|e| {
-                    log::error!("vc: load pprf in load_psks failed: {e:?}");
-                    CreateCommitError::VirtualClientsError(VirtualClientsError::StorageError)
-                })?
-                .ok_or(VirtualClientsError::MissingPprf)?;
-            let state: EmulationEpochState = storage
-                .vc_emulation_epoch_state(&emulation.epoch_id)
-                .map_err(|e| {
-                    log::error!("vc: load emulation epoch state in load_psks failed: {e:?}");
-                    CreateCommitError::VirtualClientsError(VirtualClientsError::StorageError)
-                })?
-                .ok_or(VirtualClientsError::MissingEmulationEpochState)?;
-            let (emulation_leaf_index, epoch_encryption_key, emulation_ciphersuite) =
-                state.into_parts();
-            Some(VcLoaded {
-                epoch_id: emulation.epoch_id.clone(),
-                emulation_leaf_index,
-                pprf,
-                epoch_encryption_key,
-                emulation_ciphersuite,
-            })
-        } else {
-            None
-        };
-
         Ok(self
             .map_stage(|stage| {
                 (
@@ -494,8 +508,6 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
                         external_commit_info: stage.external_commit_info,
                         #[cfg(feature = "extensions-draft-08")]
                         app_data_dictionary_updates: None,
-                        #[cfg(feature = "virtual-clients-draft")]
-                        vc_loaded,
                     },
                 )
             })
@@ -584,7 +596,8 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, LoadedPsks, G> {
         new_signer: Option<NewSignerBundle<'_, S>>,
         f: impl FnMut(&QueuedProposal) -> bool,
     ) -> Result<CommitBuilder<'a, Complete, G>, CreateCommitError> {
-        let (mut cur_stage, builder) = self.take_stage();
+        #[cfg_attr(not(feature = "virtual-clients-draft"), allow(unused_mut))]
+        let (mut cur_stage, mut builder) = self.take_stage();
 
         // retrieve the config
         let GroupInfoConfig {
@@ -709,13 +722,14 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, LoadedPsks, G> {
         // Virtual-clients sender hook: when the caller opted into VC for
         // this commit, validate that the effective leaf is configured to
         // accept the derivation-info entry (capabilities + AppComponents),
-        // then evaluate the pre-loaded PPRF (mutating it in place — the
-        // punctured state is propagated to `Complete` for `stage_commit`
-        // to persist), derive the path-secret + leaf-keypair override,
-        // and embed the `DerivationInfo` blob in the leaf's
-        // `app_data_dictionary` extension.
+        // then derive the path-secret + leaf-keypair override from the
+        // operation secret allocated in `vc_emulation` and embed the
+        // `DerivationInfo` blob in the leaf's `app_data_dictionary`
+        // extension.
         #[cfg(feature = "virtual-clients-draft")]
-        let own_update_override = if let Some(loaded) = cur_stage.vc_loaded.as_mut() {
+        let vc_loaded = builder.vc_loaded.take();
+        #[cfg(feature = "virtual-clients-draft")]
+        let own_update_override = if let Some(loaded) = vc_loaded.as_ref() {
             // Run the leaf-configuration pre-check. Returns the resolved
             // `AppDataDictionary` so the inject step can preserve every other
             // entry the application registered, including the AppComponents
@@ -731,7 +745,6 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, LoadedPsks, G> {
                 loaded,
                 &mut cur_stage.leaf_node_parameters,
                 resolved_dictionary,
-                rand,
                 crypto,
                 ciphersuite,
             )?)
@@ -1064,10 +1077,7 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, LoadedPsks, G> {
             proposal_queue,
             StagedCommitState::GroupMember(Box::new(staged_commit_state)),
             #[cfg(feature = "virtual-clients-draft")]
-            cur_stage
-                .vc_loaded
-                .as_ref()
-                .map(|loaded| loaded.epoch_id.clone()),
+            vc_loaded.as_ref().map(|loaded| loaded.epoch_id.clone()),
         );
 
         Ok(builder.into_stage(Complete {
@@ -1081,11 +1091,6 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, LoadedPsks, G> {
                 .external_commit_info
                 .as_ref()
                 .map(|info| info.wire_format_policy),
-            #[cfg(feature = "virtual-clients-draft")]
-            vc_punctured: cur_stage.vc_loaded.map(|loaded| VcPunctured {
-                epoch_id: loaded.epoch_id,
-                pprf: loaded.pprf,
-            }),
         }))
     }
 
@@ -1151,8 +1156,6 @@ impl CommitBuilder<'_, Complete, &mut MlsGroup> {
                 Complete {
                     result: create_commit_result,
                     original_wire_format_policy: _,
-                    #[cfg(feature = "virtual-clients-draft")]
-                    vc_punctured,
                 },
             ..
         } = self;
@@ -1167,15 +1170,6 @@ impl CommitBuilder<'_, Complete, &mut MlsGroup> {
             .storage()
             .write_group_state(group.group_id(), &group.group_state)
             .map_err(CommitBuilderStageError::KeyStoreError)?;
-
-        // Persist the punctured PPRF for forward secrecy.
-        #[cfg(feature = "virtual-clients-draft")]
-        if let Some(VcPunctured { epoch_id, pprf }) = vc_punctured {
-            provider
-                .storage()
-                .write_vc_pprf(&epoch_id, &pprf)
-                .map_err(CommitBuilderStageError::KeyStoreError)?;
-        }
 
         group.reset_aad();
 
@@ -1195,53 +1189,54 @@ impl CommitBuilder<'_, Complete, &mut MlsGroup> {
     }
 }
 
-/// Build the path-secret + leaf-keypair override from a [`VcEmulation`] and
-/// inject the corresponding `DerivationInfo` blob into `leaf_node_parameters`'s
-/// `app_data_dictionary` extension.
+/// Build the path-secret + leaf-keypair override from the
+/// [`OperationSecret`] allocated in [`CommitBuilder::vc_emulation`] and
+/// inject the corresponding `DerivationInfo` blob into
+/// `leaf_node_parameters`'s `app_data_dictionary` extension.
+///
+/// The `DerivationInfoTbe` wrapping stays in the emulation epoch's
+/// ciphersuite, while the operation secret is expanded under the
+/// higher-level group ciphersuite to produce MLS path material for this
+/// group. The generation was consumed and the advanced tree persisted when
+/// `vc_emulation` was called, so this helper neither allocates nor
+/// persists anything.
 #[cfg(feature = "virtual-clients-draft")]
 fn apply_vc_emulation(
-    loaded: &mut VcLoaded,
+    loaded: &VcLoaded,
     leaf_node_parameters: &mut LeafNodeParameters,
     resolved_dictionary: AppDataDictionary,
-    rand: &impl OpenMlsRand,
     crypto: &impl OpenMlsCrypto,
     group_ciphersuite: openmls_traits::types::Ciphersuite,
 ) -> Result<crate::treesync::diff::OwnUpdatePathOverride, CreateCommitError> {
     let emulation_ciphersuite = loaded.emulation_ciphersuite;
-    // Build the encrypted EpochInfoTbe payload the receiver will decrypt
-    // with `epoch_encryption_key`. EpochInfo wrapping and PPRF evaluation
-    // stay in the emulation epoch's ciphersuite; the resulting operation
-    // secret is then expanded under the higher-level group ciphersuite to
-    // produce MLS path material for this group.
-    const VC_RANDOMNESS_SIZE: usize = 32;
-    let random = rand.random_vec(VC_RANDOMNESS_SIZE).map_err(|e| {
-        log::error!("vc: per-commit randomness failed: {e:?}");
-        VirtualClientsError::RandError
-    })?;
-    let epoch_info = EpochInfoTbe {
-        // Update-path leaf-node derivations are the only operation type
-        // wired up so far; KeyPackage / Application will use this same
-        // helper with their own variants when emitted.
-        operation_type: VirtualClientOperationType::LeafNode,
-        leaf_index: loaded.emulation_leaf_index,
-        random,
-    };
 
-    let pprf_input_bytes = pprf_input(crypto, emulation_ciphersuite, &epoch_info)?;
-    let operation_secret: OperationSecret = loaded
-        .pprf
-        .evaluate(crypto, emulation_ciphersuite, &pprf_input_bytes)
-        .map_err(VirtualClientsError::from)?
+    let path_secret = loaded
+        .operation_secret
+        .derive_path_generation_secret(crypto, group_ciphersuite)?
         .into();
+    let leaf_encryption_keypair = loaded
+        .operation_secret
+        .derive_encryption_key_secret(crypto, group_ciphersuite)?
+        .generate_encryption_key_pair(crypto, group_ciphersuite)?;
 
-    let encrypted_epoch_info = epoch_info.encrypt(
+    // Wrap the TBE under the per-epoch AEAD key, bound to the new leaf via
+    // its serialized encryption key as derivation context.
+    let leaf_encryption_key = leaf_encryption_keypair
+        .public_key()
+        .tls_serialize_detached()
+        .map_err(VirtualClientsError::from)?;
+    let tbe = DerivationInfoTbe {
+        leaf_index: loaded.emulation_leaf_index,
+        generation: loaded.generation,
+    };
+    let derivation_info = DerivationInfo::encrypt(
         crypto,
-        rand,
         emulation_ciphersuite,
         &loaded.epoch_encryption_key,
-        &loaded.epoch_id,
+        loaded.epoch_id.clone(),
+        &leaf_encryption_key,
+        &tbe,
     )?;
-    let derivation_info = DerivationInfo::new(loaded.epoch_id.clone(), encrypted_epoch_info);
     let derivation_info_bytes = derivation_info
         .tls_serialize_detached()
         .map_err(VirtualClientsError::from)?;
@@ -1252,12 +1247,6 @@ fn apply_vc_emulation(
         derivation_info_bytes,
     )?;
 
-    let path_secret = operation_secret
-        .derive_path_generation_secret(crypto, group_ciphersuite)?
-        .into();
-    let leaf_encryption_keypair = operation_secret
-        .derive_encryption_key_secret(crypto, group_ciphersuite)?
-        .generate_encryption_key_pair(crypto, group_ciphersuite)?;
     Ok(crate::treesync::diff::OwnUpdatePathOverride {
         path_secret,
         leaf_encryption_keypair,

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -70,6 +70,10 @@ struct VcLoaded {
     emulation_ciphersuite: openmls_traits::types::Ciphersuite,
     generation: u32,
     operation_secret: OperationSecret,
+    /// The resolved `AppDataDictionary` produced by the leaf-configuration
+    /// pre-check in `vc_emulation`, carried to `build` so the VC
+    /// derivation-info injection preserves every other entry.
+    resolved_dictionary: AppDataDictionary,
 }
 
 pub(crate) mod external_commits;
@@ -358,9 +362,9 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
     /// emulation epoch (see
     /// [`MlsGroup::register_vc_emulation_epoch`]). This method loads the
     /// per-epoch operation secret tree and AEAD key from the storage
-    /// provider, advances the own `LeafNode` operation ratchet by one
-    /// generation, and immediately persists the advanced tree. `build`
-    /// then:
+    /// provider, validates the leaf configuration (see the preconditions
+    /// below), then advances the own `LeafNode` operation ratchet by one
+    /// generation and immediately persists the advanced tree. `build` then:
     ///
     /// - derives the path secret and the new leaf's encryption keypair
     ///   from the allocated `OperationSecret`, so a sibling virtual
@@ -374,18 +378,20 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
     /// skip over a burned generation, retaining the skipped generation
     /// secrets inside their copy of the operation secret tree.
     ///
-    /// The application is responsible for ensuring the new leaf:
+    /// The leaf configuration is validated against the
+    /// `leaf_node_parameters` set on the builder so far, so call this after
+    /// configuring the self-update leaf. The application must ensure the new
+    /// leaf:
     ///
     /// - lists [`ExtensionType::AppDataDictionary`](crate::extensions::ExtensionType::AppDataDictionary)
     ///   in its `Capabilities.extensions`, and
     /// - signals support for [`VC_COMPONENT_ID`].
     ///
-    /// If those preconditions are not met the build fails with
+    /// If those preconditions are not met this method fails with
     /// `VirtualClientsError::AppDataDictionaryNotSupported` or
     /// `VirtualClientsError::VcComponentNotListed` (wrapped in
-    /// [`CreateCommitError::VirtualClientsError`]). The generation
-    /// allocated here stays burned in that case, which is harmless for the
-    /// reason above.
+    /// [`CreateCommitError::VirtualClientsError`]) before allocating a
+    /// generation, so no operation secret is burned in that case.
     ///
     /// Fails with `VirtualClientsError::MissingEmulationEpochState` or
     /// `VirtualClientsError::MissingOperationTree` if the epoch was never
@@ -421,6 +427,21 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
         let (emulation_leaf_index, epoch_encryption_key, emulation_ciphersuite) =
             state.into_parts();
 
+        // Validate the leaf configuration before allocating a generation, so
+        // a deterministic precondition failure (the new leaf not declaring
+        // `AppDataDictionary` or not listing `VC_COMPONENT_ID`) does not burn
+        // an operation secret. Returns the resolved `AppDataDictionary`, which
+        // `build` reuses so the injection preserves the AppComponents entry
+        // across commits.
+        let own_leaf_index = self.group.borrow().own_leaf_index();
+        let is_external_commit = self.stage.external_commit_info.is_some();
+        let resolved_dictionary = check_vc_leaf_configuration(
+            &self.stage.leaf_node_parameters,
+            self.group.borrow(),
+            own_leaf_index,
+            is_external_commit,
+        )?;
+
         // Update-path leaf-node derivations are the only operation type
         // wired up so far. KeyPackage / Application will get their own
         // allocation entry points when emitted. The operation context for
@@ -449,6 +470,7 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
             emulation_ciphersuite,
             generation,
             operation_secret,
+            resolved_dictionary,
         });
         Ok(self)
     }
@@ -730,21 +752,15 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, LoadedPsks, G> {
         let vc_loaded = builder.vc_loaded.take();
         #[cfg(feature = "virtual-clients-draft")]
         let own_update_override = if let Some(loaded) = vc_loaded.as_ref() {
-            // Run the leaf-configuration pre-check. Returns the resolved
-            // `AppDataDictionary` so the inject step can preserve every other
-            // entry the application registered, including the AppComponents
-            // entry that survives across multiple VC commits.
-            let resolved_dictionary = check_vc_leaf_configuration(
-                &cur_stage.leaf_node_parameters,
-                group,
-                own_leaf_index,
-                is_external_commit,
-            )?;
-
+            // The leaf-configuration pre-check already ran in `vc_emulation`,
+            // before the generation was allocated. Reuse the resolved
+            // `AppDataDictionary` it produced so the inject step preserves
+            // every other entry, including the AppComponents entry that
+            // survives across multiple VC commits.
             Some(apply_vc_emulation(
                 loaded,
                 &mut cur_stage.leaf_node_parameters,
-                resolved_dictionary,
+                loaded.resolved_dictionary.clone(),
                 crypto,
                 ciphersuite,
             )?)

--- a/openmls/src/group/mls_group/commit_builder/external_commits.rs
+++ b/openmls/src/group/mls_group/commit_builder/external_commits.rs
@@ -362,8 +362,6 @@ impl CommitBuilder<'_, super::Complete, MlsGroup> {
                 super::Complete {
                     result: create_commit_result,
                     original_wire_format_policy,
-                    #[cfg(feature = "virtual-clients-draft")]
-                    vc_punctured,
                 },
             ..
         } = self;
@@ -382,19 +380,6 @@ impl CommitBuilder<'_, super::Complete, MlsGroup> {
         group
             .store(provider.storage())
             .map_err(ExternalCommitBuilderFinalizeError::StorageError)?;
-
-        // Persist the punctured PPRF (mirrors the regular `stage_commit`
-        // path). Without this, an external VC commit's puncture would be
-        // lost and the same per-commit input could be reused by a sibling
-        // emulator, breaking forward secrecy.
-        #[cfg(feature = "virtual-clients-draft")]
-        if let Some(super::VcPunctured { epoch_id, pprf }) = vc_punctured {
-            use openmls_traits::storage::StorageProvider as _;
-            provider
-                .storage()
-                .write_vc_pprf(&epoch_id, &pprf)
-                .map_err(ExternalCommitBuilderFinalizeError::StorageError)?;
-        }
 
         // Set the current group state to [`MlsGroupState::PendingCommit`],
         // storing the current [`StagedCommit`] from the commit results

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -624,19 +624,6 @@ mod virtual_clients_draft {
         }
     }
 
-    /// Errors when resolving the emulation-epoch state a group is bound
-    /// to at a given epoch.
-    #[derive(Error, Debug, PartialEq, Clone)]
-    pub(crate) enum VcEmulationStateError<StorageError> {
-        /// Error reading the virtual-clients state from storage.
-        #[error("Error reading virtual-clients state from storage")]
-        Storage(StorageError),
-        /// The group is bound to an emulation epoch, but the state is
-        /// missing from storage.
-        #[error("The group is bound to an emulation epoch, but the state is missing from storage")]
-        MissingEmulationEpochState,
-    }
-
     /// Errors returned by
     /// [`MlsGroup::register_vc_emulation_epoch`](crate::group::MlsGroup::register_vc_emulation_epoch).
     #[derive(Error, Debug, PartialEq, Clone)]

--- a/openmls/src/group/mls_group/exporting.rs
+++ b/openmls/src/group/mls_group/exporting.rs
@@ -15,8 +15,9 @@ use crate::{
 #[cfg(feature = "virtual-clients-draft")]
 use crate::{
     components::vc_derivation_info::{
-        build_vc_pprf, EmulationEpochState, EmulatorEpochSecret, EpochId, VC_COMPONENT_ID,
+        EmulationEpochState, EmulatorEpochSecret, EpochId, VC_COMPONENT_ID,
     },
+    components::vc_operation_tree::OperationSecretTree,
     group::mls_group::errors::RegisterVcEmulationEpochError,
 };
 
@@ -111,30 +112,18 @@ impl MlsGroup {
     ///
     /// Sources the per-emulation-epoch root secret from
     /// `self.safe_export_secret(crypto, storage, VC_COMPONENT_ID)`,
-    /// derives the [`EpochId`], the AEAD key, and the PPRF root, and
-    /// persists the PPRF + AEAD key in the storage provider keyed on the
-    /// derived `EpochId`. Returns the `EpochId` so the caller can reference
-    /// this emulation epoch on subsequent virtual-clients commits.
+    /// derives the [`EpochId`], the AEAD key, and the epoch base secret,
+    /// builds the per-epoch operation secret tree (sized like the emulation
+    /// group's ratchet tree), and persists the tree and the per-epoch state
+    /// in the storage provider keyed on the derived `EpochId`. Returns the
+    /// `EpochId` so the caller can reference this emulation epoch on
+    /// subsequent virtual-clients commits.
     ///
-    /// The emulation group must support `safe_export_secret` (i.e. it
-    /// must have been created with the appropriate
-    /// `AppDataDictionary` capability/extension wiring); otherwise this
-    /// returns [`SafeExportSecretError::Unsupported`] via
+    /// The emulation group must support `safe_export_secret`, which requires
+    /// the appropriate `AppDataDictionary` capability and extension wiring at
+    /// group creation. Otherwise this returns
+    /// [`SafeExportSecretError::Unsupported`] via
     /// [`RegisterVcEmulationEpochError::SafeExportSecret`].
-    ///
-    /// # Key-material lifecycle
-    ///
-    /// The persisted per-epoch state ([`EmulationEpochState`] and the
-    /// PPRF) is keyed by the returned [`EpochId`] and shared by all
-    /// higher-level groups bound to this emulation epoch. OpenMLS never
-    /// deletes it, not even when such a group is deleted. Once no
-    /// higher-level group references the emulation epoch anymore, the
-    /// application must remove the state via
-    /// [`delete_vc_emulation_epoch_state`] and [`delete_vc_pprf`].
-    ///
-    /// [`delete_vc_emulation_epoch_state`]:
-    ///     openmls_traits::storage::StorageProvider::delete_vc_emulation_epoch_state
-    /// [`delete_vc_pprf`]: openmls_traits::storage::StorageProvider::delete_vc_pprf
     #[cfg(feature = "virtual-clients-draft")]
     pub fn register_vc_emulation_epoch<Crypto: OpenMlsCrypto, Storage: StorageProvider>(
         &mut self,
@@ -149,22 +138,30 @@ impl MlsGroup {
         let epoch_id = emulator_epoch_secret.derive_epoch_id(crypto, ciphersuite)?;
         let epoch_encryption_key =
             emulator_epoch_secret.derive_epoch_encryption_key(crypto, ciphersuite)?;
-        let epoch_secret = emulator_epoch_secret.derive_epoch_secret(crypto, ciphersuite)?;
+        let epoch_base_secret =
+            emulator_epoch_secret.derive_epoch_base_secret(crypto, ciphersuite)?;
         let reuse_guard_secret =
             emulator_epoch_secret.derive_reuse_guard_secret(crypto, ciphersuite)?;
-        let pprf = build_vc_pprf(epoch_secret);
+        let generation_id_secret =
+            emulator_epoch_secret.derive_generation_id_secret(crypto, ciphersuite)?;
+        let operation_tree = OperationSecretTree::new(epoch_base_secret, emulation_group_size);
         let state = EmulationEpochState::new(
             leaf_index,
             epoch_encryption_key,
             reuse_guard_secret,
+            generation_id_secret,
             emulation_group_size,
             ciphersuite,
         );
 
-        storage.write_vc_pprf(&epoch_id, &pprf).map_err(|e| {
-            log::error!("vc: persist pprf in register_vc_emulation_epoch failed: {e:?}");
-            RegisterVcEmulationEpochError::Storage(e)
-        })?;
+        storage
+            .write_vc_operation_tree(&epoch_id, &operation_tree)
+            .map_err(|e| {
+                log::error!(
+                    "vc: persist operation tree in register_vc_emulation_epoch failed: {e:?}"
+                );
+                RegisterVcEmulationEpochError::Storage(e)
+            })?;
         storage
             .write_vc_emulation_epoch_state(&epoch_id, &state)
             .map_err(|e| {

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -48,9 +48,6 @@ use openmls_traits::{signatures::Signer, storage::StorageProvider as _, types::C
 #[cfg(feature = "extensions-draft-08")]
 use crate::schedule::{application_export_tree::ApplicationExportTree, ApplicationExportSecret};
 
-#[cfg(feature = "virtual-clients-draft")]
-use errors::VcEmulationStateError;
-
 // Private
 mod application;
 mod exporting;
@@ -500,13 +497,6 @@ impl MlsGroup {
     /// Remove the persisted state of this group from storage. Note that
     /// signature key material is not managed by OpenMLS and has to be removed
     /// from the storage provider separately (if desired).
-    ///
-    /// With the `virtual-clients-draft` feature, the group's
-    /// emulation-epoch bindings are removed, but the emulation-epoch
-    /// state and PPRF they point to are not: they are keyed by emulation
-    /// epoch and may still be referenced by other higher-level groups.
-    /// Deleting them is the application's responsibility, see
-    /// `MlsGroup::register_vc_emulation_epoch`.
     pub fn delete<Storage: crate::storage::StorageProvider>(
         &mut self,
         storage: &Storage,
@@ -525,9 +515,9 @@ impl MlsGroup {
         storage.delete_application_export_tree::<_, ApplicationExportTree>(self.group_id())?;
 
         // Drop this group's emulation-epoch bindings. `EmulationEpochState`
-        // and `VcPprf` are keyed on the emulation epoch and may still be
-        // referenced by other higher-level groups, so they're not
-        // deleted here.
+        // and the operation secret tree are keyed on the emulation epoch
+        // and may still be referenced by other higher-level groups, so
+        // they're not deleted here.
         #[cfg(feature = "virtual-clients-draft")]
         storage.delete_vc_emulation_bindings(self.group_id())?;
 
@@ -547,6 +537,19 @@ impl MlsGroup {
     pub fn export_ratchet_tree(&self) -> RatchetTree {
         self.public_group().export_ratchet_tree()
     }
+}
+
+/// Error resolving the [`EmulationEpochState`] bound to a group at a given
+/// epoch via [`MlsGroup::vc_emulation_state_at_epoch`]. Callers map it to
+/// their own error type.
+///
+/// [`EmulationEpochState`]: crate::components::vc_derivation_info::EmulationEpochState
+#[cfg(feature = "virtual-clients-draft")]
+pub(crate) enum VcEmulationStateError<StorageError> {
+    /// Reading the binding or the emulation-epoch state from storage failed.
+    Storage(StorageError),
+    /// The group is bound to an emulation epoch, but its state is missing.
+    MissingEmulationEpochState,
 }
 
 // Crate-public functions
@@ -688,12 +691,11 @@ impl MlsGroup {
         .map_err(|e| e.into())
     }
 
-    /// Resolve the [`EmulationEpochState`] this group is bound to at
-    /// `epoch`, if any.
-    ///
-    /// Returns `Ok(None)` if the group has no emulation-epoch binding at
-    /// `epoch`. Returns an error if a binding exists but the state is
-    /// missing from storage.
+    /// Load the [`EmulationEpochState`] this group is bound to at `epoch`, if
+    /// any. Returns `None` when the group has no virtual-clients binding for
+    /// that epoch. The binding is resolved at the epoch a message was sent in,
+    /// so a delayed message from a past epoch deprotects with the state that
+    /// was bound then, not the latest one.
     ///
     /// [`EmulationEpochState`]: crate::components::vc_derivation_info::EmulationEpochState
     #[cfg(feature = "virtual-clients-draft")]
@@ -892,27 +894,34 @@ impl MlsGroup {
     /// Delete the [`EncryptionKeyPair`]s from the previous [`GroupEpoch`] from
     /// the `provider`'s key store.
     ///
-    /// With the `virtual-clients-draft` feature, the caller passes the leaf
-    /// index under which the previous-epoch keypairs are stored. This is
-    /// needed for the sibling-resync flow, where `merge_commit` installs the
-    /// joiner's leaf as our own leaf before it filters and stores the new
-    /// epoch keypairs, so `self.own_leaf_index()` no longer points at the
-    /// previous epoch's leaf.
-    ///
     /// Returns an error if access to the key store fails.
+    #[cfg(not(feature = "virtual-clients-draft"))]
     pub(super) fn delete_previous_epoch_keypairs<Storage: StorageProvider>(
         &self,
         store: &Storage,
-        #[cfg(feature = "virtual-clients-draft")] previous_own_leaf_index: LeafNodeIndex,
     ) -> Result<(), Storage::Error> {
-        #[cfg(feature = "virtual-clients-draft")]
-        let leaf_index = previous_own_leaf_index.u32();
-        #[cfg(not(feature = "virtual-clients-draft"))]
-        let leaf_index = self.own_leaf_index().u32();
         store.delete_encryption_epoch_key_pairs(
             self.group_id(),
             &GroupEpoch::from(self.context().epoch().as_u64() - 1),
-            leaf_index,
+            self.own_leaf_index().u32(),
+        )
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    pub(super) fn delete_previous_epoch_keypairs<Storage: StorageProvider>(
+        &self,
+        store: &Storage,
+        previous_own_leaf_index: LeafNodeIndex,
+    ) -> Result<(), Storage::Error> {
+        // In the sibling-resync flow, `merge_commit` installs the joiner's
+        // leaf as our own leaf before it filters and stores the new epoch
+        // keypairs. Previous-epoch keypairs are still stored under the leaf
+        // index from that previous epoch, so the caller must pass that index
+        // explicitly instead of having this helper read `self.own_leaf_index()`.
+        store.delete_encryption_epoch_key_pairs(
+            self.group_id(),
+            &GroupEpoch::from(self.context().epoch().as_u64() - 1),
+            previous_own_leaf_index.u32(),
         )
     }
 

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -545,10 +545,13 @@ impl MlsGroup {
 ///
 /// [`EmulationEpochState`]: crate::components::vc_derivation_info::EmulationEpochState
 #[cfg(feature = "virtual-clients-draft")]
+#[derive(thiserror::Error, Debug, PartialEq, Clone)]
 pub(crate) enum VcEmulationStateError<StorageError> {
     /// Reading the binding or the emulation-epoch state from storage failed.
+    #[error("Error reading the binding or emulation-epoch state from storage: {0}")]
     Storage(StorageError),
     /// The group is bound to an emulation epoch, but its state is missing.
+    #[error("The group is bound to an emulation epoch, but its state is missing.")]
     MissingEmulationEpochState,
 }
 

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -2,8 +2,6 @@
 
 use std::mem;
 
-#[cfg(feature = "virtual-clients-draft")]
-use errors::VcEmulationStateError;
 use errors::{CommitToPendingProposalsError, MergePendingCommitError};
 use openmls_traits::{crypto::OpenMlsCrypto, signatures::Signer, storage::StorageProvider as _};
 
@@ -194,8 +192,10 @@ impl MlsGroup {
         let emulation_state = if let ProtocolMessage::PrivateMessage(private_message) = &message {
             self.vc_emulation_state_at_epoch(provider.storage(), private_message.epoch())
                 .map_err(|e| match e {
-                    VcEmulationStateError::Storage(e) => ProcessMessageError::StorageError(e),
-                    VcEmulationStateError::MissingEmulationEpochState => {
+                    super::VcEmulationStateError::Storage(e) => {
+                        ProcessMessageError::StorageError(e)
+                    }
+                    super::VcEmulationStateError::MissingEmulationEpochState => {
                         ProcessMessageError::ValidationError(
                             crate::group::ValidationError::UnableToDecrypt(
                                 crate::framing::errors::MessageDecryptionError::VirtualClientsError(
@@ -316,18 +316,23 @@ impl MlsGroup {
             .write_group_state(self.group_id(), &self.group_state)
             .map_err(MergeCommitError::StorageError)?;
 
-        // Resolve the emulation-binding update for the new epoch now,
-        // while `staged_commit` and the pre-merge `self.epoch()` are
-        // still available. It is persisted only after the merge has
-        // succeeded, so a failed merge does not leave a binding for an
-        // epoch the group never entered.
+        // Update the per-epoch emulation bindings. Self-removal drops them.
+        // Otherwise the epoch the commit moves the group into is bound to
+        // the emulation epoch of the commit's VC leaf, or, if the commit
+        // does not install a new VC leaf, to the binding of the current
+        // epoch, since the VC leaf stays active across commits by other
+        // members.
         #[cfg(feature = "virtual-clients-draft")]
-        let self_removed = staged_commit.self_removed();
-        #[cfg(feature = "virtual-clients-draft")]
-        let vc_bindings_update = if self_removed {
-            None
+        if staged_commit.self_removed() {
+            provider
+                .storage()
+                .delete_vc_emulation_bindings(self.group_id())
+                .map_err(|e| {
+                    log::error!("vc: drop emulation bindings on self-removal failed: {e:?}");
+                    MergeCommitError::StorageError(e)
+                })?;
         } else {
-            let bindings: crate::components::vc_derivation_info::VcEmulationBindings = provider
+            let mut bindings: crate::components::vc_derivation_info::VcEmulationBindings = provider
                 .storage()
                 .vc_emulation_bindings(self.group_id())
                 .map_err(MergeCommitError::StorageError)?
@@ -336,41 +341,24 @@ impl MlsGroup {
                 .vc_emulation_epoch_id
                 .clone()
                 .or_else(|| bindings.get(self.epoch()).cloned());
-            epoch_id.map(|epoch_id| (bindings, staged_commit.epoch(), epoch_id))
-        };
+            if let Some(epoch_id) = epoch_id {
+                // Keep one entry per retained message-secrets epoch plus
+                // the new current one, so bindings age out in lockstep
+                // with the message secrets they are needed for.
+                let max_entries = self.message_secrets_store.max_epochs.saturating_add(1);
+                bindings.insert(staged_commit.epoch(), epoch_id, max_entries);
+                provider
+                    .storage()
+                    .write_vc_emulation_bindings(self.group_id(), &bindings)
+                    .map_err(|e| {
+                        log::error!("vc: persist emulation bindings at merge failed: {e:?}");
+                        MergeCommitError::StorageError(e)
+                    })?;
+            }
+        }
 
         // Merge staged commit
         self.merge_commit(provider, staged_commit)?;
-
-        // Update the per-epoch emulation bindings. Self-removal drops them.
-        // Otherwise the epoch the commit moves the group into is bound to
-        // the emulation epoch of the commit's VC leaf, or, if the commit
-        // does not install a new VC leaf, to the binding of the previous
-        // epoch, since the VC leaf stays active across commits by other
-        // members.
-        #[cfg(feature = "virtual-clients-draft")]
-        if self_removed {
-            provider
-                .storage()
-                .delete_vc_emulation_bindings(self.group_id())
-                .map_err(|e| {
-                    log::error!("vc: drop emulation bindings on self-removal failed: {e:?}");
-                    MergeCommitError::StorageError(e)
-                })?;
-        } else if let Some((mut bindings, new_epoch, epoch_id)) = vc_bindings_update {
-            // Keep one entry per retained message-secrets epoch plus
-            // the new current one, so bindings age out in lockstep
-            // with the message secrets they are needed for.
-            let max_entries = self.message_secrets_store.max_epochs.saturating_add(1);
-            bindings.insert(new_epoch, epoch_id, max_entries);
-            provider
-                .storage()
-                .write_vc_emulation_bindings(self.group_id(), &bindings)
-                .map_err(|e| {
-                    log::error!("vc: persist emulation bindings at merge failed: {e:?}");
-                    MergeCommitError::StorageError(e)
-                })?;
-        }
 
         // Extract and store the resumption psk for the current epoch
         let resumption_psk = self.group_epoch_secrets().resumption_psk();
@@ -416,8 +404,8 @@ impl MlsGroup {
 
     /// Resolve a commit's virtual-clients derivation info to the per-commit
     /// `OperationSecret` the receiver needs in order to recreate the path of a
-    /// commit sent by a sibling emulator client, plus the `EpochId` the commit
-    /// binds the group to on merge.
+    /// commit sent by a sibling emulator client, plus the `EpochId` the
+    /// commit binds the group to on merge.
     ///
     /// See [`is_sibling_vc_commit`] for the precondition the caller must
     /// check before invoking this helper. Sibling commits come in two
@@ -432,13 +420,19 @@ impl MlsGroup {
     /// Returns `Ok(None)` when the commit carries no virtual-clients
     /// derivation-info entry on its update-path leaf (path-less commits, or
     /// commits without an `app_data_dictionary`). Otherwise:
-    ///   - looks up the per-epoch `VcPprf` and `EpochEncryptionKey` the
-    ///     application registered via `register_vc_emulation_epoch`,
-    ///   - decrypts the wrapped `EpochInfoTbe` with the AEAD key,
-    ///   - hashes the decrypted `EpochInfoTbe` to produce the PPRF input,
-    ///   - evaluates the PPRF (puncturing it) and persists the punctured state
-    ///     back to storage,
-    ///   - returns the resulting `OperationSecret` together with the `EpochId`.
+    ///   - looks up the per-epoch `EmulationEpochState` and operation secret
+    ///     tree the application registered via `register_vc_emulation_epoch`,
+    ///   - decrypts the wrapped `DerivationInfoTbe` with the AEAD key/nonce
+    ///     derived from the epoch encryption key and the path leaf's
+    ///     serialized encryption key,
+    ///   - derives the operation secret positionally from the tree at the
+    ///     sender's emulation-leaf coordinates and persists the advanced
+    ///     tree,
+    ///   - returns the resulting `OperationSecret` and `EpochId`.
+    ///
+    /// A generation the tree reports as already consumed fails with
+    /// `OperationGenerationConsumed`. Operation secrets are consume-once,
+    /// matching the semantics of regular PrivateMessage decryption.
     #[cfg(feature = "virtual-clients-draft")]
     fn load_vc_commit_material<Provider: OpenMlsProvider>(
         &self,
@@ -451,11 +445,15 @@ impl MlsGroup {
         )>,
         StageCommitError,
     > {
-        use tls_codec::DeserializeBytes;
+        use tls_codec::{DeserializeBytes, Serialize as _};
 
-        use crate::components::vc_derivation_info::{
-            pprf_input, DerivationInfo, EmulationEpochState, OperationSecret, VcPprf,
-            VirtualClientOperationType, VirtualClientsError, VC_COMPONENT_ID,
+        use crate::{
+            components::vc_derivation_info::{
+                DerivationInfo, EmulationEpochState, VirtualClientOperationType,
+                VirtualClientsError, VC_COMPONENT_ID,
+            },
+            components::vc_operation_tree::OperationSecretTree,
+            treesync::node::leaf_node::LeafNodeSource,
         };
 
         let Some(path) = commit.path.as_ref() else {
@@ -475,13 +473,6 @@ impl MlsGroup {
 
         let epoch_id = derivation_info.epoch_id();
         let storage = provider.storage();
-        let mut pprf: VcPprf = storage
-            .vc_pprf(epoch_id)
-            .map_err(|e| {
-                log::error!("vc: load pprf failed: {e:?}");
-                VirtualClientsError::StorageError
-            })?
-            .ok_or(VirtualClientsError::MissingPprf)?;
         let state: EmulationEpochState = storage
             .vc_emulation_epoch_state(epoch_id)
             .map_err(|e| {
@@ -489,43 +480,69 @@ impl MlsGroup {
                 VirtualClientsError::StorageError
             })?
             .ok_or(VirtualClientsError::MissingEmulationEpochState)?;
-        // Receiver uses the emulation epoch's AEAD key and ciphersuite for
-        // `EpochInfoTbe`; the leaf index travels on the wire (sender's view),
-        // so it doesn't have to come from storage on this side.
+        let mut operation_tree: OperationSecretTree = storage
+            .vc_operation_tree(epoch_id)
+            .map_err(|e| {
+                log::error!("vc: load operation tree failed: {e:?}");
+                VirtualClientsError::StorageError
+            })?
+            .ok_or(VirtualClientsError::MissingOperationTree)?;
+        // The receiver uses the emulation epoch's AEAD key and ciphersuite
+        // for `DerivationInfoTbe`. The sender's emulation leaf index travels
+        // on the wire, so it doesn't have to come from storage on this side.
         let (_state_leaf_index, epoch_encryption_key, emulation_ciphersuite) = state.into_parts();
 
         let crypto = provider.crypto();
-        let epoch_info =
-            derivation_info.decrypt(crypto, emulation_ciphersuite, &epoch_encryption_key)?;
+        let leaf_encryption_key = path
+            .leaf_node()
+            .encryption_key()
+            .tls_serialize_detached()
+            .map_err(VirtualClientsError::from)?;
+        let tbe = derivation_info.decrypt(
+            crypto,
+            emulation_ciphersuite,
+            &epoch_encryption_key,
+            &leaf_encryption_key,
+        )?;
 
-        // We only know how to consume `LeafNode` operation type for an
-        // update-path commit — anything else here is a sender bug or a
-        // cross-context replay. Treat it as malformed rather than silently
-        // deriving a secret in the wrong domain.
-        if !matches!(
-            epoch_info.operation_type,
-            VirtualClientOperationType::LeafNode
-        ) {
-            log::error!(
-                "vc: unexpected operation_type on update-path leaf: {:?}",
-                epoch_info.operation_type
-            );
-            return Err(VirtualClientsError::DerivationInfoMalformed.into());
-        }
+        // The operation type is not on the wire. It is inferred from the
+        // carrying leaf's source: key-package leaves map to `KeyPackage`,
+        // update and commit leaves map to `LeafNode`. Only `LeafNode` is
+        // wired up today, and an update-path leaf always has a commit
+        // source.
+        let operation_type = match path.leaf_node().leaf_node_source() {
+            LeafNodeSource::KeyPackage(_) => {
+                log::error!("vc: key-package leaf on an update path");
+                return Err(VirtualClientsError::DerivationInfoMalformed.into());
+            }
+            LeafNodeSource::Update | LeafNodeSource::Commit(_) => {
+                VirtualClientOperationType::LeafNode
+            }
+        };
+        // The operation context for `LeafNode` operations is the
+        // higher-level group's id.
+        let operation_context = self.group_id().as_slice().to_vec();
 
-        let pprf_input_bytes = pprf_input(crypto, emulation_ciphersuite, &epoch_info)?;
-        let operation_secret: OperationSecret = pprf
-            .evaluate(crypto, emulation_ciphersuite, &pprf_input_bytes)
-            .map_err(VirtualClientsError::from)?
-            .into();
-
-        // Persist puncture immediately. Reprocessing the same commit will
-        // fail with `PprfError::PuncturedInput`, which is exactly what we
-        // want for forward secrecy.
-        storage.write_vc_pprf(epoch_id, &pprf).map_err(|e| {
-            log::error!("vc: persist punctured pprf failed: {e:?}");
-            VirtualClientsError::StorageError
-        })?;
+        // An already-consumed generation propagates as a hard error here:
+        // operation secrets are consume-once, like the per-generation keys
+        // of regular PrivateMessage decryption.
+        let operation_secret = operation_tree.derive_operation_secret(
+            crypto,
+            emulation_ciphersuite,
+            epoch_id,
+            tbe.leaf_index,
+            operation_type,
+            tbe.generation,
+            &operation_context,
+        )?;
+        // Persist the advanced tree immediately, before any key material is
+        // derived from the secret.
+        storage
+            .write_vc_operation_tree(epoch_id, &operation_tree)
+            .map_err(|e| {
+                log::error!("vc: persist advanced operation tree failed: {e:?}");
+                VirtualClientsError::StorageError
+            })?;
 
         Ok(Some((epoch_id.clone(), operation_secret)))
     }
@@ -805,6 +822,7 @@ impl MlsGroup {
                     ProcessedMessageContent::ProposalMessage(proposal)
                 }
             }
+            #[cfg_attr(not(feature = "virtual-clients-draft"), allow(unused_variables))]
             FramedContentBody::Commit(commit) => {
                 // Since this is a commit, we need to load the private key material we need for decryption.
                 let (old_epoch_keypairs, leaf_node_keypairs) =
@@ -825,8 +843,6 @@ impl MlsGroup {
                     } else {
                         (None, None)
                     };
-                #[cfg(not(feature = "virtual-clients-draft"))]
-                let _ = commit;
 
                 let staged_commit = self.stage_commit(
                     &content,
@@ -1015,7 +1031,7 @@ impl MlsGroup {
 /// Returns `true` for:
 ///   * own-leaf commits (`Sender::Member(idx)` with `idx == own_leaf_index`),
 ///     where receiver and sender share the higher-level leaf
-///   * sibling-resync external commits (`Sender::NewMemberCommit`) whose
+///   * sibling-resync external commits (`Sender::NewMemberCommit` whose
 ///     proposal list inlines a `Remove` of `own_leaf_index`.
 ///
 /// `false` for everything else.

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -355,26 +355,29 @@ impl MlsGroup {
                 // (either our own leaf, or a sibling-resync external commit
                 // onto a new leaf), we have no HPKE recipient on the path.
                 // Re-derive the path from the per-commit `OperationSecret`
-                // the receiver computed by evaluating the per-epoch PPRF, and
-                // verify the resulting public keys against the commit. The
-                // non-VC `decrypt_path` is the fallback for everyone else.
+                // the receiver derived from the per-epoch operation secret
+                // tree, and verify the resulting public keys against the
+                // commit. The non-VC `decrypt_path` is the fallback for
+                // everyone else.
                 #[cfg(feature = "virtual-clients-draft")]
-                let vc_path: Option<(Vec<EncryptionKeyPair>, CommitSecret)> =
-                    if sender_index == self.own_leaf_index() || is_sibling_resync {
-                        let operation_secret = vc_material.ok_or(
-                            crate::components::vc_derivation_info::VirtualClientsError::MissingPprf,
+                let vc_path: Option<(Vec<EncryptionKeyPair>, CommitSecret)> = if sender_index
+                    == self.own_leaf_index()
+                    || is_sibling_resync
+                {
+                    let operation_secret = vc_material.ok_or(
+                            crate::components::vc_derivation_info::VirtualClientsError::MissingOperationTree,
                         )?;
-                        Some(self.recreate_path_for_own_commit(
-                            &diff,
-                            &path,
-                            ciphersuite,
-                            provider.crypto(),
-                            sender_index,
-                            operation_secret,
-                        )?)
-                    } else {
-                        None
-                    };
+                    Some(self.recreate_path_for_own_commit(
+                        &diff,
+                        &path,
+                        ciphersuite,
+                        provider.crypto(),
+                        sender_index,
+                        operation_secret,
+                    )?)
+                } else {
+                    None
+                };
                 #[cfg(not(feature = "virtual-clients-draft"))]
                 let vc_path: Option<(Vec<EncryptionKeyPair>, CommitSecret)> = None;
 

--- a/openmls/src/schedule/pprf/mod.rs
+++ b/openmls/src/schedule/pprf/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 use input::AsIndexBytes;
 use prefix::Prefix;
 
-pub use prefix::{Prefix16, Prefix256};
+pub use prefix::Prefix16;
 
 mod input;
 mod prefix;

--- a/openmls/src/schedule/pprf/prefix.rs
+++ b/openmls/src/schedule/pprf/prefix.rs
@@ -6,7 +6,6 @@
 //! an empty prefix, which then grows in size with each step down the tree.
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_bytes::ByteArray;
 
 use super::PprfError;
 
@@ -137,62 +136,6 @@ impl From<SerdePrefix16> for Prefix16 {
     }
 }
 
-/// A prefix in a PPRF whose inputs are 32-byte (256-bit) strings.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(from = "SerdePrefix256", into = "SerdePrefix256")]
-pub struct Prefix256 {
-    bits: [u8; Self::PPRF_INPUT_LEN],
-    len: PrefixLen<{ Self::MAX_DEPTH }, u16>,
-}
-
-impl Prefix256 {
-    pub const PPRF_INPUT_LEN: usize = Self::MAX_DEPTH / 8; // 32 bytes
-}
-
-impl Prefix for Prefix256 {
-    const MAX_DEPTH: usize = 256;
-
-    fn new() -> Self {
-        Self {
-            bits: [0; Self::PPRF_INPUT_LEN],
-            len: PrefixLen::zero(),
-        }
-    }
-
-    fn push_bit(&mut self, bit: bool) -> Result<(), PprfError> {
-        let len = self.len.as_usize();
-        let next_len = self.len.incremented()?;
-        if bit {
-            let byte_idx = len / 8;
-            let bit_idx = 7 - (len % 8) as u8;
-            self.bits[byte_idx] |= 1 << bit_idx;
-        }
-        self.len = next_len;
-        Ok(())
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-struct SerdePrefix256(
-    ByteArray<{ Prefix256::PPRF_INPUT_LEN }>,
-    PrefixLen<{ Prefix256::MAX_DEPTH }, u16>,
-);
-
-impl From<Prefix256> for SerdePrefix256 {
-    fn from(prefix: Prefix256) -> Self {
-        SerdePrefix256(ByteArray::new(prefix.bits), prefix.len)
-    }
-}
-
-impl From<SerdePrefix256> for Prefix256 {
-    fn from(prefix: SerdePrefix256) -> Self {
-        Prefix256 {
-            bits: prefix.0.into_array(),
-            len: prefix.1,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,21 +163,6 @@ mod tests {
         assert_eq!(result, Err(PprfError::PrefixMaxDepthExceeded));
         assert_eq!(prefix.len.len, max_depth);
         assert_eq!(prefix.bits, u16::MAX);
-    }
-
-    #[test]
-    fn prefix256_rejects_push_at_max_depth() {
-        let max_depth = Prefix256::MAX_DEPTH as u16;
-        let mut prefix = Prefix256 {
-            bits: [0xff; 32],
-            len: prefix_len(max_depth),
-        };
-
-        let result = prefix.push_bit(true);
-
-        assert_eq!(result, Err(PprfError::PrefixMaxDepthExceeded));
-        assert_eq!(prefix.len.len, max_depth);
-        assert_eq!(prefix.bits, [0xff; 32]);
     }
 
     #[test]

--- a/openmls/src/storage.rs
+++ b/openmls/src/storage.rs
@@ -155,8 +155,9 @@ impl traits::ApplicationExportTree<CURRENT_VERSION> for ApplicationExportTree {}
 mod virtual_clients_storage {
     use super::*;
     use crate::components::vc_derivation_info::{
-        EmulationEpochState, EpochId, VcEmulationBindings, VcPprf,
+        EmulationEpochState, EpochId, VcEmulationBindings,
     };
+    use crate::components::vc_operation_tree::OperationSecretTree;
 
     // EpochId is both used as a key and a value, so it implements both traits.
     impl Key<CURRENT_VERSION> for EpochId {}
@@ -166,11 +167,11 @@ mod virtual_clients_storage {
     impl Entity<CURRENT_VERSION> for EmulationEpochState {}
     impl traits::VcEmulationEpochState<CURRENT_VERSION> for EmulationEpochState {}
 
-    impl Entity<CURRENT_VERSION> for VcPprf {}
-    impl traits::VcPprf<CURRENT_VERSION> for VcPprf {}
-
     impl Entity<CURRENT_VERSION> for VcEmulationBindings {}
     impl traits::VcEmulationBindings<CURRENT_VERSION> for VcEmulationBindings {}
+
+    impl Entity<CURRENT_VERSION> for OperationSecretTree {}
+    impl traits::VcOperationTree<CURRENT_VERSION> for OperationSecretTree {}
 }
 
 #[cfg(test)]

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -311,7 +311,10 @@ fn join_sibling_emulator<P: OpenMlsProvider>(
     let epoch_id_b = emulator_b
         .register_vc_emulation_epoch(alice_b_provider.crypto(), alice_b_provider.storage())
         .expect("alice_b register vc epoch");
-    assert_eq!(epoch_id, epoch_id_b, "siblings must derive the same EpochId");
+    assert_eq!(
+        epoch_id, epoch_id_b,
+        "siblings must derive the same EpochId"
+    );
 
     // alice_b resyncs into the higher-level group via an external commit.
     let verifiable_group_info = {
@@ -1556,8 +1559,12 @@ fn reuse_guard_recovers_emulator_leaf_index() {
     let (vc_signer, vc_credential) =
         shared_vc_identity(ciphersuite, &alice_a_provider, &alice_b_provider);
 
-    let mut alice_a_main =
-        new_vc_main_group(ciphersuite, &alice_a_provider, &vc_signer, vc_credential.clone());
+    let mut alice_a_main = new_vc_main_group(
+        ciphersuite,
+        &alice_a_provider,
+        &vc_signer,
+        vc_credential.clone(),
+    );
 
     let (sib, resync_commit) = join_sibling_emulator(
         ciphersuite,
@@ -1698,8 +1705,11 @@ fn reuse_guard_recovery_across_mismatched_ciphersuites() {
 
     let alice_a_provider = OpenMlsRustCrypto::default();
     let alice_b_provider = OpenMlsRustCrypto::default();
-    let (vc_signer, vc_credential) =
-        shared_vc_identity(higher_level_ciphersuite, &alice_a_provider, &alice_b_provider);
+    let (vc_signer, vc_credential) = shared_vc_identity(
+        higher_level_ciphersuite,
+        &alice_a_provider,
+        &alice_b_provider,
+    );
 
     let mut alice_a_main = new_vc_main_group(
         higher_level_ciphersuite,
@@ -1935,8 +1945,12 @@ fn vc_binding_carries_forward_across_foreign_commits() {
 
     // alice (the virtual client) founds the group on the shared leaf and adds
     // Bob, a regular member.
-    let mut alice_a_main =
-        new_vc_main_group(ciphersuite, &alice_a_provider, &vc_signer, vc_credential.clone());
+    let mut alice_a_main = new_vc_main_group(
+        ciphersuite,
+        &alice_a_provider,
+        &vc_signer,
+        vc_credential.clone(),
+    );
     let (bob_credential, bob_signer) =
         new_credential(&bob_provider, b"Bob", ciphersuite.signature_algorithm());
     let bob_kp = KeyPackage::builder()

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "virtual-clients-draft")]
 use openmls::{
-    components::vc_derivation_info::{EpochId, VcEmulation, VcEmulationBindings, VC_COMPONENT_ID},
+    components::vc_derivation_info::{EpochId, VcEmulationBindings, VC_COMPONENT_ID},
     extensions::{
         AppDataDictionary, AppDataDictionaryExtension, Extension, ExtensionType, Extensions,
     },
@@ -161,7 +161,12 @@ fn send_vc_commit_with_epoch<P: OpenMlsProvider>(
 ) -> openmls::prelude::MlsMessageOut {
     let bundle = sender_group
         .commit_builder()
-        .vc_emulation(VcEmulation { epoch_id })
+        .vc_emulation(
+            sender_provider.crypto(),
+            sender_provider.storage(),
+            epoch_id,
+        )
+        .unwrap()
         .load_psks(sender_provider.storage())
         .unwrap()
         .build(
@@ -181,15 +186,214 @@ fn send_vc_commit_with_epoch<P: OpenMlsProvider>(
     bundle.into_commit()
 }
 
-/// Focused puncture-persistence test: after the sender stages a VC commit,
-/// the per-epoch PPRF must remain registered (with its puncture state)
-/// — this is verified indirectly by sending a *second* VC commit on the
-/// same epoch_id and confirming it still succeeds. If `stage_commit`
-/// dropped the puncture or wiped the registration, the second commit
-/// would either fail at lookup or, worse, silently re-derive the same
-/// secret as the first.
+/// The shared signing identity of a virtual client, stored in both emulator
+/// clients' providers so either can sign for the shared higher-level leaf.
+fn shared_vc_identity<P: OpenMlsProvider>(
+    ciphersuite: openmls_traits::types::Ciphersuite,
+    provider_a: &P,
+    provider_b: &P,
+) -> (SignatureKeyPair, openmls::credentials::CredentialWithKey) {
+    use openmls::credentials::{BasicCredential, CredentialWithKey};
+    let vc_signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).expect("vc signer");
+    vc_signer
+        .store(provider_a.storage())
+        .expect("store vc signer on alice_a");
+    vc_signer
+        .store(provider_b.storage())
+        .expect("store vc signer on alice_b");
+    let vc_credential = CredentialWithKey {
+        credential: BasicCredential::new(b"Alice (VC)".to_vec()).into(),
+        signature_key: vc_signer.public().into(),
+    };
+    (vc_signer, vc_credential)
+}
+
+/// Found a higher-level group on the shared virtual-client leaf.
+fn new_vc_main_group<P: OpenMlsProvider>(
+    ciphersuite: openmls_traits::types::Ciphersuite,
+    provider: &P,
+    signer: &SignatureKeyPair,
+    credential: openmls::credentials::CredentialWithKey,
+) -> MlsGroup {
+    let group_config = MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .capabilities(vc_capabilities())
+        .with_leaf_node_extensions(vc_leaf_extensions())
+        .expect("attach leaf-node extensions")
+        .build();
+    MlsGroup::new(provider, signer, &group_config, credential).expect("create vc main group")
+}
+
+/// The join config used by emulator clients resyncing into a higher-level
+/// group: pure-plaintext framing with the ratchet tree carried inline.
+fn vc_join_config() -> MlsGroupJoinConfig {
+    MlsGroupJoinConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .use_ratchet_tree_extension(true)
+        .build()
+}
+
+/// A second emulator client brought in alongside an existing one, sharing the
+/// virtual client's emulation epoch.
+struct SiblingEmulators {
+    emulator_a: MlsGroup,
+    emulator_a_signer: SignatureKeyPair,
+    emulator_b: MlsGroup,
+    alice_b_main: MlsGroup,
+    epoch_id: EpochId,
+}
+
+/// Bring a second emulator client (alice_b) into an existing virtual client
+/// without cloning storage. alice_a founds the emulation group and alice_b
+/// joins it via Welcome; both register the same emulation epoch; then alice_b
+/// resyncs into the higher-level group via an external commit. Returns the
+/// emulator state plus that resync commit, which the caller delivers to
+/// `alice_a_main` (and any other higher-level members) so they converge on
+/// the new virtual-client leaf.
+fn join_sibling_emulator<P: OpenMlsProvider>(
+    emulator_ciphersuite: openmls_traits::types::Ciphersuite,
+    alice_a_provider: &P,
+    alice_b_provider: &P,
+    vc_signer: &SignatureKeyPair,
+    vc_credential: openmls::credentials::CredentialWithKey,
+    alice_a_main: &MlsGroup,
+    main_join_config: MlsGroupJoinConfig,
+) -> (SiblingEmulators, openmls::prelude::MlsMessageOut) {
+    use openmls::prelude::{LeafNodeParameters, MlsMessageIn};
+    use tls_codec::Deserialize as _;
+
+    // alice_a founds the emulation group; alice_b joins it via Welcome.
+    let (mut emulator_a, emulator_a_signer) =
+        make_emulator_group(emulator_ciphersuite, alice_a_provider, b"AliceEmulatorA");
+    let (emulator_b_credential, emulator_b_signer) = new_credential(
+        alice_b_provider,
+        b"AliceEmulatorB",
+        emulator_ciphersuite.signature_algorithm(),
+    );
+    let emulator_b_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_extensions(vc_leaf_extensions())
+        .build(
+            emulator_ciphersuite,
+            alice_b_provider,
+            &emulator_b_signer,
+            emulator_b_credential,
+        )
+        .expect("emulator_b KP build")
+        .key_package()
+        .to_owned();
+    let (_e_commit, e_welcome, _e_gi) = emulator_a
+        .add_members(alice_a_provider, &emulator_a_signer, &[emulator_b_kp])
+        .expect("emulator_a add alice_b");
+    emulator_a
+        .merge_pending_commit(alice_a_provider)
+        .expect("emulator_a merge add");
+    let join_config = MlsGroupJoinConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .use_ratchet_tree_extension(true)
+        .build();
+    let mut emulator_b = StagedWelcome::new_from_welcome(
+        alice_b_provider,
+        &join_config,
+        e_welcome.into_welcome().expect("emulator welcome"),
+        Some(emulator_a.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(alice_b_provider))
+    .expect("alice_b join emulator group");
+
+    // Both clients independently register the same emulation epoch.
+    let epoch_id = emulator_a
+        .register_vc_emulation_epoch(alice_a_provider.crypto(), alice_a_provider.storage())
+        .expect("alice_a register vc epoch");
+    let epoch_id_b = emulator_b
+        .register_vc_emulation_epoch(alice_b_provider.crypto(), alice_b_provider.storage())
+        .expect("alice_b register vc epoch");
+    assert_eq!(epoch_id, epoch_id_b, "siblings must derive the same EpochId");
+
+    // alice_b resyncs into the higher-level group via an external commit.
+    let verifiable_group_info = {
+        let group_info_msg = alice_a_main
+            .export_group_info(alice_a_provider.crypto(), vc_signer, true)
+            .expect("export group info");
+        let serialized = group_info_msg
+            .tls_serialize_detached()
+            .expect("serialize group info");
+        MlsMessageIn::tls_deserialize(&mut serialized.as_slice())
+            .expect("deserialize group info message")
+            .into_verifiable_group_info()
+            .expect("into verifiable group info")
+    };
+    let (alice_b_main, bundle) = MlsGroup::external_commit_builder()
+        .with_config(main_join_config)
+        .build_group(alice_b_provider, verifiable_group_info, vc_credential)
+        .expect("build_group")
+        .leaf_node_parameters(
+            LeafNodeParameters::builder()
+                .with_capabilities(vc_capabilities())
+                .with_extensions(vc_leaf_extensions())
+                .build(),
+        )
+        .vc_emulation(
+            alice_b_provider.crypto(),
+            alice_b_provider.storage(),
+            epoch_id.clone(),
+        )
+        .expect("vc emulation")
+        .load_psks(alice_b_provider.storage())
+        .expect("load psks")
+        .build(
+            alice_b_provider.rand(),
+            alice_b_provider.crypto(),
+            vc_signer,
+            |_| true,
+        )
+        .expect("build external commit")
+        .finalize(alice_b_provider)
+        .expect("finalize external commit");
+
+    (
+        SiblingEmulators {
+            emulator_a,
+            emulator_a_signer,
+            emulator_b,
+            alice_b_main,
+            epoch_id,
+        },
+        bundle.into_commit(),
+    )
+}
+
+/// Send an application message from `sender` and process it on `receiver`,
+/// returning the processed message for inspection (e.g. the recovered
+/// emulator sender leaf index).
+fn send_and_process_app_message<P: OpenMlsProvider>(
+    sender: &mut MlsGroup,
+    sender_provider: &P,
+    sender_signer: &SignatureKeyPair,
+    receiver: &mut MlsGroup,
+    receiver_provider: &P,
+    plaintext: &[u8],
+) -> openmls::prelude::ProcessedMessage {
+    let app_msg = sender
+        .create_message(sender_provider, sender_signer, plaintext)
+        .expect("sender creates application message");
+    receiver
+        .process_message(receiver_provider, app_msg.into_protocol_message().unwrap())
+        .expect("receiver processes application message")
+}
+
+/// Focused ratchet-persistence test: after the sender builds a VC commit,
+/// the per-epoch operation secret tree must remain registered with its
+/// advanced ratchet head. A *second* VC commit on the same `epoch_id` must
+/// succeed and consume the next generation. That the generations are
+/// consumed in order is covered behaviorally by
+/// `vc_two_alice_clients_in_group_with_bob_and_charly`, where a sibling
+/// processes generations 0 and 1 positionally.
 #[openmls_test]
-fn vc_pprf_persists_across_own_commits() {
+fn vc_operation_tree_persists_across_own_commits() {
     let provider = Provider::default();
     let (alice_credential, alice_signer) =
         new_credential(&provider, b"Alice", ciphersuite.signature_algorithm());
@@ -209,18 +413,25 @@ fn vc_pprf_persists_across_own_commits() {
     // `safe_export_secret(VC_COMPONENT_ID)` punctures the emulator
     // group's application-export tree, so registering twice in the same
     // emulator-group epoch would fail with `PuncturedInput`. The point
-    // of this test is that the per-emulation-epoch *VC* PPRF survives
-    // and its puncture state is persisted across stage_commit boundaries.
+    // of this test is that the per-emulation-epoch operation secret tree
+    // survives, with its advanced ratchet head, across build boundaries.
     let epoch_id = emulator
         .register_vc_emulation_epoch(provider.crypto(), provider.storage())
         .expect("register vc epoch");
 
     let _msg1 = send_vc_commit_with_epoch(&mut alice, &provider, &alice_signer, epoch_id.clone());
+    let epoch_after_first = alice.epoch();
 
     // A *second* VC commit on the same emulation epoch must still
-    // succeed. If `stage_commit` had wiped the registration or dropped
-    // the puncture, the build would fail at PPRF lookup.
+    // succeed and consume generation 1. If `build` had wiped the
+    // registration or failed to persist the ratchet advance, this would
+    // fail at tree lookup or when the consumed generation is re-derived.
     let _msg2 = send_vc_commit_with_epoch(&mut alice, &provider, &alice_signer, epoch_id);
+    assert_eq!(
+        alice.epoch().as_u64(),
+        epoch_after_first.as_u64() + 1,
+        "second VC commit on the same emulation epoch must succeed"
+    );
 }
 
 /// A non-emulator group member processes a VC commit through the normal HPKE
@@ -252,14 +463,14 @@ fn non_emulator_processes_vc_commit_without_registering_state() {
 /// A sibling-resync external commit requires VC state on the receiving
 /// sibling. The receiver identifies itself as a sibling from the commit
 /// shape (`Sender::NewMemberCommit` plus an inline `Remove` of its own
-/// leaf), then *must* load the per-epoch PPRF and emulation-epoch state to
-/// derive the path. If the receiver hasn't yet registered the matching
-/// emulation epoch (e.g. it joined the emulator group but skipped the
-/// `register_vc_emulation_epoch` step before the sibling attempted the
-/// resync), processing must fail loudly with a virtual-clients error
-/// rather than silently fall through to HPKE.
+/// leaf), then *must* load the per-epoch operation secret tree and
+/// emulation-epoch state to derive the path. If the receiver hasn't yet
+/// registered the matching emulation epoch (e.g. it joined the emulator
+/// group but skipped the `register_vc_emulation_epoch` step before the
+/// sibling attempted the resync), processing must fail loudly with a
+/// virtual-clients error rather than silently fall through to HPKE.
 #[openmls_test]
-fn sibling_resync_external_commit_fails_when_receiver_lacks_pprf() {
+fn sibling_resync_external_commit_fails_when_receiver_lacks_operation_tree() {
     use openmls::credentials::{BasicCredential, CredentialWithKey};
     use openmls::prelude::{LeafNodeParameters, MlsMessageIn};
     use tls_codec::Deserialize as _;
@@ -382,9 +593,12 @@ fn sibling_resync_external_commit_fails_when_receiver_lacks_pprf() {
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
-        .vc_emulation(VcEmulation {
-            epoch_id: epoch_id_b,
-        })
+        .vc_emulation(
+            alice_b_provider.crypto(),
+            alice_b_provider.storage(),
+            epoch_id_b,
+        )
+        .expect("vc emulation")
         .load_psks(alice_b_provider.storage())
         .expect("load psks")
         .build(
@@ -406,7 +620,9 @@ fn sibling_resync_external_commit_fails_when_receiver_lacks_pprf() {
         .expect_err("must fail without VC state");
     let msg = format!("{err:?}");
     assert!(
-        msg.contains("MissingPprf") || msg.contains("VirtualClients") || msg.contains("Pprf"),
+        msg.contains("MissingEmulationEpochState")
+            || msg.contains("MissingOperationTree")
+            || msg.contains("VirtualClients"),
         "expected a virtual-clients error, got {msg}"
     );
 }
@@ -415,17 +631,21 @@ fn sibling_resync_external_commit_fails_when_receiver_lacks_pprf() {
 /// MLS leaf in a main group with Bob and Charly. Both Alice clients also
 /// share an *emulator group* (a separate two-member MLS group) used as the
 /// source of `safe_export_secret(VC_COMPONENT_ID)` from which both clients
-/// derive the same `EpochId`/PPRF/AEAD key.
+/// derive the same `EpochId`, operation secret tree, and AEAD key.
 ///
 /// alice_b bootstraps into the higher-level group via a sibling-resync VC
 /// external commit (auto-Remove targeting alice_a's existing leaf). After
-/// that we exercise four commits in order:
+/// that we exercise five commits in order:
 ///   1. Bob's commit: processed by alice_a, alice_b, charly via HPKE.
 ///   2. Charly's commit: processed by alice_a, alice_b, bob via HPKE.
 ///   3. alice_a's VC commit: alice_b uses own-leaf VC path, bob+charly HPKE.
 ///   4. alice_b's VC commit: alice_a uses own-leaf VC path, bob+charly HPKE.
+///   5. alice_a's second VC commit on the same emulation epoch: alice_b
+///      derives generation 1 of alice_a's ratchet positionally, having
+///      derived generation 0 for commit 3.
 ///
-/// All four parties must agree on the epoch authenticator after each commit.
+/// All four parties must agree on the epoch authenticator after each
+/// commit.
 #[openmls_test]
 fn vc_two_alice_clients_in_group_with_bob_and_charly() {
     use openmls::credentials::{BasicCredential, CredentialWithKey};
@@ -612,9 +832,12 @@ fn vc_two_alice_clients_in_group_with_bob_and_charly() {
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
-        .vc_emulation(VcEmulation {
-            epoch_id: epoch_id_b.clone(),
-        })
+        .vc_emulation(
+            alice_b_provider.crypto(),
+            alice_b_provider.storage(),
+            epoch_id_b.clone(),
+        )
+        .expect("vc emulation")
         .load_psks(alice_b_provider.storage())
         .expect("load psks")
         .build(
@@ -733,13 +956,16 @@ fn vc_two_alice_clients_in_group_with_bob_and_charly() {
     );
 
     // ---- Commit 3: alice_a's VC commit ----
+    // alice_a's first own LeafNode operation on this emulation epoch
+    // consumes generation 0 of her emulation-leaf ratchet.
     let alice_a_vc_commit = send_vc_commit_with_epoch(
         &mut alice_a_main,
         &alice_a_provider,
         &vc_signer,
         epoch_id_a.clone(),
     );
-    // alice_b processes via the own-leaf VC path.
+    // alice_b processes via the own-leaf VC path, deriving generation 0 of
+    // alice_a's ratchet positionally.
     deliver_commit(&mut alice_b_main, &alice_b_provider, &alice_a_vc_commit);
     // Bob and Charly process via the normal HPKE path.
     deliver_commit(&mut bob_main, &bob_provider, &alice_a_vc_commit);
@@ -766,12 +992,39 @@ fn vc_two_alice_clients_in_group_with_bob_and_charly() {
         "post alice_b VC commit",
     );
 
-    // After four commits, the epoch counter has advanced by 4 from the
+    // ---- Commit 5: alice_a's second VC commit on the same emulation
+    // epoch. alice_b already derived generation 0 of alice_a's ratchet for
+    // commit 3, so she now derives generation 1 positionally. This is the
+    // behavioral check that two successive VC commits from the same
+    // emulation epoch consume successive generations.
+    let alice_a_second_vc_commit = send_vc_commit_with_epoch(
+        &mut alice_a_main,
+        &alice_a_provider,
+        &vc_signer,
+        epoch_id_a.clone(),
+    );
+    deliver_commit(
+        &mut alice_b_main,
+        &alice_b_provider,
+        &alice_a_second_vc_commit,
+    );
+    deliver_commit(&mut bob_main, &bob_provider, &alice_a_second_vc_commit);
+    deliver_commit(
+        &mut charly_main,
+        &charly_provider,
+        &alice_a_second_vc_commit,
+    );
+    assert_all_agree(
+        &[&alice_a_main, &alice_b_main, &bob_main, &charly_main],
+        "post alice_a second VC commit",
+    );
+
+    // After five commits, the epoch counter has advanced by 5 from the
     // post-resync baseline.
     assert_eq!(
         alice_a_main.epoch().as_u64(),
-        baseline_epoch.as_u64() + 4,
-        "expected four-epoch advance across the four commits"
+        baseline_epoch.as_u64() + 5,
+        "expected five-epoch advance across the five commits"
     );
 }
 
@@ -788,12 +1041,13 @@ fn vc_two_alice_clients_in_group_with_bob_and_charly() {
 ///     by the virtual client's shared signature key. The auto-Remove
 ///     machinery in `build_group` picks up `alice_a`'s existing leaf
 ///     (same signature key) and inlines a `Remove` for it. `alice_b`
-///     attaches a `vc_emulation(VcEmulation { epoch_id })` so the path leaf
+///     attaches a `vc_emulation(.., epoch_id)` so the path leaf
 ///     is derived from the per-commit `OperationSecret`.
 ///   * `alice_a` processes the external commit. The sibling-resync
 ///     discriminator (registered VC epoch state + `NewMemberCommit` sender
 ///     + `Remove(self)` in the queue) triggers: she derives the path from
-///     her PPRF, skips the `self_removed` short-circuit, and after merging
+///     her operation secret tree, skips the `self_removed` short-circuit,
+///     and after merging
 ///     her `own_leaf_index` points at the joiner's new leaf. She remains
 ///     active.
 ///   * `bob` processes the same commit via the regular HPKE path.
@@ -955,9 +1209,12 @@ fn vc_sibling_emulator_resyncs_into_higher_level_group_via_external_commit() {
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
-        .vc_emulation(VcEmulation {
-            epoch_id: epoch_id_b.clone(),
-        })
+        .vc_emulation(
+            alice_b_provider.crypto(),
+            alice_b_provider.storage(),
+            epoch_id_b.clone(),
+        )
+        .expect("vc emulation")
         .load_psks(alice_b_provider.storage())
         .expect("load psks")
         .build(
@@ -1285,89 +1542,59 @@ fn old_unconfirmed_own_message_survives_later_confirmations() {
 }
 
 /// End-to-end recipient-side reuse-guard inversion across two sibling
-/// emulators.
+/// emulators. The receiving sibling is a genuinely separate client: it joins
+/// the emulation group and resyncs into the higher-level group via an
+/// external commit, with no storage cloning.
 #[openmls_test::openmls_test]
 fn reuse_guard_recovers_emulator_leaf_index() {
     let _ = ciphersuite;
     let ciphersuite =
         openmls_traits::types::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let sender_provider = OpenMlsRustCrypto::default();
-    let (alice_credential, alice_signer) = new_credential(
-        &sender_provider,
-        b"Alice",
-        ciphersuite.signature_algorithm(),
+
+    let alice_a_provider = OpenMlsRustCrypto::default();
+    let alice_b_provider = OpenMlsRustCrypto::default();
+    let (vc_signer, vc_credential) =
+        shared_vc_identity(ciphersuite, &alice_a_provider, &alice_b_provider);
+
+    let mut alice_a_main =
+        new_vc_main_group(ciphersuite, &alice_a_provider, &vc_signer, vc_credential.clone());
+
+    let (sib, resync_commit) = join_sibling_emulator(
+        ciphersuite,
+        &alice_a_provider,
+        &alice_b_provider,
+        &vc_signer,
+        vc_credential,
+        &alice_a_main,
+        vc_join_config(),
     );
+    let SiblingEmulators {
+        emulator_a,
+        mut alice_b_main,
+        ..
+    } = sib;
+    // alice_a processes the resync and converges on the shared VC leaf.
+    process_and_merge_commit(&mut alice_a_main, &alice_a_provider, resync_commit);
 
-    let group_config = MlsGroupCreateConfig::builder()
-        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-        .ciphersuite(ciphersuite)
-        .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
-        .with_leaf_node_extensions(vc_leaf_extensions())
-        .expect("attach leaf-node extensions")
-        .build();
-    let mut alice_sender = MlsGroup::new(
-        &sender_provider,
-        &alice_signer,
-        &group_config,
-        alice_credential,
-    )
-    .expect("create alice group on sender provider");
-    let group_id = alice_sender.group_id().clone();
+    // alice_a is emulation leaf 0; its reuse guard must resolve to it.
+    let expected_emulation_leaf = emulator_a.own_leaf_index();
 
-    let (mut emulator_sender, _emulator_signer) =
-        make_emulator_group(ciphersuite, &sender_provider, b"AliceEmulator");
-    let emulator_group_id = emulator_sender.group_id().clone();
-    let expected_emulation_leaf = emulator_sender.own_leaf_index();
-
-    let receiver_provider = sender_provider.clone();
-
-    let (commit_msg, epoch_id_sender) = send_vc_commit(
-        &mut alice_sender,
-        &mut emulator_sender,
-        &sender_provider,
-        &alice_signer,
-    );
-
-    let mut emulator_receiver = MlsGroup::load(receiver_provider.storage(), &emulator_group_id)
-        .expect("load emulator group on receiver provider")
-        .expect("emulator group present on receiver provider");
-    let epoch_id_receiver = emulator_receiver
-        .register_vc_emulation_epoch(receiver_provider.crypto(), receiver_provider.storage())
-        .expect("register vc epoch (receiver)");
-    assert_eq!(epoch_id_sender, epoch_id_receiver);
-
-    let mut alice_receiver = MlsGroup::load(receiver_provider.storage(), &group_id)
-        .expect("load alice group on receiver provider")
-        .expect("group present on receiver provider");
-    let processed_commit = alice_receiver
-        .process_message(
-            &receiver_provider,
-            commit_msg.into_protocol_message().unwrap(),
-        )
-        .expect("receiver processes VC commit");
-    let staged_commit = match processed_commit.into_content() {
-        ProcessedMessageContent::StagedCommitMessage(s) => *s,
-        _ => panic!("expected staged commit"),
-    };
-    alice_receiver
-        .merge_staged_commit(&receiver_provider, staged_commit)
-        .expect("receiver merges VC commit");
-
+    // alice_a sends an application message; alice_b recovers alice_a's
+    // emulation leaf index from the reuse guard.
     let plaintext = b"reuse-guard recovery payload";
-    let app_msg = alice_sender
-        .create_message(&sender_provider, &alice_signer, plaintext)
-        .expect("sender creates application message");
-
-    let processed_app = alice_receiver
-        .process_message(&receiver_provider, app_msg.into_protocol_message().unwrap())
-        .expect("receiver processes application message");
+    let processed_app = send_and_process_app_message(
+        &mut alice_a_main,
+        &alice_a_provider,
+        &vc_signer,
+        &mut alice_b_main,
+        &alice_b_provider,
+        plaintext,
+    );
 
     assert_eq!(
         processed_app.emulator_sender_leaf_index(),
         Some(expected_emulation_leaf),
     );
-
     match processed_app.into_content() {
         ProcessedMessageContent::ApplicationMessage(msg) => {
             assert_eq!(msg.into_bytes().as_slice(), plaintext);
@@ -1456,7 +1683,8 @@ fn bound_group_fails_closed_when_emulation_state_missing_on_send() {
 
 /// End-to-end reuse-guard recovery with the emulator group and the
 /// higher-level group on different ciphersuites with different AEAD key
-/// lengths. The emulation epoch's AEAD/PPRF material must use the
+/// lengths. The emulation epoch's AEAD and operation-tree material must
+/// use the
 /// emulation ciphersuite, while the generated update path remains in the
 /// higher-level group's ciphersuite.
 #[test]
@@ -1468,77 +1696,49 @@ fn reuse_guard_recovery_across_mismatched_ciphersuites() {
         openmls_traits::types::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519;
     assert_ne!(higher_level_ciphersuite, emulator_ciphersuite);
 
-    let sender_provider = OpenMlsRustCrypto::default();
-    let (alice_credential, alice_signer) = new_credential(
-        &sender_provider,
-        b"Alice",
-        higher_level_ciphersuite.signature_algorithm(),
+    let alice_a_provider = OpenMlsRustCrypto::default();
+    let alice_b_provider = OpenMlsRustCrypto::default();
+    let (vc_signer, vc_credential) =
+        shared_vc_identity(higher_level_ciphersuite, &alice_a_provider, &alice_b_provider);
+
+    let mut alice_a_main = new_vc_main_group(
+        higher_level_ciphersuite,
+        &alice_a_provider,
+        &vc_signer,
+        vc_credential.clone(),
     );
 
-    let higher_level_config = MlsGroupCreateConfig::builder()
-        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-        .ciphersuite(higher_level_ciphersuite)
-        .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
-        .with_leaf_node_extensions(vc_leaf_extensions())
-        .expect("attach leaf-node extensions")
-        .build();
-    let mut alice_sender = MlsGroup::new(
-        &sender_provider,
-        &alice_signer,
-        &higher_level_config,
-        alice_credential,
-    )
-    .expect("create alice group on sender provider");
-    let group_id = alice_sender.group_id().clone();
-
-    let (mut emulator_sender, _emulator_signer) =
-        make_emulator_group(emulator_ciphersuite, &sender_provider, b"AliceEmulator");
-    let emulator_group_id = emulator_sender.group_id().clone();
-    let expected_emulation_leaf = emulator_sender.own_leaf_index();
-
-    let receiver_provider = sender_provider.clone();
-
-    let (commit_msg, epoch_id_sender) = send_vc_commit(
-        &mut alice_sender,
-        &mut emulator_sender,
-        &sender_provider,
-        &alice_signer,
+    // The emulation group runs a different ciphersuite from the higher-level
+    // group, so the operation tree and reuse-guard PRP key are derived under
+    // the emulation ciphersuite while the update path stays in the
+    // higher-level ciphersuite.
+    let (sib, resync_commit) = join_sibling_emulator(
+        emulator_ciphersuite,
+        &alice_a_provider,
+        &alice_b_provider,
+        &vc_signer,
+        vc_credential,
+        &alice_a_main,
+        vc_join_config(),
     );
+    let SiblingEmulators {
+        emulator_a,
+        mut alice_b_main,
+        ..
+    } = sib;
+    process_and_merge_commit(&mut alice_a_main, &alice_a_provider, resync_commit);
 
-    let mut emulator_receiver = MlsGroup::load(receiver_provider.storage(), &emulator_group_id)
-        .expect("load emulator group on receiver provider")
-        .expect("emulator group present on receiver provider");
-    let epoch_id_receiver = emulator_receiver
-        .register_vc_emulation_epoch(receiver_provider.crypto(), receiver_provider.storage())
-        .expect("register vc epoch (receiver)");
-    assert_eq!(epoch_id_sender, epoch_id_receiver);
-
-    let mut alice_receiver = MlsGroup::load(receiver_provider.storage(), &group_id)
-        .expect("load alice group on receiver provider")
-        .expect("group present on receiver provider");
-    let processed_commit = alice_receiver
-        .process_message(
-            &receiver_provider,
-            commit_msg.into_protocol_message().unwrap(),
-        )
-        .expect("receiver processes VC commit");
-    let staged_commit = match processed_commit.into_content() {
-        ProcessedMessageContent::StagedCommitMessage(s) => *s,
-        _ => panic!("expected staged commit"),
-    };
-    alice_receiver
-        .merge_staged_commit(&receiver_provider, staged_commit)
-        .expect("receiver merges VC commit");
+    let expected_emulation_leaf = emulator_a.own_leaf_index();
 
     let plaintext = b"mismatched-ciphersuite reuse-guard recovery payload";
-    let app_msg = alice_sender
-        .create_message(&sender_provider, &alice_signer, plaintext)
-        .expect("sender creates application message");
-
-    let processed_app = alice_receiver
-        .process_message(&receiver_provider, app_msg.into_protocol_message().unwrap())
-        .expect("receiver processes application message");
+    let processed_app = send_and_process_app_message(
+        &mut alice_a_main,
+        &alice_a_provider,
+        &vc_signer,
+        &mut alice_b_main,
+        &alice_b_provider,
+        plaintext,
+    );
 
     assert_eq!(
         processed_app.emulator_sender_leaf_index(),
@@ -1584,11 +1784,9 @@ fn vc_binding_is_kept_per_epoch_for_delayed_messages() {
     let ciphersuite =
         openmls_traits::types::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let alice_a_provider = OpenMlsRustCrypto::default();
-    let (alice_credential, alice_signer) = new_credential(
-        &alice_a_provider,
-        b"Alice",
-        ciphersuite.signature_algorithm(),
-    );
+    let alice_b_provider = OpenMlsRustCrypto::default();
+    let (vc_signer, vc_credential) =
+        shared_vc_identity(ciphersuite, &alice_a_provider, &alice_b_provider);
 
     // Keep past epochs so the delayed message stays decryptable across the
     // second commit.
@@ -1603,107 +1801,49 @@ fn vc_binding_is_kept_per_epoch_for_delayed_messages() {
         .build();
     let mut alice_a_main = MlsGroup::new(
         &alice_a_provider,
-        &alice_signer,
+        &vc_signer,
         &group_config,
-        alice_credential,
+        vc_credential.clone(),
     )
     .expect("alice_a create main group");
     let main_group_id = alice_a_main.group_id().clone();
 
-    // Stage the emulator credentials before cloning the provider, then
-    // create the emulation group only on alice_a's provider so alice_b can
-    // join it via welcome without a group-id collision.
-    let (emulator_a_credential, emulator_a_signer) = new_credential(
+    // alice_b joins the emulation group and resyncs into the higher-level
+    // group. Its resync keeps two past epochs so it can still decrypt the
+    // delayed message after the group advances.
+    let (sib, resync_commit) = join_sibling_emulator(
+        ciphersuite,
         &alice_a_provider,
-        b"AliceEmulatorA",
-        ciphersuite.signature_algorithm(),
+        &alice_b_provider,
+        &vc_signer,
+        vc_credential,
+        &alice_a_main,
+        MlsGroupJoinConfig::builder()
+            .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .use_ratchet_tree_extension(true)
+            .max_past_epochs(2)
+            .build(),
     );
-    let (emulator_b_credential, emulator_b_signer) = new_credential(
-        &alice_a_provider,
-        b"AliceEmulatorB",
-        ciphersuite.signature_algorithm(),
-    );
-    let emulator_b_kp = KeyPackage::builder()
-        .key_package_extensions(Extensions::empty())
-        .leaf_node_capabilities(vc_capabilities())
-        .leaf_node_extensions(vc_leaf_extensions())
-        .build(
-            ciphersuite,
-            &alice_a_provider,
-            &emulator_b_signer,
-            emulator_b_credential,
-        )
-        .expect("emulator_b KP build")
-        .key_package()
-        .to_owned();
-
-    let alice_b_provider = alice_a_provider.clone();
-
-    let emulator_config = MlsGroupCreateConfig::builder()
-        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-        .ciphersuite(ciphersuite)
-        .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
-        .with_leaf_node_extensions(vc_leaf_extensions())
-        .expect("attach leaf-node extensions on emulator group config")
-        .build();
-    let mut emulator_a = MlsGroup::new(
-        &alice_a_provider,
-        &emulator_a_signer,
-        &emulator_config,
-        emulator_a_credential,
-    )
-    .expect("alice_a create emulator group");
+    let SiblingEmulators {
+        mut emulator_a,
+        emulator_a_signer,
+        mut emulator_b,
+        mut alice_b_main,
+        epoch_id: epoch_id_one,
+    } = sib;
     let expected_emulation_leaf = emulator_a.own_leaf_index();
 
-    let (_e_commit, e_welcome, _e_gi) = emulator_a
-        .add_members(&alice_a_provider, &emulator_a_signer, &[emulator_b_kp])
-        .expect("emulator_a add emulator_b");
-    emulator_a
-        .merge_pending_commit(&alice_a_provider)
-        .expect("emulator_a merge add");
-
-    let join_config = MlsGroupJoinConfig::builder()
-        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-        .build();
-    let mut emulator_b = StagedWelcome::new_from_welcome(
-        &alice_b_provider,
-        &join_config,
-        e_welcome.into_welcome().expect("emulator welcome"),
-        Some(emulator_a.export_ratchet_tree().into()),
-    )
-    .and_then(|s| s.into_group(&alice_b_provider))
-    .expect("emulator_b join emulator group");
-
-    let mut alice_b_main = MlsGroup::load(alice_b_provider.storage(), &main_group_id)
-        .expect("load alice main group on alice_b_provider")
-        .expect("alice main group present on alice_b_provider");
-
-    // ---- First emulation epoch, registered by both emulator clients. ----
-    let epoch_id_one = emulator_a
-        .register_vc_emulation_epoch(alice_a_provider.crypto(), alice_a_provider.storage())
-        .expect("register first vc epoch (alice_a)");
-    let epoch_id_one_b = emulator_b
-        .register_vc_emulation_epoch(alice_b_provider.crypto(), alice_b_provider.storage())
-        .expect("register first vc epoch (alice_b)");
-    assert_eq!(epoch_id_one, epoch_id_one_b);
-
-    // ---- First VC commit: binds the next main-group epoch to the first
-    // emulation epoch. ----
-    let commit_one = send_vc_commit_with_epoch(
-        &mut alice_a_main,
-        &alice_a_provider,
-        &alice_signer,
-        epoch_id_one.clone(),
-    );
+    // ---- The resync is the first VC commit: it binds the new main-group
+    // epoch to the first emulation epoch. alice_a converges by processing
+    // it. ----
+    process_and_merge_commit(&mut alice_a_main, &alice_a_provider, resync_commit);
     let first_bound_epoch = alice_a_main.epoch();
-    process_and_merge_commit(&mut alice_b_main, &alice_b_provider, commit_one);
 
     // ---- Delayed message, sent in the first bound epoch but delivered
     // only after the second commit below. ----
     let plaintext = b"delayed across an epoch change";
     let delayed_msg = alice_a_main
-        .create_message(&alice_a_provider, &alice_signer, plaintext)
+        .create_message(&alice_a_provider, &vc_signer, plaintext)
         .expect("alice_a creates delayed application message");
 
     // ---- Advance the emulation group and register a second emulation
@@ -1744,7 +1884,7 @@ fn vc_binding_is_kept_per_epoch_for_delayed_messages() {
     let commit_two = send_vc_commit_with_epoch(
         &mut alice_a_main,
         &alice_a_provider,
-        &alice_signer,
+        &vc_signer,
         epoch_id_two.clone(),
     );
     let second_bound_epoch = alice_a_main.epoch();
@@ -1787,38 +1927,58 @@ fn vc_binding_is_kept_per_epoch_for_delayed_messages() {
 fn vc_binding_carries_forward_across_foreign_commits() {
     let ciphersuite =
         openmls_traits::types::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let alice_provider = OpenMlsRustCrypto::default();
+    let alice_a_provider = OpenMlsRustCrypto::default();
+    let alice_b_provider = OpenMlsRustCrypto::default();
     let bob_provider = OpenMlsRustCrypto::default();
-    let (mut alice_sender, alice_signer, mut bob_group, bob_signer) =
-        setup_alice_bob_group(ciphersuite, &alice_provider, &bob_provider);
-    let group_id = alice_sender.group_id().clone();
+    let (vc_signer, vc_credential) =
+        shared_vc_identity(ciphersuite, &alice_a_provider, &alice_b_provider);
 
-    let (mut emulator_sender, _emulator_signer) =
-        make_emulator_group(ciphersuite, &alice_provider, b"AliceEmulator");
-    let emulator_group_id = emulator_sender.group_id().clone();
-    let expected_emulation_leaf = emulator_sender.own_leaf_index();
+    // alice (the virtual client) founds the group on the shared leaf and adds
+    // Bob, a regular member.
+    let mut alice_a_main =
+        new_vc_main_group(ciphersuite, &alice_a_provider, &vc_signer, vc_credential.clone());
+    let (bob_credential, bob_signer) =
+        new_credential(&bob_provider, b"Bob", ciphersuite.signature_algorithm());
+    let bob_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .build(ciphersuite, &bob_provider, &bob_signer, bob_credential)
+        .expect("bob KP build")
+        .key_package()
+        .to_owned();
+    let (_commit, welcome, _gi) = alice_a_main
+        .add_members(&alice_a_provider, &vc_signer, &[bob_kp])
+        .expect("alice add bob");
+    alice_a_main
+        .merge_pending_commit(&alice_a_provider)
+        .expect("alice merge add");
+    let mut bob_group = StagedWelcome::new_from_welcome(
+        &bob_provider,
+        &vc_join_config(),
+        welcome.into_welcome().expect("welcome present"),
+        Some(alice_a_main.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(&bob_provider))
+    .expect("bob join");
 
-    let receiver_provider = alice_provider.clone();
-
-    // ---- VC commit binds the new epoch. Bob and the sibling process it. ----
-    let (commit_msg, _epoch_id) = send_vc_commit(
-        &mut alice_sender,
-        &mut emulator_sender,
-        &alice_provider,
-        &alice_signer,
+    // alice_b joins as a sibling emulator and resyncs into the group; alice_a
+    // and Bob process the resync and converge on the new virtual-client leaf.
+    let (sib, resync_commit) = join_sibling_emulator(
+        ciphersuite,
+        &alice_a_provider,
+        &alice_b_provider,
+        &vc_signer,
+        vc_credential,
+        &alice_a_main,
+        vc_join_config(),
     );
-
-    let mut emulator_receiver = MlsGroup::load(receiver_provider.storage(), &emulator_group_id)
-        .expect("load emulator group on receiver provider")
-        .expect("emulator group present on receiver provider");
-    emulator_receiver
-        .register_vc_emulation_epoch(receiver_provider.crypto(), receiver_provider.storage())
-        .expect("register vc epoch (receiver)");
-    let mut alice_receiver = MlsGroup::load(receiver_provider.storage(), &group_id)
-        .expect("load alice group on receiver provider")
-        .expect("group present on receiver provider");
-    process_and_merge_commit(&mut alice_receiver, &receiver_provider, commit_msg.clone());
-    process_and_merge_commit(&mut bob_group, &bob_provider, commit_msg);
+    let SiblingEmulators {
+        emulator_a,
+        mut alice_b_main,
+        ..
+    } = sib;
+    let expected_emulation_leaf = emulator_a.own_leaf_index();
+    process_and_merge_commit(&mut alice_a_main, &alice_a_provider, resync_commit.clone());
+    process_and_merge_commit(&mut bob_group, &bob_provider, resync_commit);
 
     // ---- Bob commits; the VC leaf is untouched. ----
     let bob_commit = {
@@ -1841,18 +2001,20 @@ fn vc_binding_carries_forward_across_foreign_commits() {
             .expect("bob merge");
         bundle.into_commit()
     };
-    process_and_merge_commit(&mut alice_sender, &alice_provider, bob_commit.clone());
-    process_and_merge_commit(&mut alice_receiver, &receiver_provider, bob_commit);
+    process_and_merge_commit(&mut alice_a_main, &alice_a_provider, bob_commit.clone());
+    process_and_merge_commit(&mut alice_b_main, &alice_b_provider, bob_commit);
 
-    // ---- The sender still derives deterministic reuse guards in the new
-    // epoch, and the sibling still attributes them. ----
+    // ---- alice_a still derives deterministic reuse guards in the new epoch,
+    // and the sibling still attributes them. ----
     let plaintext = b"carried-forward binding";
-    let app_msg = alice_sender
-        .create_message(&alice_provider, &alice_signer, plaintext)
-        .expect("sender creates application message");
-    let processed_app = alice_receiver
-        .process_message(&receiver_provider, app_msg.into_protocol_message().unwrap())
-        .expect("receiver processes application message");
+    let processed_app = send_and_process_app_message(
+        &mut alice_a_main,
+        &alice_a_provider,
+        &vc_signer,
+        &mut alice_b_main,
+        &alice_b_provider,
+        plaintext,
+    );
     assert_eq!(
         processed_app.emulator_sender_leaf_index(),
         Some(expected_emulation_leaf),

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -1668,8 +1668,8 @@ fn bound_group_fails_closed_when_emulation_state_missing_on_send() {
     );
     provider
         .storage()
-        .delete_vc_emulation_epoch_state(&epoch_id)
-        .expect("delete emulation epoch state");
+        .delete_vc_emulation_state(&epoch_id)
+        .expect("delete emulation state");
 
     let err = alice_group
         .create_message(&provider, &alice_signer, b"must not send")
@@ -1682,6 +1682,51 @@ fn bound_group_fails_closed_when_emulation_state_missing_on_send() {
                 openmls::framing::errors::MessageEncryptionError::VirtualClientsError(
                     openmls::components::vc_derivation_info::VirtualClientsError::MissingEmulationEpochState
                 )
+            )
+        ),
+        "unexpected error: {err:?}"
+    );
+}
+
+/// `vc_emulation` validates the leaf configuration before allocating an
+/// operation secret. A leaf that supports `AppDataDictionary` but does not
+/// list `VC_COMPONENT_ID` is rejected at the builder step rather than at
+/// `build`, so no generation is burned on this deterministic failure.
+#[test]
+fn vc_emulation_rejects_misconfigured_leaf_before_allocating() {
+    let ciphersuite =
+        openmls_traits::types::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let provider = OpenMlsRustCrypto::default();
+    let (alice_credential, alice_signer) =
+        new_credential(&provider, b"Alice", ciphersuite.signature_algorithm());
+
+    // The leaf advertises `AppDataDictionary` support but carries no
+    // `AppComponents` entry, so `VC_COMPONENT_ID` is not listed.
+    let group_config = MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .capabilities(vc_capabilities())
+        .build();
+    let mut alice_group = MlsGroup::new(&provider, &alice_signer, &group_config, alice_credential)
+        .expect("create alice group");
+    let (mut emulator_group, _emulator_signer) =
+        make_emulator_group(ciphersuite, &provider, b"AliceEmulator");
+
+    let epoch_id = emulator_group
+        .register_vc_emulation_epoch(provider.crypto(), provider.storage())
+        .expect("register vc epoch");
+
+    let err = alice_group
+        .commit_builder()
+        .vc_emulation(provider.crypto(), provider.storage(), epoch_id)
+        .expect_err("misconfigured leaf must be rejected at the builder step");
+
+    assert!(
+        matches!(
+            err,
+            openmls::group::CreateCommitError::VirtualClientsError(
+                openmls::components::vc_derivation_info::VirtualClientsError::VcComponentNotListed
             )
         ),
         "unexpected error: {err:?}"

--- a/sqlite_storage/migrations/V5__vc_operation_secrets.sql
+++ b/sqlite_storage/migrations/V5__vc_operation_secrets.sql
@@ -1,0 +1,11 @@
+-- Per-emulation-epoch Virtual Client Operation Secret Tree. One row per
+-- emulation epoch, holding the serialized tree (node secrets plus per-leaf
+-- operation ratchets). Written back after every ratchet advance, stored
+-- separately from the static emulation epoch state so per-operation writes
+-- do not rewrite the static fields.
+CREATE TABLE vc_operation_trees (
+    provider_version INTEGER NOT NULL,
+    epoch_id BLOB NOT NULL,
+    operation_tree BLOB NOT NULL,
+    PRIMARY KEY (epoch_id)
+);

--- a/sqlite_storage/src/storage_provider.rs
+++ b/sqlite_storage/src/storage_provider.rs
@@ -775,37 +775,6 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
     }
 
     #[cfg(feature = "virtual-clients-draft")]
-    fn write_vc_pprf<
-        EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>,
-        VcPprf: traits::VcPprf<STORAGE_PROVIDER_VERSION>,
-    >(
-        &self,
-        epoch_id: &EpochId,
-        vc_pprf: &VcPprf,
-    ) -> Result<(), Self::Error> {
-        StorableVcSecretRef(vc_pprf).store_vc_pprf::<C, _>(self.connection.borrow(), epoch_id)
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
-    fn vc_pprf<
-        EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>,
-        VcPprf: traits::VcPprf<STORAGE_PROVIDER_VERSION>,
-    >(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<Option<VcPprf>, Self::Error> {
-        StorableKeyRef(epoch_id).load_vc_pprf::<C, VcPprf>(self.connection.borrow())
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_pprf<EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>>(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<(), Self::Error> {
-        StorableKeyRef(epoch_id).delete_vc_pprf::<C>(self.connection.borrow())
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
     fn write_vc_emulation_bindings<
         GroupId: traits::GroupId<STORAGE_PROVIDER_VERSION>,
         VcEmulationBindings: traits::VcEmulationBindings<STORAGE_PROVIDER_VERSION>,
@@ -836,5 +805,38 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
         group_id: &GroupId,
     ) -> Result<(), Self::Error> {
         StorableKeyRef(group_id).delete_vc_emulation_bindings::<C>(self.connection.borrow())
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn write_vc_operation_tree<
+        EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>,
+        VcOperationTree: traits::VcOperationTree<STORAGE_PROVIDER_VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+        vc_operation_tree: &VcOperationTree,
+    ) -> Result<(), Self::Error> {
+        crate::vc_secrets::StorableOperationTreeRef(vc_operation_tree)
+            .store_vc_operation_tree::<C, _>(self.connection.borrow(), epoch_id)
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn vc_operation_tree<
+        EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>,
+        VcOperationTree: traits::VcOperationTree<STORAGE_PROVIDER_VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<Option<VcOperationTree>, Self::Error> {
+        StorableKeyRef(epoch_id)
+            .load_vc_operation_tree::<C, VcOperationTree>(self.connection.borrow())
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn delete_vc_operation_tree<EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>>(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<(), Self::Error> {
+        StorableKeyRef(epoch_id).delete_vc_operation_tree::<C>(self.connection.borrow())
     }
 }

--- a/sqlite_storage/src/storage_provider.rs
+++ b/sqlite_storage/src/storage_provider.rs
@@ -767,11 +767,12 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
     }
 
     #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_emulation_epoch_state<EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>>(
+    fn delete_vc_emulation_state<EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>>(
         &self,
         epoch_id: &EpochId,
     ) -> Result<(), Self::Error> {
-        StorableKeyRef(epoch_id).delete_vc_emulation_epoch_state::<C>(self.connection.borrow())
+        StorableKeyRef(epoch_id).delete_vc_emulation_epoch_state::<C>(self.connection.borrow())?;
+        StorableKeyRef(epoch_id).delete_vc_operation_tree::<C>(self.connection.borrow())
     }
 
     #[cfg(feature = "virtual-clients-draft")]
@@ -830,13 +831,5 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
     ) -> Result<Option<VcOperationTree>, Self::Error> {
         StorableKeyRef(epoch_id)
             .load_vc_operation_tree::<C, VcOperationTree>(self.connection.borrow())
-    }
-
-    #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_operation_tree<EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>>(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<(), Self::Error> {
-        StorableKeyRef(epoch_id).delete_vc_operation_tree::<C>(self.connection.borrow())
     }
 }

--- a/sqlite_storage/src/vc_secrets.rs
+++ b/sqlite_storage/src/vc_secrets.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use openmls_traits::storage::{
     traits::GroupId as GroupIdTrait, traits::VcEmulationEpochState as VcEmulationEpochStateTrait,
-    traits::VcEpochId as VcEpochIdTrait, traits::VcPprf as VcPprfTrait, Entity as EntityTrait, Key,
+    traits::VcEpochId as VcEpochIdTrait, Entity as EntityTrait, Key,
 };
 use rusqlite::{params, OptionalExtension as _, ToSql};
 
@@ -13,14 +13,12 @@ use crate::{
 };
 
 enum SecretType {
-    Pprf,
     EmulationEpochState,
 }
 
 impl ToSql for SecretType {
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
         let secret_type_str = match self {
-            SecretType::Pprf => "pprf",
             SecretType::EmulationEpochState => "emulation_epoch_state",
         };
         Ok(rusqlite::types::ToSqlOutput::Borrowed(
@@ -53,28 +51,6 @@ impl<'a, VcEmulationEpochState: VcEmulationEpochStateTrait<STORAGE_PROVIDER_VERS
                 STORAGE_PROVIDER_VERSION,
                 KeyRefWrapper::<C, _>(epoch_id, PhantomData),
                 SecretType::EmulationEpochState,
-                EntityRefWrapper::<C, _>(self.0, PhantomData)
-            ],
-        )?;
-        Ok(())
-    }
-}
-
-impl<'a, VcPprf: VcPprfTrait<STORAGE_PROVIDER_VERSION>> StorableEntityRef<'a, VcPprf> {
-    pub(super) fn store_vc_pprf<C: Codec, EpochId: Key<STORAGE_PROVIDER_VERSION>>(
-        &self,
-        connection: &rusqlite::Connection,
-        epoch_id: &EpochId,
-    ) -> Result<(), rusqlite::Error> {
-        connection.execute(
-            "INSERT INTO vc_emulation_group_secrets (provider_version, epoch_id, secret_type, vc_secret)
-            VALUES (?1, ?2, ?3, ?4)
-            ON CONFLICT(epoch_id, secret_type) DO UPDATE SET
-                vc_secret = excluded.vc_secret",
-            params![
-                STORAGE_PROVIDER_VERSION,
-                KeyRefWrapper::<C, _>(epoch_id, PhantomData),
-                SecretType::Pprf,
                 EntityRefWrapper::<C, _>(self.0, PhantomData)
             ],
         )?;
@@ -131,46 +107,45 @@ impl<VcEpochId: VcEpochIdTrait<STORAGE_PROVIDER_VERSION>> StorableKeyRef<'_, VcE
         Ok(())
     }
 
-    pub(super) fn load_vc_pprf<C: Codec, VcPprf: VcPprfTrait<STORAGE_PROVIDER_VERSION>>(
+    pub(super) fn load_vc_operation_tree<
+        C: Codec,
+        VcOperationTree: EntityTrait<STORAGE_PROVIDER_VERSION>,
+    >(
         &self,
         connection: &rusqlite::Connection,
-    ) -> Result<Option<VcPprf>, rusqlite::Error> {
+    ) -> Result<Option<VcOperationTree>, rusqlite::Error> {
         let Self(epoch_id) = self;
         let mut stmt = connection.prepare(
-            "SELECT vc_secret
-            FROM vc_emulation_group_secrets
+            "SELECT operation_tree
+            FROM vc_operation_trees
             WHERE epoch_id = ?1
-                AND provider_version = ?2
-                AND secret_type = ?3",
+                AND provider_version = ?2",
         )?;
         stmt.query_row(
             params![
                 KeyRefWrapper::<C, VcEpochId>(epoch_id, PhantomData),
-                STORAGE_PROVIDER_VERSION,
-                SecretType::Pprf
+                STORAGE_PROVIDER_VERSION
             ],
             |row| {
-                let EntityWrapper::<C, VcPprf>(pprf, ..) = row.get(0)?;
-                Ok(pprf)
+                let EntityWrapper::<C, VcOperationTree>(tree, ..) = row.get(0)?;
+                Ok(tree)
             },
         )
         .optional()
     }
 
-    pub(super) fn delete_vc_pprf<C: Codec>(
+    pub(super) fn delete_vc_operation_tree<C: Codec>(
         &self,
         connection: &rusqlite::Connection,
     ) -> Result<(), rusqlite::Error> {
         let Self(epoch_id) = self;
         connection.execute(
-            "DELETE FROM vc_emulation_group_secrets
+            "DELETE FROM vc_operation_trees
             WHERE epoch_id = ?1
-                AND provider_version = ?2
-                AND secret_type = ?3",
+                AND provider_version = ?2",
             params![
                 KeyRefWrapper::<C, VcEpochId>(epoch_id, PhantomData),
-                STORAGE_PROVIDER_VERSION,
-                SecretType::Pprf
+                STORAGE_PROVIDER_VERSION
             ],
         )?;
         Ok(())
@@ -252,6 +227,41 @@ impl<GroupId: GroupIdTrait<STORAGE_PROVIDER_VERSION>> StorableKeyRef<'_, GroupId
             params![
                 KeyRefWrapper::<C, GroupId>(group_id, PhantomData),
                 STORAGE_PROVIDER_VERSION
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+/// Per-emulation-epoch Virtual Client Operation Secret Tree. One row per
+/// emulation epoch, holding the serialized tree (node secrets plus per-leaf
+/// operation ratchets). Written back after every ratchet advance.
+pub(super) struct StorableOperationTreeRef<
+    'a,
+    VcOperationTree: EntityTrait<STORAGE_PROVIDER_VERSION>,
+>(pub &'a VcOperationTree);
+
+impl<'a, VcOperationTree: EntityTrait<STORAGE_PROVIDER_VERSION>>
+    StorableOperationTreeRef<'a, VcOperationTree>
+{
+    pub(super) fn store_vc_operation_tree<
+        C: Codec,
+        EpochId: VcEpochIdTrait<STORAGE_PROVIDER_VERSION>,
+    >(
+        &self,
+        connection: &rusqlite::Connection,
+        epoch_id: &EpochId,
+    ) -> Result<(), rusqlite::Error> {
+        connection.execute(
+            "INSERT INTO vc_operation_trees (provider_version, epoch_id, operation_tree)
+            VALUES (?1, ?2, ?3)
+            ON CONFLICT(epoch_id) DO UPDATE SET
+                operation_tree = excluded.operation_tree,
+                provider_version = excluded.provider_version",
+            params![
+                STORAGE_PROVIDER_VERSION,
+                KeyRefWrapper::<C, _>(epoch_id, PhantomData),
+                EntityRefWrapper::<C, _>(self.0, PhantomData)
             ],
         )?;
         Ok(())

--- a/sqlite_storage/tests/vc_operation_tree.rs
+++ b/sqlite_storage/tests/vc_operation_tree.rs
@@ -72,8 +72,8 @@ fn operation_tree_read_write_delete() {
     let read: Option<TestOperationTree> = storage.vc_operation_tree(&other_epoch_id).unwrap();
     assert_eq!(read, None);
 
-    // Delete and read None.
-    storage.delete_vc_operation_tree(&epoch_id).unwrap();
+    // Deleting the emulation state removes the operation tree too.
+    storage.delete_vc_emulation_state(&epoch_id).unwrap();
     let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
     assert_eq!(read, None);
 }

--- a/sqlite_storage/tests/vc_operation_tree.rs
+++ b/sqlite_storage/tests/vc_operation_tree.rs
@@ -1,0 +1,79 @@
+#![cfg(feature = "virtual-clients-draft")]
+
+use openmls_sqlite_storage::Codec;
+use openmls_traits::storage::{
+    traits::{self},
+    Entity, Key, StorageProvider,
+};
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default)]
+pub struct JsonCodec;
+
+impl Codec for JsonCodec {
+    type Error = serde_json::Error;
+
+    fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>, Self::Error> {
+        serde_json::to_vec(value)
+    }
+
+    fn from_slice<T: serde::de::DeserializeOwned>(slice: &[u8]) -> Result<T, Self::Error> {
+        serde_json::from_slice(slice)
+    }
+}
+
+// Test types
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestEpochId(Vec<u8>);
+impl traits::VcEpochId<1> for TestEpochId {}
+impl Key<1> for TestEpochId {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestOperationTree(Vec<u8>);
+impl traits::VcOperationTree<1> for TestOperationTree {}
+impl Entity<1> for TestOperationTree {}
+
+fn storage() -> openmls_sqlite_storage::SqliteStorageProvider<JsonCodec, Connection> {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    let mut storage =
+        openmls_sqlite_storage::SqliteStorageProvider::<JsonCodec, Connection>::new(connection);
+    storage.run_migrations().unwrap();
+    storage
+}
+
+/// Write, read back, overwrite, and delete an operation secret tree.
+#[test]
+fn operation_tree_read_write_delete() {
+    let storage = storage();
+    let epoch_id = TestEpochId(b"TestEpochId".to_vec());
+
+    // Nothing is stored initially.
+    let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert_eq!(read, None);
+
+    // Write and read back.
+    let tree = TestOperationTree(b"TestOperationTree".to_vec());
+    storage.write_vc_operation_tree(&epoch_id, &tree).unwrap();
+    let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert_eq!(read, Some(tree));
+
+    // A second write replaces the stored tree (write-back after a ratchet
+    // advance).
+    let advanced_tree = TestOperationTree(b"AdvancedOperationTree".to_vec());
+    storage
+        .write_vc_operation_tree(&epoch_id, &advanced_tree)
+        .unwrap();
+    let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert_eq!(read, Some(advanced_tree));
+
+    // A different epoch id reads nothing.
+    let other_epoch_id = TestEpochId(b"OtherEpochId".to_vec());
+    let read: Option<TestOperationTree> = storage.vc_operation_tree(&other_epoch_id).unwrap();
+    assert_eq!(read, None);
+
+    // Delete and read None.
+    storage.delete_vc_operation_tree(&epoch_id).unwrap();
+    let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert_eq!(read, None);
+}

--- a/traits/src/storage.rs
+++ b/traits/src/storage.rs
@@ -667,8 +667,11 @@ pub trait StorageProvider<const VERSION: u16> {
         group_id: &GroupId,
     ) -> Result<(), Self::Error>;
 
+    /// Delete all per-epoch state for the given emulation epoch: both the
+    /// emulation epoch state and the Virtual Client Operation Secret Tree.
+    /// Called by the application when it removes an emulation epoch.
     #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_emulation_epoch_state<EpochId: traits::VcEpochId<VERSION>>(
+    fn delete_vc_emulation_state<EpochId: traits::VcEpochId<VERSION>>(
         &self,
         epoch_id: &EpochId,
     ) -> Result<(), Self::Error>;
@@ -679,14 +682,6 @@ pub trait StorageProvider<const VERSION: u16> {
     fn delete_vc_emulation_bindings<GroupId: traits::GroupId<VERSION>>(
         &self,
         group_id: &GroupId,
-    ) -> Result<(), Self::Error>;
-
-    /// Delete the Virtual Client Operation Secret Tree of the given epoch.
-    /// Called when the emulation epoch's state is being removed.
-    #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_operation_tree<EpochId: traits::VcEpochId<VERSION>>(
-        &self,
-        epoch_id: &EpochId,
     ) -> Result<(), Self::Error>;
 }
 

--- a/traits/src/storage.rs
+++ b/traits/src/storage.rs
@@ -185,14 +185,6 @@ pub trait StorageProvider<const VERSION: u16> {
         vc_emulation_epoch_state: &VcEmulationEpochState,
     ) -> Result<(), Self::Error>;
 
-    /// Write the virtual clients PPRF for the given epoch.
-    #[cfg(feature = "virtual-clients-draft")]
-    fn write_vc_pprf<EpochId: traits::VcEpochId<VERSION>, VcPprf: traits::VcPprf<VERSION>>(
-        &self,
-        epoch_id: &EpochId,
-        vc_pprf: &VcPprf,
-    ) -> Result<(), Self::Error>;
-
     /// Store the record binding each recent epoch of a higher-level group to
     /// the emulation-group epoch whose virtual-client LeafNode was active at
     /// that epoch. Used by the reuse-guard derivation path to look up the
@@ -210,6 +202,22 @@ pub trait StorageProvider<const VERSION: u16> {
         &self,
         group_id: &GroupId,
         bindings: &VcEmulationBindings,
+    ) -> Result<(), Self::Error>;
+
+    /// Write the per-emulation-epoch Virtual Client Operation Secret Tree
+    /// (the lazily derived node secrets plus the per-leaf operation
+    /// ratchets) for the given epoch. The tree is written back after every
+    /// ratchet advance. It is stored separately from the static
+    /// `EmulationEpochState` so that per-operation writes do not rewrite
+    /// the static fields.
+    #[cfg(feature = "virtual-clients-draft")]
+    fn write_vc_operation_tree<
+        EpochId: traits::VcEpochId<VERSION>,
+        VcOperationTree: traits::VcOperationTree<VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+        vc_operation_tree: &VcOperationTree,
     ) -> Result<(), Self::Error>;
 
     //
@@ -486,13 +494,6 @@ pub trait StorageProvider<const VERSION: u16> {
         epoch_id: &EpochId,
     ) -> Result<Option<VcEmulationEpochState>, Self::Error>;
 
-    #[cfg(feature = "virtual-clients-draft")]
-    /// Get the virtual clients PPRF for the given epoch.
-    fn vc_pprf<EpochId: traits::VcEpochId<VERSION>, VcPprf: traits::VcPprf<VERSION>>(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<Option<VcPprf>, Self::Error>;
-
     /// Load the per-epoch emulation bindings of a higher-level group (see
     /// [`Self::write_vc_emulation_bindings`]). Returns `None` if no VC
     /// commit has been merged on this higher-level group.
@@ -504,6 +505,18 @@ pub trait StorageProvider<const VERSION: u16> {
         &self,
         group_id: &GroupId,
     ) -> Result<Option<VcEmulationBindings>, Self::Error>;
+
+    /// Get the per-emulation-epoch Virtual Client Operation Secret Tree for
+    /// the given epoch (the lazily derived node secrets plus the per-leaf
+    /// operation ratchets).
+    #[cfg(feature = "virtual-clients-draft")]
+    fn vc_operation_tree<
+        EpochId: traits::VcEpochId<VERSION>,
+        VcOperationTree: traits::VcOperationTree<VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<Option<VcOperationTree>, Self::Error>;
 
     //
     //     ---    deleters for group state    ---
@@ -654,26 +667,8 @@ pub trait StorageProvider<const VERSION: u16> {
         group_id: &GroupId,
     ) -> Result<(), Self::Error>;
 
-    /// Delete the emulation-epoch state stored under the given epoch id.
-    ///
-    /// Never called by OpenMLS: the state is keyed by emulation epoch and
-    /// may be referenced by several higher-level groups, so the
-    /// application must call this once the emulation epoch is no longer
-    /// referenced by any group.
     #[cfg(feature = "virtual-clients-draft")]
     fn delete_vc_emulation_epoch_state<EpochId: traits::VcEpochId<VERSION>>(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<(), Self::Error>;
-
-    /// Delete the virtual-clients PPRF stored under the given epoch id.
-    ///
-    /// Never called by OpenMLS: like the emulation-epoch state, the PPRF
-    /// is keyed by emulation epoch and may be referenced by several
-    /// higher-level groups, so the application must call this once the
-    /// emulation epoch is no longer referenced by any group.
-    #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_pprf<EpochId: traits::VcEpochId<VERSION>>(
         &self,
         epoch_id: &EpochId,
     ) -> Result<(), Self::Error>;
@@ -684,6 +679,14 @@ pub trait StorageProvider<const VERSION: u16> {
     fn delete_vc_emulation_bindings<GroupId: traits::GroupId<VERSION>>(
         &self,
         group_id: &GroupId,
+    ) -> Result<(), Self::Error>;
+
+    /// Delete the Virtual Client Operation Secret Tree of the given epoch.
+    /// Called when the emulation epoch's state is being removed.
+    #[cfg(feature = "virtual-clients-draft")]
+    fn delete_vc_operation_tree<EpochId: traits::VcEpochId<VERSION>>(
+        &self,
+        epoch_id: &EpochId,
     ) -> Result<(), Self::Error>;
 }
 
@@ -745,9 +748,9 @@ pub mod traits {
     #[cfg(feature = "virtual-clients-draft")]
     pub trait VcEmulationEpochState<const VERSION: u16>: Entity<VERSION> {}
     #[cfg(feature = "virtual-clients-draft")]
-    pub trait VcPprf<const VERSION: u16>: Entity<VERSION> {}
-    #[cfg(feature = "virtual-clients-draft")]
     pub trait VcEmulationBindings<const VERSION: u16>: Entity<VERSION> {}
+    #[cfg(feature = "virtual-clients-draft")]
+    pub trait VcOperationTree<const VERSION: u16>: Entity<VERSION> {}
 
     // traits for types that implement both
     pub trait ProposalRef<const VERSION: u16>: Entity<VERSION> + Key<VERSION> {}


### PR DESCRIPTION
This PR switches virtual client operations from the 32byte PPRF to a more efficient SecretTree-style PR with one leaf per emulation group member plus on ratchet per operation type.

This PR should be reviewable commit-by-commit.

This PR defers to follow-up PRs:

- KeyPackage creation and Welcome processing
- `GenerationId` usage
- `VirtualClientAction` via SafeAAD
- Backwards-compat pass

Completely out of scope for now:

- Onboarding new emulator clients via state transfer
- Update proposals (in higher-level groups)
- Private handshake messages