### PR TITLE
refactor: make KeyPackage::into_unchecked infallible

### DIFF
--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -216,7 +216,7 @@ impl KeyPackageIn {
     ///
     /// The caller must guarantee that the key package is verified.
     #[cfg(feature = "unchecked-conversions")]
-    pub fn into_unchecked(self) -> Result<KeyPackage, KeyPackageVerifyError> {
+    pub fn into_unchecked(self) -> KeyPackage {
         let payload = KeyPackageTbs {
             protocol_version: self.payload.protocol_version,
             ciphersuite: self.payload.ciphersuite,
@@ -224,11 +224,11 @@ impl KeyPackageIn {
             leaf_node: self.payload.leaf_node.into_unchecked(),
             extensions: self.payload.extensions.into_unchecked(),
         };
-        Ok(KeyPackage {
+        KeyPackage {
             payload,
             signature: self.signature,
             serialized_payload: None,
-        })
+        }
     }
 }
 


### PR DESCRIPTION
The function should have been infallible from the beginning. This is a remnant from #2045.