### PR TITLE
Expose more From<Out> for In impls without testing feature flag

### DIFF
--- a/openmls/src/framing/message_out.rs
+++ b/openmls/src/framing/message_out.rs
@@ -193,6 +193,30 @@ impl MlsMessageOut {
     }
 }
 
+impl From<MlsMessageBodyOut> for MlsMessageBodyIn {
+    fn from(value: MlsMessageBodyOut) -> Self {
+        match value {
+            MlsMessageBodyOut::PublicMessage(pm) => MlsMessageBodyIn::PublicMessage(pm.into()),
+            MlsMessageBodyOut::PrivateMessage(pm) => MlsMessageBodyIn::PrivateMessage(pm.into()),
+            MlsMessageBodyOut::Welcome(w) => MlsMessageBodyIn::Welcome(w),
+            MlsMessageBodyOut::GroupInfo(gi) => {
+                MlsMessageBodyIn::GroupInfo(gi.into_verifiable_group_info())
+            }
+            MlsMessageBodyOut::KeyPackage(kp) => MlsMessageBodyIn::KeyPackage(kp.into()),
+        }
+    }
+}
+
+impl From<MlsMessageOut> for MlsMessageIn {
+    fn from(mls_message_out: MlsMessageOut) -> Self {
+        let MlsMessageOut { version, body } = mls_message_out;
+        Self {
+            version,
+            body: body.into(),
+        }
+    }
+}
+
 // The following two `From` implementations break abstraction layers and MUST
 // NOT be made available outside of tests or "test-utils".
 
@@ -206,23 +230,6 @@ impl From<MlsMessageIn> for MlsMessageOut {
             MlsMessageBodyIn::KeyPackage(kp) => MlsMessageBodyOut::KeyPackage(kp.into()),
             MlsMessageBodyIn::PublicMessage(pm) => MlsMessageBodyOut::PublicMessage(pm.into()),
             MlsMessageBodyIn::PrivateMessage(pm) => MlsMessageBodyOut::PrivateMessage(pm.into()),
-        };
-        Self { version, body }
-    }
-}
-
-#[cfg(any(feature = "test-utils", test))]
-impl From<MlsMessageOut> for MlsMessageIn {
-    fn from(mls_message_out: MlsMessageOut) -> Self {
-        let version = mls_message_out.version;
-        let body = match mls_message_out.body {
-            MlsMessageBodyOut::PublicMessage(pm) => MlsMessageBodyIn::PublicMessage(pm.into()),
-            MlsMessageBodyOut::PrivateMessage(pm) => MlsMessageBodyIn::PrivateMessage(pm.into()),
-            MlsMessageBodyOut::Welcome(w) => MlsMessageBodyIn::Welcome(w),
-            MlsMessageBodyOut::GroupInfo(gi) => {
-                MlsMessageBodyIn::GroupInfo(gi.into_verifiable_group_info())
-            }
-            MlsMessageBodyOut::KeyPackage(kp) => MlsMessageBodyIn::KeyPackage(kp.into()),
         };
         Self { version, body }
     }

--- a/openmls/src/framing/private_message_in.rs
+++ b/openmls/src/framing/private_message_in.rs
@@ -312,11 +312,8 @@ pub(crate) struct PrivateMessageContentIn {
     pub(crate) auth: FramedContentAuthData,
 }
 
-// The following `From` implementation( breaks abstraction layers and MUST
-// NOT be made available outside of tests or "test-utils".
-#[cfg(any(feature = "test-utils", test))]
-impl From<PrivateMessageIn> for PrivateMessage {
-    fn from(value: PrivateMessageIn) -> Self {
+impl From<PrivateMessage> for PrivateMessageIn {
+    fn from(value: PrivateMessage) -> Self {
         Self {
             group_id: value.group_id,
             epoch: value.epoch,
@@ -328,9 +325,11 @@ impl From<PrivateMessageIn> for PrivateMessage {
     }
 }
 
+// The following `From` implementation( breaks abstraction layers and MUST
+// NOT be made available outside of tests or "test-utils".
 #[cfg(any(feature = "test-utils", test))]
-impl From<PrivateMessage> for PrivateMessageIn {
-    fn from(value: PrivateMessage) -> Self {
+impl From<PrivateMessageIn> for PrivateMessage {
+    fn from(value: PrivateMessageIn) -> Self {
         Self {
             group_id: value.group_id,
             epoch: value.epoch,

--- a/openmls/src/framing/public_message_in.rs
+++ b/openmls/src/framing/public_message_in.rs
@@ -276,12 +276,9 @@ impl TlsSerializeTrait for PublicMessageIn {
     }
 }
 
-// The following `From` implementation( breaks abstraction layers and MUST
-// NOT be made available outside of tests or "test-utils".
-#[cfg(any(feature = "test-utils", test))]
-impl From<PublicMessageIn> for PublicMessage {
-    fn from(v: PublicMessageIn) -> Self {
-        PublicMessage {
+impl From<PublicMessage> for PublicMessageIn {
+    fn from(v: PublicMessage) -> Self {
+        PublicMessageIn {
             content: v.content.into(),
             auth: v.auth,
             membership_tag: v.membership_tag,
@@ -289,10 +286,12 @@ impl From<PublicMessageIn> for PublicMessage {
     }
 }
 
+// The following `From` implementation( breaks abstraction layers and MUST
+// NOT be made available outside of tests or "test-utils".
 #[cfg(any(feature = "test-utils", test))]
-impl From<PublicMessage> for PublicMessageIn {
-    fn from(v: PublicMessage) -> Self {
-        PublicMessageIn {
+impl From<PublicMessageIn> for PublicMessage {
+    fn from(v: PublicMessageIn) -> Self {
+        PublicMessage {
             content: v.content.into(),
             auth: v.auth,
             membership_tag: v.membership_tag,

--- a/openmls/src/messages/group_info.rs
+++ b/openmls/src/messages/group_info.rs
@@ -208,7 +208,8 @@ impl GroupInfo {
         &self.payload.confirmation_tag
     }
 
-    #[cfg(any(feature = "test-utils", test))]
+    /// Returns the GroupInfo with a type that signals it is unverified.
+    /// A form of downcasting to an equivalent type with a weaker type invariant.
     pub(crate) fn into_verifiable_group_info(self) -> VerifiableGroupInfo {
         VerifiableGroupInfo {
             payload: GroupInfoTBS {


### PR DESCRIPTION
These impls mostly existed before, but were behind the test-utils feature flag and had a comment that they are dangerous. However, converting this way is not dangerous, just the other way around: It is safe to convert from a type assumed to be validated to an equivalent type with no such assumption.

We already allow converting this way for several types (e.g. KeyPackage, Commit). This commit adds the same impls for the remaining types, allowing to convert an MlsMessageOut to an MlsMessageIn.