### PR TITLE
VC KeyPackage handling

### DIFF
--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -265,6 +265,10 @@ const VC_EMULATION_EPOCH_STATE_LABEL: &[u8] = b"VcEmulationEpochState";
 const VC_EMULATION_BINDING_LABEL: &[u8] = b"VcEmulationBinding";
 #[cfg(feature = "virtual-clients-draft")]
 const VC_OPERATION_TREE_LABEL: &[u8] = b"VcOperationTree";
+#[cfg(feature = "virtual-clients-draft")]
+const RETAINED_KEY_PACKAGE_MATERIAL_LABEL: &[u8] = b"RetainedKeyPackageMaterial";
+#[cfg(feature = "virtual-clients-draft")]
+const RETAINED_KEY_PACKAGE_EPOCH_LABEL: &[u8] = b"RetainedKeyPackageEpoch";
 const INTERIM_TRANSCRIPT_HASH_LABEL: &[u8] = b"InterimTranscriptHash";
 const CONFIRMATION_TAG_LABEL: &[u8] = b"ConfirmationTag";
 
@@ -613,6 +617,12 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         &self,
         hash_ref: &KeyPackageRef,
     ) -> Result<(), Self::Error> {
+        #[cfg(feature = "virtual-clients-draft")]
+        {
+            let serialized_ref = serde_json::to_vec(&hash_ref)?;
+            self.delete::<CURRENT_VERSION>(RETAINED_KEY_PACKAGE_MATERIAL_LABEL, &serialized_ref)?;
+            self.delete::<CURRENT_VERSION>(RETAINED_KEY_PACKAGE_EPOCH_LABEL, &serialized_ref)?;
+        }
         self.delete::<CURRENT_VERSION>(KEY_PACKAGE_LABEL, &serde_json::to_vec(&hash_ref)?)
     }
 
@@ -1066,13 +1076,29 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
     }
 
     #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_emulation_state<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
+    fn delete_vc_emulation_state_if_unreferenced<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
         &self,
         epoch_id: &EpochId,
-    ) -> Result<(), Self::Error> {
-        let serialized_epoch_id = serde_json::to_vec(epoch_id).unwrap();
-        self.delete::<CURRENT_VERSION>(VC_EMULATION_EPOCH_STATE_LABEL, &serialized_epoch_id)?;
-        self.delete::<CURRENT_VERSION>(VC_OPERATION_TREE_LABEL, &serialized_epoch_id)
+    ) -> Result<bool, Self::Error> {
+        let serialized_epoch_id = serde_json::to_vec(epoch_id)?;
+        // Hold the write lock across the liveness check and the deletion so a
+        // material stored concurrently cannot be orphaned.
+        let mut values = self.values.write().unwrap();
+        let referenced = values
+            .iter()
+            .any(|(key, value)| is_epoch_tag(key) && value == &serialized_epoch_id);
+        if referenced {
+            return Ok(false);
+        }
+        let state_key = build_key_from_vec::<CURRENT_VERSION>(
+            VC_EMULATION_EPOCH_STATE_LABEL,
+            serialized_epoch_id.clone(),
+        );
+        let tree_key =
+            build_key_from_vec::<CURRENT_VERSION>(VC_OPERATION_TREE_LABEL, serialized_epoch_id);
+        values.remove(&state_key);
+        values.remove(&tree_key);
+        Ok(true)
     }
 
     #[cfg(feature = "virtual-clients-draft")]
@@ -1149,6 +1175,88 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         };
         Ok(serde_json::from_slice(value).unwrap())
     }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn write_retained_key_package_material_batch<
