### PR TITLE
fix: align doc generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,3 +18,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
       - run: RUSTDOCFLAGS="--cfg doc_cfg --cfg docsrs" cargo +nightly doc --all-features --no-deps
+        working-directory: openmls

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc -p openmls --message-format json
+      - run: RUSTDOCFLAGS="--cfg doc_cfg --cfg docsrs" cargo +nightly doc --all-features --no-deps

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -530,9 +530,8 @@ pub enum ProcessedMessageContent {
     /// [`PublicMessage`](crate::framing::MlsMessageBodyIn::PublicMessage). A
     /// Commit framed as a
     /// [`PrivateMessage`](crate::framing::MlsMessageBodyIn::PrivateMessage)
-    /// cannot be decrypted by its own author and will be rejected during
-    /// decryption with
-    /// [`ValidationError::CannotDecryptOwnMessage`](crate::group::errors::ValidationError::CannotDecryptOwnMessage).
+    /// cannot be decrypted by its own author and is instead rejected during
+    /// decryption.
     OwnPendingCommit,
 }
 


### PR DESCRIPTION
I broke the doc generation in GH pages with #2084, and it went unnoticed because the commands were not aligned. This PR fixes that.