### PR TITLE
Derive TlsSerialize for MlsMessageIn unconditionally

### DIFF
--- a/openmls/src/framing/message_in.rs
+++ b/openmls/src/framing/message_in.rs
@@ -68,8 +68,7 @@ pub struct MlsMessageIn {
 ///     }
 /// } MLSMessage;
 /// ```
-#[derive(Debug, PartialEq, Clone, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
-#[cfg_attr(feature = "test-utils", derive(TlsSerialize))]
+#[derive(Debug, PartialEq, Clone, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize)]
 #[repr(u16)]
 pub enum MlsMessageBodyIn {
     /// Plaintext message

--- a/openmls/src/messages/group_info.rs
+++ b/openmls/src/messages/group_info.rs
@@ -28,8 +28,7 @@ const SIGNATURE_GROUP_INFO_LABEL: &str = "GroupInfoTBS";
 /// `verify(...)` with the signature key of the [`Credential`](crate::credentials::Credential).
 /// When receiving a serialized group info, it can only be deserialized into a
 /// [`VerifiableGroupInfo`], which can then be turned into a group info as described above.
-#[derive(Debug, PartialEq, Clone, TlsDeserialize, TlsDeserializeBytes, TlsSize)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(TlsSerialize))]
+#[derive(Debug, PartialEq, Clone, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize)]
 pub struct VerifiableGroupInfo {
     payload: GroupInfoTBS,
     signature: Signature,


### PR DESCRIPTION
So far it was only derived if the test-utils feature is set. The main point of the In packages is not to prevent us from serializing received messages, but from derializing into types we assume are verified.

When using these types in APIs in other projects, it's a little annoying having to propagate or work around this In/Out split on the higher layer as well. For example, when submitting an MlsMessage as an HTTP POST body to a relay, if we only impl one of Serialize and Deserialize, then the request type would have to be different on client on server, which reduces code reuse.