+        EpochId: traits::VcEpochId<CURRENT_VERSION>,
+        VcOperationTree: traits::VcOperationTree<CURRENT_VERSION>,
+        KeyPackageRef: traits::HashReference<CURRENT_VERSION>,
+        RetainedKeyPackageMaterial: traits::RetainedKeyPackageMaterial<CURRENT_VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+        operation_tree: &VcOperationTree,
+        materials: &[(KeyPackageRef, RetainedKeyPackageMaterial)],
+    ) -> Result<(), Self::Error> {
+        let serialized_epoch_id = serde_json::to_vec(epoch_id)?;
+        // Take the write lock once so the advanced tree and all materials are
+        // written together. A reader cannot observe an advanced tree without
+        // the materials it produced.
+        let mut values = self.values.write().unwrap();
+        let tree_key = build_key_from_vec::<CURRENT_VERSION>(
+            VC_OPERATION_TREE_LABEL,
+            serialized_epoch_id.clone(),
+        );
+        values.insert(tree_key, serde_json::to_vec(operation_tree)?);
+        for (hash_ref, record) in materials {
+            let serialized_ref = serde_json::to_vec(hash_ref)?;
+            let material_key = build_key_from_vec::<CURRENT_VERSION>(
+                RETAINED_KEY_PACKAGE_MATERIAL_LABEL,
+                serialized_ref.clone(),
+            );
+            values.insert(material_key, serde_json::to_vec(record)?);
+            let epoch_tag_key = build_key_from_vec::<CURRENT_VERSION>(
+                RETAINED_KEY_PACKAGE_EPOCH_LABEL,
+                serialized_ref,
+            );
+            values.insert(epoch_tag_key, serialized_epoch_id.clone());
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn retained_key_package_material<
+        KeyPackageRef: traits::HashReference<CURRENT_VERSION>,
+        RetainedKeyPackageMaterial: traits::RetainedKeyPackageMaterial<CURRENT_VERSION>,
+    >(
+        &self,
+        hash_ref: &KeyPackageRef,
+    ) -> Result<Option<RetainedKeyPackageMaterial>, Self::Error> {
+        let values = self.values.read().unwrap();
+        let key = build_key::<CURRENT_VERSION, &KeyPackageRef>(
+            RETAINED_KEY_PACKAGE_MATERIAL_LABEL,
+            hash_ref,
+        );
+        let Some(value) = values.get(&key) else {
+            return Ok(None);
+        };
+        Ok(serde_json::from_slice(value).unwrap())
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_retained_key_package_material_for_epoch<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error> {
+        let serialized_epoch_id = serde_json::to_vec(epoch_id)?;
+        let values = self.values.read().unwrap();
+        let referenced = values
+            .iter()
+            .any(|(key, value)| is_epoch_tag(key) && value == &serialized_epoch_id);
+        Ok(referenced)
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn delete_retained_key_package_material<
+        KeyPackageRef: traits::HashReference<CURRENT_VERSION>,
+    >(
+        &self,
+        hash_ref: &KeyPackageRef,
+    ) -> Result<(), Self::Error> {
+        let serialized_ref = serde_json::to_vec(hash_ref)?;
+        self.delete::<CURRENT_VERSION>(RETAINED_KEY_PACKAGE_MATERIAL_LABEL, &serialized_ref)?;
+        self.delete::<CURRENT_VERSION>(RETAINED_KEY_PACKAGE_EPOCH_LABEL, &serialized_ref)
+    }
 }
 
 /// Build a key with version and label.
@@ -1157,6 +1265,12 @@ fn build_key_from_vec<const V: u16>(label: &[u8], key: Vec<u8>) -> Vec<u8> {
     key_out.extend_from_slice(&key);
     key_out.extend_from_slice(&u16::to_be_bytes(V));
     key_out
+}
+
+/// Whether a storage key belongs to a retained-KeyPackage epoch tag entry.
+#[cfg(feature = "virtual-clients-draft")]
+fn is_epoch_tag(storage_key: &[u8]) -> bool {
+    storage_key.starts_with(RETAINED_KEY_PACKAGE_EPOCH_LABEL)
 }
 
 /// Build a key with version and label.

--- a/memory_storage/src/test_store.rs
+++ b/memory_storage/src/test_store.rs
@@ -587,10 +587,10 @@ impl StorageProvider<V_TEST> for MemoryStorage {
     }
 
     #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_emulation_state<EpochId: traits::VcEpochId<V_TEST>>(
+    fn delete_vc_emulation_state_if_unreferenced<EpochId: traits::VcEpochId<V_TEST>>(
         &self,
         _epoch_id: &EpochId,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<bool, Self::Error> {
         todo!()
     }
 
@@ -645,6 +645,48 @@ impl StorageProvider<V_TEST> for MemoryStorage {
         &self,
         _epoch_id: &EpochId,
     ) -> Result<Option<VcOperationTree>, Self::Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn write_retained_key_package_material_batch<
+        EpochId: traits::VcEpochId<V_TEST>,
+        VcOperationTree: traits::VcOperationTree<V_TEST>,
+        KeyPackageRef: traits::HashReference<V_TEST>,
+        RetainedKeyPackageMaterial: traits::RetainedKeyPackageMaterial<V_TEST>,
+    >(
+        &self,
+        _epoch_id: &EpochId,
+        _operation_tree: &VcOperationTree,
+        _materials: &[(KeyPackageRef, RetainedKeyPackageMaterial)],
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn retained_key_package_material<
+        KeyPackageRef: traits::HashReference<V_TEST>,
+        RetainedKeyPackageMaterial: traits::RetainedKeyPackageMaterial<V_TEST>,
+    >(
+        &self,
+        _hash_ref: &KeyPackageRef,
+    ) -> Result<Option<RetainedKeyPackageMaterial>, Self::Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_retained_key_package_material_for_epoch<EpochId: traits::VcEpochId<V_TEST>>(
+        &self,
+        _epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn delete_retained_key_package_material<KeyPackageRef: traits::HashReference<V_TEST>>(
+        &self,
+        _hash_ref: &KeyPackageRef,
+    ) -> Result<(), Self::Error> {
         todo!()
     }
 }

--- a/memory_storage/tests/vc_operation_tree.rs
+++ b/memory_storage/tests/vc_operation_tree.rs
@@ -18,6 +18,96 @@ struct TestOperationTree(Vec<u8>);
 impl traits::VcOperationTree<CURRENT_VERSION> for TestOperationTree {}
 impl Entity<CURRENT_VERSION> for TestOperationTree {}
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestKeyPackageRef(Vec<u8>);
+impl traits::HashReference<CURRENT_VERSION> for TestKeyPackageRef {}
+impl Key<CURRENT_VERSION> for TestKeyPackageRef {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestRetainedMaterial(Vec<u8>);
+impl traits::RetainedKeyPackageMaterial<CURRENT_VERSION> for TestRetainedMaterial {}
+impl Entity<CURRENT_VERSION> for TestRetainedMaterial {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestEmulationState(Vec<u8>);
+impl traits::VcEmulationEpochState<CURRENT_VERSION> for TestEmulationState {}
+impl Entity<CURRENT_VERSION> for TestEmulationState {}
+
+/// A batch write stores the operation tree and the retained material, the
+/// material ties the epoch into liveness, and the guarded delete keeps the
+/// epoch state while material references it but removes it afterwards.
+#[test]
+fn batch_write_ties_retained_material_into_epoch_liveness() {
+    let storage = MemoryStorage::default();
+    let epoch_id = TestEpochId(b"LiveEpoch".to_vec());
+    let other_epoch_id = TestEpochId(b"OtherEpoch".to_vec());
+    let kp_ref = TestKeyPackageRef(b"kp-ref".to_vec());
+
+    // Register the emulation epoch state so the guarded delete has something to
+    // remove. The operation tree is written by the batch below.
+    storage
+        .write_vc_emulation_epoch_state(&epoch_id, &TestEmulationState(b"state".to_vec()))
+        .unwrap();
+
+    // No retained material yet.
+    assert!(!storage
+        .has_retained_key_package_material_for_epoch(&epoch_id)
+        .unwrap());
+
+    let tree = TestOperationTree(b"AdvancedTree".to_vec());
+    let material = TestRetainedMaterial(b"material".to_vec());
+    storage
+        .write_retained_key_package_material_batch(
+            &epoch_id,
+            &tree,
+            &[(kp_ref.clone(), material.clone())],
+        )
+        .unwrap();
+
+    // The batch wrote both the tree and the material.
+    let read_tree: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert_eq!(read_tree, Some(tree));
+    let read_material: Option<TestRetainedMaterial> =
+        storage.retained_key_package_material(&kp_ref).unwrap();
+    assert_eq!(read_material, Some(material));
+
+    // The epoch is now referenced, a different epoch is not.
+    assert!(storage
+        .has_retained_key_package_material_for_epoch(&epoch_id)
+        .unwrap());
+    assert!(!storage
+        .has_retained_key_package_material_for_epoch(&other_epoch_id)
+        .unwrap());
+
+    // While material references the epoch the guarded delete is a no-op and the
+    // epoch state and tree stay readable.
+    assert!(!storage
+        .delete_vc_emulation_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestEmulationState> =
+        storage.vc_emulation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_some());
+    let read_tree: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert!(read_tree.is_some());
+
+    // After deleting the material the epoch is unreferenced, so the guarded
+    // delete removes both the epoch state and the operation tree.
+    storage
+        .delete_retained_key_package_material(&kp_ref)
+        .unwrap();
+    assert!(!storage
+        .has_retained_key_package_material_for_epoch(&epoch_id)
+        .unwrap());
+    assert!(storage
+        .delete_vc_emulation_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestEmulationState> =
+        storage.vc_emulation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_none());
+    let read_tree: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert!(read_tree.is_none());
+}
+
 /// Write, read back, overwrite, and delete an operation secret tree.
 #[test]
 fn operation_tree_read_write_delete() {
@@ -48,8 +138,12 @@ fn operation_tree_read_write_delete() {
     let read: Option<TestOperationTree> = storage.vc_operation_tree(&other_epoch_id).unwrap();
     assert_eq!(read, None);
 
-    // Deleting the emulation state removes the operation tree too.
-    storage.delete_vc_emulation_state(&epoch_id).unwrap();
+    // Deleting the emulation state removes the operation tree too. No retained
+    // material references this epoch, so the deletion goes through.
+    let deleted = storage
+        .delete_vc_emulation_state_if_unreferenced(&epoch_id)
+        .unwrap();
+    assert!(deleted);
     let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
     assert_eq!(read, None);
 }

--- a/openmls/src/components/vc_derivation_info.rs
+++ b/openmls/src/components/vc_derivation_info.rs
@@ -1,6 +1,7 @@
 use openmls_traits::{
     crypto::OpenMlsCrypto,
     types::{Ciphersuite, CryptoError},
+    OpenMlsProvider,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -10,7 +11,7 @@ use tls_codec::{
 
 use crate::{
     binary_tree::{array_representation::TreeSize, LeafNodeIndex},
-    ciphersuite::Secret,
+    ciphersuite::{hash_ref::KeyPackageRef, Secret},
     messages::PathSecret,
     treesync::node::encryption_keys::EncryptionKeyPair,
 };
@@ -23,14 +24,20 @@ use crate::{
 pub const VC_COMPONENT_ID: u16 = 0x0006;
 
 // Operation-secret child labels. Each child is derived from the per-operation
-// secret produced by the per-epoch operation secret tree. Only
-// `Encryption Key` and `Path Generation` are wired up at the moment, which is
-// all the `leaf_node` commit path needs. The spec also defines
-// `Signature Key` and `Init Key` children. Those, together with the
-// `key_package` and `application` operation paths that consume them, are
-// deferred to a follow-up PR.
+// secret produced by the per-epoch operation secret tree. `Encryption Key`
+// and `Path Generation` cover the `leaf_node` commit path, and `Init Key`
+// covers the `key_package` operation path. The spec also defines a
+// `Signature Key` child, which together with the operation paths that consume
+// it is deferred to a follow-up PR.
 const ENCRYPTION_KEY_LABEL: &str = "Encryption Key";
 const PATH_GENERATION_LABEL: &str = "Path Generation";
+const INIT_KEY_LABEL: &str = "Init Key";
+/// `ExpandWithLabel` label for the per-KeyPackage seed secret derived from a
+/// `key_package` operation secret (mls-virtual-clients draft, batch KeyPackage
+/// derivation). One operation secret covers a batch of KeyPackages, and each
+/// KeyPackage's seed is expanded from it using the KeyPackage's index as the
+/// context.
+const KEY_PACKAGE_SEED_LABEL: &str = "key package seed";
 
 /// `ExpandWithLabel` label for the [`DerivationInfoTbe`] AEAD key derived
 /// from the per-epoch [`EpochEncryptionKey`].
@@ -124,6 +131,14 @@ pub enum VirtualClientsError {
     /// implementation.
     #[error("An unrecoverable error has occurred due to a bug in the implementation.")]
     LibraryError,
+    /// The `KeyPackageUpload` lists the same `key_package_index` more than
+    /// once. Each batch index must appear at most once.
+    #[error("KeyPackageUpload contains a duplicate key_package_index: {0}.")]
+    DuplicateKeyPackageIndex(u32),
+    /// The `KeyPackageUpload` lists the same [`KeyPackageRef`] more than once.
+    /// Each KeyPackage reference must appear at most once.
+    #[error("KeyPackageUpload contains a duplicate KeyPackageRef.")]
+    DuplicateKeyPackageRef,
 }
 
 /// Per-emulation-epoch root secret. Sourced internally by
@@ -343,6 +358,7 @@ impl DerivationInfo {
         ciphersuite: Ciphersuite,
         key: &EpochEncryptionKey,
         leaf_encryption_key: &[u8],
+        operation_type: VirtualClientOperationType,
     ) -> Result<DerivationInfoTbe, VirtualClientsError> {
         let (aead_key, aead_nonce) =
             key.derive_key_nonce(crypto, ciphersuite, leaf_encryption_key)?;
@@ -358,7 +374,7 @@ impl DerivationInfo {
                 log::error!("vc: aead decrypt derivation info failed: {e:?}");
                 VirtualClientsError::DerivationInfoDecryptionFailed
             })?;
-        Ok(DerivationInfoTbe::tls_deserialize_exact_bytes(&plaintext)?)
+        DerivationInfoTbe::deserialize_for_operation(&plaintext, operation_type)
     }
 }
 
@@ -372,6 +388,264 @@ impl DerivationInfo {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
 )]
 pub struct EpochId(VLBytes);
+
+/// Wire struct a virtual client hands to a sibling so the sibling can fetch
+/// and process the matching KeyPackage (mls-virtual-clients draft):
+///
+/// ```text
+/// struct {
+///   opaque key_package_ref<V>;
+///   uint32 key_package_index;
+/// } KeyPackageInfo
+/// ```
+///
+/// `key_package_ref` is the [`KeyPackageRef`] (a [`HashReference`]) of the
+/// KeyPackage built by [`KeyPackageBuilder::build_vc_batch`]. `key_package_index`
+/// is the KeyPackage's position within the `key_package` operation batch: one
+/// operation secret covers the whole batch and each KeyPackage's seed is
+/// derived from it under this index.
+///
+/// [`HashReference`]: crate::ciphersuite::hash_ref::HashReference
+/// [`KeyPackageBuilder::build_vc_batch`]: crate::key_packages::KeyPackageBuilder::build_vc_batch
+#[derive(Debug, TlsSize, TlsSerialize, TlsDeserializeBytes)]
+pub struct KeyPackageInfo {
+    /// Hash reference of the virtual client's KeyPackage.
+    pub key_package_ref: KeyPackageRef,
+    /// Position of this KeyPackage within the operation batch.
+    pub key_package_index: u32,
+}
+
+/// Wire struct a virtual client uploads to a sibling so the sibling learns
+/// about the KeyPackages the virtual client published for an emulation epoch
+/// (mls-virtual-clients draft):
+///
+/// ```text
+/// struct {
+///   opaque epoch_id<V>;
+///   uint32 leaf_index;
+///   uint32 generation;
+///   KeyPackageInfo key_package_info<V>;
+/// } KeyPackageUpload
+/// ```
+///
+/// `epoch_id` identifies the emulation epoch the KeyPackages belong to.
+/// `leaf_index` is the uploading client's emulation-group leaf index at that
+/// epoch. The receiver stores this leaf index: the KeyPackage operation
+/// secret was allocated from the uploader's per-leaf ratchet, so a sibling
+/// rederiving the KeyPackage material must walk that same leaf's ratchet, not
+/// its own. `generation` is the single `key_package` operation generation
+/// consumed for the whole batch. `key_package_info` carries one
+/// [`KeyPackageInfo`] per uploaded KeyPackage, each with its index within the
+/// batch.
+#[derive(Debug, TlsSize, TlsSerialize, TlsDeserializeBytes)]
+pub struct KeyPackageUpload {
+    /// Emulation epoch the uploaded KeyPackages belong to.
+    pub epoch_id: EpochId,
+    /// Uploading client's emulation-group leaf index at that epoch.
+    pub leaf_index: LeafNodeIndex,
+    /// Operation-ratchet generation consumed for the whole batch.
+    pub generation: u32,
+    /// One entry per uploaded KeyPackage.
+    pub key_package_info: Vec<KeyPackageInfo>,
+}
+
+/// Per-`KeyPackageRef` material a sibling retains when it processes a
+/// [`KeyPackageUpload`]. It captures what the Welcome path needs to later
+/// rederive the KeyPackage's init and leaf-encryption keys without touching
+/// the operation tree: the per-KeyPackage seed secret, plus the emulation
+/// epoch, leaf index, generation, and batch index used to validate the leaf
+/// found in the ratchet tree.
+///
+/// The seed is pinned here at upload-processing time so the Welcome path stays
+/// independent of the operation tree's bounded out-of-order tolerance: a batch
+/// can hold more KeyPackages than that tolerance, and Welcomes can arrive in
+/// any order, yet every seed remains available because the single batch
+/// generation is consumed once and each seed is stored alongside its index.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RetainedKeyPackageMaterial {
+    /// Emulation epoch the KeyPackage belongs to.
+    pub epoch_id: EpochId,
+    /// Uploader's emulation-group leaf index, identifying the operation
+    /// ratchet the batch generation was allocated from.
+    pub leaf_index: LeafNodeIndex,
+    /// Operation-ratchet generation consumed for the whole batch.
+    pub generation: u32,
+    /// Position of this KeyPackage within the batch.
+    pub key_package_index: u32,
+    /// Per-KeyPackage seed secret from which the init and leaf-encryption keys
+    /// are derived at Welcome time.
+    pub key_package_seed_secret: KeyPackageSeedSecret,
+}
+
+/// Reject a batch whose [`KeyPackageInfo`] entries are not all distinct.
+///
+/// Returns [`VirtualClientsError::DuplicateKeyPackageIndex`] if any
+/// `key_package_index` repeats, and
+/// [`VirtualClientsError::DuplicateKeyPackageRef`] if any `key_package_ref`
+/// repeats. A duplicate index would map two KeyPackages onto the same
+/// per-index seed, and a duplicate reference would have the second upload
+/// entry overwrite the first's retained material, so both are rejected before
+/// any state is loaded or any operation generation is consumed.
+fn validate_key_package_infos(infos: &[KeyPackageInfo]) -> Result<(), VirtualClientsError> {
+    let mut seen_indices = std::collections::BTreeSet::new();
+    let mut seen_refs = std::collections::BTreeSet::new();
+    for info in infos {
+        if !seen_indices.insert(info.key_package_index) {
+            return Err(VirtualClientsError::DuplicateKeyPackageIndex(
+                info.key_package_index,
+            ));
+        }
+        if !seen_refs.insert(&info.key_package_ref) {
+            return Err(VirtualClientsError::DuplicateKeyPackageRef);
+        }
+    }
+    Ok(())
+}
+
+/// Build a [`KeyPackageUpload`] for `epoch_id` from a batch's `generation` and
+/// its [`KeyPackageInfo`] entries, filling `leaf_index` from the
+/// [`EmulationEpochState`] stored for that epoch.
+///
+/// The virtual client calls this after building a batch of KeyPackages with
+/// [`KeyPackageBuilder::build_vc_batch`] to assemble the message it hands to
+/// its sibling. `generation` is the single `key_package` operation generation
+/// the batch consumed.
+///
+/// Returns [`VirtualClientsError::MissingEmulationEpochState`] if no state is
+/// registered for `epoch_id`.
+///
+/// [`KeyPackageBuilder::build_vc_batch`]: crate::key_packages::KeyPackageBuilder::build_vc_batch
+pub fn assemble_vc_key_package_upload<Storage: crate::storage::StorageProvider>(
+    storage: &Storage,
+    epoch_id: EpochId,
+    generation: u32,
+    key_package_info: Vec<KeyPackageInfo>,
+) -> Result<KeyPackageUpload, VirtualClientsError> {
+    validate_key_package_infos(&key_package_info)?;
+    let state: EmulationEpochState = storage
+        .vc_emulation_epoch_state(&epoch_id)
+        .map_err(|e| {
+            log::error!("vc: load emulation epoch state in assemble upload failed: {e:?}");
+            VirtualClientsError::StorageError
+        })?
+        .ok_or(VirtualClientsError::MissingEmulationEpochState)?;
+    Ok(KeyPackageUpload {
+        epoch_id,
+        leaf_index: state.leaf_index,
+        generation,
+        key_package_info,
+    })
+}
+
+/// Process a [`KeyPackageUpload`] received from a sibling virtual client.
+///
+/// Derives the batch's single `key_package` operation secret once from the
+/// uploader's leaf ratchet at `(epoch_id, leaf_index, generation)`, then
+/// stores the advanced operation tree and one [`RetainedKeyPackageMaterial`]
+/// per [`KeyPackageInfo`] (keyed by the info's [`KeyPackageRef`]) in a single
+/// atomic batch write.
+///
+/// The operation secret and the per-index seeds are derived under the
+/// emulation ciphersuite (the operation tree's ciphersuite). The init and
+/// leaf-encryption keys are later derived from each seed under the KeyPackage's
+/// own ciphersuite at Welcome time. The operation secret is dropped once all
+/// seeds are derived. The batch generation is consumed in the tree exactly
+/// once.
+pub fn process_vc_key_package_upload<Provider: OpenMlsProvider>(
+    provider: &Provider,
+    upload: &KeyPackageUpload,
+) -> Result<(), VirtualClientsError> {
+    use crate::components::vc_operation_tree::OperationSecretTree;
+    use openmls_traits::storage::StorageProvider as _;
+
+    validate_key_package_infos(&upload.key_package_info)?;
+
+    let storage = provider.storage();
+    let crypto = provider.crypto();
+
+    let state: EmulationEpochState = storage
+        .vc_emulation_epoch_state(&upload.epoch_id)
+        .map_err(|e| {
+            log::error!("vc: load emulation epoch state in process upload failed: {e:?}");
+            VirtualClientsError::StorageError
+        })?
+        .ok_or(VirtualClientsError::MissingEmulationEpochState)?;
+    let mut operation_tree: OperationSecretTree = storage
+        .vc_operation_tree(&upload.epoch_id)
+        .map_err(|e| {
+            log::error!("vc: load operation tree in process upload failed: {e:?}");
+            VirtualClientsError::StorageError
+        })?
+        .ok_or(VirtualClientsError::MissingOperationTree)?;
+    let emulation_ciphersuite = state.emulation_ciphersuite;
+
+    // The KeyPackage operation context is empty, matching `build_vc_batch`.
+    let operation_secret = operation_tree.derive_operation_secret(
+        crypto,
+        emulation_ciphersuite,
+        &upload.epoch_id,
+        upload.leaf_index,
+        VirtualClientOperationType::KeyPackage,
+        upload.generation,
+        b"",
+    )?;
+
+    let mut materials = Vec::with_capacity(upload.key_package_info.len());
+    for info in &upload.key_package_info {
+        let key_package_seed_secret = operation_secret.derive_key_package_seed_secret(
+            crypto,
+            emulation_ciphersuite,
+            info.key_package_index,
+        )?;
+        let material = RetainedKeyPackageMaterial {
+            epoch_id: upload.epoch_id.clone(),
+            leaf_index: upload.leaf_index,
+            generation: upload.generation,
+            key_package_index: info.key_package_index,
+            key_package_seed_secret,
+        };
+        materials.push((info.key_package_ref.clone(), material));
+    }
+
+    storage
+        .write_retained_key_package_material_batch(&upload.epoch_id, &operation_tree, &materials)
+        .map_err(|e| {
+            log::error!("vc: persist batch key package material in process upload failed: {e:?}");
+            VirtualClientsError::StorageError
+        })?;
+    Ok(())
+}
+
+/// Material a sibling emulator derives to join a higher-level group via a
+/// virtual client's KeyPackage.
+///
+/// Carried from the first Welcome stage (where the init private key decrypts
+/// the group secrets, before the ratchet tree is available) into staging
+/// (where the derived `encryption_keypair` becomes the joiner's leaf keypair
+/// and the recorded `(epoch_id, leaf_index, generation, key_package_index)`
+/// validate the leaf found in the tree). The keys are derived from the
+/// per-KeyPackage seed pinned in [`RetainedKeyPackageMaterial`], not by
+/// re-walking the operation tree.
+#[derive(Debug)]
+pub(crate) struct VcWelcomeMaterial {
+    /// The [`KeyPackageRef`] the welcome's encrypted group secrets addressed.
+    pub(crate) key_package_ref: KeyPackageRef,
+    /// Emulation epoch the KeyPackage belongs to.
+    pub(crate) epoch_id: EpochId,
+    /// Uploader's emulation-group leaf index, identifying the operation
+    /// ratchet the batch generation was allocated from.
+    pub(crate) leaf_index: LeafNodeIndex,
+    /// Operation-ratchet generation consumed for the whole batch.
+    pub(crate) generation: u32,
+    /// Position of this KeyPackage within the batch.
+    pub(crate) key_package_index: u32,
+    /// Init private key derived from the seed, used to decrypt the encrypted
+    /// group secrets.
+    pub(crate) init_private_key: openmls_traits::types::HpkePrivateKey,
+    /// Leaf encryption keypair derived from the seed, used as the joiner's
+    /// leaf keypair.
+    pub(crate) encryption_keypair: EncryptionKeyPair,
+}
 
 /// Per-higher-level-group record of which emulation-group epoch produced the
 /// virtual-client LeafNode that was active at each recent epoch of that
@@ -594,6 +868,91 @@ impl OperationSecret {
                 .derive_secret(crypto, ciphersuite, PATH_GENERATION_LABEL)?;
         Ok(PathGenerationSecret(path_generation_secret))
     }
+
+    /// Derive the per-KeyPackage seed secret for the KeyPackage at
+    /// `key_package_index` within this operation's batch:
+    ///
+    /// ```text
+    /// key_package_seed_secret = ExpandWithLabel(operation_secret,
+    ///                                           "key package seed",
+    ///                                           KeyPackageSeedContext, Kdf.Nh)
+    /// ```
+    ///
+    /// The KeyPackage's init and leaf-encryption keys are then derived from the
+    /// returned [`KeyPackageSeedSecret`], not from the operation secret
+    /// directly, so a single `key_package` operation secret can cover a batch
+    /// of KeyPackages with distinct key material.
+    pub(crate) fn derive_key_package_seed_secret(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+        key_package_index: u32,
+    ) -> Result<KeyPackageSeedSecret, VirtualClientsError> {
+        let context = KeyPackageSeedContext { key_package_index }.tls_serialize_detached()?;
+        let seed = self.0.kdf_expand_label(
+            crypto,
+            ciphersuite,
+            KEY_PACKAGE_SEED_LABEL,
+            &context,
+            ciphersuite.hash_length(),
+        )?;
+        Ok(KeyPackageSeedSecret(seed))
+    }
+}
+
+/// `ExpandWithLabel` context for [`OperationSecret::derive_key_package_seed_secret`]
+/// (mls-virtual-clients draft):
+///
+/// ```text
+/// struct {
+///   uint32 key_package_index;
+/// } KeyPackageSeedContext
+/// ```
+///
+/// Only ever serialized as a derivation context, never parsed back, so it
+/// needs serialization only.
+#[derive(Debug, TlsSize, TlsSerialize)]
+struct KeyPackageSeedContext {
+    key_package_index: u32,
+}
+
+/// Per-KeyPackage seed secret from which a single KeyPackage's init and
+/// leaf-encryption keys are derived. Produced by
+/// `OperationSecret::derive_key_package_seed_secret` for one index within a
+/// `key_package` operation's batch. Persisted in [`RetainedKeyPackageMaterial`]
+/// so the Welcome path can rederive the keys without re-walking the operation
+/// tree.
+#[derive(Serialize, Deserialize)]
+pub struct KeyPackageSeedSecret(Secret);
+
+impl std::fmt::Debug for KeyPackageSeedSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KeyPackageSeedSecret")
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+impl KeyPackageSeedSecret {
+    pub(crate) fn derive_init_key_secret(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+    ) -> Result<InitKeySecret, VirtualClientsError> {
+        let init_key_secret = self.0.derive_secret(crypto, ciphersuite, INIT_KEY_LABEL)?;
+        Ok(InitKeySecret(init_key_secret))
+    }
+
+    pub(crate) fn derive_encryption_key_secret(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+    ) -> Result<EncryptionKeySecret, VirtualClientsError> {
+        let encryption_key_secret =
+            self.0
+                .derive_secret(crypto, ciphersuite, ENCRYPTION_KEY_LABEL)?;
+        Ok(EncryptionKeySecret(encryption_key_secret))
+    }
 }
 
 pub(crate) struct EncryptionKeySecret(Secret);
@@ -607,6 +966,20 @@ impl EncryptionKeySecret {
         let hpke_config = ciphersuite.hpke_config();
         let key_pair = crypto.derive_hpke_keypair(hpke_config, self.0.as_slice())?;
         Ok(EncryptionKeyPair::from(key_pair))
+    }
+}
+
+pub(crate) struct InitKeySecret(Secret);
+
+impl InitKeySecret {
+    pub(crate) fn generate_init_key_pair(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+        ciphersuite: Ciphersuite,
+    ) -> Result<openmls_traits::types::HpkeKeyPair, VirtualClientsError> {
+        let hpke_config = ciphersuite.hpke_config();
+        let key_pair = crypto.derive_hpke_keypair(hpke_config, self.0.as_slice())?;
+        Ok(key_pair)
     }
 }
 
@@ -652,26 +1025,380 @@ pub enum VirtualClientOperationType {
 /// struct {
 ///   uint32 leaf_index;
 ///   uint32 generation;
+///   select (LeafNode.leaf_node_source) {
+///     case key_package:  uint32 key_package_index;
+///     case update:
+///     case commit:       struct{};
+///   };
 /// } DerivationInfoTBE
 /// ```
 ///
 /// `leaf_index` is the *emulation*-group leaf index of the sending virtual
 /// client, *not* the leaf index in the group that carries this commit.
 /// `generation` is the operation-ratchet generation the sender consumed for
-/// this operation.
-#[derive(Debug, PartialEq, Eq, TlsSize, TlsSerialize, TlsDeserializeBytes)]
-pub(crate) struct DerivationInfoTbe {
-    pub leaf_index: LeafNodeIndex,
-    pub generation: u32,
+/// this operation. `key_package_index`, present only for the `KeyPackage`
+/// variant, is the KeyPackage's position within its `key_package` operation
+/// batch.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum DerivationInfoTbe {
+    /// Carried by `update` and `commit` leaves. No `key_package_index`.
+    LeafNode {
+        leaf_index: LeafNodeIndex,
+        generation: u32,
+    },
+    /// Carried by `key_package` leaves. Adds the position within the batch.
+    KeyPackage {
+        leaf_index: LeafNodeIndex,
+        generation: u32,
+        key_package_index: u32,
+    },
+}
+
+impl DerivationInfoTbe {
+    /// The emulation-group leaf index of the sending virtual client.
+    pub(crate) fn leaf_index(&self) -> LeafNodeIndex {
+        match self {
+            Self::LeafNode { leaf_index, .. } | Self::KeyPackage { leaf_index, .. } => *leaf_index,
+        }
+    }
+
+    /// The operation-ratchet generation the sender consumed.
+    pub(crate) fn generation(&self) -> u32 {
+        match self {
+            Self::LeafNode { generation, .. } | Self::KeyPackage { generation, .. } => *generation,
+        }
+    }
+
+    /// Serialize the variant's fields in order, with no variant tag, matching
+    /// the `DerivationInfoTBE` select. The TLS derive macros cannot express a
+    /// tagless select, so this codec is written by hand.
+    fn tls_serialize_detached(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        let mut out = Vec::new();
+        match self {
+            Self::LeafNode {
+                leaf_index,
+                generation,
+            } => {
+                leaf_index.tls_serialize(&mut out)?;
+                generation.tls_serialize(&mut out)?;
+            }
+            Self::KeyPackage {
+                leaf_index,
+                generation,
+                key_package_index,
+            } => {
+                leaf_index.tls_serialize(&mut out)?;
+                generation.tls_serialize(&mut out)?;
+                key_package_index.tls_serialize(&mut out)?;
+            }
+        }
+        Ok(out)
+    }
+
+    /// Deserialize the tagless select for the given operation type. The
+    /// operation type stands in for the carrying leaf's `leaf_node_source`:
+    /// [`KeyPackage`](VirtualClientOperationType::KeyPackage) parses the
+    /// `KeyPackage` variant, [`LeafNode`](VirtualClientOperationType::LeafNode)
+    /// the `LeafNode` variant. The plaintext must be consumed exactly.
+    fn deserialize_for_operation(
+        bytes: &[u8],
+        operation_type: VirtualClientOperationType,
+    ) -> Result<Self, VirtualClientsError> {
+        let (leaf_index, rest) = LeafNodeIndex::tls_deserialize_bytes(bytes)?;
+        let (generation, rest) = u32::tls_deserialize_bytes(rest)?;
+        let tbe = match operation_type {
+            VirtualClientOperationType::KeyPackage => {
+                let (key_package_index, rest) = u32::tls_deserialize_bytes(rest)?;
+                if !rest.is_empty() {
+                    return Err(VirtualClientsError::DerivationInfoMalformed);
+                }
+                Self::KeyPackage {
+                    leaf_index,
+                    generation,
+                    key_package_index,
+                }
+            }
+            VirtualClientOperationType::LeafNode => {
+                if !rest.is_empty() {
+                    return Err(VirtualClientsError::DerivationInfoMalformed);
+                }
+                Self::LeafNode {
+                    leaf_index,
+                    generation,
+                }
+            }
+            VirtualClientOperationType::Application => {
+                return Err(VirtualClientsError::DerivationInfoMalformed);
+            }
+        };
+        Ok(tbe)
+    }
+}
+
+/// Verify that the effective leaf about to carry a VC derivation-info entry
+/// declares `AppDataDictionary` and lists [`VC_COMPONENT_ID`] in its
+/// `AppComponents` entry, and return the resolved `AppDataDictionary`.
+///
+/// `caller_capabilities` and `caller_extensions` are the leaf parameters the
+/// caller supplied for this operation. `current_leaf` is the leaf being
+/// replaced, or `None` when there is none (a fresh KeyPackage, or an external
+/// commit). The caller's `AppDataDictionary` is merged over the current
+/// leaf's, with the caller winning on duplicate component ids, so injecting
+/// the VC derivation-info preserves the `AppComponents` entry across
+/// operations.
+pub(crate) fn resolve_vc_leaf_dictionary(
+    caller_capabilities: Option<&crate::treesync::node::leaf_node::Capabilities>,
+    caller_extensions: Option<
+        &crate::extensions::Extensions<crate::treesync::node::leaf_node::LeafNode>,
+    >,
+    current_leaf: Option<&crate::treesync::node::leaf_node::LeafNode>,
+) -> Result<crate::extensions::AppDataDictionary, VirtualClientsError> {
+    use crate::{
+        component::{ComponentId, ComponentType},
+        extensions::ExtensionType,
+    };
+    use tls_codec::DeserializeBytes as _;
+
+    let supports_app_data_dictionary = match caller_capabilities {
+        Some(c) => c.extensions().contains(&ExtensionType::AppDataDictionary),
+        None => current_leaf
+            .map(|leaf| {
+                leaf.capabilities()
+                    .extensions()
+                    .contains(&ExtensionType::AppDataDictionary)
+            })
+            .unwrap_or(false),
+    };
+    if !supports_app_data_dictionary {
+        return Err(VirtualClientsError::AppDataDictionaryNotSupported);
+    }
+
+    let mut resolved_dictionary = current_leaf
+        .and_then(|leaf| leaf.extensions().app_data_dictionary())
+        .map(|ext| ext.dictionary().clone())
+        .unwrap_or_default();
+    if let Some(caller_dict) = caller_extensions.and_then(|exts| exts.app_data_dictionary()) {
+        for entry in caller_dict.dictionary().entries() {
+            resolved_dictionary.insert(entry.id(), entry.data().to_vec());
+        }
+    }
+
+    let app_components_bytes = resolved_dictionary
+        .get(&ComponentId::from(ComponentType::AppComponents))
+        .map(<[u8]>::to_vec);
+    let Some(app_components_bytes) = app_components_bytes else {
+        return Err(VirtualClientsError::VcComponentNotListed);
+    };
+
+    // The AppComponents body is `ComponentID supported_components<V>`, i.e.
+    // a TLS-encoded variable-length vector of u16.
+    let supported_components = Vec::<u16>::tls_deserialize_exact_bytes(&app_components_bytes)
+        .map_err(|e| {
+            log::error!("vc: AppComponents body failed to deserialize: {e:?}");
+            VirtualClientsError::VcComponentNotListed
+        })?;
+    if !supported_components.contains(&VC_COMPONENT_ID) {
+        return Err(VirtualClientsError::VcComponentNotListed);
+    }
+
+    Ok(resolved_dictionary)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openmls_rust_crypto::OpenMlsRustCrypto;
-    use openmls_traits::{random::OpenMlsRand, OpenMlsProvider};
+    use openmls_rust_crypto::{MemoryStorage, OpenMlsRustCrypto};
+    use openmls_traits::{
+        random::OpenMlsRand,
+        storage::{StorageProvider, CURRENT_VERSION},
+        OpenMlsProvider,
+    };
 
     const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+    /// Register a full `EmulationEpochState` and a matching
+    /// `OperationSecretTree` for a fresh epoch, returning the derived
+    /// `EpochId` and the leaf index it was registered with.
+    fn register_epoch_state(provider: &OpenMlsRustCrypto, leaf_index: LeafNodeIndex) -> EpochId {
+        use crate::components::vc_operation_tree::OperationSecretTree;
+
+        let emulator = EmulatorEpochSecret::new(
+            &provider
+                .rand()
+                .random_vec(CIPHERSUITE.hash_length())
+                .expect("randomness"),
+        );
+        let epoch_id = emulator
+            .derive_epoch_id(provider.crypto(), CIPHERSUITE)
+            .expect("derive epoch id");
+        let epoch_encryption_key = emulator
+            .derive_epoch_encryption_key(provider.crypto(), CIPHERSUITE)
+            .expect("derive epoch encryption key");
+        let reuse_guard_secret = emulator
+            .derive_reuse_guard_secret(provider.crypto(), CIPHERSUITE)
+            .expect("derive reuse guard secret");
+        let generation_id_secret = emulator
+            .derive_generation_id_secret(provider.crypto(), CIPHERSUITE)
+            .expect("derive generation id secret");
+        let epoch_base_secret = emulator
+            .derive_epoch_base_secret(provider.crypto(), CIPHERSUITE)
+            .expect("derive epoch base secret");
+        let emulation_group_size = TreeSize::new(2);
+        let state = EmulationEpochState::new(
+            leaf_index,
+            epoch_encryption_key,
+            reuse_guard_secret,
+            generation_id_secret,
+            emulation_group_size,
+            CIPHERSUITE,
+        );
+        <MemoryStorage as StorageProvider<CURRENT_VERSION>>::write_vc_emulation_epoch_state(
+            provider.storage(),
+            &epoch_id,
+            &state,
+        )
+        .expect("write emulation epoch state");
+        let operation_tree = OperationSecretTree::new(epoch_base_secret, emulation_group_size);
+        <MemoryStorage as StorageProvider<CURRENT_VERSION>>::write_vc_operation_tree(
+            provider.storage(),
+            &epoch_id,
+            &operation_tree,
+        )
+        .expect("write operation tree");
+        epoch_id
+    }
+
+    /// The assembly helper fills `leaf_index` from the registered
+    /// `EmulationEpochState` for the epoch.
+    #[test]
+    fn assemble_upload_reads_leaf_index_from_state() {
+        let provider = OpenMlsRustCrypto::default();
+        let leaf_index = LeafNodeIndex::new(5);
+        let epoch_id = register_epoch_state(&provider, leaf_index);
+        let infos = vec![
+            KeyPackageInfo {
+                key_package_ref: KeyPackageRef::from_slice(b"kp-ref-a"),
+                key_package_index: 0,
+            },
+            KeyPackageInfo {
+                key_package_ref: KeyPackageRef::from_slice(b"kp-ref-b"),
+                key_package_index: 1,
+            },
+        ];
+
+        let upload = assemble_vc_key_package_upload(provider.storage(), epoch_id.clone(), 4, infos)
+            .expect("assemble upload");
+
+        assert_eq!(upload.epoch_id, epoch_id);
+        assert_eq!(upload.leaf_index, leaf_index);
+        assert_eq!(upload.generation, 4);
+        assert_eq!(upload.key_package_info.len(), 2);
+    }
+
+    /// Assembling for an unregistered epoch fails with
+    /// `MissingEmulationEpochState`.
+    #[test]
+    fn assemble_upload_without_state_fails() {
+        let provider = OpenMlsRustCrypto::default();
+        let epoch_id = EpochId(b"unregistered-epoch".to_vec().into());
+        let err = assemble_vc_key_package_upload(provider.storage(), epoch_id, 0, Vec::new())
+            .expect_err("assemble must fail without registered state");
+        assert_eq!(err, VirtualClientsError::MissingEmulationEpochState);
+    }
+
+    /// `process_vc_key_package_upload` stores one material entry per info,
+    /// readable back via `retained_key_package_material` keyed by the
+    /// KeyPackage reference, each carrying its own batch index.
+    #[test]
+    fn process_upload_stores_records() {
+        let provider = OpenMlsRustCrypto::default();
+        let leaf_index = LeafNodeIndex::new(0);
+        let epoch_id = register_epoch_state(&provider, leaf_index);
+        let ref_a = KeyPackageRef::from_slice(b"kp-ref-a");
+        let ref_b = KeyPackageRef::from_slice(b"kp-ref-b");
+        let upload = KeyPackageUpload {
+            epoch_id: epoch_id.clone(),
+            leaf_index,
+            generation: 0,
+            key_package_info: vec![
+                KeyPackageInfo {
+                    key_package_ref: ref_a.clone(),
+                    key_package_index: 0,
+                },
+                KeyPackageInfo {
+                    key_package_ref: ref_b.clone(),
+                    key_package_index: 1,
+                },
+            ],
+        };
+
+        process_vc_key_package_upload(&provider, &upload).expect("process upload");
+
+        let material_a: RetainedKeyPackageMaterial = <MemoryStorage as StorageProvider<
+            CURRENT_VERSION,
+        >>::retained_key_package_material(
+            provider.storage(), &ref_a
+        )
+        .expect("read material a")
+        .expect("material a present");
+        assert_eq!(material_a.epoch_id, epoch_id);
+        assert_eq!(material_a.leaf_index, leaf_index);
+        assert_eq!(material_a.generation, 0);
+        assert_eq!(material_a.key_package_index, 0);
+
+        let material_b: RetainedKeyPackageMaterial = <MemoryStorage as StorageProvider<
+            CURRENT_VERSION,
+        >>::retained_key_package_material(
+            provider.storage(), &ref_b
+        )
+        .expect("read material b")
+        .expect("material b present");
+        assert_eq!(material_b.epoch_id, epoch_id);
+        assert_eq!(material_b.leaf_index, leaf_index);
+        assert_eq!(material_b.generation, 0);
+        assert_eq!(material_b.key_package_index, 1);
+    }
+
+    /// `delete_key_package` removes the associated retained VC material.
+    #[test]
+    fn delete_key_package_removes_vc_record() {
+        let provider = OpenMlsRustCrypto::default();
+        let leaf_index = LeafNodeIndex::new(0);
+        let epoch_id = register_epoch_state(&provider, leaf_index);
+        let kp_ref = KeyPackageRef::from_slice(b"kp-ref");
+        let upload = KeyPackageUpload {
+            epoch_id,
+            leaf_index,
+            generation: 0,
+            key_package_info: vec![KeyPackageInfo {
+                key_package_ref: kp_ref.clone(),
+                key_package_index: 0,
+            }],
+        };
+        process_vc_key_package_upload(&provider, &upload).expect("process upload");
+
+        let present: Option<RetainedKeyPackageMaterial> = <MemoryStorage as StorageProvider<
+            CURRENT_VERSION,
+        >>::retained_key_package_material(
+            provider.storage(), &kp_ref
+        )
+        .expect("read material");
+        assert!(present.is_some());
+
+        <MemoryStorage as StorageProvider<CURRENT_VERSION>>::delete_key_package(
+            provider.storage(),
+            &kp_ref,
+        )
+        .expect("delete key package");
+
+        let after: Option<RetainedKeyPackageMaterial> = <MemoryStorage as StorageProvider<
+            CURRENT_VERSION,
+        >>::retained_key_package_material(
+            provider.storage(), &kp_ref
+        )
+        .expect("read material after delete");
+        assert!(after.is_none());
+    }
 
     fn setup_key_and_epoch_id(provider: &OpenMlsRustCrypto) -> (EpochEncryptionKey, EpochId) {
         let emulator = EmulatorEpochSecret::new(
@@ -689,32 +1416,62 @@ mod tests {
         (key, epoch_id)
     }
 
-    /// Round-trip a `DerivationInfoTbe` through `encrypt` and `decrypt`.
-    /// Catches any disagreement between the two methods on the derived
-    /// key/nonce, the AAD, or the TLS layout of the plaintext.
+    /// Round-trip both `DerivationInfoTbe` variants through `encrypt` and
+    /// `decrypt`. Catches any disagreement between the two methods on the
+    /// derived key/nonce, the AAD, or the tagless TLS layout of the
+    /// plaintext, and confirms each variant decodes only under its own
+    /// operation type.
     #[test]
     fn derivation_info_tbe_roundtrip() {
         let provider = OpenMlsRustCrypto::default();
         let (key, epoch_id) = setup_key_and_epoch_id(&provider);
         let leaf_encryption_key = provider.rand().random_vec(32).expect("randomness");
-        let original = DerivationInfoTbe {
+
+        let key_package_tbe = DerivationInfoTbe::KeyPackage {
+            leaf_index: LeafNodeIndex::new(7),
+            generation: 3,
+            key_package_index: 5,
+        };
+        let leaf_node_tbe = DerivationInfoTbe::LeafNode {
             leaf_index: LeafNodeIndex::new(7),
             generation: 3,
         };
-        let derivation_info = DerivationInfo::encrypt(
-            provider.crypto(),
-            CIPHERSUITE,
-            &key,
-            epoch_id.clone(),
-            &leaf_encryption_key,
-            &original,
-        )
-        .expect("encrypt");
-        assert_eq!(derivation_info.epoch_id(), &epoch_id);
-        let decrypted = derivation_info
-            .decrypt(provider.crypto(), CIPHERSUITE, &key, &leaf_encryption_key)
-            .expect("decrypt");
-        assert_eq!(original, decrypted);
+
+        // The leaf_node form omits the trailing key_package_index, so its
+        // plaintext is exactly four bytes shorter.
+        let key_package_bytes = key_package_tbe
+            .tls_serialize_detached()
+            .expect("serialize key package tbe");
+        let leaf_node_bytes = leaf_node_tbe
+            .tls_serialize_detached()
+            .expect("serialize leaf node tbe");
+        assert_eq!(key_package_bytes.len(), leaf_node_bytes.len() + 4);
+
+        for (original, operation_type) in [
+            (key_package_tbe, VirtualClientOperationType::KeyPackage),
+            (leaf_node_tbe, VirtualClientOperationType::LeafNode),
+        ] {
+            let derivation_info = DerivationInfo::encrypt(
+                provider.crypto(),
+                CIPHERSUITE,
+                &key,
+                epoch_id.clone(),
+                &leaf_encryption_key,
+                &original,
+            )
+            .expect("encrypt");
+            assert_eq!(derivation_info.epoch_id(), &epoch_id);
+            let decrypted = derivation_info
+                .decrypt(
+                    provider.crypto(),
+                    CIPHERSUITE,
+                    &key,
+                    &leaf_encryption_key,
+                    operation_type,
+                )
+                .expect("decrypt");
+            assert_eq!(original, decrypted);
+        }
     }
 
     /// Decryption must fail when the leaf encryption key used as the
@@ -726,7 +1483,7 @@ mod tests {
         let provider = OpenMlsRustCrypto::default();
         let (key, epoch_id) = setup_key_and_epoch_id(&provider);
         let leaf_encryption_key = provider.rand().random_vec(32).expect("randomness");
-        let tbe = DerivationInfoTbe {
+        let tbe = DerivationInfoTbe::LeafNode {
             leaf_index: LeafNodeIndex::new(1),
             generation: 0,
         };
@@ -746,8 +1503,185 @@ mod tests {
                 CIPHERSUITE,
                 &key,
                 &other_leaf_encryption_key,
+                VirtualClientOperationType::LeafNode,
             )
             .expect_err("decryption with the wrong context must fail");
         assert_eq!(err, VirtualClientsError::DerivationInfoDecryptionFailed);
+    }
+
+    /// The per-KeyPackage seed secret is deterministic for a given index,
+    /// distinct across indices, and the init and encryption keys derived from
+    /// one seed are separated from each other.
+    #[test]
+    fn key_package_seed_derivation_is_indexed_and_label_separated() {
+        let provider = OpenMlsRustCrypto::default();
+        let operation_secret = OperationSecret::from(Secret::from_slice(
+            &provider
+                .rand()
+                .random_vec(CIPHERSUITE.hash_length())
+                .expect("randomness"),
+        ));
+
+        let seed_zero = operation_secret
+            .derive_key_package_seed_secret(provider.crypto(), CIPHERSUITE, 0)
+            .expect("derive seed 0");
+        let seed_zero_again = operation_secret
+            .derive_key_package_seed_secret(provider.crypto(), CIPHERSUITE, 0)
+            .expect("derive seed 0 again");
+        let seed_one = operation_secret
+            .derive_key_package_seed_secret(provider.crypto(), CIPHERSUITE, 1)
+            .expect("derive seed 1");
+
+        let init_zero = seed_zero
+            .derive_init_key_secret(provider.crypto(), CIPHERSUITE)
+            .expect("derive init key 0")
+            .generate_init_key_pair(provider.crypto(), CIPHERSUITE)
+            .expect("generate init pair 0");
+        let init_zero_again = seed_zero_again
+            .derive_init_key_secret(provider.crypto(), CIPHERSUITE)
+            .expect("derive init key 0 again")
+            .generate_init_key_pair(provider.crypto(), CIPHERSUITE)
+            .expect("generate init pair 0 again");
+        let init_one = seed_one
+            .derive_init_key_secret(provider.crypto(), CIPHERSUITE)
+            .expect("derive init key 1")
+            .generate_init_key_pair(provider.crypto(), CIPHERSUITE)
+            .expect("generate init pair 1");
+
+        // Same index derives deterministically.
+        assert_eq!(init_zero.public, init_zero_again.public);
+        // Different indices derive distinct seeds, hence distinct init keys.
+        assert_ne!(init_zero.public, init_one.public);
+
+        // Init and encryption keys from one seed are label-separated.
+        let encryption_zero = seed_zero
+            .derive_encryption_key_secret(provider.crypto(), CIPHERSUITE)
+            .expect("derive encryption key 0")
+            .generate_encryption_key_pair(provider.crypto(), CIPHERSUITE)
+            .expect("generate encryption pair 0");
+        assert_ne!(
+            init_zero.public.as_slice(),
+            encryption_zero.public_key().as_slice()
+        );
+    }
+
+    /// A repeated `key_package_index` is rejected with
+    /// `DuplicateKeyPackageIndex` carrying the offending index.
+    #[test]
+    fn validate_rejects_duplicate_index() {
+        let infos = vec![
+            KeyPackageInfo {
+                key_package_ref: KeyPackageRef::from_slice(b"kp-ref-a"),
+                key_package_index: 2,
+            },
+            KeyPackageInfo {
+                key_package_ref: KeyPackageRef::from_slice(b"kp-ref-b"),
+                key_package_index: 2,
+            },
+        ];
+        let err = validate_key_package_infos(&infos).expect_err("duplicate index must be rejected");
+        assert_eq!(err, VirtualClientsError::DuplicateKeyPackageIndex(2));
+    }
+
+    /// A repeated `KeyPackageRef` is rejected with `DuplicateKeyPackageRef`.
+    #[test]
+    fn validate_rejects_duplicate_ref() {
+        let infos = vec![
+            KeyPackageInfo {
+                key_package_ref: KeyPackageRef::from_slice(b"kp-ref-a"),
+                key_package_index: 0,
+            },
+            KeyPackageInfo {
+                key_package_ref: KeyPackageRef::from_slice(b"kp-ref-a"),
+                key_package_index: 1,
+            },
+        ];
+        let err = validate_key_package_infos(&infos).expect_err("duplicate ref must be rejected");
+        assert_eq!(err, VirtualClientsError::DuplicateKeyPackageRef);
+    }
+
+    /// A batch with distinct indices and references passes validation.
+    #[test]
+    fn validate_accepts_distinct_infos() {
+        let infos = vec![
+            KeyPackageInfo {
+                key_package_ref: KeyPackageRef::from_slice(b"kp-ref-a"),
+                key_package_index: 0,
+            },
+            KeyPackageInfo {
+                key_package_ref: KeyPackageRef::from_slice(b"kp-ref-b"),
+                key_package_index: 1,
+            },
+        ];
+        validate_key_package_infos(&infos).expect("distinct infos must pass");
+    }
+
+    /// A malformed upload is rejected before the batch generation is consumed,
+    /// so a later valid upload reusing the same generation still succeeds and
+    /// stores its retained material.
+    #[test]
+    fn process_upload_rejects_malformed_without_consuming_generation() {
+        let provider = OpenMlsRustCrypto::default();
+        let leaf_index = LeafNodeIndex::new(0);
+        let epoch_id = register_epoch_state(&provider, leaf_index);
+        let ref_a = KeyPackageRef::from_slice(b"kp-ref-a");
+        let ref_b = KeyPackageRef::from_slice(b"kp-ref-b");
+
+        let malformed = KeyPackageUpload {
+            epoch_id: epoch_id.clone(),
+            leaf_index,
+            generation: 0,
+            key_package_info: vec![
+                KeyPackageInfo {
+                    key_package_ref: ref_a.clone(),
+                    key_package_index: 0,
+                },
+                KeyPackageInfo {
+                    key_package_ref: ref_b.clone(),
+                    key_package_index: 0,
+                },
+            ],
+        };
+        let err = process_vc_key_package_upload(&provider, &malformed)
+            .expect_err("malformed upload must be rejected");
+        assert_eq!(err, VirtualClientsError::DuplicateKeyPackageIndex(0));
+
+        let valid = KeyPackageUpload {
+            epoch_id: epoch_id.clone(),
+            leaf_index,
+            generation: 0,
+            key_package_info: vec![
+                KeyPackageInfo {
+                    key_package_ref: ref_a.clone(),
+                    key_package_index: 0,
+                },
+                KeyPackageInfo {
+                    key_package_ref: ref_b.clone(),
+                    key_package_index: 1,
+                },
+            ],
+        };
+        process_vc_key_package_upload(&provider, &valid)
+            .expect("valid upload reusing the same generation must succeed");
+
+        let material_a: RetainedKeyPackageMaterial = <MemoryStorage as StorageProvider<
+            CURRENT_VERSION,
+        >>::retained_key_package_material(
+            provider.storage(), &ref_a
+        )
+        .expect("read material a")
+        .expect("material a present");
+        assert_eq!(material_a.epoch_id, epoch_id);
+        assert_eq!(material_a.generation, 0);
+        assert_eq!(material_a.key_package_index, 0);
+
+        let material_b: RetainedKeyPackageMaterial = <MemoryStorage as StorageProvider<
+            CURRENT_VERSION,
+        >>::retained_key_package_material(
+            provider.storage(), &ref_b
+        )
+        .expect("read material b")
+        .expect("material b present");
+        assert_eq!(material_b.key_package_index, 1);
     }
 }

--- a/openmls/src/components/vc_derivation_info.rs
+++ b/openmls/src/components/vc_derivation_info.rs
@@ -6,7 +6,8 @@ use openmls_traits::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tls_codec::{
-    DeserializeBytes, Serialize as _, TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes,
+    DeserializeBytes, Serialize as _, Size as _, TlsDeserializeBytes, TlsSerialize, TlsSize,
+    VLBytes,
 };
 
 use crate::{
@@ -1073,26 +1074,34 @@ impl DerivationInfoTbe {
     /// the `DerivationInfoTBE` select. The TLS derive macros cannot express a
     /// tagless select, so this codec is written by hand.
     fn tls_serialize_detached(&self) -> Result<Vec<u8>, tls_codec::Error> {
-        let mut out = Vec::new();
         match self {
             Self::LeafNode {
                 leaf_index,
                 generation,
             } => {
+                let mut out = Vec::with_capacity(
+                    leaf_index.tls_serialized_len() + generation.tls_serialized_len(),
+                );
                 leaf_index.tls_serialize(&mut out)?;
                 generation.tls_serialize(&mut out)?;
+                Ok(out)
             }
             Self::KeyPackage {
                 leaf_index,
                 generation,
                 key_package_index,
             } => {
+                let mut out = Vec::with_capacity(
+                    leaf_index.tls_serialized_len()
+                        + generation.tls_serialized_len()
+                        + key_package_index.tls_serialized_len(),
+                );
                 leaf_index.tls_serialize(&mut out)?;
                 generation.tls_serialize(&mut out)?;
                 key_package_index.tls_serialize(&mut out)?;
+                Ok(out)
             }
         }
-        Ok(out)
     }
 
     /// Deserialize the tagless select for the given operation type. The

--- a/openmls/src/components/vc_derivation_info.rs
+++ b/openmls/src/components/vc_derivation_info.rs
@@ -1213,6 +1213,45 @@ pub(crate) fn resolve_vc_leaf_dictionary(
     Ok(resolved_dictionary)
 }
 
+/// Merge a virtual-clients derivation-info blob into `resolved_dictionary`
+/// under [`VC_COMPONENT_ID`] and build the resulting leaf-node extensions.
+///
+/// Every other component id in `resolved_dictionary` (notably `AppComponents`)
+/// is preserved, as is every non-`AppDataDictionary` extension the caller
+/// supplied in `caller_extensions`. The rebuilt dictionary replaces any
+/// `AppDataDictionary` entry already in that list.
+pub(crate) fn merge_vc_derivation_info(
+    caller_extensions: Option<
+        &crate::extensions::Extensions<crate::treesync::node::leaf_node::LeafNode>,
+    >,
+    mut resolved_dictionary: crate::extensions::AppDataDictionary,
+    derivation_info_bytes: Vec<u8>,
+) -> Result<
+    crate::extensions::Extensions<crate::treesync::node::leaf_node::LeafNode>,
+    crate::error::LibraryError,
+> {
+    use crate::extensions::{AppDataDictionaryExtension, Extension, Extensions};
+
+    resolved_dictionary.insert(VC_COMPONENT_ID, derivation_info_bytes);
+    let vc_extension =
+        Extension::AppDataDictionary(AppDataDictionaryExtension::new(resolved_dictionary));
+
+    let other_extensions = caller_extensions
+        .map(|exts| {
+            exts.iter()
+                .filter(|ext| !matches!(ext, Extension::AppDataDictionary(_)))
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let new_extensions: Vec<Extension> = other_extensions
+        .into_iter()
+        .chain(std::iter::once(vc_extension))
+        .collect();
+    Extensions::from_vec(new_extensions)
+        .map_err(|_| crate::error::LibraryError::custom("Failed to build VC leaf-node extensions"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/openmls/src/components/vc_operation_tree.rs
+++ b/openmls/src/components/vc_operation_tree.rs
@@ -8,10 +8,10 @@
 //! from the RFC 9420 secret tree in two ways: the root is the
 //! per-emulation-epoch `epoch_base_secret` rather than a secret derived
 //! from `encryption_secret`, and each leaf expands into one operation
-//! ratchet per [`VirtualClientOperationType`] instead of a handshake and an
+//! ratchet per `VirtualClientOperationType` instead of a handshake and an
 //! application sender ratchet.
 //!
-//! Each ratchet hands out one [`OperationSecret`] per generation, bound to
+//! Each ratchet hands out one `OperationSecret` per generation, bound to
 //! the spec's `OperationContext`
 //! `(epoch_id, leaf_index, generation, operation_type, operation_context)`.
 //!
@@ -25,7 +25,7 @@
 //! generation, since the final operation secret also binds the (then still
 //! unknown) operation context. The retained entry is deleted when the
 //! operation for that generation arrives. Retention is bounded by
-//! [`MAXIMUM_FORWARD_DISTANCE`] and [`OUT_OF_ORDER_TOLERANCE`].
+//! `MAXIMUM_FORWARD_DISTANCE` and `OUT_OF_ORDER_TOLERANCE`.
 
 use std::collections::BTreeMap;
 

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -101,6 +101,11 @@ pub enum WelcomeError<StorageError> {
     /// A group with this [`GroupId`] already exists.
     #[error("A group with this [`GroupId`] already exists.")]
     GroupAlreadyExists,
+    /// A virtual-clients error occurred while deriving or validating the
+    /// virtual client's join material.
+    #[cfg(feature = "virtual-clients-draft")]
+    #[error(transparent)]
+    VirtualClientsError(#[from] crate::components::vc_derivation_info::VirtualClientsError),
 }
 
 /// External Commit error

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -1241,7 +1241,10 @@ fn apply_vc_emulation(
         .public_key()
         .tls_serialize_detached()
         .map_err(VirtualClientsError::from)?;
-    let tbe = DerivationInfoTbe {
+    // leaf_node operations are not batched, so the TBE carries no
+    // key_package_index: the select resolves to the empty `update`/`commit`
+    // case and the field is absent on the wire.
+    let tbe = DerivationInfoTbe::LeafNode {
         leaf_index: loaded.emulation_leaf_index,
         generation: loaded.generation,
     };
@@ -1287,12 +1290,6 @@ fn check_vc_leaf_configuration(
     own_leaf_index: LeafNodeIndex,
     is_external_commit: bool,
 ) -> Result<AppDataDictionary, CreateCommitError> {
-    use crate::{
-        component::{ComponentId, ComponentType},
-        extensions::ExtensionType,
-    };
-    use tls_codec::DeserializeBytes as _;
-
     let current_leaf = if is_external_commit {
         None
     } else {
@@ -1301,62 +1298,12 @@ fn check_vc_leaf_configuration(
         })?)
     };
 
-    let supports_app_data_dictionary = match leaf_node_parameters.capabilities() {
-        Some(c) => c.extensions().contains(&ExtensionType::AppDataDictionary),
-        None => current_leaf
-            .map(|leaf| {
-                leaf.capabilities()
-                    .extensions()
-                    .contains(&ExtensionType::AppDataDictionary)
-            })
-            .unwrap_or(false),
-    };
-    if !supports_app_data_dictionary {
-        return Err(CreateCommitError::VirtualClientsError(
-            VirtualClientsError::AppDataDictionaryNotSupported,
-        ));
-    }
-
-    // Merge the dictionary from the current leaf with anything the
-    // caller passed in `leaf_node_parameters`, with the caller winning.
-    // For external commits there's no current leaf to merge from.
-    let mut resolved_dictionary = current_leaf
-        .and_then(|leaf| leaf.extensions().app_data_dictionary())
-        .map(|ext| ext.dictionary().clone())
-        .unwrap_or_default();
-    if let Some(caller_dict) = leaf_node_parameters
-        .extensions()
-        .and_then(|exts| exts.app_data_dictionary())
-    {
-        for entry in caller_dict.dictionary().entries() {
-            resolved_dictionary.insert(entry.id(), entry.data().to_vec());
-        }
-    }
-
-    let app_components_bytes = resolved_dictionary
-        .get(&ComponentId::from(ComponentType::AppComponents))
-        .map(|bytes| bytes.to_vec());
-    let Some(app_components_bytes) = app_components_bytes else {
-        return Err(CreateCommitError::VirtualClientsError(
-            VirtualClientsError::VcComponentNotListed,
-        ));
-    };
-
-    // The AppComponents body is `ComponentID supported_components<V>`,
-    // i.e. a TLS-encoded variable-length vector of u16. `Vec<u16>`'s
-    // `DeserializeBytes` impl handles the length prefix.
-    let supported_components = Vec::<u16>::tls_deserialize_exact_bytes(&app_components_bytes)
-        .map_err(|e| {
-            log::error!("vc: AppComponents body failed to deserialize: {e:?}");
-            CreateCommitError::VirtualClientsError(VirtualClientsError::VcComponentNotListed)
-        })?;
-    if !supported_components.contains(&VC_COMPONENT_ID) {
-        return Err(CreateCommitError::VirtualClientsError(
-            VirtualClientsError::VcComponentNotListed,
-        ));
-    }
-
-    Ok(resolved_dictionary)
+    crate::components::vc_derivation_info::resolve_vc_leaf_dictionary(
+        leaf_node_parameters.capabilities(),
+        leaf_node_parameters.extensions(),
+        current_leaf,
+    )
+    .map_err(CreateCommitError::VirtualClientsError)
 }
 
 /// Merge a virtual-clients derivation info blob into

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -39,11 +39,10 @@ use crate::{
 use crate::{
     components::vc_derivation_info::{
         DerivationInfo, DerivationInfoTbe, EmulationEpochState, EpochEncryptionKey, EpochId,
-        OperationSecret, VirtualClientOperationType, VirtualClientsError, VC_COMPONENT_ID,
+        OperationSecret, VirtualClientOperationType, VirtualClientsError,
     },
     components::vc_operation_tree::OperationSecretTree,
-    extensions::{AppDataDictionary, AppDataDictionaryExtension},
-    treesync::node::leaf_node::LeafNode,
+    extensions::AppDataDictionary,
 };
 #[cfg(feature = "extensions-draft-08")]
 use crate::{
@@ -1313,32 +1312,14 @@ fn check_vc_leaf_configuration(
 #[cfg(feature = "virtual-clients-draft")]
 fn inject_vc_derivation_info(
     leaf_node_parameters: &mut LeafNodeParameters,
-    mut resolved_dictionary: AppDataDictionary,
+    resolved_dictionary: AppDataDictionary,
     derivation_info_bytes: Vec<u8>,
 ) -> Result<(), CreateCommitError> {
-    resolved_dictionary.insert(VC_COMPONENT_ID, derivation_info_bytes);
-    let vc_extension =
-        Extension::AppDataDictionary(AppDataDictionaryExtension::new(resolved_dictionary));
-
-    // Drop any pre-existing AppDataDictionary entry from the caller-
-    // supplied extension list (we just rebuilt it) and append the merged
-    // one.
-    let other_extensions = leaf_node_parameters
-        .extensions()
-        .map(|exts| {
-            exts.iter()
-                .filter(|ext| !matches!(ext, Extension::AppDataDictionary(_)))
-                .cloned()
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    let new_extensions: Vec<Extension> = other_extensions
-        .into_iter()
-        .chain(std::iter::once(vc_extension))
-        .collect();
-    let extensions = crate::extensions::Extensions::<LeafNode>::from_vec(new_extensions)
-        .map_err(|_| LibraryError::custom("Failed to build leaf-node extensions"))?;
-
+    let extensions = crate::components::vc_derivation_info::merge_vc_derivation_info(
+        leaf_node_parameters.extensions(),
+        resolved_dictionary,
+        derivation_info_bytes,
+    )?;
     leaf_node_parameters.set_extensions(extensions);
     Ok(())
 }

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -841,10 +841,6 @@ fn find_and_validate_vc_own_leaf<Provider: OpenMlsProvider>(
         log::error!("vc: welcome leaf derivation info does not match the retained material");
         return Err(VirtualClientsError::DerivationInfoMalformed.into());
     }
-    if own_leaf.encryption_key().as_slice() != derived_encryption_key {
-        log::error!("vc: welcome leaf encryption key does not match the derived key");
-        return Err(VirtualClientsError::EncryptionKeyMismatch.into());
-    }
 
     Ok(own_index)
 }

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -145,28 +145,29 @@ impl ProcessedWelcome {
         mls_group_config: &MlsGroupJoinConfig,
         welcome: Welcome,
     ) -> Result<Self, WelcomeError<Provider::StorageError>> {
-        let (resumption_psk_store, key_package_bundle) =
+        let (resumption_psk_store, key_material) =
             keys_for_welcome(mls_group_config, &welcome, provider)?;
 
         let ciphersuite = welcome.ciphersuite();
-        let Some(egs) = welcome.find_encrypted_group_secret(
-            key_package_bundle
-                .key_package()
-                .hash_ref(provider.crypto())?,
-        ) else {
+        let Some(egs) =
+            welcome.find_encrypted_group_secret(key_material.key_package_ref(provider.crypto())?)
+        else {
             return Err(WelcomeError::JoinerSecretNotFound);
         };
 
         // This check seems to be superfluous from the perspective of the RFC, but still doesn't
-        // seem like a bad idea.
-        if welcome.ciphersuite() != key_package_bundle.key_package().ciphersuite() {
-            let e = WelcomeError::CiphersuiteMismatch;
-            log::debug!("new_from_welcome {e:?}");
-            return Err(e);
+        // seem like a bad idea. There is no local KeyPackage to compare against on the
+        // virtual-client path, where the derived material is implicitly the welcome's ciphersuite.
+        if let Some(key_package_bundle) = key_material.key_package_bundle() {
+            if welcome.ciphersuite() != key_package_bundle.key_package().ciphersuite() {
+                let e = WelcomeError::CiphersuiteMismatch;
+                log::debug!("new_from_welcome {e:?}");
+                return Err(e);
+            }
         }
 
         let group_secrets = GroupSecrets::try_from_ciphertext(
-            key_package_bundle.init_private_key(),
+            key_material.init_private_key(),
             egs.encrypted_group_secrets(),
             welcome.encrypted_group_info(),
             ciphersuite,
@@ -204,25 +205,32 @@ impl ProcessedWelcome {
             provider.crypto(),
         )?;
 
-        if let Some(required_capabilities) =
-            verifiable_group_info.extensions().required_capabilities()
-        {
-            // Also check that our key package actually supports the extensions.
-            // As per the spec, the sender must have checked this. But you never know.
-            key_package_bundle
-                .key_package()
-                .leaf_node()
-                .capabilities()
-                .supports_required_capabilities(required_capabilities)?;
-        }
+        // On the bundle path, check the required capabilities and the
+        // ciphersuite against the local KeyPackage. On the virtual-client path
+        // there is no local KeyPackage: these are checked in staging against
+        // the own tree leaf instead.
+        if let Some(key_package_bundle) = key_material.key_package_bundle() {
+            if let Some(required_capabilities) =
+                verifiable_group_info.extensions().required_capabilities()
+            {
+                // Also check that our key package actually supports the extensions.
+                // As per the spec, the sender must have checked this. But you never know.
+                key_package_bundle
+                    .key_package()
+                    .leaf_node()
+                    .capabilities()
+                    .supports_required_capabilities(required_capabilities)?;
+            }
 
-        // https://validation.openmls.tech/#valn1404
-        // Verify that the cipher_suite in the GroupInfo matches the cipher_suite in the
-        // KeyPackage.
-        if verifiable_group_info.ciphersuite() != key_package_bundle.key_package().ciphersuite() {
-            let e = WelcomeError::CiphersuiteMismatch;
-            log::debug!("new_from_welcome {e:?}");
-            return Err(e);
+            // https://validation.openmls.tech/#valn1404
+            // Verify that the cipher_suite in the GroupInfo matches the cipher_suite in the
+            // KeyPackage.
+            if verifiable_group_info.ciphersuite() != key_package_bundle.key_package().ciphersuite()
+            {
+                let e = WelcomeError::CiphersuiteMismatch;
+                log::debug!("new_from_welcome {e:?}");
+                return Err(e);
+            }
         }
 
         Ok(Self {
@@ -232,7 +240,7 @@ impl ProcessedWelcome {
             key_schedule,
             verifiable_group_info,
             resumption_psk_store,
-            key_package_bundle,
+            key_material,
         })
     }
 
@@ -307,43 +315,54 @@ impl ProcessedWelcome {
             validate_lifetimes,
         )?;
 
-        // Check that the leaf node of the added key package supports all extensions in the group
-        // context.
-        // https://validation.openmls.tech/#valn1415
-        let added_leaf_supports_all_group_context_extensions = public_group
-            .group_context()
-            .extensions()
-            .iter()
-            .all(|extension| {
-                self.key_package_bundle
-                    .key_package
-                    .leaf_node()
-                    .supports_extension(&extension.extension_type())
-            });
-        if !added_leaf_supports_all_group_context_extensions {
-            return Err(WelcomeError::UnsupportedExtensions);
-        }
-
-        // Find our own leaf in the tree.
-        let own_leaf_index = public_group
-            .members()
-            .find_map(|m| {
-                if m.signature_key
-                    == self
-                        .key_package_bundle
-                        .key_package()
-                        .leaf_node()
-                        .signature_key()
-                        .as_slice()
-                {
-                    Some(m.index)
-                } else {
-                    None
+        // Find our own leaf in the tree. On the bundle path this is the leaf
+        // whose signature key matches the local KeyPackage. On the
+        // virtual-client path there is no local signature key, so the leaf is
+        // located by its derived encryption key and validated against the
+        // emulation epoch's derivation info.
+        let own_leaf_index = match &self.key_material {
+            WelcomeKeyMaterial::KeyPackage(key_package_bundle) => {
+                // Check that the leaf node of the added key package supports all extensions in
+                // the group context.
+                // https://validation.openmls.tech/#valn1415
+                let added_leaf_supports_all_group_context_extensions = public_group
+                    .group_context()
+                    .extensions()
+                    .iter()
+                    .all(|extension| {
+                        key_package_bundle
+                            .key_package
+                            .leaf_node()
+                            .supports_extension(&extension.extension_type())
+                    });
+                if !added_leaf_supports_all_group_context_extensions {
+                    return Err(WelcomeError::UnsupportedExtensions);
                 }
-            })
-            .ok_or(WelcomeError::PublicTreeError(
-                PublicTreeError::MalformedTree,
-            ))?;
+
+                public_group
+                    .members()
+                    .find_map(|m| {
+                        if m.signature_key
+                            == key_package_bundle
+                                .key_package()
+                                .leaf_node()
+                                .signature_key()
+                                .as_slice()
+                        {
+                            Some(m.index)
+                        } else {
+                            None
+                        }
+                    })
+                    .ok_or(WelcomeError::PublicTreeError(
+                        PublicTreeError::MalformedTree,
+                    ))?
+            }
+            #[cfg(feature = "virtual-clients-draft")]
+            WelcomeKeyMaterial::VirtualClient(material) => {
+                find_and_validate_vc_own_leaf(provider, &public_group, material)?
+            }
+        };
 
         struct KeyScheduleResult {
             group_epoch_secrets: GroupEpochSecrets,
@@ -454,7 +473,7 @@ impl ProcessedWelcome {
             application_export_secret,
             resumption_psk_store: self.resumption_psk_store,
             verifiable_group_info: self.verifiable_group_info,
-            key_package_bundle: self.key_package_bundle,
+            key_material: self.key_material,
             path_keypairs,
         };
 
@@ -542,11 +561,11 @@ impl StagedWelcome {
         // If we got a path secret, derive the path (which also checks if the
         // public keys match) and store the derived keys in the key store.
         let group_keypairs = if let Some(path_keypairs) = self.path_keypairs {
-            let mut keypairs = vec![self.key_package_bundle.encryption_key_pair()];
+            let mut keypairs = vec![self.key_material.encryption_key_pair()];
             keypairs.extend_from_slice(&path_keypairs);
             keypairs
         } else {
-            vec![self.key_package_bundle.encryption_key_pair()]
+            vec![self.key_material.encryption_key_pair()]
         };
 
         #[cfg(feature = "extensions-draft-08")]
@@ -618,32 +637,216 @@ fn keys_for_welcome<Provider: OpenMlsProvider>(
     welcome: &Welcome,
     provider: &Provider,
 ) -> Result<
-    (ResumptionPskStore, KeyPackageBundle),
+    (ResumptionPskStore, WelcomeKeyMaterial),
     WelcomeError<<Provider as OpenMlsProvider>::StorageError>,
 > {
     let resumption_psk_store = ResumptionPskStore::new(mls_group_config.number_of_resumption_psks);
-    let key_package_bundle: KeyPackageBundle = welcome
-        .secrets()
-        .iter()
-        .find_map(|egs| {
-            let hash_ref = egs.new_member();
 
-            provider
-                .storage()
-                .key_package(&hash_ref)
-                .map_err(WelcomeError::StorageError)
-                .transpose()
-        })
-        .ok_or(WelcomeError::NoMatchingKeyPackage)??;
-    if !key_package_bundle.key_package().last_resort() {
-        provider
+    for egs in welcome.secrets() {
+        let hash_ref = egs.new_member();
+        if let Some(key_package_bundle) = provider
             .storage()
-            .delete_key_package(&key_package_bundle.key_package.hash_ref(provider.crypto())?)
-            .map_err(WelcomeError::StorageError)?;
-    } else {
-        log::debug!("Key package has last resort extension, not deleting");
+            .key_package(&hash_ref)
+            .map_err(WelcomeError::StorageError)?
+        {
+            let key_package_bundle: KeyPackageBundle = key_package_bundle;
+            if !key_package_bundle.key_package().last_resort() {
+                provider
+                    .storage()
+                    .delete_key_package(
+                        &key_package_bundle.key_package.hash_ref(provider.crypto())?,
+                    )
+                    .map_err(WelcomeError::StorageError)?;
+            } else {
+                log::debug!("Key package has last resort extension, not deleting");
+            }
+            return Ok((
+                resumption_psk_store,
+                WelcomeKeyMaterial::KeyPackage(Box::new(key_package_bundle)),
+            ));
+        }
+
+        #[cfg(feature = "virtual-clients-draft")]
+        if let Some(material) = vc_welcome_material(provider, welcome.ciphersuite(), &hash_ref)? {
+            return Ok((
+                resumption_psk_store,
+                WelcomeKeyMaterial::VirtualClient(material),
+            ));
+        }
     }
-    Ok((resumption_psk_store, key_package_bundle))
+
+    Err(WelcomeError::NoMatchingKeyPackage)
+}
+
+/// Try to derive virtual-client welcome material for `hash_ref`. Returns
+/// `None` if no [`RetainedKeyPackageMaterial`] is stored for the ref, so the
+/// caller can keep scanning the welcome's encrypted group secrets.
+///
+/// On a match this reconstructs the per-KeyPackage seed pinned in the retained
+/// material at upload-processing time, deletes the consumed material, and
+/// derives the init and leaf-encryption keypairs from the seed under the
+/// Welcome's ciphersuite. It does not touch the operation tree: the batch
+/// generation was already consumed once when the upload was processed, and the
+/// seed is enough to reproduce the keys.
+///
+/// [`RetainedKeyPackageMaterial`]: crate::components::vc_derivation_info::RetainedKeyPackageMaterial
+#[cfg(feature = "virtual-clients-draft")]
+fn vc_welcome_material<Provider: OpenMlsProvider>(
+    provider: &Provider,
+    ciphersuite: Ciphersuite,
+    hash_ref: &crate::ciphersuite::hash_ref::KeyPackageRef,
+) -> Result<
+    Option<crate::components::vc_derivation_info::VcWelcomeMaterial>,
+    WelcomeError<<Provider as OpenMlsProvider>::StorageError>,
+> {
+    use crate::components::vc_derivation_info::{
+        RetainedKeyPackageMaterial, VcWelcomeMaterial, VirtualClientsError,
+    };
+
+    let storage = provider.storage();
+    let Some(material) = storage
+        .retained_key_package_material::<_, RetainedKeyPackageMaterial>(hash_ref)
+        .map_err(WelcomeError::StorageError)?
+    else {
+        return Ok(None);
+    };
+
+    let crypto = provider.crypto();
+    // The material is consumed once, mirroring the non-last-resort
+    // `delete_key_package` on the bundle path.
+    storage
+        .delete_retained_key_package_material(hash_ref)
+        .map_err(|e| {
+            log::error!("vc: delete retained key package material in welcome failed: {e:?}");
+            VirtualClientsError::StorageError
+        })?;
+
+    // The seed was derived under the emulation ciphersuite at
+    // upload-processing time. The init and leaf-encryption keys are derived
+    // from it under the KeyPackage's own (the welcome's) ciphersuite.
+    let init_key_pair = material
+        .key_package_seed_secret
+        .derive_init_key_secret(crypto, ciphersuite)?
+        .generate_init_key_pair(crypto, ciphersuite)?;
+    let encryption_keypair = material
+        .key_package_seed_secret
+        .derive_encryption_key_secret(crypto, ciphersuite)?
+        .generate_encryption_key_pair(crypto, ciphersuite)?;
+
+    Ok(Some(VcWelcomeMaterial {
+        key_package_ref: hash_ref.clone(),
+        epoch_id: material.epoch_id,
+        leaf_index: material.leaf_index,
+        generation: material.generation,
+        key_package_index: material.key_package_index,
+        init_private_key: init_key_pair.private,
+        encryption_keypair,
+    }))
+}
+
+/// Find and validate the virtual client's own leaf in the ratchet tree.
+///
+/// A virtual client has no signature key of its own, so the leaf is located by
+/// the derivation info the VC sender embedded under [`VC_COMPONENT_ID`]: the
+/// leaf whose cleartext `epoch_id` equals the material's and whose
+/// `encryption_key` equals the key derived in the first welcome stage. That
+/// leaf's encrypted [`DerivationInfoTbe`] is then decrypted with the emulation
+/// epoch state and its `leaf_index`, `generation`, and `key_package_index`
+/// must equal the material's.
+///
+/// [`VC_COMPONENT_ID`]: crate::components::vc_derivation_info::VC_COMPONENT_ID
+/// [`DerivationInfoTbe`]: crate::components::vc_derivation_info::DerivationInfoTbe
+#[cfg(feature = "virtual-clients-draft")]
+fn find_and_validate_vc_own_leaf<Provider: OpenMlsProvider>(
+    provider: &Provider,
+    public_group: &PublicGroup,
+    material: &crate::components::vc_derivation_info::VcWelcomeMaterial,
+) -> Result<LeafNodeIndex, WelcomeError<<Provider as OpenMlsProvider>::StorageError>> {
+    use tls_codec::{DeserializeBytes as _, Serialize as _};
+
+    use crate::components::vc_derivation_info::{
+        DerivationInfo, DerivationInfoTbe, EmulationEpochState, VirtualClientOperationType,
+        VirtualClientsError, VC_COMPONENT_ID,
+    };
+
+    let crypto = provider.crypto();
+    let derived_encryption_key = material.encryption_keypair.public_key().as_slice().to_vec();
+
+    let own_index = public_group
+        .members()
+        .find(|m| m.encryption_key == derived_encryption_key)
+        .map(|m| m.index)
+        .ok_or(WelcomeError::PublicTreeError(
+            PublicTreeError::MalformedTree,
+        ))?;
+
+    let own_leaf = public_group
+        .leaf(own_index)
+        .ok_or(WelcomeError::PublicTreeError(
+            PublicTreeError::MalformedTree,
+        ))?;
+
+    let derivation_info_bytes = own_leaf
+        .extensions()
+        .app_data_dictionary()
+        .and_then(|dict| dict.dictionary().get(&VC_COMPONENT_ID))
+        .ok_or(VirtualClientsError::VcComponentNotListed)?;
+    let derivation_info = DerivationInfo::tls_deserialize_exact_bytes(derivation_info_bytes)
+        .map_err(|e| {
+            log::error!("vc: welcome leaf derivation info deserialize failed: {e:?}");
+            VirtualClientsError::DerivationInfoMalformed
+        })?;
+    if derivation_info.epoch_id() != &material.epoch_id {
+        log::error!("vc: welcome leaf epoch id does not match the retained material");
+        return Err(VirtualClientsError::DerivationInfoMalformed.into());
+    }
+
+    let state: EmulationEpochState = provider
+        .storage()
+        .vc_emulation_epoch_state(&material.epoch_id)
+        .map_err(|e| {
+            log::error!("vc: load emulation epoch state in welcome staging failed: {e:?}");
+            VirtualClientsError::StorageError
+        })?
+        .ok_or(VirtualClientsError::MissingEmulationEpochState)?;
+    let (_state_leaf_index, epoch_encryption_key, emulation_ciphersuite) = state.into_parts();
+
+    let leaf_encryption_key = own_leaf
+        .encryption_key()
+        .tls_serialize_detached()
+        .map_err(VirtualClientsError::from)?;
+    // A KeyPackage leaf carries the `KeyPackage` variant of the tagless
+    // select, so it decodes with `key_package_index` present.
+    let tbe = derivation_info.decrypt(
+        crypto,
+        emulation_ciphersuite,
+        &epoch_encryption_key,
+        &leaf_encryption_key,
+        VirtualClientOperationType::KeyPackage,
+    )?;
+
+    let DerivationInfoTbe::KeyPackage {
+        leaf_index,
+        generation,
+        key_package_index,
+    } = tbe
+    else {
+        log::error!("vc: welcome leaf derivation info is not a key-package variant");
+        return Err(VirtualClientsError::DerivationInfoMalformed.into());
+    };
+    if leaf_index != material.leaf_index
+        || generation != material.generation
+        || key_package_index != material.key_package_index
+    {
+        log::error!("vc: welcome leaf derivation info does not match the retained material");
+        return Err(VirtualClientsError::DerivationInfoMalformed.into());
+    }
+    if own_leaf.encryption_key().as_slice() != derived_encryption_key {
+        log::error!("vc: welcome leaf encryption key does not match the derived key");
+        return Err(VirtualClientsError::EncryptionKeyMismatch.into());
+    }
+
+    Ok(own_index)
 }
 
 /// Verify or skip the validation of leaf node lifetimes in the ratchet tree

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -43,7 +43,9 @@ use crate::{
     },
     versions::ProtocolVersion,
 };
-use openmls_traits::{signatures::Signer, storage::StorageProvider as _, types::Ciphersuite};
+use openmls_traits::{
+    crypto::OpenMlsCrypto, signatures::Signer, storage::StorageProvider as _, types::Ciphersuite,
+};
 
 #[cfg(feature = "extensions-draft-08")]
 use crate::schedule::{application_export_tree::ApplicationExportTree, ApplicationExportSecret};
@@ -1164,8 +1166,8 @@ pub struct StagedWelcome {
     /// The [`VerifiableGroupInfo`] from the [`Welcome`] message.
     verifiable_group_info: VerifiableGroupInfo,
 
-    /// The key package bundle used for this welcome.
-    key_package_bundle: KeyPackageBundle,
+    /// The key material used to join via this welcome.
+    key_material: WelcomeKeyMaterial,
 
     /// If we got a path secret, these are the derived path keys.
     path_keypairs: Option<Vec<EncryptionKeyPair>>,
@@ -1188,5 +1190,71 @@ pub struct ProcessedWelcome {
     key_schedule: crate::schedule::KeySchedule,
     verifiable_group_info: crate::messages::group_info::VerifiableGroupInfo,
     resumption_psk_store: crate::schedule::psk::store::ResumptionPskStore,
-    key_package_bundle: KeyPackageBundle,
+    key_material: WelcomeKeyMaterial,
+}
+
+/// The key material a client uses to process a [`Welcome`] message.
+///
+/// A regular member holds a local [`KeyPackageBundle`]. A sibling emulator
+/// joining a higher-level group as a virtual client has no local bundle: it
+/// derives the init and leaf-encryption keys from the operation secret tree of
+/// the emulation epoch the KeyPackage belongs to.
+///
+/// [`Welcome`]: crate::messages::Welcome
+#[derive(Debug)]
+pub(crate) enum WelcomeKeyMaterial {
+    /// A locally stored [`KeyPackageBundle`]. Boxed to keep the enum small,
+    /// since the virtual-client variant is much smaller.
+    KeyPackage(Box<KeyPackageBundle>),
+    /// Virtual-client material derived from an emulation epoch's operation
+    /// secret tree.
+    #[cfg(feature = "virtual-clients-draft")]
+    VirtualClient(crate::components::vc_derivation_info::VcWelcomeMaterial),
+}
+
+impl WelcomeKeyMaterial {
+    /// The [`KeyPackageRef`] addressed by the welcome's encrypted group
+    /// secrets. The bundle computes it from its KeyPackage, the virtual-client
+    /// material carries the ref it was matched on.
+    ///
+    /// [`KeyPackageRef`]: crate::ciphersuite::hash_ref::KeyPackageRef
+    fn key_package_ref(
+        &self,
+        crypto: &impl OpenMlsCrypto,
+    ) -> Result<crate::ciphersuite::hash_ref::KeyPackageRef, LibraryError> {
+        match self {
+            WelcomeKeyMaterial::KeyPackage(bundle) => bundle.key_package().hash_ref(crypto),
+            #[cfg(feature = "virtual-clients-draft")]
+            WelcomeKeyMaterial::VirtualClient(material) => Ok(material.key_package_ref.clone()),
+        }
+    }
+
+    /// The init private key used to decrypt the encrypted group secrets.
+    fn init_private_key(&self) -> &crate::ciphersuite::HpkePrivateKey {
+        match self {
+            WelcomeKeyMaterial::KeyPackage(bundle) => bundle.init_private_key(),
+            #[cfg(feature = "virtual-clients-draft")]
+            WelcomeKeyMaterial::VirtualClient(material) => &material.init_private_key,
+        }
+    }
+
+    /// The local [`KeyPackageBundle`] on the regular path, or `None` on the
+    /// virtual-client path. Checks that only apply when there is a local
+    /// KeyPackage to compare against branch on this.
+    fn key_package_bundle(&self) -> Option<&KeyPackageBundle> {
+        match self {
+            WelcomeKeyMaterial::KeyPackage(bundle) => Some(bundle),
+            #[cfg(feature = "virtual-clients-draft")]
+            WelcomeKeyMaterial::VirtualClient(_) => None,
+        }
+    }
+
+    /// The joiner's leaf encryption keypair.
+    fn encryption_key_pair(&self) -> EncryptionKeyPair {
+        match self {
+            WelcomeKeyMaterial::KeyPackage(bundle) => bundle.encryption_key_pair(),
+            #[cfg(feature = "virtual-clients-draft")]
+            WelcomeKeyMaterial::VirtualClient(material) => material.encryption_keypair.clone(),
+        }
+    }
 }

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -498,18 +498,12 @@ impl MlsGroup {
             .encryption_key()
             .tls_serialize_detached()
             .map_err(VirtualClientsError::from)?;
-        let tbe = derivation_info.decrypt(
-            crypto,
-            emulation_ciphersuite,
-            &epoch_encryption_key,
-            &leaf_encryption_key,
-        )?;
-
         // The operation type is not on the wire. It is inferred from the
         // carrying leaf's source: key-package leaves map to `KeyPackage`,
         // update and commit leaves map to `LeafNode`. Only `LeafNode` is
         // wired up today, and an update-path leaf always has a commit
-        // source.
+        // source. It selects the tagless `DerivationInfoTbe` variant the
+        // plaintext decodes into.
         let operation_type = match path.leaf_node().leaf_node_source() {
             LeafNodeSource::KeyPackage(_) => {
                 log::error!("vc: key-package leaf on an update path");
@@ -519,6 +513,13 @@ impl MlsGroup {
                 VirtualClientOperationType::LeafNode
             }
         };
+        let tbe = derivation_info.decrypt(
+            crypto,
+            emulation_ciphersuite,
+            &epoch_encryption_key,
+            &leaf_encryption_key,
+            operation_type,
+        )?;
         // The operation context for `LeafNode` operations is the
         // higher-level group's id.
         let operation_context = self.group_id().as_slice().to_vec();
@@ -530,9 +531,9 @@ impl MlsGroup {
             crypto,
             emulation_ciphersuite,
             epoch_id,
-            tbe.leaf_index,
+            tbe.leaf_index(),
             operation_type,
-            tbe.generation,
+            tbe.generation(),
             &operation_context,
         )?;
         // Persist the advanced tree immediately, before any key material is

--- a/openmls/src/key_packages/errors.rs
+++ b/openmls/src/key_packages/errors.rs
@@ -71,4 +71,8 @@ pub enum KeyPackageNewError {
     #[cfg(feature = "virtual-clients-draft")]
     #[error(transparent)]
     VirtualClientsError(#[from] crate::components::vc_derivation_info::VirtualClientsError),
+    /// A virtual-clients KeyPackage batch was requested with a count of 0.
+    #[cfg(feature = "virtual-clients-draft")]
+    #[error("A virtual-clients KeyPackage batch must request at least one KeyPackage.")]
+    EmptyBatch,
 }

--- a/openmls/src/key_packages/errors.rs
+++ b/openmls/src/key_packages/errors.rs
@@ -67,4 +67,8 @@ pub enum KeyPackageNewError {
     /// See [`SignatureError`] for more details.
     #[error(transparent)]
     SignatureError(#[from] SignatureError),
+    /// A virtual-clients operation failed while building the key package.
+    #[cfg(feature = "virtual-clients-draft")]
+    #[error(transparent)]
+    VirtualClientsError(#[from] crate::components::vc_derivation_info::VirtualClientsError),
 }

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -664,12 +664,15 @@ impl KeyPackageBuilder {
     /// builder burns a generation. That is harmless: sibling ratchets skip
     /// over a burned generation.
     ///
-    /// Returns the batch's `generation` and one
+    /// Returns a [`VcKeyPackageBatch`] holding the batch's `generation` and one
     /// `(KeyPackageBundle, KeyPackageInfo)` per KeyPackage. Each bundle is also
     /// written to storage so the creating client can process its own Welcomes,
     /// and each [`KeyPackageInfo`](crate::components::vc_derivation_info::KeyPackageInfo)
     /// carries the index the client hands to its
     /// sibling.
+    ///
+    /// Returns [`KeyPackageNewError::EmptyBatch`] when `count` is 0, before
+    /// loading any state or consuming a generation.
     #[cfg(feature = "virtual-clients-draft")]
     pub fn build_vc_batch(
         self,
@@ -679,16 +682,7 @@ impl KeyPackageBuilder {
         credential_with_key: CredentialWithKey,
         epoch_id: crate::components::vc_derivation_info::EpochId,
         count: u32,
-    ) -> Result<
-        (
-            u32,
-            Vec<(
-                KeyPackageBundle,
-                crate::components::vc_derivation_info::KeyPackageInfo,
-            )>,
-        ),
-        KeyPackageNewError,
-    > {
+    ) -> Result<VcKeyPackageBatch, KeyPackageNewError> {
         use crate::components::vc_derivation_info::{
             EmulationEpochState, VirtualClientOperationType, VirtualClientsError,
         };
@@ -697,6 +691,21 @@ impl KeyPackageBuilder {
         if ciphersuite.signature_algorithm() != signer.signature_scheme() {
             return Err(KeyPackageNewError::CiphersuiteSignatureSchemeMismatch);
         }
+
+        // Reject an empty batch before loading state or consuming a generation.
+        if count == 0 {
+            return Err(KeyPackageNewError::EmptyBatch);
+        }
+
+        // Resolve and validate the leaf configuration once for the whole batch
+        // (it does not depend on the per-KeyPackage index) before consuming a
+        // generation, so a misconfigured leaf fails without burning one.
+        let resolved_dictionary =
+            crate::components::vc_derivation_info::resolve_vc_leaf_dictionary(
+                self.leaf_node_capabilities.as_ref(),
+                self.leaf_node_extensions.as_ref(),
+                None,
+            )?;
 
         // Allocate a single generation of the key_package operation ratchet
         // for the whole batch and persist the advanced tree right away,
@@ -746,9 +755,10 @@ impl KeyPackageBuilder {
             emulation_leaf_index,
             generation,
             operation_secret,
+            resolved_dictionary,
         };
 
-        let mut built = Vec::with_capacity(count as usize);
+        let mut key_packages = Vec::with_capacity(count as usize);
         for key_package_index in 0..count {
             let entry = self.build_vc_key_package_for_index(
                 provider,
@@ -757,10 +767,13 @@ impl KeyPackageBuilder {
                 &batch_ctx,
                 key_package_index,
             )?;
-            built.push(entry);
+            key_packages.push(entry);
         }
 
-        Ok((generation, built))
+        Ok(VcKeyPackageBatch {
+            generation,
+            key_packages,
+        })
     }
 
     /// Derive and build a single KeyPackage at `key_package_index` from the
@@ -802,14 +815,10 @@ impl KeyPackageBuilder {
             .derive_encryption_key_secret(provider.crypto(), ciphersuite)?
             .generate_encryption_key_pair(provider.crypto(), ciphersuite)?;
 
-        // Enforce the capability check and resolve the dictionary, then wrap
-        // the TBE bound to the new leaf via its serialized encryption key.
-        let resolved_dictionary =
-            crate::components::vc_derivation_info::resolve_vc_leaf_dictionary(
-                self.leaf_node_capabilities.as_ref(),
-                self.leaf_node_extensions.as_ref(),
-                None,
-            )?;
+        // Wrap the TBE bound to the new leaf via its serialized encryption key.
+        // The leaf dictionary was resolved and validated once for the whole
+        // batch, so reuse a clone here.
+        let resolved_dictionary = batch_ctx.resolved_dictionary.clone();
         let leaf_encryption_key = encryption_key_pair
             .public_key()
             .tls_serialize_detached()
@@ -832,11 +841,12 @@ impl KeyPackageBuilder {
             .map_err(VirtualClientsError::from)?;
         let mut builder = self.clone();
         builder.ensure_last_resort();
-        let leaf_node_extensions = inject_vc_derivation_info(
+        let leaf_node_extensions = crate::components::vc_derivation_info::merge_vc_derivation_info(
             builder.leaf_node_extensions.as_ref(),
             resolved_dictionary,
             derivation_info_bytes,
-        )?;
+        )
+        .map_err(KeyPackageNewError::LibraryError)?;
 
         let leaf_node_params = KeyPackageLeafNodeParams {
             lifetime: builder.key_package_lifetime.unwrap_or_default(),
@@ -886,46 +896,22 @@ struct VcBatchContext {
     emulation_leaf_index: crate::binary_tree::LeafNodeIndex,
     generation: u32,
     operation_secret: crate::components::vc_derivation_info::OperationSecret,
+    resolved_dictionary: crate::extensions::AppDataDictionary,
 }
 
-/// Merge a virtual-clients derivation-info blob into `resolved_dictionary`
-/// under [`VC_COMPONENT_ID`] and build the resulting leaf-node extensions.
-/// The dictionary already carries every other component id (notably
-/// `AppComponents`), so injecting the derivation info preserves them.
+/// The result of [`KeyPackageBuilder::build_vc_batch`]: the single
+/// `key_package` operation generation the batch consumed, and one
+/// `(KeyPackageBundle, KeyPackageInfo)` per KeyPackage built.
 #[cfg(feature = "virtual-clients-draft")]
-fn inject_vc_derivation_info(
-    caller_extensions: Option<&Extensions<LeafNode>>,
-    mut resolved_dictionary: crate::extensions::AppDataDictionary,
-    derivation_info_bytes: Vec<u8>,
-) -> Result<Extensions<LeafNode>, KeyPackageNewError> {
-    use crate::{
-        components::vc_derivation_info::VC_COMPONENT_ID,
-        extensions::{AppDataDictionaryExtension, Extension},
-    };
-
-    resolved_dictionary.insert(VC_COMPONENT_ID, derivation_info_bytes);
-    let vc_extension =
-        Extension::AppDataDictionary(AppDataDictionaryExtension::new(resolved_dictionary));
-
-    // Keep every non-AppDataDictionary extension the caller supplied and
-    // append the merged dictionary.
-    let other_extensions = caller_extensions
-        .map(|exts| {
-            exts.iter()
-                .filter(|ext| !matches!(ext, Extension::AppDataDictionary(_)))
-                .cloned()
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    let new_extensions: Vec<Extension> = other_extensions
-        .into_iter()
-        .chain(std::iter::once(vc_extension))
-        .collect();
-    Extensions::<LeafNode>::from_vec(new_extensions).map_err(|_| {
-        KeyPackageNewError::LibraryError(LibraryError::custom(
-            "Failed to build VC leaf-node extensions",
-        ))
-    })
+#[derive(Debug)]
+pub struct VcKeyPackageBatch {
+    /// The `key_package` operation generation consumed for the whole batch.
+    pub generation: u32,
+    /// One entry per KeyPackage built, in batch-index order. Never empty.
+    pub key_packages: Vec<(
+        KeyPackageBundle,
+        crate::components::vc_derivation_info::KeyPackageInfo,
+    )>,
 }
 
 /// A [`KeyPackageBundle`] contains a [`KeyPackage`] and the init and encryption

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -637,15 +637,15 @@ impl KeyPackageBuilder {
 
     /// Build a batch of virtual-client KeyPackages a sibling can reproduce.
     ///
-    /// Allocates a single generation of the `key_package` operation ratchet
-    /// for the emulation epoch identified by `epoch_id` and persists the
-    /// advanced tree once. For each `key_package_index` in `0..count` it
-    /// derives a per-KeyPackage seed secret from that one operation secret and
-    /// derives the KeyPackage's init key and leaf encryption key from the
-    /// seed. Each leaf carries an encrypted `DerivationInfo` under
+    /// Allocates a single generation of the `key_package` operation ratchet for
+    /// the emulation epoch identified by `epoch_id`. For each
+    /// `key_package_index` in `0..count` it derives a per-KeyPackage seed
+    /// secret from that one operation secret and derives the KeyPackage's init
+    /// key and leaf encryption key from the seed. Each leaf carries an
+    /// encrypted `DerivationInfo` under
     /// [`VC_COMPONENT_ID`](crate::components::vc_derivation_info::VC_COMPONENT_ID)
-    /// so a sibling can recover the emulation leaf index,
-    /// generation, and index.
+    /// so a sibling can recover the emulation leaf index, generation, and
+    /// index.
     ///
     /// The operation secret and the seeds are derived under the emulation
     /// epoch's ciphersuite (the operation tree's ciphersuite). The init and
@@ -654,22 +654,17 @@ impl KeyPackageBuilder {
     ///
     /// Each leaf must declare `AppDataDictionary` support and list
     /// [`VC_COMPONENT_ID`](crate::components::vc_derivation_info::VC_COMPONENT_ID)
-    /// in its `AppComponents` entry, otherwise this
-    /// returns
+    /// in its `AppComponents` entry, otherwise this returns
     /// [`VirtualClientsError::AppDataDictionaryNotSupported`](crate::components::vc_derivation_info::VirtualClientsError::AppDataDictionaryNotSupported)
     /// or
     /// [`VirtualClientsError::VcComponentNotListed`](crate::components::vc_derivation_info::VirtualClientsError::VcComponentNotListed).
     ///
-    /// The advanced operation tree is persisted immediately, so a discarded
-    /// builder burns a generation. That is harmless: sibling ratchets skip
-    /// over a burned generation.
-    ///
     /// Returns a [`VcKeyPackageBatch`] holding the batch's `generation` and one
     /// `(KeyPackageBundle, KeyPackageInfo)` per KeyPackage. Each bundle is also
     /// written to storage so the creating client can process its own Welcomes,
-    /// and each [`KeyPackageInfo`](crate::components::vc_derivation_info::KeyPackageInfo)
-    /// carries the index the client hands to its
-    /// sibling.
+    /// and each
+    /// [`KeyPackageInfo`](crate::components::vc_derivation_info::KeyPackageInfo)
+    /// carries the index the client hands to its sibling.
     ///
     /// Returns [`KeyPackageNewError::EmptyBatch`] when `count` is 0, before
     /// loading any state or consuming a generation.
@@ -708,8 +703,9 @@ impl KeyPackageBuilder {
             )?;
 
         // Allocate a single generation of the key_package operation ratchet
-        // for the whole batch and persist the advanced tree right away,
-        // mirroring the commit builder's persist-on-allocate.
+        // for the whole batch. The advanced tree is held in memory and only
+        // persisted once every KeyPackage has been built, so a failure during
+        // building consumes no generation.
         let state: EmulationEpochState = provider
             .storage()
             .vc_emulation_epoch_state(&epoch_id)
@@ -739,13 +735,6 @@ impl KeyPackageBuilder {
             VirtualClientOperationType::KeyPackage,
             b"",
         )?;
-        provider
-            .storage()
-            .write_vc_operation_tree(&epoch_id, &operation_tree)
-            .map_err(|e| {
-                log::error!("vc: persist advanced operation tree in build_vc_batch failed: {e:?}");
-                VirtualClientsError::StorageError
-            })?;
 
         let batch_ctx = VcBatchContext {
             ciphersuite,
@@ -768,6 +757,24 @@ impl KeyPackageBuilder {
                 key_package_index,
             )?;
             key_packages.push(entry);
+        }
+
+        // Persist the advanced operation tree before the KeyPackages it backs.
+        // If a KeyPackage write fails after this, the burned generation is
+        // harmless, but writing KeyPackages first would let the next batch
+        // reuse the same key material under an unconsumed generation.
+        provider
+            .storage()
+            .write_vc_operation_tree(&batch_ctx.epoch_id, &operation_tree)
+            .map_err(|e| {
+                log::error!("vc: persist advanced operation tree in build_vc_batch failed: {e:?}");
+                VirtualClientsError::StorageError
+            })?;
+        for (full_kp, info) in &key_packages {
+            provider
+                .storage()
+                .write_key_package(&info.key_package_ref, full_kp)
+                .map_err(|_| KeyPackageNewError::StorageError)?;
         }
 
         Ok(VcKeyPackageBatch {
@@ -869,10 +876,6 @@ impl KeyPackageBuilder {
             private_init_key: init_key_pair.private,
             private_encryption_key: encryption_key_pair.private_key().clone(),
         };
-        provider
-            .storage()
-            .write_key_package(&key_package_ref, &full_kp)
-            .map_err(|_| KeyPackageNewError::StorageError)?;
 
         Ok((
             full_kp,

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -219,6 +219,13 @@ impl SignedStruct<KeyPackageTbs> for KeyPackage {
 
 const SIGNATURE_KEY_PACKAGE_LABEL: &str = "KeyPackageTBS";
 
+/// The leaf-node-specific parameters used when creating a [`KeyPackage`].
+pub(crate) struct KeyPackageLeafNodeParams {
+    pub(crate) lifetime: Lifetime,
+    pub(crate) capabilities: Capabilities,
+    pub(crate) extensions: Extensions<LeafNode>,
+}
+
 /// Helper struct containing the results of building a new [`KeyPackage`].
 pub(crate) struct KeyPackageCreationResult {
     pub key_package: KeyPackage,
@@ -277,17 +284,14 @@ impl KeyPackage {
         KeyPackageBuilder::new()
     }
 
-    #[allow(clippy::too_many_arguments)]
     /// Create a new key package for the given `ciphersuite` and `identity`.
     pub(crate) fn create(
         ciphersuite: Ciphersuite,
         provider: &impl OpenMlsProvider,
         signer: &impl Signer,
         credential_with_key: CredentialWithKey,
-        lifetime: Lifetime,
         extensions: Extensions<KeyPackage>,
-        leaf_node_capabilities: Capabilities,
-        leaf_node_extensions: Extensions<LeafNode>,
+        leaf_node_params: KeyPackageLeafNodeParams,
     ) -> Result<KeyPackageCreationResult, KeyPackageNewError> {
         if ciphersuite.signature_algorithm() != signer.signature_scheme() {
             return Err(KeyPackageNewError::CiphersuiteSignatureSchemeMismatch);
@@ -307,10 +311,8 @@ impl KeyPackage {
             provider,
             signer,
             credential_with_key,
-            lifetime,
             extensions,
-            leaf_node_capabilities,
-            leaf_node_extensions,
+            leaf_node_params,
             init_key.public.into(),
         )?;
 
@@ -330,25 +332,28 @@ impl KeyPackage {
     /// encryption key ([`HpkeKeyPair`]) of the leaf node.
     ///
     /// The caller is responsible for storing the new values.
-    #[allow(clippy::too_many_arguments)]
     fn new_from_keys(
         ciphersuite: Ciphersuite,
         provider: &impl OpenMlsProvider,
         signer: &impl Signer,
         credential_with_key: CredentialWithKey,
-        lifetime: Lifetime,
         extensions: Extensions<KeyPackage>,
-        capabilities: Capabilities,
-        leaf_node_extensions: Extensions<LeafNode>,
+        leaf_node_params: KeyPackageLeafNodeParams,
         init_key: InitKey,
     ) -> Result<(Self, EncryptionKeyPair), KeyPackageNewError> {
         // We don't need the private key here. It's stored in the key store for
         // use later when creating a group with this key package.
 
+        let KeyPackageLeafNodeParams {
+            lifetime,
+            capabilities,
+            extensions: leaf_node_extensions,
+        } = leaf_node_params;
+
         let new_leaf_node_params = NewLeafNodeParams {
             ciphersuite,
-            leaf_node_source: LeafNodeSource::KeyPackage(lifetime),
             credential_with_key,
+            leaf_node_source: LeafNodeSource::KeyPackage(lifetime),
             capabilities,
             extensions: leaf_node_extensions,
             tree_info_tbs: TreeInfoTbs::KeyPackage,
@@ -356,6 +361,56 @@ impl KeyPackage {
 
         let (leaf_node, encryption_key_pair) =
             LeafNode::new(provider, signer, new_leaf_node_params)?;
+
+        let key_package_tbs = KeyPackageTbs {
+            protocol_version: ProtocolVersion::default(),
+            ciphersuite,
+            init_key,
+            leaf_node,
+            extensions,
+        };
+
+        let key_package = key_package_tbs.sign(signer)?;
+
+        Ok((key_package, encryption_key_pair))
+    }
+
+    /// Create a new KeyPackage from caller-provided init and encryption keys.
+    ///
+    /// Mirrors [`KeyPackage::new_from_keys`] but takes a caller-provided
+    /// encryption key pair for the leaf instead of generating a fresh one.
+    /// Used by the virtual-clients KeyPackage build path, where both keys are
+    /// derived from a per-operation secret so a sibling can reproduce them.
+    #[cfg(feature = "virtual-clients-draft")]
+    fn new_from_vc_keys(
+        ciphersuite: Ciphersuite,
+        signer: &impl Signer,
+        credential_with_key: CredentialWithKey,
+        extensions: Extensions<KeyPackage>,
+        leaf_node_params: KeyPackageLeafNodeParams,
+        init_key: InitKey,
+        encryption_key_pair: EncryptionKeyPair,
+    ) -> Result<(Self, EncryptionKeyPair), KeyPackageNewError> {
+        let KeyPackageLeafNodeParams {
+            lifetime,
+            capabilities,
+            extensions: leaf_node_extensions,
+        } = leaf_node_params;
+
+        let new_leaf_node_params = NewLeafNodeParams {
+            ciphersuite,
+            credential_with_key,
+            leaf_node_source: LeafNodeSource::KeyPackage(lifetime),
+            capabilities,
+            extensions: leaf_node_extensions,
+            tree_info_tbs: TreeInfoTbs::KeyPackage,
+        };
+
+        let (leaf_node, encryption_key_pair) = LeafNode::new_with_encryption_key_pair(
+            signer,
+            new_leaf_node_params,
+            encryption_key_pair,
+        )?;
 
         let key_package_tbs = KeyPackageTbs {
             protocol_version: ProtocolVersion::default(),
@@ -522,15 +577,18 @@ impl KeyPackageBuilder {
         credential_with_key: CredentialWithKey,
     ) -> Result<KeyPackageCreationResult, KeyPackageNewError> {
         self.ensure_last_resort();
+        let leaf_node_params = KeyPackageLeafNodeParams {
+            lifetime: self.key_package_lifetime.unwrap_or_default(),
+            capabilities: self.leaf_node_capabilities.unwrap_or_default(),
+            extensions: self.leaf_node_extensions.unwrap_or_default(),
+        };
         KeyPackage::create(
             ciphersuite,
             provider,
             signer,
             credential_with_key,
-            self.key_package_lifetime.unwrap_or_default(),
             self.key_package_extensions.unwrap_or_default(),
-            self.leaf_node_capabilities.unwrap_or_default(),
-            self.leaf_node_extensions.unwrap_or_default(),
+            leaf_node_params,
         )
     }
 
@@ -544,6 +602,11 @@ impl KeyPackageBuilder {
     ) -> Result<KeyPackageBundle, KeyPackageNewError> {
         self.ensure_last_resort();
 
+        let leaf_node_params = KeyPackageLeafNodeParams {
+            lifetime: self.key_package_lifetime.unwrap_or_default(),
+            capabilities: self.leaf_node_capabilities.unwrap_or_default(),
+            extensions: self.leaf_node_extensions.unwrap_or_default(),
+        };
         let KeyPackageCreationResult {
             key_package,
             encryption_keypair,
@@ -553,10 +616,8 @@ impl KeyPackageBuilder {
             provider,
             signer,
             credential_with_key,
-            self.key_package_lifetime.unwrap_or_default(),
             self.key_package_extensions.unwrap_or_default(),
-            self.leaf_node_capabilities.unwrap_or_default(),
-            self.leaf_node_extensions.unwrap_or_default(),
+            leaf_node_params,
         )?;
 
         // Store the key package in the key store with the hash reference as id
@@ -573,6 +634,298 @@ impl KeyPackageBuilder {
 
         Ok(full_kp)
     }
+
+    /// Build a batch of virtual-client KeyPackages a sibling can reproduce.
+    ///
+    /// Allocates a single generation of the `key_package` operation ratchet
+    /// for the emulation epoch identified by `epoch_id` and persists the
+    /// advanced tree once. For each `key_package_index` in `0..count` it
+    /// derives a per-KeyPackage seed secret from that one operation secret and
+    /// derives the KeyPackage's init key and leaf encryption key from the
+    /// seed. Each leaf carries an encrypted `DerivationInfo` under
+    /// [`VC_COMPONENT_ID`](crate::components::vc_derivation_info::VC_COMPONENT_ID)
+    /// so a sibling can recover the emulation leaf index,
+    /// generation, and index.
+    ///
+    /// The operation secret and the seeds are derived under the emulation
+    /// epoch's ciphersuite (the operation tree's ciphersuite). The init and
+    /// leaf-encryption keys are derived from each seed under the KeyPackage's
+    /// own `ciphersuite`.
+    ///
+    /// Each leaf must declare `AppDataDictionary` support and list
+    /// [`VC_COMPONENT_ID`](crate::components::vc_derivation_info::VC_COMPONENT_ID)
+    /// in its `AppComponents` entry, otherwise this
+    /// returns
+    /// [`VirtualClientsError::AppDataDictionaryNotSupported`](crate::components::vc_derivation_info::VirtualClientsError::AppDataDictionaryNotSupported)
+    /// or
+    /// [`VirtualClientsError::VcComponentNotListed`](crate::components::vc_derivation_info::VirtualClientsError::VcComponentNotListed).
+    ///
+    /// The advanced operation tree is persisted immediately, so a discarded
+    /// builder burns a generation. That is harmless: sibling ratchets skip
+    /// over a burned generation.
+    ///
+    /// Returns the batch's `generation` and one
+    /// `(KeyPackageBundle, KeyPackageInfo)` per KeyPackage. Each bundle is also
+    /// written to storage so the creating client can process its own Welcomes,
+    /// and each [`KeyPackageInfo`](crate::components::vc_derivation_info::KeyPackageInfo)
+    /// carries the index the client hands to its
+    /// sibling.
+    #[cfg(feature = "virtual-clients-draft")]
+    pub fn build_vc_batch(
+        self,
+        ciphersuite: Ciphersuite,
+        provider: &impl OpenMlsProvider,
+        signer: &impl Signer,
+        credential_with_key: CredentialWithKey,
+        epoch_id: crate::components::vc_derivation_info::EpochId,
+        count: u32,
+    ) -> Result<
+        (
+            u32,
+            Vec<(
+                KeyPackageBundle,
+                crate::components::vc_derivation_info::KeyPackageInfo,
+            )>,
+        ),
+        KeyPackageNewError,
+    > {
+        use crate::components::vc_derivation_info::{
+            EmulationEpochState, VirtualClientOperationType, VirtualClientsError,
+        };
+        use crate::components::vc_operation_tree::OperationSecretTree;
+
+        if ciphersuite.signature_algorithm() != signer.signature_scheme() {
+            return Err(KeyPackageNewError::CiphersuiteSignatureSchemeMismatch);
+        }
+
+        // Allocate a single generation of the key_package operation ratchet
+        // for the whole batch and persist the advanced tree right away,
+        // mirroring the commit builder's persist-on-allocate.
+        let state: EmulationEpochState = provider
+            .storage()
+            .vc_emulation_epoch_state(&epoch_id)
+            .map_err(|e| {
+                log::error!("vc: load emulation epoch state in build_vc_batch failed: {e:?}");
+                VirtualClientsError::StorageError
+            })?
+            .ok_or(VirtualClientsError::MissingEmulationEpochState)?;
+        let mut operation_tree: OperationSecretTree = provider
+            .storage()
+            .vc_operation_tree(&epoch_id)
+            .map_err(|e| {
+                log::error!("vc: load operation tree in build_vc_batch failed: {e:?}");
+                VirtualClientsError::StorageError
+            })?
+            .ok_or(VirtualClientsError::MissingOperationTree)?;
+        let (emulation_leaf_index, epoch_encryption_key, emulation_ciphersuite) =
+            state.into_parts();
+
+        // The operation context for KeyPackage operations is empty, since a
+        // KeyPackage is not tied to a higher-level group at build time.
+        let (generation, operation_secret) = operation_tree.next_operation_secret(
+            provider.crypto(),
+            emulation_ciphersuite,
+            &epoch_id,
+            emulation_leaf_index,
+            VirtualClientOperationType::KeyPackage,
+            b"",
+        )?;
+        provider
+            .storage()
+            .write_vc_operation_tree(&epoch_id, &operation_tree)
+            .map_err(|e| {
+                log::error!("vc: persist advanced operation tree in build_vc_batch failed: {e:?}");
+                VirtualClientsError::StorageError
+            })?;
+
+        let batch_ctx = VcBatchContext {
+            ciphersuite,
+            epoch_id,
+            emulation_ciphersuite,
+            epoch_encryption_key,
+            emulation_leaf_index,
+            generation,
+            operation_secret,
+        };
+
+        let mut built = Vec::with_capacity(count as usize);
+        for key_package_index in 0..count {
+            let entry = self.build_vc_key_package_for_index(
+                provider,
+                signer,
+                credential_with_key.clone(),
+                &batch_ctx,
+                key_package_index,
+            )?;
+            built.push(entry);
+        }
+
+        Ok((generation, built))
+    }
+
+    /// Derive and build a single KeyPackage at `key_package_index` from the
+    /// batch's shared `operation_secret`. Used by [`Self::build_vc_batch`].
+    #[cfg(feature = "virtual-clients-draft")]
+    fn build_vc_key_package_for_index(
+        &self,
+        provider: &impl OpenMlsProvider,
+        signer: &impl Signer,
+        credential_with_key: CredentialWithKey,
+        batch_ctx: &VcBatchContext,
+        key_package_index: u32,
+    ) -> Result<
+        (
+            KeyPackageBundle,
+            crate::components::vc_derivation_info::KeyPackageInfo,
+        ),
+        KeyPackageNewError,
+    > {
+        use crate::components::vc_derivation_info::{
+            DerivationInfo, DerivationInfoTbe, KeyPackageInfo, VirtualClientsError,
+        };
+        use tls_codec::Serialize as _;
+
+        let ciphersuite = batch_ctx.ciphersuite;
+
+        // Derive the per-index seed under the emulation ciphersuite, then the
+        // init and leaf encryption keys from the seed under the KeyPackage's
+        // own ciphersuite.
+        let seed = batch_ctx.operation_secret.derive_key_package_seed_secret(
+            provider.crypto(),
+            batch_ctx.emulation_ciphersuite,
+            key_package_index,
+        )?;
+        let init_key_pair = seed
+            .derive_init_key_secret(provider.crypto(), ciphersuite)?
+            .generate_init_key_pair(provider.crypto(), ciphersuite)?;
+        let encryption_key_pair = seed
+            .derive_encryption_key_secret(provider.crypto(), ciphersuite)?
+            .generate_encryption_key_pair(provider.crypto(), ciphersuite)?;
+
+        // Enforce the capability check and resolve the dictionary, then wrap
+        // the TBE bound to the new leaf via its serialized encryption key.
+        let resolved_dictionary =
+            crate::components::vc_derivation_info::resolve_vc_leaf_dictionary(
+                self.leaf_node_capabilities.as_ref(),
+                self.leaf_node_extensions.as_ref(),
+                None,
+            )?;
+        let leaf_encryption_key = encryption_key_pair
+            .public_key()
+            .tls_serialize_detached()
+            .map_err(VirtualClientsError::from)?;
+        let tbe = DerivationInfoTbe::KeyPackage {
+            leaf_index: batch_ctx.emulation_leaf_index,
+            generation: batch_ctx.generation,
+            key_package_index,
+        };
+        let derivation_info = DerivationInfo::encrypt(
+            provider.crypto(),
+            batch_ctx.emulation_ciphersuite,
+            &batch_ctx.epoch_encryption_key,
+            batch_ctx.epoch_id.clone(),
+            &leaf_encryption_key,
+            &tbe,
+        )?;
+        let derivation_info_bytes = derivation_info
+            .tls_serialize_detached()
+            .map_err(VirtualClientsError::from)?;
+        let mut builder = self.clone();
+        builder.ensure_last_resort();
+        let leaf_node_extensions = inject_vc_derivation_info(
+            builder.leaf_node_extensions.as_ref(),
+            resolved_dictionary,
+            derivation_info_bytes,
+        )?;
+
+        let leaf_node_params = KeyPackageLeafNodeParams {
+            lifetime: builder.key_package_lifetime.unwrap_or_default(),
+            capabilities: builder.leaf_node_capabilities.unwrap_or_default(),
+            extensions: leaf_node_extensions,
+        };
+        let (key_package, encryption_key_pair) = KeyPackage::new_from_vc_keys(
+            ciphersuite,
+            signer,
+            credential_with_key,
+            builder.key_package_extensions.unwrap_or_default(),
+            leaf_node_params,
+            init_key_pair.public.into(),
+            encryption_key_pair,
+        )?;
+
+        let key_package_ref = key_package.hash_ref(provider.crypto())?;
+        let full_kp = KeyPackageBundle {
+            key_package,
+            private_init_key: init_key_pair.private,
+            private_encryption_key: encryption_key_pair.private_key().clone(),
+        };
+        provider
+            .storage()
+            .write_key_package(&key_package_ref, &full_kp)
+            .map_err(|_| KeyPackageNewError::StorageError)?;
+
+        Ok((
+            full_kp,
+            KeyPackageInfo {
+                key_package_ref,
+                key_package_index,
+            },
+        ))
+    }
+}
+
+/// Shared inputs for building each KeyPackage in a `build_vc_batch` call:
+/// the batch's single operation secret plus the epoch material every
+/// KeyPackage in the batch derives against.
+#[cfg(feature = "virtual-clients-draft")]
+struct VcBatchContext {
+    ciphersuite: Ciphersuite,
+    epoch_id: crate::components::vc_derivation_info::EpochId,
+    emulation_ciphersuite: Ciphersuite,
+    epoch_encryption_key: crate::components::vc_derivation_info::EpochEncryptionKey,
+    emulation_leaf_index: crate::binary_tree::LeafNodeIndex,
+    generation: u32,
+    operation_secret: crate::components::vc_derivation_info::OperationSecret,
+}
+
+/// Merge a virtual-clients derivation-info blob into `resolved_dictionary`
+/// under [`VC_COMPONENT_ID`] and build the resulting leaf-node extensions.
+/// The dictionary already carries every other component id (notably
+/// `AppComponents`), so injecting the derivation info preserves them.
+#[cfg(feature = "virtual-clients-draft")]
+fn inject_vc_derivation_info(
+    caller_extensions: Option<&Extensions<LeafNode>>,
+    mut resolved_dictionary: crate::extensions::AppDataDictionary,
+    derivation_info_bytes: Vec<u8>,
+) -> Result<Extensions<LeafNode>, KeyPackageNewError> {
+    use crate::{
+        components::vc_derivation_info::VC_COMPONENT_ID,
+        extensions::{AppDataDictionaryExtension, Extension},
+    };
+
+    resolved_dictionary.insert(VC_COMPONENT_ID, derivation_info_bytes);
+    let vc_extension =
+        Extension::AppDataDictionary(AppDataDictionaryExtension::new(resolved_dictionary));
+
+    // Keep every non-AppDataDictionary extension the caller supplied and
+    // append the merged dictionary.
+    let other_extensions = caller_extensions
+        .map(|exts| {
+            exts.iter()
+                .filter(|ext| !matches!(ext, Extension::AppDataDictionary(_)))
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let new_extensions: Vec<Extension> = other_extensions
+        .into_iter()
+        .chain(std::iter::once(vc_extension))
+        .collect();
+    Extensions::<LeafNode>::from_vec(new_extensions).map_err(|_| {
+        KeyPackageNewError::LibraryError(LibraryError::custom(
+            "Failed to build VC leaf-node extensions",
+        ))
+    })
 }
 
 /// A [`KeyPackageBundle`] contains a [`KeyPackage`] and the init and encryption

--- a/openmls/src/key_packages/tests.rs
+++ b/openmls/src/key_packages/tests.rs
@@ -216,3 +216,146 @@ fn last_resort_key_package() {
         .expect("An unexpected error occurred.");
     assert!(key_package.key_package().last_resort());
 }
+
+/// Build a batch of virtual-client KeyPackages and verify the first carries a
+/// reproducible derivation info. Registers an emulation epoch on a VC-capable
+/// emulator group, calls `build_vc_batch`, and checks that the batch reports
+/// generation 0, that the first leaf carries a `VC_COMPONENT_ID` entry in its
+/// `app_data_dictionary`, and that the embedded `DerivationInfo` decrypts
+/// (with the epoch's encryption key) to a `DerivationInfoTbe` whose
+/// `leaf_index`, `generation`, and `key_package_index` match the emulator
+/// leaf, the consumed generation, and the batch index.
+#[cfg(feature = "virtual-clients-draft")]
+#[openmls_test::openmls_test]
+fn build_vc_key_package_carries_reproducible_derivation_info() {
+    use crate::{
+        components::vc_derivation_info::{
+            DerivationInfo, DerivationInfoTbe, EmulationEpochState, VirtualClientOperationType,
+            VC_COMPONENT_ID,
+        },
+        credentials::test_utils::new_credential,
+        extensions::{AppDataDictionary, AppDataDictionaryExtension},
+        group::{MlsGroup, MlsGroupCreateConfig, PURE_PLAINTEXT_WIRE_FORMAT_POLICY},
+        treesync::node::leaf_node::Capabilities,
+    };
+    use tls_codec::{DeserializeBytes as _, Serialize as _};
+
+    let provider = Provider::default();
+
+    // VC-capable leaf config: declares AppDataDictionary support and lists
+    // VC_COMPONENT_ID in its AppComponents entry (component id 1).
+    let capabilities = Capabilities::builder()
+        .extensions(vec![ExtensionType::AppDataDictionary])
+        .build();
+    let vc_leaf_extensions = {
+        let supported_components: Vec<u16> = vec![VC_COMPONENT_ID];
+        let app_components_body = supported_components
+            .tls_serialize_detached()
+            .expect("serialize AppComponents body");
+        let mut dictionary = AppDataDictionary::new();
+        dictionary.insert(1, app_components_body);
+        let ext = Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary));
+        Extensions::from_vec(vec![ext]).expect("build leaf-node Extensions")
+    };
+
+    // Emulator group: source of safe_export_secret(VC_COMPONENT_ID).
+    let (emulator_credential, emulator_signer) =
+        new_credential(&provider, b"Emulator", ciphersuite.signature_algorithm());
+    let emulator_config = MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .capabilities(capabilities.clone())
+        .with_leaf_node_extensions(vc_leaf_extensions.clone())
+        .expect("attach emulator leaf-node extensions")
+        .build();
+    let mut emulator = MlsGroup::new(
+        &provider,
+        &emulator_signer,
+        &emulator_config,
+        emulator_credential,
+    )
+    .expect("create emulator group");
+    let emulation_leaf_index = emulator.own_leaf_index();
+
+    let epoch_id = emulator
+        .register_vc_emulation_epoch(provider.crypto(), provider.storage())
+        .expect("register vc emulation epoch");
+
+    // The virtual client's own signing identity for the KeyPackage.
+    let (vc_credential, vc_signer) = new_credential(
+        &provider,
+        b"VirtualClient",
+        ciphersuite.signature_algorithm(),
+    );
+
+    let (generation, mut batch) = KeyPackage::builder()
+        .leaf_node_capabilities(capabilities)
+        .leaf_node_extensions(vc_leaf_extensions)
+        .build_vc_batch(
+            ciphersuite,
+            &provider,
+            &vc_signer,
+            vc_credential,
+            epoch_id.clone(),
+            1,
+        )
+        .expect("build_vc_batch must succeed");
+
+    assert_eq!(
+        generation, 0,
+        "the first key_package operation must consume generation 0"
+    );
+    assert_eq!(batch.len(), 1, "a count of 1 must produce one KeyPackage");
+    let (bundle, key_package_info) = batch.remove(0);
+    assert_eq!(
+        key_package_info.key_package_index, 0,
+        "the only KeyPackage in the batch has index 0"
+    );
+
+    // The leaf carries a VC_COMPONENT_ID entry in its app_data_dictionary.
+    let leaf = bundle.key_package().leaf_node();
+    let dictionary = leaf
+        .extensions()
+        .app_data_dictionary()
+        .expect("leaf must carry an AppDataDictionary extension")
+        .dictionary();
+    let derivation_info_bytes = dictionary
+        .get(&VC_COMPONENT_ID)
+        .expect("leaf must carry a VC_COMPONENT_ID entry");
+
+    // The embedded DerivationInfo decrypts with the epoch's encryption key.
+    let state: EmulationEpochState = provider
+        .storage()
+        .vc_emulation_epoch_state(&epoch_id)
+        .expect("load emulation epoch state")
+        .expect("emulation epoch state present");
+    let (_leaf_index, epoch_encryption_key, emulation_ciphersuite) = state.into_parts();
+    let derivation_info = DerivationInfo::tls_deserialize_exact_bytes(derivation_info_bytes)
+        .expect("deserialize DerivationInfo");
+    assert_eq!(derivation_info.epoch_id(), &epoch_id);
+    let leaf_encryption_key = leaf
+        .encryption_key()
+        .tls_serialize_detached()
+        .expect("serialize leaf encryption key");
+    let tbe = derivation_info
+        .decrypt(
+            provider.crypto(),
+            emulation_ciphersuite,
+            &epoch_encryption_key,
+            &leaf_encryption_key,
+            VirtualClientOperationType::KeyPackage,
+        )
+        .expect("decrypt DerivationInfoTbe");
+    let DerivationInfoTbe::KeyPackage {
+        leaf_index,
+        generation: tbe_generation,
+        key_package_index,
+    } = tbe
+    else {
+        panic!("a key-package leaf must decode to the KeyPackage variant");
+    };
+    assert_eq!(leaf_index, emulation_leaf_index);
+    assert_eq!(tbe_generation, generation);
+    assert_eq!(key_package_index, key_package_info.key_package_index);
+}

--- a/openmls/src/key_packages/tests.rs
+++ b/openmls/src/key_packages/tests.rs
@@ -224,7 +224,8 @@ fn last_resort_key_package() {
 /// `app_data_dictionary`, and that the embedded `DerivationInfo` decrypts
 /// (with the epoch's encryption key) to a `DerivationInfoTbe` whose
 /// `leaf_index`, `generation`, and `key_package_index` match the emulator
-/// leaf, the consumed generation, and the batch index.
+/// leaf, the consumed generation, and the batch index. Also checks that a
+/// count of 0 is rejected with `EmptyBatch`.
 #[cfg(feature = "virtual-clients-draft")]
 #[openmls_test::openmls_test]
 fn build_vc_key_package_carries_reproducible_derivation_info() {
@@ -236,6 +237,7 @@ fn build_vc_key_package_carries_reproducible_derivation_info() {
         credentials::test_utils::new_credential,
         extensions::{AppDataDictionary, AppDataDictionaryExtension},
         group::{MlsGroup, MlsGroupCreateConfig, PURE_PLAINTEXT_WIRE_FORMAT_POLICY},
+        key_packages::errors::KeyPackageNewError,
         treesync::node::leaf_node::Capabilities,
     };
     use tls_codec::{DeserializeBytes as _, Serialize as _};
@@ -289,7 +291,18 @@ fn build_vc_key_package_carries_reproducible_derivation_info() {
         ciphersuite.signature_algorithm(),
     );
 
-    let (generation, mut batch) = KeyPackage::builder()
+    // A count of 0 is rejected before any state is loaded or consumed.
+    let empty = KeyPackage::builder().build_vc_batch(
+        ciphersuite,
+        &provider,
+        &vc_signer,
+        vc_credential.clone(),
+        epoch_id.clone(),
+        0,
+    );
+    assert_eq!(empty.unwrap_err(), KeyPackageNewError::EmptyBatch);
+
+    let mut batch = KeyPackage::builder()
         .leaf_node_capabilities(capabilities)
         .leaf_node_extensions(vc_leaf_extensions)
         .build_vc_batch(
@@ -303,11 +316,15 @@ fn build_vc_key_package_carries_reproducible_derivation_info() {
         .expect("build_vc_batch must succeed");
 
     assert_eq!(
-        generation, 0,
+        batch.generation, 0,
         "the first key_package operation must consume generation 0"
     );
-    assert_eq!(batch.len(), 1, "a count of 1 must produce one KeyPackage");
-    let (bundle, key_package_info) = batch.remove(0);
+    assert_eq!(
+        batch.key_packages.len(),
+        1,
+        "a count of 1 must produce one KeyPackage"
+    );
+    let (bundle, key_package_info) = batch.key_packages.remove(0);
     assert_eq!(
         key_package_info.key_package_index, 0,
         "the only KeyPackage in the batch has index 0"
@@ -356,6 +373,6 @@ fn build_vc_key_package_carries_reproducible_derivation_info() {
         panic!("a key-package leaf must decode to the KeyPackage variant");
     };
     assert_eq!(leaf_index, emulation_leaf_index);
-    assert_eq!(tbe_generation, generation);
+    assert_eq!(tbe_generation, batch.generation);
     assert_eq!(key_package_index, key_package_info.key_package_index);
 }

--- a/openmls/src/storage.rs
+++ b/openmls/src/storage.rs
@@ -155,7 +155,7 @@ impl traits::ApplicationExportTree<CURRENT_VERSION> for ApplicationExportTree {}
 mod virtual_clients_storage {
     use super::*;
     use crate::components::vc_derivation_info::{
-        EmulationEpochState, EpochId, VcEmulationBindings,
+        EmulationEpochState, EpochId, RetainedKeyPackageMaterial, VcEmulationBindings,
     };
     use crate::components::vc_operation_tree::OperationSecretTree;
 
@@ -172,6 +172,9 @@ mod virtual_clients_storage {
 
     impl Entity<CURRENT_VERSION> for OperationSecretTree {}
     impl traits::VcOperationTree<CURRENT_VERSION> for OperationSecretTree {}
+
+    impl Entity<CURRENT_VERSION> for RetainedKeyPackageMaterial {}
+    impl traits::RetainedKeyPackageMaterial<CURRENT_VERSION> for RetainedKeyPackageMaterial {}
 }
 
 #[cfg(test)]

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -220,6 +220,40 @@ impl LeafNode {
         Ok((leaf_node, encryption_key_pair))
     }
 
+    /// Create a new [`LeafNode`] from a caller-provided encryption key pair.
+    ///
+    /// Mirrors [`LeafNode::new`] but uses `encryption_key_pair` instead of
+    /// generating a fresh one. This is the virtual-clients KeyPackage build
+    /// hook: the encryption key is derived from the per-operation secret so a
+    /// sibling can reproduce it.
+    #[cfg(feature = "virtual-clients-draft")]
+    pub(crate) fn new_with_encryption_key_pair(
+        signer: &impl Signer,
+        new_leaf_node_params: NewLeafNodeParams,
+        encryption_key_pair: EncryptionKeyPair,
+    ) -> Result<(Self, EncryptionKeyPair), LibraryError> {
+        let NewLeafNodeParams {
+            ciphersuite: _,
+            credential_with_key,
+            leaf_node_source,
+            capabilities,
+            extensions,
+            tree_info_tbs,
+        } = new_leaf_node_params;
+
+        let leaf_node = Self::new_with_key(
+            encryption_key_pair.public_key().clone(),
+            credential_with_key,
+            leaf_node_source,
+            capabilities,
+            extensions,
+            tree_info_tbs,
+            signer,
+        )?;
+
+        Ok((leaf_node, encryption_key_pair))
+    }
+
     /// Creates a new placeholder [`LeafNode`] that is used to build external
     /// commits.
     ///

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -1487,7 +1487,7 @@ fn vc_sibling_joins_higher_level_group_via_key_package_welcome() {
     // alice_a publishes a virtual-client KeyPackage and hands the upload to
     // alice_b. alice_b only learns about the KeyPackage through the upload, it
     // never stores the bundle.
-    let (generation, mut batch) = KeyPackage::builder()
+    let mut batch = KeyPackage::builder()
         .leaf_node_capabilities(vc_capabilities())
         .leaf_node_extensions(vc_leaf_extensions())
         .build_vc_batch(
@@ -1499,7 +1499,8 @@ fn vc_sibling_joins_higher_level_group_via_key_package_welcome() {
             1,
         )
         .expect("alice_a build_vc_batch");
-    let (vc_key_package_bundle, kp_info) = batch.remove(0);
+    let generation = batch.generation;
+    let (vc_key_package_bundle, kp_info) = batch.key_packages.remove(0);
     let upload = assemble_vc_key_package_upload(
         alice_a_provider.storage(),
         epoch_id_a.clone(),
@@ -1668,7 +1669,7 @@ fn vc_batch_key_packages_join_in_any_order() {
 
     // One batch of 40 KeyPackages, larger than OUT_OF_ORDER_TOLERANCE (32).
     let count: u32 = 40;
-    let (generation, batch) = KeyPackage::builder()
+    let batch = KeyPackage::builder()
         .leaf_node_capabilities(vc_capabilities())
         .leaf_node_extensions(vc_leaf_extensions())
         .build_vc_batch(
@@ -1680,10 +1681,12 @@ fn vc_batch_key_packages_join_in_any_order() {
             count,
         )
         .expect("alice_a build_vc_batch");
+    let generation = batch.generation;
     assert_eq!(generation, 0, "the batch consumes a single generation");
-    assert_eq!(batch.len(), count as usize);
+    assert_eq!(batch.key_packages.len(), count as usize);
 
     let kp_infos = batch
+        .key_packages
         .iter()
         .map(|(_bundle, info)| info)
         .map(
@@ -1704,8 +1707,11 @@ fn vc_batch_key_packages_join_in_any_order() {
 
     // The sibling joins via a HIGH batch index first and a LOW one second,
     // each through a separate higher-level group.
-    let high_bundle = batch[(count - 1) as usize].0.key_package().clone();
-    let low_bundle = batch[0].0.key_package().clone();
+    let high_bundle = batch.key_packages[(count - 1) as usize]
+        .0
+        .key_package()
+        .clone();
+    let low_bundle = batch.key_packages[0].0.key_package().clone();
 
     for (label, kp) in [
         (b"BobHigh".as_slice(), high_bundle),

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -1401,6 +1401,359 @@ fn vc_sibling_emulator_resyncs_into_higher_level_group_via_external_commit() {
     );
 }
 
+/// A sibling emulator joins a higher-level group via a virtual client's
+/// KeyPackage that another emulator published.
+///
+///   * `alice_a` and `alice_b` share an emulator group and both register the
+///     same emulation epoch, so both hold its `EmulationEpochState` and
+///     `OperationSecretTree`.
+///   * `alice_a` builds a one-KeyPackage batch with `build_vc_batch`
+///     (consuming generation 0 of its `key_package` operation ratchet) and
+///     hands the resulting `KeyPackageUpload` to `alice_b`, who stores a
+///     `RetainedKeyPackageMaterial` per ref via
+///     `process_vc_key_package_upload`.
+///   * An ordinary MLS client, `bob`, founds a higher-level group and adds the
+///     virtual client using that KeyPackage, producing a Welcome and ratchet
+///     tree.
+///   * `alice_b` (the *sibling*, not the KeyPackage's creator) processes the
+///     Welcome: the first stage rederives the init key from the operation tree
+///     to decrypt the group secrets, then staging locates and validates its
+///     own leaf via the derivation info and the derived encryption key.
+///   * `alice_b` joins as the virtual client at the expected leaf, and an
+///     application message round-trips between `bob` and `alice_b`.
+#[openmls_test]
+fn vc_sibling_joins_higher_level_group_via_key_package_welcome() {
+    use openmls::components::vc_derivation_info::{
+        assemble_vc_key_package_upload, process_vc_key_package_upload,
+    };
+
+    let alice_a_provider = Provider::default();
+    let alice_b_provider = Provider::default();
+    let bob_provider = Provider::default();
+
+    // Shared virtual-client signer + credential, held by both emulator
+    // clients so either could sign for the shared higher-level leaf.
+    let (vc_signer, vc_credential) =
+        shared_vc_identity(ciphersuite, &alice_a_provider, &alice_b_provider);
+
+    // Emulator group: alice_a creates, alice_b joins via Welcome.
+    let (mut emulator_a, emulator_a_signer) =
+        make_emulator_group(ciphersuite, &alice_a_provider, b"AliceEmulatorA");
+    let (emulator_b_credential, emulator_b_signer) = new_credential(
+        &alice_b_provider,
+        b"AliceEmulatorB",
+        ciphersuite.signature_algorithm(),
+    );
+    let emulator_b_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_extensions(vc_leaf_extensions())
+        .build(
+            ciphersuite,
+            &alice_b_provider,
+            &emulator_b_signer,
+            emulator_b_credential,
+        )
+        .expect("emulator_b KP build")
+        .key_package()
+        .to_owned();
+    let (_e_commit, e_welcome, _e_gi) = emulator_a
+        .add_members(&alice_a_provider, &emulator_a_signer, &[emulator_b_kp])
+        .expect("emulator_a add alice_b");
+    emulator_a
+        .merge_pending_commit(&alice_a_provider)
+        .expect("emulator_a merge add");
+    let mut emulator_b = StagedWelcome::new_from_welcome(
+        &alice_b_provider,
+        &vc_join_config(),
+        e_welcome.into_welcome().expect("emulator welcome"),
+        Some(emulator_a.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(&alice_b_provider))
+    .expect("alice_b join emulator group");
+
+    // Both emulators register the same emulation epoch.
+    let epoch_id_a = emulator_a
+        .register_vc_emulation_epoch(alice_a_provider.crypto(), alice_a_provider.storage())
+        .expect("alice_a register vc epoch");
+    let epoch_id_b = emulator_b
+        .register_vc_emulation_epoch(alice_b_provider.crypto(), alice_b_provider.storage())
+        .expect("alice_b register vc epoch");
+    assert_eq!(
+        epoch_id_a, epoch_id_b,
+        "siblings must derive the same EpochId"
+    );
+
+    // alice_a publishes a virtual-client KeyPackage and hands the upload to
+    // alice_b. alice_b only learns about the KeyPackage through the upload, it
+    // never stores the bundle.
+    let (generation, mut batch) = KeyPackage::builder()
+        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_extensions(vc_leaf_extensions())
+        .build_vc_batch(
+            ciphersuite,
+            &alice_a_provider,
+            &vc_signer,
+            vc_credential.clone(),
+            epoch_id_a.clone(),
+            1,
+        )
+        .expect("alice_a build_vc_batch");
+    let (vc_key_package_bundle, kp_info) = batch.remove(0);
+    let upload = assemble_vc_key_package_upload(
+        alice_a_provider.storage(),
+        epoch_id_a.clone(),
+        generation,
+        vec![kp_info],
+    )
+    .expect("assemble upload");
+    process_vc_key_package_upload(&alice_b_provider, &upload).expect("alice_b process upload");
+
+    // Bob founds a higher-level group and adds the virtual client via the
+    // published KeyPackage.
+    let (bob_credential, bob_signer) =
+        new_credential(&bob_provider, b"Bob", ciphersuite.signature_algorithm());
+    let bob_group_config = MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .build();
+    let mut bob_main = MlsGroup::new(
+        &bob_provider,
+        &bob_signer,
+        &bob_group_config,
+        bob_credential,
+    )
+    .expect("bob create higher-level group");
+    let (_commit, welcome, _gi) = bob_main
+        .add_members(
+            &bob_provider,
+            &bob_signer,
+            &[vc_key_package_bundle.key_package().clone()],
+        )
+        .expect("bob add virtual client");
+    bob_main
+        .merge_pending_commit(&bob_provider)
+        .expect("bob merge add");
+    let ratchet_tree = bob_main.export_ratchet_tree();
+
+    // alice_b, the sibling that only holds the RetainedKeyPackageMaterial,
+    // processes the Welcome and joins as the virtual client.
+    let processed = openmls::group::ProcessedWelcome::new_from_welcome(
+        &alice_b_provider,
+        &vc_join_config(),
+        welcome.into_welcome().expect("welcome present"),
+    )
+    .expect("alice_b process welcome");
+    let mut alice_b_main = processed
+        .into_staged_welcome(&alice_b_provider, Some(ratchet_tree.into()))
+        .expect("alice_b stage welcome")
+        .into_group(&alice_b_provider)
+        .expect("alice_b join higher-level group");
+
+    // alice_b's leaf carries the virtual client's signature key.
+    let vc_signature_key = vc_signer.public().to_vec();
+    let own_member = alice_b_main
+        .members()
+        .find(|m| m.index == alice_b_main.own_leaf_index())
+        .expect("own member present");
+    assert_eq!(
+        own_member.signature_key, vc_signature_key,
+        "alice_b's joined leaf must carry the virtual client's signature key"
+    );
+    assert_eq!(
+        bob_main.epoch_authenticator(),
+        alice_b_main.epoch_authenticator(),
+        "bob and the joined virtual client must agree on the epoch"
+    );
+
+    // An application message round-trips both ways.
+    let to_vc = send_and_process_app_message(
+        &mut bob_main,
+        &bob_provider,
+        &bob_signer,
+        &mut alice_b_main,
+        &alice_b_provider,
+        b"hello virtual client",
+    );
+    match to_vc.into_content() {
+        ProcessedMessageContent::ApplicationMessage(msg) => {
+            assert_eq!(msg.into_bytes().as_slice(), b"hello virtual client");
+        }
+        _ => panic!("expected application message from bob"),
+    }
+    let from_vc = send_and_process_app_message(
+        &mut alice_b_main,
+        &alice_b_provider,
+        &vc_signer,
+        &mut bob_main,
+        &bob_provider,
+        b"hello bob",
+    );
+    match from_vc.into_content() {
+        ProcessedMessageContent::ApplicationMessage(msg) => {
+            assert_eq!(msg.into_bytes().as_slice(), b"hello bob");
+        }
+        _ => panic!("expected application message from virtual client"),
+    }
+}
+
+/// Regression test for the batch-model switch. A virtual client builds one
+/// batch of KeyPackages larger than the operation tree's
+/// `OUT_OF_ORDER_TOLERANCE` (32), so the old per-KeyPackage-generation model
+/// would have evicted the lowest generations before they could be used at
+/// Welcome time. The sibling then joins two separate higher-level groups via
+/// KeyPackages from that batch, picking a HIGH batch index first and a LOW one
+/// second. Both joins must succeed because the batch shares a single
+/// generation and every per-index seed is pinned in the retained material at
+/// upload-processing time, independent of Welcome order.
+#[openmls_test]
+fn vc_batch_key_packages_join_in_any_order() {
+    use openmls::components::vc_derivation_info::{
+        assemble_vc_key_package_upload, process_vc_key_package_upload,
+    };
+
+    let alice_a_provider = Provider::default();
+    let alice_b_provider = Provider::default();
+
+    let (vc_signer, vc_credential) =
+        shared_vc_identity(ciphersuite, &alice_a_provider, &alice_b_provider);
+
+    // Emulator group: alice_a creates, alice_b joins via Welcome.
+    let (mut emulator_a, emulator_a_signer) =
+        make_emulator_group(ciphersuite, &alice_a_provider, b"AliceEmulatorA");
+    let (emulator_b_credential, emulator_b_signer) = new_credential(
+        &alice_b_provider,
+        b"AliceEmulatorB",
+        ciphersuite.signature_algorithm(),
+    );
+    let emulator_b_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_extensions(vc_leaf_extensions())
+        .build(
+            ciphersuite,
+            &alice_b_provider,
+            &emulator_b_signer,
+            emulator_b_credential,
+        )
+        .expect("emulator_b KP build")
+        .key_package()
+        .to_owned();
+    let (_e_commit, e_welcome, _e_gi) = emulator_a
+        .add_members(&alice_a_provider, &emulator_a_signer, &[emulator_b_kp])
+        .expect("emulator_a add alice_b");
+    emulator_a
+        .merge_pending_commit(&alice_a_provider)
+        .expect("emulator_a merge add");
+    let mut emulator_b = StagedWelcome::new_from_welcome(
+        &alice_b_provider,
+        &vc_join_config(),
+        e_welcome.into_welcome().expect("emulator welcome"),
+        Some(emulator_a.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(&alice_b_provider))
+    .expect("alice_b join emulator group");
+
+    let epoch_id_a = emulator_a
+        .register_vc_emulation_epoch(alice_a_provider.crypto(), alice_a_provider.storage())
+        .expect("alice_a register vc epoch");
+    let epoch_id_b = emulator_b
+        .register_vc_emulation_epoch(alice_b_provider.crypto(), alice_b_provider.storage())
+        .expect("alice_b register vc epoch");
+    assert_eq!(
+        epoch_id_a, epoch_id_b,
+        "siblings must derive the same EpochId"
+    );
+
+    // One batch of 40 KeyPackages, larger than OUT_OF_ORDER_TOLERANCE (32).
+    let count: u32 = 40;
+    let (generation, batch) = KeyPackage::builder()
+        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_extensions(vc_leaf_extensions())
+        .build_vc_batch(
+            ciphersuite,
+            &alice_a_provider,
+            &vc_signer,
+            vc_credential.clone(),
+            epoch_id_a.clone(),
+            count,
+        )
+        .expect("alice_a build_vc_batch");
+    assert_eq!(generation, 0, "the batch consumes a single generation");
+    assert_eq!(batch.len(), count as usize);
+
+    let kp_infos = batch
+        .iter()
+        .map(|(_bundle, info)| info)
+        .map(
+            |info| openmls::components::vc_derivation_info::KeyPackageInfo {
+                key_package_ref: info.key_package_ref.clone(),
+                key_package_index: info.key_package_index,
+            },
+        )
+        .collect::<Vec<_>>();
+    let upload = assemble_vc_key_package_upload(
+        alice_a_provider.storage(),
+        epoch_id_a.clone(),
+        generation,
+        kp_infos,
+    )
+    .expect("assemble upload");
+    process_vc_key_package_upload(&alice_b_provider, &upload).expect("alice_b process upload");
+
+    // The sibling joins via a HIGH batch index first and a LOW one second,
+    // each through a separate higher-level group.
+    let high_bundle = batch[(count - 1) as usize].0.key_package().clone();
+    let low_bundle = batch[0].0.key_package().clone();
+
+    for (label, kp) in [
+        (b"BobHigh".as_slice(), high_bundle),
+        (b"BobLow".as_slice(), low_bundle),
+    ] {
+        let bob_provider = Provider::default();
+        let (bob_credential, bob_signer) =
+            new_credential(&bob_provider, label, ciphersuite.signature_algorithm());
+        let bob_group_config = MlsGroupCreateConfig::builder()
+            .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .ciphersuite(ciphersuite)
+            .use_ratchet_tree_extension(true)
+            .build();
+        let mut bob_main = MlsGroup::new(
+            &bob_provider,
+            &bob_signer,
+            &bob_group_config,
+            bob_credential,
+        )
+        .expect("bob create higher-level group");
+        let (_commit, welcome, _gi) = bob_main
+            .add_members(&bob_provider, &bob_signer, &[kp])
+            .expect("bob add virtual client");
+        bob_main
+            .merge_pending_commit(&bob_provider)
+            .expect("bob merge add");
+        let ratchet_tree = bob_main.export_ratchet_tree();
+
+        let processed = openmls::group::ProcessedWelcome::new_from_welcome(
+            &alice_b_provider,
+            &vc_join_config(),
+            welcome.into_welcome().expect("welcome present"),
+        )
+        .expect("alice_b process welcome");
+        let alice_b_main = processed
+            .into_staged_welcome(&alice_b_provider, Some(ratchet_tree.into()))
+            .expect("alice_b stage welcome")
+            .into_group(&alice_b_provider)
+            .expect("alice_b join higher-level group");
+
+        assert_eq!(
+            bob_main.epoch_authenticator(),
+            alice_b_main.epoch_authenticator(),
+            "bob and the joined virtual client must agree on the epoch"
+        );
+    }
+}
+
 #[openmls_test::openmls_test]
 fn processing_own_application_message() {
     let alice_provider = &Provider::default();
@@ -1666,10 +2019,14 @@ fn bound_group_fails_closed_when_emulation_state_missing_on_send() {
         &provider,
         &alice_signer,
     );
-    provider
+    let deleted = provider
         .storage()
-        .delete_vc_emulation_state(&epoch_id)
+        .delete_vc_emulation_state_if_unreferenced(&epoch_id)
         .expect("delete emulation state");
+    assert!(
+        deleted,
+        "no retained material, so the epoch state is deleted"
+    );
 
     let err = alice_group
         .create_message(&provider, &alice_signer, b"must not send")

--- a/sqlite_storage/migrations/V5__vc_operation_secrets.sql
+++ b/sqlite_storage/migrations/V5__vc_operation_secrets.sql
@@ -9,3 +9,20 @@ CREATE TABLE vc_operation_trees (
     operation_tree BLOB NOT NULL,
     PRIMARY KEY (epoch_id)
 );
+
+-- Per-KeyPackage material a sibling retains when it processes a
+-- KeyPackageUpload. One row per KeyPackage reference, holding the emulation
+-- epoch the KeyPackage belongs to and the per-KeyPackage seed secret needed to
+-- rederive its keys. Deleted together with the KeyPackage it describes. The
+-- epoch_id column lets an emulation epoch's state stay alive while KeyPackages
+-- derived from it can still be welcomed.
+CREATE TABLE vc_retained_key_package_material (
+    provider_version INTEGER NOT NULL,
+    key_package_ref BLOB NOT NULL,
+    epoch_id BLOB NOT NULL,
+    record BLOB NOT NULL,
+    PRIMARY KEY (key_package_ref)
+);
+
+CREATE INDEX vc_retained_key_package_material_epoch_id
+    ON vc_retained_key_package_material (epoch_id);

--- a/sqlite_storage/src/storage_provider.rs
+++ b/sqlite_storage/src/storage_provider.rs
@@ -686,6 +686,9 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
         &self,
         hash_ref: &KeyPackageRef,
     ) -> Result<(), Self::Error> {
+        #[cfg(feature = "virtual-clients-draft")]
+        StorableKeyRef(hash_ref)
+            .delete_retained_key_package_material::<C>(self.connection.borrow())?;
         StorableHashRef(hash_ref).delete_key_package::<C>(self.connection.borrow())
     }
 
@@ -767,12 +770,23 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
     }
 
     #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_emulation_state<EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>>(
+    fn delete_vc_emulation_state_if_unreferenced<
+        EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>,
+    >(
         &self,
         epoch_id: &EpochId,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<bool, Self::Error> {
+        // The application should call this within a transaction so the liveness
+        // check and the deletions apply atomically and a material stored
+        // concurrently cannot be orphaned.
+        if StorableKeyRef(epoch_id)
+            .has_retained_key_package_material_for_epoch::<C>(self.connection.borrow())?
+        {
+            return Ok(false);
+        }
         StorableKeyRef(epoch_id).delete_vc_emulation_epoch_state::<C>(self.connection.borrow())?;
-        StorableKeyRef(epoch_id).delete_vc_operation_tree::<C>(self.connection.borrow())
+        StorableKeyRef(epoch_id).delete_vc_operation_tree::<C>(self.connection.borrow())?;
+        Ok(true)
     }
 
     #[cfg(feature = "virtual-clients-draft")]
@@ -831,5 +845,68 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
     ) -> Result<Option<VcOperationTree>, Self::Error> {
         StorableKeyRef(epoch_id)
             .load_vc_operation_tree::<C, VcOperationTree>(self.connection.borrow())
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn write_retained_key_package_material_batch<
+        EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>,
+        VcOperationTree: traits::VcOperationTree<STORAGE_PROVIDER_VERSION>,
+        KeyPackageRef: traits::HashReference<STORAGE_PROVIDER_VERSION>,
+        RetainedKeyPackageMaterial: traits::RetainedKeyPackageMaterial<STORAGE_PROVIDER_VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+        operation_tree: &VcOperationTree,
+        materials: &[(KeyPackageRef, RetainedKeyPackageMaterial)],
+    ) -> Result<(), Self::Error> {
+        // The application should call this within a transaction so the advanced
+        // tree and all materials are written together and roll back together on
+        // error, leaving the tree unadvanced.
+        crate::vc_secrets::StorableOperationTreeRef(operation_tree)
+            .store_vc_operation_tree::<C, _>(self.connection.borrow(), epoch_id)?;
+        for (hash_ref, record) in materials {
+            crate::vc_secrets::StorableRetainedKeyPackageMaterialRef(record)
+                .store_retained_key_package_material::<C, _, _>(
+                    self.connection.borrow(),
+                    epoch_id,
+                    hash_ref,
+                )?;
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn retained_key_package_material<
+        KeyPackageRef: traits::HashReference<STORAGE_PROVIDER_VERSION>,
+        RetainedKeyPackageMaterial: traits::RetainedKeyPackageMaterial<STORAGE_PROVIDER_VERSION>,
+    >(
+        &self,
+        hash_ref: &KeyPackageRef,
+    ) -> Result<Option<RetainedKeyPackageMaterial>, Self::Error> {
+        StorableKeyRef(hash_ref)
+            .load_retained_key_package_material::<C, RetainedKeyPackageMaterial>(
+                self.connection.borrow(),
+            )
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_retained_key_package_material_for_epoch<
+        EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error> {
+        StorableKeyRef(epoch_id)
+            .has_retained_key_package_material_for_epoch::<C>(self.connection.borrow())
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn delete_retained_key_package_material<
+        KeyPackageRef: traits::HashReference<STORAGE_PROVIDER_VERSION>,
+    >(
+        &self,
+        hash_ref: &KeyPackageRef,
+    ) -> Result<(), Self::Error> {
+        StorableKeyRef(hash_ref).delete_retained_key_package_material::<C>(self.connection.borrow())
     }
 }

--- a/sqlite_storage/src/vc_secrets.rs
+++ b/sqlite_storage/src/vc_secrets.rs
@@ -1,7 +1,8 @@
 use std::marker::PhantomData;
 
 use openmls_traits::storage::{
-    traits::GroupId as GroupIdTrait, traits::VcEmulationEpochState as VcEmulationEpochStateTrait,
+    traits::GroupId as GroupIdTrait, traits::HashReference as HashReferenceTrait,
+    traits::VcEmulationEpochState as VcEmulationEpochStateTrait,
     traits::VcEpochId as VcEpochIdTrait, Entity as EntityTrait, Key,
 };
 use rusqlite::{params, OptionalExtension as _, ToSql};
@@ -150,6 +151,27 @@ impl<VcEpochId: VcEpochIdTrait<STORAGE_PROVIDER_VERSION>> StorableKeyRef<'_, VcE
         )?;
         Ok(())
     }
+
+    pub(super) fn has_retained_key_package_material_for_epoch<C: Codec>(
+        &self,
+        connection: &rusqlite::Connection,
+    ) -> Result<bool, rusqlite::Error> {
+        let Self(epoch_id) = self;
+        let mut stmt = connection.prepare(
+            "SELECT EXISTS(
+                SELECT 1 FROM vc_retained_key_package_material
+                WHERE epoch_id = ?1
+                    AND provider_version = ?2
+            )",
+        )?;
+        stmt.query_row(
+            params![
+                KeyRefWrapper::<C, VcEpochId>(epoch_id, PhantomData),
+                STORAGE_PROVIDER_VERSION
+            ],
+            |row| row.get::<_, bool>(0),
+        )
+    }
 }
 
 /// Per-epoch bindings from a higher-level group to emulation epochs. One row
@@ -262,6 +284,94 @@ impl<'a, VcOperationTree: EntityTrait<STORAGE_PROVIDER_VERSION>>
                 STORAGE_PROVIDER_VERSION,
                 KeyRefWrapper::<C, _>(epoch_id, PhantomData),
                 EntityRefWrapper::<C, _>(self.0, PhantomData)
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+/// Per-KeyPackage material a sibling retains when it processes a
+/// KeyPackageUpload. One row per KeyPackage reference, holding the emulation
+/// epoch and the per-KeyPackage seed secret needed to rederive the
+/// KeyPackage's keys.
+pub(super) struct StorableRetainedKeyPackageMaterialRef<
+    'a,
+    RetainedKeyPackageMaterial: EntityTrait<STORAGE_PROVIDER_VERSION>,
+>(pub &'a RetainedKeyPackageMaterial);
+
+impl<'a, RetainedKeyPackageMaterial: EntityTrait<STORAGE_PROVIDER_VERSION>>
+    StorableRetainedKeyPackageMaterialRef<'a, RetainedKeyPackageMaterial>
+{
+    pub(super) fn store_retained_key_package_material<
+        C: Codec,
+        EpochId: VcEpochIdTrait<STORAGE_PROVIDER_VERSION>,
+        KeyPackageRef: HashReferenceTrait<STORAGE_PROVIDER_VERSION>,
+    >(
+        &self,
+        connection: &rusqlite::Connection,
+        epoch_id: &EpochId,
+        key_package_ref: &KeyPackageRef,
+    ) -> Result<(), rusqlite::Error> {
+        connection.execute(
+            "INSERT INTO vc_retained_key_package_material (provider_version, key_package_ref, epoch_id, record)
+            VALUES (?1, ?2, ?3, ?4)
+            ON CONFLICT(key_package_ref) DO UPDATE SET
+                epoch_id = excluded.epoch_id,
+                record = excluded.record,
+                provider_version = excluded.provider_version",
+            params![
+                STORAGE_PROVIDER_VERSION,
+                KeyRefWrapper::<C, _>(key_package_ref, PhantomData),
+                KeyRefWrapper::<C, _>(epoch_id, PhantomData),
+                EntityRefWrapper::<C, _>(self.0, PhantomData)
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+impl<KeyPackageRef: HashReferenceTrait<STORAGE_PROVIDER_VERSION>>
+    StorableKeyRef<'_, KeyPackageRef>
+{
+    pub(super) fn load_retained_key_package_material<
+        C: Codec,
+        RetainedKeyPackageMaterial: EntityTrait<STORAGE_PROVIDER_VERSION>,
+    >(
+        &self,
+        connection: &rusqlite::Connection,
+    ) -> Result<Option<RetainedKeyPackageMaterial>, rusqlite::Error> {
+        let Self(key_package_ref) = self;
+        let mut stmt = connection.prepare(
+            "SELECT record
+            FROM vc_retained_key_package_material
+            WHERE key_package_ref = ?1
+                AND provider_version = ?2",
+        )?;
+        stmt.query_row(
+            params![
+                KeyRefWrapper::<C, KeyPackageRef>(key_package_ref, PhantomData),
+                STORAGE_PROVIDER_VERSION
+            ],
+            |row| {
+                let EntityWrapper::<C, RetainedKeyPackageMaterial>(record, ..) = row.get(0)?;
+                Ok(record)
+            },
+        )
+        .optional()
+    }
+
+    pub(super) fn delete_retained_key_package_material<C: Codec>(
+        &self,
+        connection: &rusqlite::Connection,
+    ) -> Result<(), rusqlite::Error> {
+        let Self(key_package_ref) = self;
+        connection.execute(
+            "DELETE FROM vc_retained_key_package_material
+            WHERE key_package_ref = ?1
+                AND provider_version = ?2",
+            params![
+                KeyRefWrapper::<C, KeyPackageRef>(key_package_ref, PhantomData),
+                STORAGE_PROVIDER_VERSION
             ],
         )?;
         Ok(())

--- a/sqlite_storage/tests/vc_operation_tree.rs
+++ b/sqlite_storage/tests/vc_operation_tree.rs
@@ -34,6 +34,90 @@ struct TestOperationTree(Vec<u8>);
 impl traits::VcOperationTree<1> for TestOperationTree {}
 impl Entity<1> for TestOperationTree {}
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestKeyPackageRef(Vec<u8>);
+impl traits::HashReference<1> for TestKeyPackageRef {}
+impl Key<1> for TestKeyPackageRef {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestRetainedMaterial(Vec<u8>);
+impl traits::RetainedKeyPackageMaterial<1> for TestRetainedMaterial {}
+impl Entity<1> for TestRetainedMaterial {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestEmulationState(Vec<u8>);
+impl traits::VcEmulationEpochState<1> for TestEmulationState {}
+impl Entity<1> for TestEmulationState {}
+
+/// A batch write stores the operation tree and the retained material, the
+/// material ties the epoch into liveness, and the guarded delete keeps the
+/// epoch state while material references it but removes it afterwards.
+#[test]
+fn batch_write_ties_retained_material_into_epoch_liveness() {
+    let storage = storage();
+    let epoch_id = TestEpochId(b"LiveEpoch".to_vec());
+    let other_epoch_id = TestEpochId(b"OtherEpoch".to_vec());
+    let kp_ref = TestKeyPackageRef(b"kp-ref".to_vec());
+
+    storage
+        .write_vc_emulation_epoch_state(&epoch_id, &TestEmulationState(b"state".to_vec()))
+        .unwrap();
+
+    assert!(!storage
+        .has_retained_key_package_material_for_epoch(&epoch_id)
+        .unwrap());
+
+    let tree = TestOperationTree(b"AdvancedTree".to_vec());
+    let material = TestRetainedMaterial(b"material".to_vec());
+    storage
+        .write_retained_key_package_material_batch(
+            &epoch_id,
+            &tree,
+            &[(kp_ref.clone(), material.clone())],
+        )
+        .unwrap();
+
+    let read_tree: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert_eq!(read_tree, Some(tree));
+    let read_material: Option<TestRetainedMaterial> =
+        storage.retained_key_package_material(&kp_ref).unwrap();
+    assert_eq!(read_material, Some(material));
+
+    assert!(storage
+        .has_retained_key_package_material_for_epoch(&epoch_id)
+        .unwrap());
+    assert!(!storage
+        .has_retained_key_package_material_for_epoch(&other_epoch_id)
+        .unwrap());
+
+    // While material references the epoch the guarded delete is a no-op.
+    assert!(!storage
+        .delete_vc_emulation_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestEmulationState> =
+        storage.vc_emulation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_some());
+    let read_tree: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert!(read_tree.is_some());
+
+    // After deleting the material the guarded delete removes the epoch state
+    // and the operation tree.
+    storage
+        .delete_retained_key_package_material(&kp_ref)
+        .unwrap();
+    assert!(!storage
+        .has_retained_key_package_material_for_epoch(&epoch_id)
+        .unwrap());
+    assert!(storage
+        .delete_vc_emulation_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestEmulationState> =
+        storage.vc_emulation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_none());
+    let read_tree: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
+    assert!(read_tree.is_none());
+}
+
 fn storage() -> openmls_sqlite_storage::SqliteStorageProvider<JsonCodec, Connection> {
     let connection = rusqlite::Connection::open_in_memory().unwrap();
     let mut storage =
@@ -72,8 +156,12 @@ fn operation_tree_read_write_delete() {
     let read: Option<TestOperationTree> = storage.vc_operation_tree(&other_epoch_id).unwrap();
     assert_eq!(read, None);
 
-    // Deleting the emulation state removes the operation tree too.
-    storage.delete_vc_emulation_state(&epoch_id).unwrap();
+    // Deleting the emulation state removes the operation tree too. No retained
+    // material references this epoch, so the deletion goes through.
+    let deleted = storage
+        .delete_vc_emulation_state_if_unreferenced(&epoch_id)
+        .unwrap();
+    assert!(deleted);
     let read: Option<TestOperationTree> = storage.vc_operation_tree(&epoch_id).unwrap();
     assert_eq!(read, None);
 }

--- a/traits/src/storage.rs
+++ b/traits/src/storage.rs
@@ -220,6 +220,36 @@ pub trait StorageProvider<const VERSION: u16> {
         vc_operation_tree: &VcOperationTree,
     ) -> Result<(), Self::Error>;
 
+    /// Store the advanced operation secret tree for `epoch_id` together with
+    /// the retained virtual clients KeyPackage material for every reference in
+    /// `materials`.
+    ///
+    /// A sibling calls this once when it processes a `KeyPackageUpload`: the
+    /// upload consumes one operation generation in the tree and produces one
+    /// [`RetainedKeyPackageMaterial`](traits::RetainedKeyPackageMaterial) per
+    /// KeyPackage. These writes belong together: the tree must never be
+    /// persisted as advanced without the materials it produced. Providers do
+    /// not open their own transaction, so an application using a transactional
+    /// provider (such as SQLite) should call this within a transaction to get
+    /// atomicity and rollback on error. The in-memory provider applies the
+    /// writes while holding its write lock. Each material is keyed by its
+    /// [`HashReference`](traits::HashReference)
+    /// and tagged with `epoch_id` so the epoch-liveness query
+    /// ([`Self::has_retained_key_package_material_for_epoch`]) can find it. A
+    /// subsequent write for the same reference replaces the stored material.
+    #[cfg(feature = "virtual-clients-draft")]
+    fn write_retained_key_package_material_batch<
+        EpochId: traits::VcEpochId<VERSION>,
+        VcOperationTree: traits::VcOperationTree<VERSION>,
+        KeyPackageRef: traits::HashReference<VERSION>,
+        RetainedKeyPackageMaterial: traits::RetainedKeyPackageMaterial<VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+        operation_tree: &VcOperationTree,
+        materials: &[(KeyPackageRef, RetainedKeyPackageMaterial)],
+    ) -> Result<(), Self::Error>;
+
     //
     //    ---   setters/writers/enqueuers for crypto objects  ---
     //
@@ -518,6 +548,28 @@ pub trait StorageProvider<const VERSION: u16> {
         epoch_id: &EpochId,
     ) -> Result<Option<VcOperationTree>, Self::Error>;
 
+    /// Get the retained virtual clients KeyPackage material for the given
+    /// KeyPackage reference. Returns `None` if no material was stored for that
+    /// reference.
+    #[cfg(feature = "virtual-clients-draft")]
+    fn retained_key_package_material<
+        KeyPackageRef: traits::HashReference<VERSION>,
+        RetainedKeyPackageMaterial: traits::RetainedKeyPackageMaterial<VERSION>,
+    >(
+        &self,
+        hash_ref: &KeyPackageRef,
+    ) -> Result<Option<RetainedKeyPackageMaterial>, Self::Error>;
+
+    /// Return `true` if any retained virtual clients KeyPackage material still
+    /// references `epoch_id`. Used to keep an emulation epoch's state alive
+    /// while KeyPackages derived from it can still be welcomed (see
+    /// [`Self::delete_vc_emulation_state_if_unreferenced`]).
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_retained_key_package_material_for_epoch<EpochId: traits::VcEpochId<VERSION>>(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error>;
+
     //
     //     ---    deleters for group state    ---
     //
@@ -646,6 +698,12 @@ pub trait StorageProvider<const VERSION: u16> {
     ///
     /// This function only deletes the key package.
     /// The corresponding encryption keys must be deleted separately.
+    ///
+    /// Under the `virtual-clients-draft` feature, an implementation must also
+    /// delete the retained virtual clients KeyPackage material stored for the
+    /// same reference (see [`Self::delete_retained_key_package_material`]).
+    /// Deleting non-existent material is a no-op, so this is safe for
+    /// KeyPackages that were never uploaded by a virtual client.
     fn delete_key_package<KeyPackageRef: traits::HashReference<VERSION>>(
         &self,
         hash_ref: &KeyPackageRef,
@@ -667,14 +725,24 @@ pub trait StorageProvider<const VERSION: u16> {
         group_id: &GroupId,
     ) -> Result<(), Self::Error>;
 
-    /// Delete all per-epoch state for the given emulation epoch: both the
-    /// emulation epoch state and the Virtual Client Operation Secret Tree.
-    /// Called by the application when it removes an emulation epoch.
+    /// Delete all per-epoch state for the given emulation epoch (both the
+    /// emulation epoch state and the Virtual Client Operation Secret Tree),
+    /// but only if no retained virtual clients KeyPackage material still
+    /// references it.
+    ///
+    /// Returns `Ok(true)` if the epoch state was deleted, and `Ok(false)` if
+    /// it was kept because retained material still references the epoch. The
+    /// liveness check and the deletion belong together. Providers do not open
+    /// their own transaction, so an application using a transactional provider
+    /// (such as SQLite) should call this within a transaction, so a material
+    /// stored concurrently cannot be orphaned by a deletion that already
+    /// observed the epoch as unreferenced. The in-memory provider holds its
+    /// write lock across both.
     #[cfg(feature = "virtual-clients-draft")]
-    fn delete_vc_emulation_state<EpochId: traits::VcEpochId<VERSION>>(
+    fn delete_vc_emulation_state_if_unreferenced<EpochId: traits::VcEpochId<VERSION>>(
         &self,
         epoch_id: &EpochId,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<bool, Self::Error>;
 
     /// Remove the per-epoch emulation bindings of the given group. Called
     /// when the group is being deleted.
@@ -682,6 +750,15 @@ pub trait StorageProvider<const VERSION: u16> {
     fn delete_vc_emulation_bindings<GroupId: traits::GroupId<VERSION>>(
         &self,
         group_id: &GroupId,
+    ) -> Result<(), Self::Error>;
+
+    /// Delete the retained virtual clients KeyPackage material stored for the
+    /// given KeyPackage reference. Called from [`Self::delete_key_package`] so
+    /// the material is removed together with the KeyPackage it describes.
+    #[cfg(feature = "virtual-clients-draft")]
+    fn delete_retained_key_package_material<KeyPackageRef: traits::HashReference<VERSION>>(
+        &self,
+        hash_ref: &KeyPackageRef,
     ) -> Result<(), Self::Error>;
 }
 
@@ -746,6 +823,8 @@ pub mod traits {
     pub trait VcEmulationBindings<const VERSION: u16>: Entity<VERSION> {}
     #[cfg(feature = "virtual-clients-draft")]
     pub trait VcOperationTree<const VERSION: u16>: Entity<VERSION> {}
+    #[cfg(feature = "virtual-clients-draft")]
+    pub trait RetainedKeyPackageMaterial<const VERSION: u16>: Entity<VERSION> {}
 
     // traits for types that implement both
     pub trait ProposalRef<const VERSION: u16>: Entity<VERSION> + Key<VERSION> {}


### PR DESCRIPTION
Adds KeyPackage building and Welcome processing for virtual clients (behind `virtual-clients-draft`), so a virtual client can publish KeyPackages that a sibling recovers and uses to join higher-level groups.

- **Building:** `KeyPackageBuilder::build_vc_batch` allocates one `key_package` operation generation per batch, derives a per-KeyPackage seed (and from it the init and leaf encryption keys) for each index, and embeds an encrypted `DerivationInfo` in each leaf under `VC_COMPONENT_ID`. Returns a `VcKeyPackageBatch` with the generation and the built bundles.
- **Carrying between siblings:** `assemble_vc_key_package_upload` builds and retains the key material for a received KeyPackage upload message.
- **Welcome:** `find_and_validate_vc_own_leaf` locates the joined leaf by its derived encryption key, decrypts the leaf's `DerivationInfo`, and checks the embedded `(leaf_index, generation, key_package_index)` against the retained material.

