### PR TITLE
refactor(ds): port delivery service from actix-web to axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,190 +3,6 @@
 version = 4
 
 [[package]]
-name = "actix-codec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-sink",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "actix-http"
-version = "3.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "base64",
- "bitflags",
- "brotli",
- "bytes",
- "bytestring",
- "derive_more",
- "encoding_rs",
- "flate2",
- "foldhash",
- "futures-core",
- "h2 0.3.27",
- "http 0.2.12",
- "httparse",
- "httpdate",
- "itoa",
- "language-tags",
- "local-channel",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand 0.10.1",
- "sha1",
- "smallvec",
- "tokio",
- "tokio-util",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "actix-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "actix-router"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
-dependencies = [
- "bytestring",
- "cfg-if",
- "http 0.2.12",
- "regex",
- "regex-lite",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "actix-rt"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
-dependencies = [
- "actix-macros",
- "futures-core",
- "tokio",
-]
-
-[[package]]
-name = "actix-server"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
-dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "futures-util",
- "mio",
- "socket2 0.5.10",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "actix-service"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-utils"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
-dependencies = [
- "local-waker",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-web"
-version = "4.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-macros",
- "actix-router",
- "actix-rt",
- "actix-server",
- "actix-service",
- "actix-utils",
- "actix-web-codegen",
- "bytes",
- "bytestring",
- "cfg-if",
- "cookie",
- "derive_more",
- "encoding_rs",
- "foldhash",
- "futures-core",
- "futures-util",
- "impl-more",
- "itoa",
- "language-tags",
- "log",
- "mime",
- "once_cell",
- "pin-project-lite",
- "regex",
- "regex-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec",
- "socket2 0.6.4",
- "time",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "actix-web-codegen"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
-dependencies = [
- "actix-router",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,21 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,15 +75,6 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "anstream"
@@ -408,10 +200,13 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
- "http 1.4.2",
+ "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -419,10 +214,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -433,7 +233,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http",
  "http-body",
  "http-body-util",
  "mime",
@@ -441,6 +241,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -501,27 +302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,15 +318,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "bytestring"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
-dependencies = [
- "bytes",
-]
 
 [[package]]
 name = "cast"
@@ -717,7 +488,6 @@ dependencies = [
  "serde",
  "serde_json",
  "termion",
- "thiserror",
  "url",
 ]
 
@@ -794,26 +564,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "cookie"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1083,29 +833,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,7 +873,6 @@ version = "0.1.0"
 dependencies = [
  "openmls",
  "openmls_basic_credential",
- "openmls_memory_storage",
  "openmls_rust_crypto",
  "openmls_traits",
  "rand 0.10.1",
@@ -1407,17 +1133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,7 +1152,6 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1528,25 +1242,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
@@ -1556,7 +1251,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1789,17 +1484,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
@@ -1815,7 +1499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http",
 ]
 
 [[package]]
@@ -1826,7 +1510,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -1869,8 +1553,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
- "http 1.4.2",
+ "h2",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -1887,7 +1571,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1919,14 +1603,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2042,12 +1726,6 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
-
-[[package]]
-name = "impl-more"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
@@ -2249,12 +1927,6 @@ dependencies = [
  "crypto-common 0.2.2",
  "rand_core 0.10.1",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -2542,23 +2214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "local-channel"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
-dependencies = [
- "futures-core",
- "futures-sink",
- "local-waker",
-]
-
-[[package]]
-name = "local-waker"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,7 +2288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2671,23 +2325,20 @@ dependencies = [
 name = "mls-ds"
 version = "0.1.0"
 dependencies = [
- "actix-rt",
- "actix-web",
+ "axum",
  "base64",
  "clap",
  "ds-lib",
- "futures-core",
- "futures-util",
+ "http-body-util",
  "log",
  "openmls",
  "openmls_basic_credential",
  "openmls_rust_crypto",
  "openmls_traits",
+ "parking_lot",
  "pretty_env_logger",
- "serde",
- "serde_json",
- "time",
- "uuid",
+ "tokio",
+ "tower",
 ]
 
 [[package]]
@@ -2940,7 +2591,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.10.1",
  "rand_core 0.6.4",
- "serde",
  "sha2 0.11.0",
  "thiserror",
  "tls_codec",
@@ -2963,25 +2613,21 @@ dependencies = [
 name = "openmls_sqlite_storage"
 version = "0.2.0"
 dependencies = [
- "log",
  "openmls_traits",
  "refinery",
  "rusqlite",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
 name = "openmls_test"
 version = "0.2.1"
 dependencies = [
- "ansi_term",
  "openmls_libcrux_crypto",
  "openmls_rust_crypto",
  "openmls_sqlite_storage",
  "openmls_traits",
- "proc-macro2",
  "quote",
  "syn",
 ]
@@ -3353,7 +2999,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -3391,7 +3037,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3612,12 +3258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,8 +3275,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
- "http 1.4.2",
+ "h2",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3945,6 +3585,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3963,17 +3614,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
 ]
 
 [[package]]
@@ -4035,16 +3675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4103,16 +3733,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -4389,10 +4009,8 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4493,8 +4111,8 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
- "h2 0.4.14",
- "http 1.4.2",
+ "h2",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4502,7 +4120,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.4",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -4579,7 +4197,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.2",
+ "http",
  "http-body",
  "pin-project-lite",
  "tower",
@@ -4687,12 +4305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4758,7 +4370,6 @@ checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "serde_core",
  "wasm-bindgen",
 ]
 
@@ -5469,31 +5080,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,6 @@ openmls_rust_crypto = { workspace = true }
 openmls_memory_storage = { workspace = true, features = ["persistence"] }
 openmls_basic_credential = { workspace = true }
 serde = { workspace = true }
-thiserror = { workspace = true }
 serde_json = "1.0"
 
 [dependencies.termion]

--- a/delivery-service/ds-lib/Cargo.toml
+++ b/delivery-service/ds-lib/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 openmls = { workspace = true, features = ["test-utils"] }
 openmls_traits = { workspace = true }
 openmls_rust_crypto = { workspace = true }
-openmls_memory_storage = { workspace = true }
 openmls_basic_credential = { workspace = true }
 
 rand = { version = "0.10" }

--- a/delivery-service/ds/Cargo.toml
+++ b/delivery-service/ds/Cargo.toml
@@ -8,22 +8,22 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-rt = "2.0"
-actix-web = "4"
-futures-core = "0.3"
-futures-util = "0.3"
-serde_json = "1.0"
+axum = "0.8"
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 log = "0.4"
 pretty_env_logger = "0.5"
-serde = { workspace = true, features = ["derive"] }
-uuid = { version = "1", features = ["serde", "v4"] }
 clap = "4"
 base64 = "0.22"
-time = ">=0.3.36"
+parking_lot = "0.12"
 
 openmls = { path = "../../openmls", features = ["test-utils"] }
 
 ds-lib = { path = "../ds-lib/" }
+
+[dev-dependencies]
+http-body-util = "0.1"
+tower = { version = "0.5", features = ["util"] }
+
 openmls_rust_crypto = { path = "../../openmls_rust_crypto" }
 openmls_traits = { path = "../../traits" }
 openmls_basic_credential = { path = "../../basic_credential" }

--- a/delivery-service/ds/src/main.rs
+++ b/delivery-service/ds/src/main.rs
@@ -30,12 +30,20 @@
 //! The DS returns a list of messages queued for the client in all groups they
 //! are part of.
 
-use actix_web::{get, post, web, web::Payload, App, HttpRequest, HttpServer, Responder};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::{
+    body::Bytes,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Router,
+};
 use base64::Engine;
 use clap::Command;
-use futures_util::StreamExt;
-use std::collections::HashMap;
-use std::sync::Mutex;
+use parking_lot::Mutex;
 use tls_codec::{Deserialize, Serialize, TlsSliceU16, TlsVecU32};
 
 use ds_lib::{
@@ -61,20 +69,11 @@ pub struct DsData {
     groups: Mutex<HashMap<Vec<u8>, u64>>,
 }
 
-macro_rules! unwrap_item {
-    ( $e:expr ) => {
-        match $e {
-            Ok(x) => x,
-            Err(_) => return actix_web::HttpResponse::PartialContent().finish(),
-        }
-    };
-}
-
 macro_rules! unwrap_data {
     ( $e:expr ) => {
         match $e {
             Ok(x) => x,
-            Err(_) => return actix_web::HttpResponse::InternalServerError().finish(),
+            Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
         }
     };
 }
@@ -85,23 +84,18 @@ macro_rules! unwrap_data {
 /// a simple "Welcome {client name}" on success.
 /// An HTTP conflict (409) is returned if a client with this name exists
 /// already.
-#[post("/clients/register")]
-async fn register_client(mut body: Payload, data: web::Data<DsData>) -> impl Responder {
-    let mut bytes = web::BytesMut::new();
-    while let Some(item) = body.next().await {
-        bytes.extend_from_slice(&unwrap_item!(item));
-    }
-    let req = match RegisterClientRequest::tls_deserialize(&mut &bytes[..]) {
+async fn register_client(State(data): State<Arc<DsData>>, body: Bytes) -> Response {
+    let req = match RegisterClientRequest::tls_deserialize(&mut &body[..]) {
         Ok(i) => i,
         Err(_) => {
-            log::error!("Invalid payload for /clients/register\n{bytes:?}");
-            return actix_web::HttpResponse::BadRequest().finish();
+            log::error!("Invalid payload for /clients/register\n{body:?}");
+            return StatusCode::BAD_REQUEST.into_response();
         }
     };
 
     if req.key_packages.0.is_empty() {
         log::error!("Invalid payload for /clients/register: no key packages");
-        return actix_web::HttpResponse::BadRequest().finish();
+        return StatusCode::BAD_REQUEST.into_response();
     }
 
     let key_packages = req
@@ -119,21 +113,20 @@ async fn register_client(mut body: Payload, data: web::Data<DsData>) -> impl Res
         auth_token: new_client_info.auth_token.clone(),
     };
 
-    let mut clients = unwrap_data!(data.clients.lock());
+    let mut clients = data.clients.lock();
     if clients.contains_key(&new_client_info.id) {
-        return actix_web::HttpResponse::Conflict().finish();
+        return StatusCode::CONFLICT.into_response();
     }
     let old = clients.insert(new_client_info.id.clone(), new_client_info);
     assert!(old.is_none());
 
-    actix_web::HttpResponse::Ok().body(response.tls_serialize_detached().unwrap())
+    response.tls_serialize_detached().unwrap().into_response()
 }
 
 /// Returns a list of clients with their names and IDs.
-#[get("/clients/list")]
-async fn list_clients(_req: HttpRequest, data: web::Data<DsData>) -> impl Responder {
+async fn list_clients(State(data): State<Arc<DsData>>) -> Response {
     log::debug!("Listing clients");
-    let clients = unwrap_data!(data.clients.lock());
+    let clients = data.clients.lock();
 
     // XXX: we could encode while iterating to be less wasteful.
     let clients: TlsVecU32<Vec<u8>> = clients
@@ -143,91 +136,83 @@ async fn list_clients(_req: HttpRequest, data: web::Data<DsData>) -> impl Respon
         .into();
     let mut out_bytes = Vec::new();
     if clients.tls_serialize(&mut out_bytes).is_err() {
-        return actix_web::HttpResponse::InternalServerError().finish();
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     };
-    actix_web::HttpResponse::Ok().body(out_bytes)
+    out_bytes.into_response()
 }
 
 /// Resets the server state.
-#[get("/reset")]
-async fn reset(req: HttpRequest, data: web::Data<DsData>) -> impl Responder {
-    if let Some(reset_key) = req.headers().get("reset-key") {
+async fn reset(headers: HeaderMap, State(data): State<Arc<DsData>>) -> Response {
+    if let Some(reset_key) = headers.get("reset-key") {
         if reset_key != "poc-reset-password" {
-            return actix_web::HttpResponse::NetworkAuthenticationRequired().finish();
+            return StatusCode::NETWORK_AUTHENTICATION_REQUIRED.into_response();
         }
     }
     log::debug!("Resetting server");
-    let mut clients = unwrap_data!(data.clients.lock());
-    let mut groups = unwrap_data!(data.groups.lock());
+    let mut clients = data.clients.lock();
+    let mut groups = data.groups.lock();
     clients.clear();
     groups.clear();
-    actix_web::HttpResponse::Ok().finish()
+    StatusCode::OK.into_response()
 }
 
 /// Get the list of key packages for a given client `{id}`.
 /// This returns a serialised vector of `ClientKeyPackages` (see the `ds-lib`
 /// for details).
-#[get("/clients/key_packages/{id}")]
-async fn get_key_packages(path: web::Path<String>, data: web::Data<DsData>) -> impl Responder {
-    let clients = unwrap_data!(data.clients.lock());
+async fn get_key_packages(Path(path): Path<String>, State(data): State<Arc<DsData>>) -> Response {
+    let clients = data.clients.lock();
 
-    let id = match base64::engine::general_purpose::URL_SAFE.decode(path.into_inner()) {
+    let id = match base64::engine::general_purpose::URL_SAFE.decode(path) {
         Ok(v) => v,
-        Err(_) => return actix_web::HttpResponse::BadRequest().finish(),
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
     };
 
     log::debug!("Getting key packages for {id:?}");
 
     let client = match clients.get(&id) {
         Some(c) => c,
-        None => return actix_web::HttpResponse::NoContent().finish(),
+        None => return StatusCode::NO_CONTENT.into_response(),
     };
-    actix_web::HttpResponse::Ok().body(unwrap_data!(client.key_packages.tls_serialize_detached()))
+    unwrap_data!(client.key_packages.tls_serialize_detached()).into_response()
 }
 
 /// Publish key packages for a given client `{id}`.
-#[post("/clients/key_packages/{id}")]
 async fn publish_key_packages(
-    path: web::Path<String>,
-    mut body: Payload,
-    data: web::Data<DsData>,
-) -> impl Responder {
-    let mut bytes = web::BytesMut::new();
-    while let Some(item) = body.next().await {
-        bytes.extend_from_slice(&unwrap_item!(item));
-    }
+    Path(path): Path<String>,
+    State(data): State<Arc<DsData>>,
+    body: Bytes,
+) -> Response {
+    let mut clients = data.clients.lock();
 
-    let mut clients = unwrap_data!(data.clients.lock());
-
-    let id = match base64::engine::general_purpose::URL_SAFE.decode(path.into_inner()) {
+    let id = match base64::engine::general_purpose::URL_SAFE.decode(path) {
         Ok(v) => v,
-        Err(_) => return actix_web::HttpResponse::BadRequest().finish(),
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
     };
 
     let client = match clients.get(&id) {
         Some(c) => c,
-        None => return actix_web::HttpResponse::NotFound().finish(),
+        None => return StatusCode::NOT_FOUND.into_response(),
     };
 
     // Deserialize request
-    let req = match PublishKeyPackagesRequest::tls_deserialize(&mut &bytes[..]) {
+    let req = match PublishKeyPackagesRequest::tls_deserialize(&mut &body[..]) {
         Ok(i) => i,
         Err(_) => {
-            log::error!("Invalid payload for /clients/key_packages/{id:?}\n{bytes:?}");
-            return actix_web::HttpResponse::BadRequest().finish();
+            log::error!("Invalid payload for /clients/key_packages/{id:?}\n{body:?}");
+            return StatusCode::BAD_REQUEST.into_response();
         }
     };
 
     // Auth
     if client.auth_token != req.auth_token {
-        return actix_web::HttpResponse::Unauthorized().finish();
+        return StatusCode::UNAUTHORIZED.into_response();
     }
 
     log::debug!("Add key package for {id:?}");
 
     let client = match clients.get_mut(&id) {
         Some(client) => client,
-        None => return actix_web::HttpResponse::NotFound().finish(),
+        None => return StatusCode::NOT_FOUND.into_response(),
     };
 
     req.key_packages
@@ -236,19 +221,21 @@ async fn publish_key_packages(
         .into_iter()
         .for_each(|value| client.key_packages.0.push(value));
 
-    actix_web::HttpResponse::Ok().finish()
+    StatusCode::OK.into_response()
 }
 
 /// Consume a key package for a given client `{id}`.
 /// This returns a serialised `KeyPackage` (see the `ds-lib`
 /// for details).
-#[get("/clients/key_package/{id}")]
-async fn consume_key_package(path: web::Path<String>, data: web::Data<DsData>) -> impl Responder {
-    let mut clients = unwrap_data!(data.clients.lock());
+async fn consume_key_package(
+    Path(path): Path<String>,
+    State(data): State<Arc<DsData>>,
+) -> Response {
+    let mut clients = data.clients.lock();
 
-    let id = match base64::engine::general_purpose::URL_SAFE.decode(path.into_inner()) {
+    let id = match base64::engine::general_purpose::URL_SAFE.decode(path) {
         Ok(v) => v,
-        Err(_) => return actix_web::HttpResponse::BadRequest().finish(),
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
     };
     log::debug!("Consuming key package for {id:?}");
 
@@ -257,29 +244,24 @@ async fn consume_key_package(path: web::Path<String>, data: web::Data<DsData>) -
             Ok(kp) => kp,
             Err(e) => {
                 log::debug!("Error consuming key package: {e}");
-                return actix_web::HttpResponse::NoContent().finish();
+                return StatusCode::NO_CONTENT.into_response();
             }
         },
-        None => return actix_web::HttpResponse::NoContent().finish(),
+        None => return StatusCode::NO_CONTENT.into_response(),
     };
 
-    actix_web::HttpResponse::Ok().body(unwrap_data!(key_package.tls_serialize_detached()))
+    unwrap_data!(key_package.tls_serialize_detached()).into_response()
 }
 
 /// Send a welcome message to a client.
 /// This takes a serialised `Welcome` message and stores the message for all
 /// clients in the welcome message.
-#[post("/send/welcome")]
-async fn send_welcome(mut body: Payload, data: web::Data<DsData>) -> impl Responder {
-    let mut bytes = web::BytesMut::new();
-    while let Some(item) = body.next().await {
-        bytes.extend_from_slice(&unwrap_item!(item));
-    }
-    let welcome_msg = unwrap_data!(MlsMessageIn::tls_deserialize(&mut &bytes[..]));
+async fn send_welcome(State(data): State<Arc<DsData>>, body: Bytes) -> Response {
+    let welcome_msg = unwrap_data!(MlsMessageIn::tls_deserialize(&mut &body[..]));
     let welcome = welcome_msg.clone().into_welcome().unwrap();
     log::debug!("Storing welcome message: {welcome_msg:?}");
 
-    let mut clients = unwrap_data!(data.clients.lock());
+    let mut clients = data.clients.lock();
     for secret in welcome.secrets().iter() {
         let key_package_hash = &secret.new_member();
         for (_client_name, client) in clients.iter_mut() {
@@ -289,13 +271,13 @@ async fn send_welcome(mut body: Payload, data: web::Data<DsData>) -> impl Respon
             {
                 Some(_kp_hash) => {
                     client.welcome_queue.push(welcome_msg);
-                    return actix_web::HttpResponse::Ok().finish();
+                    return StatusCode::OK.into_response();
                 }
                 None => continue,
             };
         }
     }
-    actix_web::HttpResponse::NoContent().finish()
+    StatusCode::NO_CONTENT.into_response()
 }
 
 /// Send an MLS message to a set of clients (group).
@@ -304,17 +286,12 @@ async fn send_welcome(mut body: Payload, data: web::Data<DsData>) -> impl Respon
 /// If a handshake message is sent with an epoch smaller or equal to another
 /// handshake message this DS has seen, a 409 is returned and the message is not
 /// processed.
-#[post("/send/message")]
-async fn msg_send(mut body: Payload, data: web::Data<DsData>) -> impl Responder {
-    let mut bytes = web::BytesMut::new();
-    while let Some(item) = body.next().await {
-        bytes.extend_from_slice(&unwrap_item!(item));
-    }
-    let group_msg = unwrap_data!(GroupMessage::tls_deserialize(&mut &bytes[..]));
+async fn msg_send(State(data): State<Arc<DsData>>, body: Bytes) -> Response {
+    let group_msg = unwrap_data!(GroupMessage::tls_deserialize(&mut &body[..]));
     log::debug!("Storing group message: {group_msg:?}");
 
-    let mut clients = unwrap_data!(data.clients.lock());
-    let mut groups = unwrap_data!(data.groups.lock());
+    let mut clients = data.clients.lock();
+    let mut groups = data.groups.lock();
 
     let protocol_msg: ProtocolMessage = group_msg.msg.clone().try_into().unwrap();
 
@@ -328,18 +305,18 @@ async fn msg_send(mut body: Payload, data: web::Data<DsData>) -> impl Responder 
         let group_id = protocol_msg.group_id().as_slice();
         if let Some(&group_epoch) = groups.get(group_id) {
             if group_epoch > epoch {
-                return actix_web::HttpResponse::Conflict().finish();
+                return StatusCode::CONFLICT.into_response();
             }
             // Update server state to the latest epoch.
             let old_value = groups.insert(group_id.to_vec(), epoch);
             if old_value.is_none() {
-                return actix_web::HttpResponse::InternalServerError().finish();
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
             }
         } else {
             // We haven't seen this group_id yet. Store it.
             let old_value = groups.insert(group_id.to_vec(), epoch);
             if old_value.is_some() {
-                return actix_web::HttpResponse::InternalServerError().finish();
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
             }
         }
     }
@@ -347,52 +324,46 @@ async fn msg_send(mut body: Payload, data: web::Data<DsData>) -> impl Responder 
     for recipient in group_msg.recipients.iter() {
         let client = match clients.get_mut(recipient.as_slice()) {
             Some(client) => client,
-            None => return actix_web::HttpResponse::NotFound().finish(),
+            None => return StatusCode::NOT_FOUND.into_response(),
         };
         client.msgs.push(group_msg.msg.clone());
     }
-    actix_web::HttpResponse::Ok().finish()
+    StatusCode::OK.into_response()
 }
 
 /// Receive all messages stored for the client `{id}`.
 /// This returns a serialised vector of `Message`s (see the `ds-lib` for
 /// details) the DS has stored for the given client.
 /// The messages are deleted on the DS when sent out.
-#[get("/recv/{id}")]
 async fn msg_recv(
-    path: web::Path<String>,
-    mut body: Payload,
-    data: web::Data<DsData>,
-) -> impl Responder {
-    let mut bytes = web::BytesMut::new();
-    while let Some(item) = body.next().await {
-        bytes.extend_from_slice(&unwrap_item!(item));
-    }
+    Path(path): Path<String>,
+    State(data): State<Arc<DsData>>,
+    body: Bytes,
+) -> Response {
+    let mut clients = data.clients.lock();
 
-    let mut clients = unwrap_data!(data.clients.lock());
-
-    let id = match base64::engine::general_purpose::URL_SAFE.decode(path.into_inner()) {
+    let id = match base64::engine::general_purpose::URL_SAFE.decode(path) {
         Ok(v) => v,
-        Err(_) => return actix_web::HttpResponse::BadRequest().finish(),
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
     };
 
     let client = match clients.get_mut(&id) {
         Some(client) => client,
-        None => return actix_web::HttpResponse::NotFound().finish(),
+        None => return StatusCode::NOT_FOUND.into_response(),
     };
 
     // Auth
     // Deserialize request
-    let req = match RecvMessageRequest::tls_deserialize(&mut &bytes[..]) {
+    let req = match RecvMessageRequest::tls_deserialize(&mut &body[..]) {
         Ok(i) => i,
         Err(_) => {
-            log::error!("Invalid payload for /clients/key_packages/{id:?}\n{bytes:?}");
-            return actix_web::HttpResponse::BadRequest().finish();
+            log::error!("Invalid payload for /clients/key_packages/{id:?}\n{body:?}");
+            return StatusCode::BAD_REQUEST.into_response();
         }
     };
 
     if req.auth_token != client.auth_token {
-        return actix_web::HttpResponse::Unauthorized().finish();
+        return StatusCode::UNAUTHORIZED.into_response();
     }
 
     log::debug!("Getting messages for client {id:?}");
@@ -404,14 +375,31 @@ async fn msg_recv(
     out.append(&mut msgs);
 
     match TlsSliceU16(&out).tls_serialize_detached() {
-        Ok(out) => actix_web::HttpResponse::Ok().body(out),
-        Err(_) => actix_web::HttpResponse::InternalServerError().finish(),
+        Ok(out) => out.into_response(),
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
+}
+
+/// Build the axum router for the DS.
+fn app(data: Arc<DsData>) -> Router {
+    Router::new()
+        .route("/clients/register", post(register_client))
+        .route("/clients/list", get(list_clients))
+        .route(
+            "/clients/key_packages/{id}",
+            get(get_key_packages).post(publish_key_packages),
+        )
+        .route("/clients/key_package/{id}", get(consume_key_package))
+        .route("/send/welcome", post(send_welcome))
+        .route("/send/message", post(msg_send))
+        .route("/recv/{id}", get(msg_recv))
+        .route("/reset", get(reset))
+        .with_state(data)
 }
 
 // === Main function driving the DS ===
 
-#[actix_web::main]
+#[tokio::main]
 async fn main() -> std::io::Result<()> {
     pretty_env_logger::init();
 
@@ -425,35 +413,22 @@ async fn main() -> std::io::Result<()> {
                 .short('p')
                 .long("port")
                 .value_name("port")
+                .value_parser(clap::value_parser!(u16))
                 .help("Sets a custom port number"),
         )
         .get_matches();
 
     // The data this app operates on.
-    let data = web::Data::new(DsData::default());
+    let data = Arc::new(DsData::default());
 
     // Set default port or use port provided on the command line.
-    let port = matches.get_one("port").unwrap_or(&8080u16);
+    let port = *matches.get_one("port").unwrap_or(&8080u16);
 
     let ip = "127.0.0.1";
     let addr = format!("{ip}:{port}");
     log::info!("Listening on: {addr}");
 
     // Start the server.
-    HttpServer::new(move || {
-        App::new()
-            .app_data(data.clone())
-            .service(register_client)
-            .service(list_clients)
-            .service(publish_key_packages)
-            .service(get_key_packages)
-            .service(consume_key_package)
-            .service(send_welcome)
-            .service(msg_recv)
-            .service(msg_send)
-            .service(reset)
-    })
-    .bind(addr)?
-    .run()
-    .await
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app(data)).await
 }

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -1,10 +1,15 @@
 use super::*;
-use actix_web::{body::MessageBody, http::StatusCode, test, web, web::Bytes, App};
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::types::SignatureScheme;
 use openmls_traits::OpenMlsProvider;
 use tls_codec::{TlsByteVecU8, TlsVecU16};
+use tower::ServiceExt;
 
 fn generate_credential(
     identity: Vec<u8>,
@@ -33,27 +38,21 @@ fn generate_key_package(
         .unwrap()
 }
 
-#[actix_rt::test]
+async fn body_bytes(response: axum::response::Response) -> Bytes {
+    response.into_body().collect().await.unwrap().to_bytes()
+}
+
+#[tokio::test]
 async fn test_list_clients() {
-    let data = web::Data::new(DsData::default());
-    let app = test::init_service(
-        App::new()
-            .app_data(data.clone())
-            .service(get_key_packages)
-            .service(consume_key_package)
-            .service(publish_key_packages)
-            .service(list_clients)
-            .service(register_client),
-    )
-    .await;
+    let app = app(Arc::new(DsData::default()));
 
     // There is no client. So the response body is empty.
-    let req = test::TestRequest::with_uri("/clients/list").to_request();
+    let req = Request::get("/clients/list").body(Body::empty()).unwrap();
 
-    let response = test::call_service(&app, req).await;
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let bytes = response.into_body().try_into_bytes().unwrap();
+    let bytes = body_bytes(response).await;
     let client_info =
         TlsVecU32::<ClientInfo>::tls_deserialize(&mut bytes.as_ref()).expect("Invalid client list");
 
@@ -100,28 +99,23 @@ async fn test_list_clients() {
         ),
     };
 
-    let req = test::TestRequest::post()
-        .uri("/clients/register")
-        .set_payload(Bytes::copy_from_slice(
-            &body.tls_serialize_detached().unwrap(),
-        ))
-        .to_request();
+    let req = Request::post("/clients/register")
+        .body(Body::from(body.tls_serialize_detached().unwrap()))
+        .unwrap();
 
-    let response = test::call_service(&app, req).await;
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
-    let response_body = RegisterClientSuccessResponse::tls_deserialize_exact(
-        response.into_body().try_into_bytes().unwrap(),
-    )
-    .unwrap();
+    let response_body =
+        RegisterClientSuccessResponse::tls_deserialize_exact(body_bytes(response).await).unwrap();
     client_data.auth_token = response_body.auth_token;
 
     // There should be Client1 now.
-    let req = test::TestRequest::with_uri("/clients/list").to_request();
+    let req = Request::get("/clients/list").body(Body::empty()).unwrap();
 
-    let response = test::call_service(&app, req).await;
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let bytes = response.into_body().try_into_bytes().unwrap();
+    let bytes = body_bytes(response).await;
     let client_ids =
         TlsVecU32::<Vec<u8>>::tls_deserialize(&mut bytes.as_ref()).expect("Invalid client list");
 
@@ -135,12 +129,12 @@ async fn test_list_clients() {
     // Get Client1 key packages.
     let path = "/clients/key_packages/".to_owned()
         + &base64::engine::general_purpose::URL_SAFE.encode(client_id);
-    let req = test::TestRequest::with_uri(&path).to_request();
+    let req = Request::get(&path).body(Body::empty()).unwrap();
 
-    let response = test::call_service(&app, req).await;
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let bytes = response.into_body().try_into_bytes().unwrap();
+    let bytes = body_bytes(response).await;
     let mut key_packages =
         TlsVecU32::<(TlsByteVecU8, KeyPackageIn)>::tls_deserialize(&mut bytes.as_ref())
             .expect("Invalid key package response")
@@ -154,24 +148,11 @@ async fn test_list_clients() {
     assert_eq!(client_key_package, key_packages);
 }
 
-#[actix_rt::test]
+#[tokio::test]
 async fn test_group() {
     let crypto = &OpenMlsRustCrypto::default();
     let mls_group_create_config = MlsGroupCreateConfig::default();
-    let data = web::Data::new(DsData::default());
-    let app = test::init_service(
-        App::new()
-            .app_data(data.clone())
-            .service(register_client)
-            .service(list_clients)
-            .service(get_key_packages)
-            .service(consume_key_package)
-            .service(publish_key_packages)
-            .service(send_welcome)
-            .service(msg_recv)
-            .service(msg_send),
-    )
-    .await;
+    let app = app(Arc::new(DsData::default()));
 
     // Add two clients.
     let clients = ["Client1", "Client2"];
@@ -221,18 +202,14 @@ async fn test_group() {
             ),
         };
 
-        let req = test::TestRequest::post()
-            .uri("/clients/register")
-            .set_payload(Bytes::copy_from_slice(
-                &body.tls_serialize_detached().unwrap(),
-            ))
-            .to_request();
-        let response = test::call_service(&app, req).await;
+        let req = Request::post("/clients/register")
+            .body(Body::from(body.tls_serialize_detached().unwrap()))
+            .unwrap();
+        let response = app.clone().oneshot(req).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let response_body = RegisterClientSuccessResponse::tls_deserialize_exact(
-            response.into_body().try_into_bytes().unwrap(),
-        )
-        .unwrap();
+        let response_body =
+            RegisterClientSuccessResponse::tls_deserialize_exact(body_bytes(response).await)
+                .unwrap();
         client_data.auth_token = response_body.auth_token;
         client_data_vec.push(client_data);
     }
@@ -272,15 +249,12 @@ async fn test_group() {
         key_packages: ckp,
         auth_token: client_data_vec[1].auth_token.clone(),
     };
-    let req = test::TestRequest::post()
-        .uri(&path)
-        .set_payload(Bytes::copy_from_slice(
-            &body.tls_serialize_detached().unwrap(),
-        ))
-        .to_request();
+    let req = Request::post(&path)
+        .body(Body::from(body.tls_serialize_detached().unwrap()))
+        .unwrap();
 
     // The response should be empty.
-    let response = test::call_service(&app, req).await;
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
     // Client1 creates MyFirstGroup
@@ -302,12 +276,12 @@ async fn test_group() {
     let path = "/clients/key_package/".to_owned()
         + &base64::engine::general_purpose::URL_SAFE.encode(&client_ids[1]);
 
-    let req = test::TestRequest::with_uri(&path).to_request();
+    let req = Request::get(&path).body(Body::empty()).unwrap();
 
-    let response = test::call_service(&app, req).await;
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let bytes = response.into_body().try_into_bytes().unwrap();
+    let bytes = body_bytes(response).await;
     let client2_key_package =
         KeyPackageIn::tls_deserialize(&mut bytes.as_ref()).expect("Invalid key package response");
 
@@ -321,13 +295,10 @@ async fn test_group() {
         .expect("error merging pending commit");
 
     // Send welcome message for Client2
-    let req = test::TestRequest::post()
-        .uri("/send/welcome")
-        .set_payload(Bytes::copy_from_slice(
-            &welcome_msg.tls_serialize_detached().unwrap(),
-        ))
-        .to_request();
-    let response = test::call_service(&app, req).await;
+    let req = Request::post("/send/welcome")
+        .body(Body::from(welcome_msg.tls_serialize_detached().unwrap()))
+        .unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
     // There should be a welcome message now for Client2.
@@ -335,15 +306,13 @@ async fn test_group() {
         auth_token: client_data_vec[1].auth_token.clone(),
     };
     let path = "/recv/".to_owned() + &base64::engine::general_purpose::URL_SAFE.encode(clients[1]);
-    let req = test::TestRequest::with_uri(&path)
-        .set_payload(Bytes::copy_from_slice(
-            &body.tls_serialize_detached().unwrap(),
-        ))
-        .to_request();
-    let response = test::call_service(&app, req).await;
+    let req = Request::get(&path)
+        .body(Body::from(body.tls_serialize_detached().unwrap()))
+        .unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let bytes = response.into_body().try_into_bytes().unwrap();
+    let bytes = body_bytes(response).await;
     let mut messages = TlsVecU16::<MlsMessageIn>::tls_deserialize(&mut bytes.as_ref())
         .expect("Invalid message list")
         .into_vec();
@@ -389,13 +358,10 @@ async fn test_group() {
 
     // Send private_message to the group
     let msg = GroupMessage::new(out_messages.into(), &client_ids);
-    let req = test::TestRequest::post()
-        .uri("/send/message")
-        .set_payload(Bytes::copy_from_slice(
-            &msg.tls_serialize_detached().unwrap(),
-        ))
-        .to_request();
-    let response = test::call_service(&app, req).await;
+    let req = Request::post("/send/message")
+        .body(Body::from(msg.tls_serialize_detached().unwrap()))
+        .unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
     // Client1 retrieves messages from the DS
@@ -403,15 +369,13 @@ async fn test_group() {
         auth_token: client_data_vec[0].auth_token.clone(),
     };
     let path = "/recv/".to_owned() + &base64::engine::general_purpose::URL_SAFE.encode(clients[0]);
-    let req = test::TestRequest::with_uri(&path)
-        .set_payload(Bytes::copy_from_slice(
-            &body.tls_serialize_detached().unwrap(),
-        ))
-        .to_request();
-    let response = test::call_service(&app, req).await;
+    let req = Request::get(&path)
+        .body(Body::from(body.tls_serialize_detached().unwrap()))
+        .unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let bytes = response.into_body().try_into_bytes().unwrap();
+    let bytes = body_bytes(response).await;
     let mut messages = TlsVecU16::<MlsMessageIn>::tls_deserialize(&mut bytes.as_ref())
         .expect("Invalid message list");
 

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -35,7 +35,6 @@ hpke-rs-rust-crypto = { version = "0.6.1", features = ["experimental"] }
 tls_codec = { workspace = true }
 ml-dsa = "0.1.0"
 thiserror = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 # FF1-AES128 backing for the virtual-clients-draft reuse-guard PRP.
 fpe = { version = "0.6", optional = true }
 aes = { version = "0.8", optional = true }

--- a/openmls_test/Cargo.toml
+++ b/openmls_test/Cargo.toml
@@ -29,8 +29,6 @@ all-ciphersuites = []
 
 [dependencies]
 syn = { version = "2.0", features = ["full", "visit"] }
-proc-macro2 = { version = "1.0.10", features = ["span-locations"] }
-ansi_term = "0.12.1"
 quote = "1.0"
 openmls_rust_crypto = { workspace = true }
 openmls_libcrux_crypto = { workspace = true, optional = true }

--- a/sqlite_storage/Cargo.toml
+++ b/sqlite_storage/Cargo.toml
@@ -11,9 +11,7 @@ readme = "README.md"
 
 [dependencies]
 openmls_traits = { workspace = true }
-thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-log = { version = "0.4" }
 rusqlite = { version = "0.37", features = ["bundled"] }
 refinery = { version = "0.9", features = ["rusqlite", "enums"] }
 


### PR DESCRIPTION
Replace the actix-web stack with axum 0.8 + tokio, dropping a large
transitive dependency tree (actix-*, brotli, zstd, cookie, h2, ...).

Also remove unused dependencies.