### PR TITLE
docs: remove legacy MlsGroup::new doc comment

### DIFF
--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -39,9 +39,6 @@ impl MlsGroup {
 
     /// Creates a new group with the creator as the only member (and a random
     /// group ID).
-    ///
-    /// This function removes the private key corresponding to the
-    /// `key_package` from the key store.
     pub fn new<Provider: OpenMlsProvider>(
         provider: &Provider,
         signer: &impl Signer,


### PR DESCRIPTION
## Problem 

The doc comment on `MlsGroup::new` incorrectly mentions that private keys are deleted from store when creating a new `MlsGroup`. This appears to be a left over comment from before #1177 when `MlsGroup` required KeyPackages during initialization. 

As this is a high level entry point - this doc comment is used by developers use during debugging. In many cases this is even displayed within IDEs. Having incorrect information adds friction for developers

## Solution

Remove the doc comment as it's no longer correct.