### PR TITLE
allow staging of own pathless commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2084](https://github.com/openmls/openmls/pull/2084): Added the `ProcessedMessageContent::OwnPendingCommit` variant, returned when processing a Commit authored by this client that matches the group's pending commit. Callers should merge the pending commit via `MlsGroup::merge_pending_commit()`.
 
 ### Fixed
+
+- [#XXXX](https://github.com/openmls/openmls/pull/XXXX): A path-less Commit from this client's own leaf that does not match the pending commit is now staged as a regular commit instead of being rejected as a mismatched own commit.
 - [#2034](https://github.com/openmls/openmls/pull/2034): Fixes a bug where the integer storage tags for `serde` non-self-describing serializations were changed, leading to incorrect deserializations. By default, storage format compatibility with `openmls` v0.7.1 and earlier is now restored. Enabling the `0-8-1-storage-format` feature maintains storage format compatibility with `openmls` v0.8.1 (the previous `openmls` release).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#2089](https://github.com/openmls/openmls/pull/2089): A Commit without an `UpdatePath` from this client's own leaf that does not match the pending commit is now staged as a regular commit instead of being rejected as a mismatched own commit.
+- [#2089](https://github.com/openmls/openmls/pull/2089): A Commit without an UpdatePath from this client's own leaf that does not match the pending commit is now staged as a regular commit instead of being rejected as a mismatched own commit.
 - [#2034](https://github.com/openmls/openmls/pull/2034): Fixes a bug where the integer storage tags for `serde` non-self-describing serializations were changed, leading to incorrect deserializations. By default, storage format compatibility with `openmls` v0.7.1 and earlier is now restored. Enabling the `0-8-1-storage-format` feature maintains storage format compatibility with `openmls` v0.8.1 (the previous `openmls` release).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#2089](https://github.com/openmls/openmls/pull/2089): A path-less Commit from this client's own leaf that does not match the pending commit is now staged as a regular commit instead of being rejected as a mismatched own commit.
+- [#2089](https://github.com/openmls/openmls/pull/2089): A Commit without an `UpdatePath` from this client's own leaf that does not match the pending commit is now staged as a regular commit instead of being rejected as a mismatched own commit.
 - [#2034](https://github.com/openmls/openmls/pull/2034): Fixes a bug where the integer storage tags for `serde` non-self-describing serializations were changed, leading to incorrect deserializations. By default, storage format compatibility with `openmls` v0.7.1 and earlier is now restored. Enabling the `0-8-1-storage-format` feature maintains storage format compatibility with `openmls` v0.8.1 (the previous `openmls` release).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#XXXX](https://github.com/openmls/openmls/pull/XXXX): A path-less Commit from this client's own leaf that does not match the pending commit is now staged as a regular commit instead of being rejected as a mismatched own commit.
+- [#2089](https://github.com/openmls/openmls/pull/2089): A path-less Commit from this client's own leaf that does not match the pending commit is now staged as a regular commit instead of being rejected as a mismatched own commit.
 - [#2034](https://github.com/openmls/openmls/pull/2034): Fixes a bug where the integer storage tags for `serde` non-self-describing serializations were changed, leading to incorrect deserializations. By default, storage format compatibility with `openmls` v0.7.1 and earlier is now restored. Enabling the `0-8-1-storage-format` feature maintains storage format compatibility with `openmls` v0.8.1 (the previous `openmls` release).
 
 ### Changed

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -513,13 +513,17 @@ pub enum ProcessedMessageContent {
     ///
     /// This is returned instead of
     /// [`StagedCommitMessage`](Self::StagedCommitMessage) when the processed
-    /// Commit was created by this client. Since this client already holds the
-    /// corresponding pending commit, the incoming Commit is not staged. To
-    /// apply it, merge the pending commit using
+    /// Commit was created by this client and matches the group's pending commit.
+    /// Since this client already holds the corresponding pending commit, the
+    /// incoming Commit is not staged. To apply it, merge the pending commit
+    /// using
     /// [`MlsGroup::merge_pending_commit()`](crate::group::mls_group::MlsGroup::merge_pending_commit()).
+    /// An own Commit that does not match the pending commit is instead returned
+    /// as a [`StagedCommitMessage`](Self::StagedCommitMessage) (if it carries no
+    /// path) or rejected (if it carries a path we cannot decrypt).
     ///
     /// The match against the pending commit is established by comparing the
-    /// confirmation tag of the incoming Commit against one recomputed from the
+    /// confirmation tag of the incoming Commit against the one stored with the
     /// pending commit. The message signature has already been verified, which
     /// authenticates the Commit as ours, and a matching confirmation tag binds
     /// the confirmed transcript hash of the new epoch. We do not otherwise

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -508,8 +508,8 @@ pub enum ProcessedMessageContent {
     /// the commit should be merged into the group's state using
     /// [`MlsGroup::merge_staged_commit()`](crate::group::mls_group::MlsGroup::merge_staged_commit()).
     StagedCommitMessage(Box<StagedCommit>),
-    /// A Commit authored by this client and echoed back to it, matching the
-    /// group's pending commit.
+    /// A Commit authored by this client that it got fanned out by the delivery
+    /// service, matching the group's pending commit.
     ///
     /// This is returned instead of
     /// [`StagedCommitMessage`](Self::StagedCommitMessage) when the processed

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -519,8 +519,8 @@ pub enum ProcessedMessageContent {
     /// using
     /// [`MlsGroup::merge_pending_commit()`](crate::group::mls_group::MlsGroup::merge_pending_commit()).
     /// An own Commit that does not match the pending commit is instead returned
-    /// as a [`StagedCommitMessage`](Self::StagedCommitMessage) (if it carries no
-    /// path) or rejected (if it carries a path we cannot decrypt).
+    /// as a [`StagedCommitMessage`](Self::StagedCommitMessage) (if it has no
+    /// UpdatePath) or rejected (if it has an UpdatePath we cannot decrypt).
     ///
     /// The match against the pending commit is established by comparing the
     /// confirmation tag of the incoming Commit against the one stored with the

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -738,17 +738,12 @@ impl MlsGroup {
                 }
             }
             FramedContentBody::Commit(commit) => {
-                // A Commit from our own leaf that carries no virtual-client
-                // derivation info is our own commit echoed back. We confirm it
-                // matches the pending commit and signal the caller to merge
-                // that instead of staging the incoming Commit. When the commit
-                // does carry VC material it is a sibling virtual-client commit
-                // and must be staged via the VC path below. We branch on the
-                // presence of VC material rather than the feature flag so that
-                // own commits are recognized in both configurations.
-                //
-                // The receiver only loads VC material when it can identify
-                // itself as a sibling from the commit shape:
+                // Load virtual-client derivation info when this commit was
+                // authored by a sibling emulator through a leaf shared with us.
+                // A path commit carrying this material is staged via the VC path
+                // below rather than treated as our own (see the own-commit
+                // handling further down). The receiver only loads it when the
+                // commit shape lets it identify itself as a sibling:
                 //
                 // * `Sender::Member(idx)` with `idx == own_leaf_index`: the
                 //   sender committed through our shared higher-level leaf, so
@@ -770,23 +765,39 @@ impl MlsGroup {
                 #[cfg(not(feature = "virtual-clients-draft"))]
                 let _ = commit;
 
-                let is_own_pending_commit =
+                let is_own_commit =
                     matches!(&sender, Sender::Member(member) if member == &self.own_leaf_index());
                 #[cfg(feature = "virtual-clients-draft")]
-                let is_own_pending_commit = is_own_pending_commit && vc_material.is_none();
+                let is_own_commit = is_own_commit && vc_material.is_none();
 
-                if is_own_pending_commit {
-                    self.check_own_pending_commit(provider.crypto(), &content)?;
-                    return Ok(ProcessedMessage::new(
-                        self.group_id().clone(),
-                        epoch,
-                        sender,
-                        authenticated_data,
-                        ProcessedMessageContent::OwnPendingCommit,
-                        credential,
-                        #[cfg(feature = "virtual-clients-draft")]
-                        emulator_sender_leaf_index,
-                    ));
+                if is_own_commit {
+                    let received_tag = content
+                        .confirmation_tag()
+                        .ok_or(StageCommitError::ConfirmationTagMissing)?;
+                    if self.matches_pending_commit(received_tag) {
+                        // The Commit is our pending commit echoed back to us:
+                        // surface `OwnPendingCommit` so the caller merges the
+                        // pending commit instead of staging the echo.
+                        return Ok(ProcessedMessage::new(
+                            self.group_id().clone(),
+                            epoch,
+                            sender,
+                            authenticated_data,
+                            ProcessedMessageContent::OwnPendingCommit,
+                            credential,
+                            #[cfg(feature = "virtual-clients-draft")]
+                            emulator_sender_leaf_index,
+                        ));
+                    }
+                    // Not our pending commit. We cannot decrypt a path we
+                    // encrypted to the other members, so a path-carrying commit
+                    // is unprocessable. A path-less commit carries no
+                    // author-private material and falls through to staging (a
+                    // sibling's path-less commit, or our own commit replayed
+                    // after the pending commit was cleared).
+                    if commit.path.is_some() {
+                        return Err(StageCommitError::OwnCommitMismatch.into());
+                    }
                 }
 
                 // Since this is a commit, we need to load the private key material we need for decryption.
@@ -853,13 +864,12 @@ impl MlsGroup {
             }
             FramedContentBody::Commit(commit) => {
                 // See `process_internal_authenticated_content_with_app_data_updates`
-                // for the rationale. A Commit from our own leaf that carries no
-                // VC derivation info is our own commit echoed back and signals
-                // the caller to merge the pending commit; one that does carry VC
-                // material is a sibling virtual-client commit and is staged. The
-                // receiver only loads VC material when it can identify itself as
-                // a sibling from the commit shape: own-leaf sender, or external
-                // commit with an inline `Remove(own_leaf)`.
+                // for the rationale. We load VC derivation info for a sibling's
+                // path commit through a shared leaf, and otherwise apply the
+                // own-commit handling below. The receiver only loads VC material
+                // when the commit shape lets it identify itself as a sibling:
+                // own-leaf sender, or external commit with an inline
+                // `Remove(own_leaf)`.
                 #[cfg(feature = "virtual-clients-draft")]
                 let (vc_material, vc_emulation_epoch_id) =
                     if is_sibling_vc_commit(commit, &sender, self.own_leaf_index()) {
@@ -873,23 +883,39 @@ impl MlsGroup {
                 #[cfg(not(feature = "virtual-clients-draft"))]
                 let _ = commit;
 
-                let is_own_pending_commit =
+                let is_own_commit =
                     matches!(&sender, Sender::Member(member) if member == &self.own_leaf_index());
                 #[cfg(feature = "virtual-clients-draft")]
-                let is_own_pending_commit = is_own_pending_commit && vc_material.is_none();
+                let is_own_commit = is_own_commit && vc_material.is_none();
 
-                if is_own_pending_commit {
-                    self.check_own_pending_commit(provider.crypto(), &content)?;
-                    return Ok(ProcessedMessage::new(
-                        self.group_id().clone(),
-                        epoch,
-                        sender,
-                        authenticated_data,
-                        ProcessedMessageContent::OwnPendingCommit,
-                        credential,
-                        #[cfg(feature = "virtual-clients-draft")]
-                        emulator_sender_leaf_index,
-                    ));
+                if is_own_commit {
+                    let received_tag = content
+                        .confirmation_tag()
+                        .ok_or(StageCommitError::ConfirmationTagMissing)?;
+                    if self.matches_pending_commit(received_tag) {
+                        // The Commit is our pending commit echoed back to us:
+                        // surface `OwnPendingCommit` so the caller merges the
+                        // pending commit instead of staging the echo.
+                        return Ok(ProcessedMessage::new(
+                            self.group_id().clone(),
+                            epoch,
+                            sender,
+                            authenticated_data,
+                            ProcessedMessageContent::OwnPendingCommit,
+                            credential,
+                            #[cfg(feature = "virtual-clients-draft")]
+                            emulator_sender_leaf_index,
+                        ));
+                    }
+                    // Not our pending commit. We cannot decrypt a path we
+                    // encrypted to the other members, so a path-carrying commit
+                    // is unprocessable. A path-less commit carries no
+                    // author-private material and falls through to staging (a
+                    // sibling's path-less commit, or our own commit replayed
+                    // after the pending commit was cleared).
+                    if commit.path.is_some() {
+                        return Err(StageCommitError::OwnCommitMismatch.into());
+                    }
                 }
 
                 // Since this is a commit, we need to load the private key material we need for decryption.

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -740,7 +740,7 @@ impl MlsGroup {
             FramedContentBody::Commit(commit) => {
                 // Load virtual-client derivation info when this commit was
                 // authored by a sibling emulator through a leaf shared with us.
-                // A Commit with an `UpdatePath` carrying this material is staged
+                // A Commit with an UpdatePath carrying this material is staged
                 // via the VC path below rather than treated as our own (see the
                 // own-commit handling further down). The receiver only loads it
                 // when the commit shape lets it identify itself as a sibling:
@@ -791,10 +791,10 @@ impl MlsGroup {
                     }
                     // Not our pending commit. We cannot decrypt a path we
                     // encrypted to the other members, so a Commit with an
-                    // `UpdatePath` is unprocessable. A Commit without an
-                    // `UpdatePath` carries no author-private material and falls
+                    // UpdatePath is unprocessable. A Commit without an
+                    // UpdatePath carries no author-private material and falls
                     // through to staging (a sibling's Commit without an
-                    // `UpdatePath`, or our own commit replayed after the pending
+                    // UpdatePath, or our own commit replayed after the pending
                     // commit was cleared).
                     if commit.path.is_some() {
                         return Err(StageCommitError::OwnCommitMismatch.into());
@@ -866,7 +866,7 @@ impl MlsGroup {
             FramedContentBody::Commit(commit) => {
                 // See `process_internal_authenticated_content_with_app_data_updates`
                 // for the rationale. We load VC derivation info for a sibling's
-                // Commit with an `UpdatePath` through a shared leaf, and
+                // Commit with an UpdatePath through a shared leaf, and
                 // otherwise apply the own-commit handling below. The receiver
                 // only loads VC material
                 // when the commit shape lets it identify itself as a sibling:
@@ -911,10 +911,10 @@ impl MlsGroup {
                     }
                     // Not our pending commit. We cannot decrypt a path we
                     // encrypted to the other members, so a Commit with an
-                    // `UpdatePath` is unprocessable. A Commit without an
-                    // `UpdatePath` carries no author-private material and falls
+                    // UpdatePath is unprocessable. A Commit without an
+                    // UpdatePath carries no author-private material and falls
                     // through to staging (a sibling's Commit without an
-                    // `UpdatePath`, or our own commit replayed after the pending
+                    // UpdatePath, or our own commit replayed after the pending
                     // commit was cleared).
                     if commit.path.is_some() {
                         return Err(StageCommitError::OwnCommitMismatch.into());

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -775,9 +775,10 @@ impl MlsGroup {
                         .confirmation_tag()
                         .ok_or(StageCommitError::ConfirmationTagMissing)?;
                     if self.matches_pending_commit(received_tag) {
-                        // The Commit is our pending commit echoed back to us:
-                        // surface `OwnPendingCommit` so the caller merges the
-                        // pending commit instead of staging the echo.
+                        // The Commit is our pending commit this client got
+                        // fanned out by the delivery service: surface
+                        // `OwnPendingCommit` so the caller merges the pending
+                        // commit instead of staging the fanned-out Commit.
                         return Ok(ProcessedMessage::new(
                             self.group_id().clone(),
                             epoch,
@@ -895,9 +896,10 @@ impl MlsGroup {
                         .confirmation_tag()
                         .ok_or(StageCommitError::ConfirmationTagMissing)?;
                     if self.matches_pending_commit(received_tag) {
-                        // The Commit is our pending commit echoed back to us:
-                        // surface `OwnPendingCommit` so the caller merges the
-                        // pending commit instead of staging the echo.
+                        // The Commit is our pending commit this client got
+                        // fanned out by the delivery service: surface
+                        // `OwnPendingCommit` so the caller merges the pending
+                        // commit instead of staging the fanned-out Commit.
                         return Ok(ProcessedMessage::new(
                             self.group_id().clone(),
                             epoch,

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -740,10 +740,10 @@ impl MlsGroup {
             FramedContentBody::Commit(commit) => {
                 // Load virtual-client derivation info when this commit was
                 // authored by a sibling emulator through a leaf shared with us.
-                // A path commit carrying this material is staged via the VC path
-                // below rather than treated as our own (see the own-commit
-                // handling further down). The receiver only loads it when the
-                // commit shape lets it identify itself as a sibling:
+                // A Commit with an `UpdatePath` carrying this material is staged
+                // via the VC path below rather than treated as our own (see the
+                // own-commit handling further down). The receiver only loads it
+                // when the commit shape lets it identify itself as a sibling:
                 //
                 // * `Sender::Member(idx)` with `idx == own_leaf_index`: the
                 //   sender committed through our shared higher-level leaf, so
@@ -790,11 +790,12 @@ impl MlsGroup {
                         ));
                     }
                     // Not our pending commit. We cannot decrypt a path we
-                    // encrypted to the other members, so a path-carrying commit
-                    // is unprocessable. A path-less commit carries no
-                    // author-private material and falls through to staging (a
-                    // sibling's path-less commit, or our own commit replayed
-                    // after the pending commit was cleared).
+                    // encrypted to the other members, so a Commit with an
+                    // `UpdatePath` is unprocessable. A Commit without an
+                    // `UpdatePath` carries no author-private material and falls
+                    // through to staging (a sibling's Commit without an
+                    // `UpdatePath`, or our own commit replayed after the pending
+                    // commit was cleared).
                     if commit.path.is_some() {
                         return Err(StageCommitError::OwnCommitMismatch.into());
                     }
@@ -865,8 +866,9 @@ impl MlsGroup {
             FramedContentBody::Commit(commit) => {
                 // See `process_internal_authenticated_content_with_app_data_updates`
                 // for the rationale. We load VC derivation info for a sibling's
-                // path commit through a shared leaf, and otherwise apply the
-                // own-commit handling below. The receiver only loads VC material
+                // Commit with an `UpdatePath` through a shared leaf, and
+                // otherwise apply the own-commit handling below. The receiver
+                // only loads VC material
                 // when the commit shape lets it identify itself as a sibling:
                 // own-leaf sender, or external commit with an inline
                 // `Remove(own_leaf)`.
@@ -908,11 +910,12 @@ impl MlsGroup {
                         ));
                     }
                     // Not our pending commit. We cannot decrypt a path we
-                    // encrypted to the other members, so a path-carrying commit
-                    // is unprocessable. A path-less commit carries no
-                    // author-private material and falls through to staging (a
-                    // sibling's path-less commit, or our own commit replayed
-                    // after the pending commit was cleared).
+                    // encrypted to the other members, so a Commit with an
+                    // `UpdatePath` is unprocessable. A Commit without an
+                    // `UpdatePath` carries no author-private material and falls
+                    // through to staging (a sibling's Commit without an
+                    // `UpdatePath`, or our own commit replayed after the pending
+                    // commit was cleared).
                     if commit.path.is_some() {
                         return Err(StageCommitError::OwnCommitMismatch.into());
                     }

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -47,8 +47,8 @@ use crate::prelude::processing::AppDataUpdates;
 impl MlsGroup {
     /// Returns `true` when `received_tag` is the confirmation tag produced by
     /// our pending member commit, i.e. the incoming Commit is that pending
-    /// commit echoed back to us. Returns `false` when we hold no member pending
-    /// commit or its tag differs.
+    /// commit this client got fanned out by the delivery service. Returns
+    /// `false` when we hold no member pending commit or its tag differs.
     ///
     /// We compare confirmation tags rather than the full Commit contents: the
     /// signature has already authenticated the Commit as ours, and a matching

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -140,7 +140,7 @@ impl MlsGroup {
     }
 
     /// Stages a commit message. The commit may have been sent by another group
-    /// member or be our own path-less commit. This
+    /// member or be our own Commit without an UpdatePath. This
     /// function does the following:
     ///  - Applies the proposals covered by the commit to the tree
     ///  - Applies the (optional) update path to the tree

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -139,7 +139,8 @@ impl MlsGroup {
             .map_err(|_| LibraryError::custom("Using the key schedule in the wrong state"))?)
     }
 
-    /// Stages a commit message that was sent by another group member. This
+    /// Stages a commit message. The commit may have been sent by another group
+    /// member or be our own path-less commit. This
     /// function does the following:
     ///  - Applies the proposals covered by the commit to the tree
     ///  - Applies the (optional) update path to the tree

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -12,13 +12,13 @@ use super::proposal_store::{
 #[cfg(feature = "virtual-clients-draft")]
 use super::Sender;
 use super::{
-    super::errors::*, errors::ProcessMessageError, load_psks, Credential, Extension, GroupContext,
-    GroupEpochSecrets, GroupId, JoinerSecret, KeySchedule, LeafNode, LibraryError, MessageSecrets,
-    MlsGroup, MlsGroupState, OpenMlsProvider, PendingCommitState, Proposal, ProposalQueue,
-    PskSecret, QueuedProposal,
+    super::errors::*, load_psks, Credential, Extension, GroupContext, GroupEpochSecrets, GroupId,
+    JoinerSecret, KeySchedule, LeafNode, LibraryError, MessageSecrets, MlsGroup, MlsGroupState,
+    OpenMlsProvider, PendingCommitState, Proposal, ProposalQueue, PskSecret, QueuedProposal,
 };
 use crate::group::diff::PublicGroupDiff;
 use crate::group::GroupEpoch;
+use crate::messages::ConfirmationTag;
 use crate::prelude::{Commit, LeafNodeIndex};
 #[cfg(feature = "extensions-draft")]
 use crate::{component::ComponentId, schedule::application_export_tree::ApplicationExportTree};
@@ -45,46 +45,25 @@ use super::proposal_store::{QueuedAppDataUpdateProposal, QueuedAppEphemeralPropo
 use crate::prelude::processing::AppDataUpdates;
 
 impl MlsGroup {
-    /// Confirms that an incoming Commit authored by this client matches the
-    /// group's pending commit, by recomputing the confirmation tag from the
-    /// pending commit and comparing it against the tag carried by the message.
+    /// Returns `true` when `received_tag` is the confirmation tag produced by
+    /// our pending member commit, i.e. the incoming Commit is that pending
+    /// commit echoed back to us. Returns `false` when we hold no member pending
+    /// commit or its tag differs.
     ///
-    /// We deliberately do not compare the full contents of the incoming Commit
-    /// against the pending commit. The message signature has already been
-    /// verified, which authenticates the Commit as ours, and a matching
+    /// We compare confirmation tags rather than the full Commit contents: the
+    /// signature has already authenticated the Commit as ours, and a matching
     /// confirmation tag binds the confirmed transcript hash of the new epoch.
-    /// We never adopt the incoming Commit's state: the caller applies the
-    /// locally built pending commit via [`MlsGroup::merge_pending_commit()`].
-    pub(crate) fn check_own_pending_commit<StorageError>(
-        &self,
-        crypto: &impl OpenMlsCrypto,
-        content: &AuthenticatedContent,
-    ) -> Result<(), ProcessMessageError<StorageError>> {
-        let received_tag = content
-            .confirmation_tag()
-            .ok_or(StageCommitError::ConfirmationTagMissing)?;
+    pub(crate) fn matches_pending_commit(&self, received_tag: &ConfirmationTag) -> bool {
         let MlsGroupState::PendingCommit(pending_commit_state) = &self.group_state else {
-            return Err(StageCommitError::OwnCommitMismatch.into());
+            return false;
         };
         let PendingCommitState::Member(staged_commit) = pending_commit_state.as_ref() else {
-            return Err(StageCommitError::OwnCommitMismatch.into());
+            return false;
         };
         let StagedCommitState::GroupMember(member_state) = &staged_commit.state else {
-            return Err(StageCommitError::OwnCommitMismatch.into());
+            return false;
         };
-        let expected_tag = member_state
-            .message_secrets
-            .confirmation_key()
-            .tag(
-                crypto,
-                self.ciphersuite(),
-                member_state.group_context().confirmed_transcript_hash(),
-            )
-            .map_err(LibraryError::unexpected_crypto_error)?;
-        if &expected_tag != received_tag {
-            return Err(StageCommitError::OwnCommitMismatch.into());
-        }
-        Ok(())
+        member_state.staged_diff.confirmation_tag() == received_tag
     }
 
     fn derive_epoch_secrets(

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -3078,12 +3078,13 @@ fn own_commit_mismatch() {
     );
 }
 
-// A path-less Commit from our own leaf that no longer matches a pending commit
-// is staged as a regular commit rather than rejected. Unlike a path-carrying
-// commit, a path-less commit holds no author-private material, so it applies
-// from the prior epoch and the public proposals alone.
+// A Commit without an `UpdatePath` from our own leaf that no longer matches a
+// pending commit is staged as a regular commit rather than rejected. Unlike a
+// Commit with an `UpdatePath`, a Commit without an `UpdatePath` holds no
+// author-private material, so it applies from the prior epoch and the public
+// proposals alone.
 #[openmls_test::openmls_test]
-fn own_pathless_commit_without_pending_is_staged() {
+fn own_commit_without_update_path_without_pending_is_staged() {
     let alice_provider = &Provider::default();
     let bob_provider = &Provider::default();
 
@@ -3134,8 +3135,9 @@ fn own_pathless_commit_without_pending_is_staged() {
     ));
 
     // Alice discards the pending commit without advancing the epoch. The echo
-    // no longer matches a pending commit, but a path-less commit can be staged
-    // from public information, so it is applied rather than rejected.
+    // no longer matches a pending commit, but a Commit without an `UpdatePath`
+    // can be staged from public information, so it is applied rather than
+    // rejected.
     alice_group
         .clear_pending_commit(alice_provider.storage())
         .expect("error clearing pending commit");
@@ -3143,14 +3145,14 @@ fn own_pathless_commit_without_pending_is_staged() {
 
     let processed = alice_group
         .process_message(alice_provider, commit)
-        .expect("path-less own commit without pending must be staged");
+        .expect("own commit without an UpdatePath without pending must be staged");
     let staged = match processed.into_content() {
         ProcessedMessageContent::StagedCommitMessage(staged) => *staged,
         other => panic!("expected staged commit, got {other:?}"),
     };
     alice_group
         .merge_staged_commit(alice_provider, staged)
-        .expect("error merging staged path-less commit");
+        .expect("error merging staged commit without an UpdatePath");
 
     // The commit applied: Bob is now a member.
     assert_eq!(alice_group.members().count(), 2);

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -3078,6 +3078,84 @@ fn own_commit_mismatch() {
     );
 }
 
+// A path-less Commit from our own leaf that no longer matches a pending commit
+// is staged as a regular commit rather than rejected. Unlike a path-carrying
+// commit, a path-less commit holds no author-private material, so it applies
+// from the prior epoch and the public proposals alone.
+#[openmls_test::openmls_test]
+fn own_pathless_commit_without_pending_is_staged() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let (alice_credential_with_key, alice_signature_keys) =
+        new_credential(alice_provider, b"Alice", ciphersuite.signature_algorithm());
+    let (_bob_credential, bob_kpb, _bob_signer, _bob_pk) =
+        setup_client("Bob", ciphersuite, bob_provider);
+
+    let mut alice_group = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .build(
+            alice_provider,
+            &alice_signature_keys,
+            alice_credential_with_key,
+        )
+        .expect("Error creating group.");
+
+    // Alice creates an add-only commit, which carries no path.
+    let (commit_out, _welcome, _group_info) = alice_group
+        .add_members_without_update(
+            alice_provider,
+            &alice_signature_keys,
+            &[bob_kpb.key_package().clone()],
+        )
+        .expect("Could not create add-only commit");
+    assert!(
+        alice_group
+            .pending_commit()
+            .expect("pending commit")
+            .update_path_leaf_node()
+            .is_none(),
+        "an add-only commit must not carry a path"
+    );
+
+    let commit = MlsMessageIn::from(commit_out)
+        .into_protocol_message()
+        .unwrap();
+
+    // While the pending commit is held, the echo matches it and surfaces as
+    // `OwnPendingCommit`.
+    let processed = alice_group
+        .process_message(alice_provider, commit.clone())
+        .expect("error while processing own pending add-only commit");
+    assert!(matches!(
+        processed.into_content(),
+        ProcessedMessageContent::OwnPendingCommit
+    ));
+
+    // Alice discards the pending commit without advancing the epoch. The echo
+    // no longer matches a pending commit, but a path-less commit can be staged
+    // from public information, so it is applied rather than rejected.
+    alice_group
+        .clear_pending_commit(alice_provider.storage())
+        .expect("error clearing pending commit");
+    assert!(alice_group.pending_commit().is_none());
+
+    let processed = alice_group
+        .process_message(alice_provider, commit)
+        .expect("path-less own commit without pending must be staged");
+    let staged = match processed.into_content() {
+        ProcessedMessageContent::StagedCommitMessage(staged) => *staged,
+        other => panic!("expected staged commit, got {other:?}"),
+    };
+    alice_group
+        .merge_staged_commit(alice_provider, staged)
+        .expect("error merging staged path-less commit");
+
+    // The commit applied: Bob is now a member.
+    assert_eq!(alice_group.members().count(), 2);
+}
+
 #[openmls_test::openmls_test]
 fn proposal_application_after_self_was_removed() {
     // We're going to test if proposals are still applied, even after a client

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -3078,9 +3078,9 @@ fn own_commit_mismatch() {
     );
 }
 
-// A Commit without an `UpdatePath` from our own leaf that no longer matches a
+// A Commit without an UpdatePath from our own leaf that no longer matches a
 // pending commit is staged as a regular commit rather than rejected. Unlike a
-// Commit with an `UpdatePath`, a Commit without an `UpdatePath` holds no
+// Commit with an UpdatePath, a Commit without an UpdatePath holds no
 // author-private material, so it applies from the prior epoch and the public
 // proposals alone.
 #[openmls_test::openmls_test]
@@ -3135,7 +3135,7 @@ fn own_commit_without_update_path_without_pending_is_staged() {
     ));
 
     // Alice discards the pending commit without advancing the epoch. The echo
-    // no longer matches a pending commit, but a Commit without an `UpdatePath`
+    // no longer matches a pending commit, but a Commit without an UpdatePath
     // can be staged from public information, so it is applied rather than
     // rejected.
     alice_group

--- a/openmls/src/group/public_group/diff.rs
+++ b/openmls/src/group/public_group/diff.rs
@@ -279,6 +279,11 @@ impl StagedPublicGroupDiff {
         &self.group_context
     }
 
+    /// Get the [`ConfirmationTag`] of the commit that produced this diff.
+    pub(crate) fn confirmation_tag(&self) -> &ConfirmationTag {
+        &self.confirmation_tag
+    }
+
     /// Export the staged [`RatchetTree`]
     pub(crate) fn export_ratchet_tree(
         &self,

--- a/openmls/src/group/public_group/staged_commit.rs
+++ b/openmls/src/group/public_group/staged_commit.rs
@@ -253,7 +253,7 @@ impl PublicGroup {
     }
 
     /// Stages a commit message. The commit may have been sent by another group
-    /// member or be our own path-less commit.
+    /// member or be our own Commit without an UpdatePath.
     /// This function does the following:
     ///  - Applies the proposals covered by the commit to the tree
     ///  - Applies the (optional) update path to the tree

--- a/openmls/src/group/public_group/staged_commit.rs
+++ b/openmls/src/group/public_group/staged_commit.rs
@@ -252,7 +252,8 @@ impl PublicGroup {
         Ok(())
     }
 
-    /// Stages a commit message that was sent by another group member.
+    /// Stages a commit message. The commit may have been sent by another group
+    /// member or be our own path-less commit.
     /// This function does the following:
     ///  - Applies the proposals covered by the commit to the tree
     ///  - Applies the (optional) update path to the tree
@@ -285,9 +286,6 @@ impl PublicGroup {
     ///  - ValSem241
     ///  - ValSem242
     ///  - ValSem244
-    ///
-    /// Returns an error if the given commit was sent by the owner of this
-    /// group.
     pub(crate) fn stage_commit(
         &self,
         mls_content: &AuthenticatedContent,

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -2506,24 +2506,24 @@ fn vc_binding_carries_forward_across_foreign_commits() {
     }
 }
 
-/// A virtual client issues a commit *without* a path (an add-only commit) and a
-/// sibling emulator client applies it.
+/// A virtual client issues a Commit *without* an `UpdatePath` (an add-only
+/// commit) and a sibling emulator client applies it.
 ///
 ///   * `alice_a` and `alice_b` are two emulator clients of one virtual client,
 ///     sharing a single leaf in a higher-level group that also contains `bob`.
 ///   * `alice_a` adds `charly` with `add_members_without_update`, producing a
-///     commit with no `UpdatePath`. A path-less commit cannot carry a
-///     virtual-clients `DerivationInfo`, so on shape alone it is
+///     commit with no `UpdatePath`. A Commit without an `UpdatePath` cannot
+///     carry a virtual-clients `DerivationInfo`, so on shape alone it is
 ///     indistinguishable from `alice_a`'s own commit echoed back.
 ///   * `alice_b` (the sibling) processes it. Because the group's current epoch
 ///     is bound to the emulation epoch and `alice_b` holds no pending commit of
-///     its own, the commit is recognized as a sibling's path-less commit and
-///     staged as a regular commit rather than rejected as a mismatched own
-///     commit. `bob` processes it through the ordinary path.
+///     its own, the commit is recognized as a sibling's Commit without an
+///     `UpdatePath` and staged as a regular commit rather than rejected as a
+///     mismatched own commit. `bob` processes it through the ordinary path.
 ///   * All four parties converge on the same epoch authenticator, and an
 ///     application message round-trips from the new member to the sibling.
 #[openmls_test]
-fn vc_sibling_applies_pathless_commit() {
+fn vc_sibling_applies_commit_without_update_path() {
     use openmls::credentials::{BasicCredential, CredentialWithKey};
 
     let alice_a_provider = Provider::default();
@@ -2612,7 +2612,8 @@ fn vc_sibling_applies_pathless_commit() {
         "both Alice clients must share the higher-level leaf"
     );
 
-    // alice_a issues a path-less commit: an add-only commit for charly.
+    // alice_a issues a Commit without an `UpdatePath`: an add-only commit for
+    // charly.
     let (charly_credential, charly_signer) = new_credential(
         &charly_provider,
         b"Charly",
@@ -2631,7 +2632,7 @@ fn vc_sibling_applies_pathless_commit() {
         .to_owned();
     let (commit, charly_welcome, _) = alice_a_main
         .add_members_without_update(&alice_a_provider, &vc_signer, &[charly_kp])
-        .expect("alice_a path-less add charly");
+        .expect("alice_a add charly without an UpdatePath");
     let staged_pending = alice_a_main
         .pending_commit()
         .expect("alice_a has a pending commit");
@@ -2641,16 +2642,16 @@ fn vc_sibling_applies_pathless_commit() {
     );
     alice_a_main
         .merge_pending_commit(&alice_a_provider)
-        .expect("alice_a merge path-less add");
+        .expect("alice_a merge add without an UpdatePath");
 
-    // The sibling (alice_b) applies alice_a's path-less commit. It is staged as
-    // a regular commit, not surfaced as an own pending commit.
+    // The sibling (alice_b) applies alice_a's Commit without an `UpdatePath`. It
+    // is staged as a regular commit, not surfaced as an own pending commit.
     let processed = alice_b_main
         .process_message(
             &alice_b_provider,
             commit.clone().into_protocol_message().unwrap(),
         )
-        .expect("alice_b processes sibling path-less commit");
+        .expect("alice_b processes sibling commit without an UpdatePath");
     let staged = match processed.into_content() {
         ProcessedMessageContent::StagedCommitMessage(s) => *s,
         other => panic!("expected staged commit, got {other:?}"),
@@ -2661,19 +2662,19 @@ fn vc_sibling_applies_pathless_commit() {
     );
     alice_b_main
         .merge_staged_commit(&alice_b_provider, staged)
-        .expect("alice_b merge sibling path-less commit");
+        .expect("alice_b merge sibling commit without an UpdatePath");
 
     // bob applies it through the ordinary path.
     let processed = bob_main
         .process_message(&bob_provider, commit.into_protocol_message().unwrap())
-        .expect("bob processes path-less commit");
+        .expect("bob processes commit without an UpdatePath");
     let staged = match processed.into_content() {
         ProcessedMessageContent::StagedCommitMessage(s) => *s,
         _ => panic!("expected staged commit"),
     };
     bob_main
         .merge_staged_commit(&bob_provider, staged)
-        .expect("bob merge path-less commit");
+        .expect("bob merge commit without an UpdatePath");
 
     // charly joins from the welcome the add produced.
     let mut charly_main = StagedWelcome::new_from_welcome(
@@ -2695,7 +2696,8 @@ fn vc_sibling_applies_pathless_commit() {
     assert_eq!(bob_main.epoch_authenticator(), authenticator);
     assert_eq!(charly_main.epoch_authenticator(), authenticator);
 
-    // The new member can message the sibling that applied the path-less commit.
+    // The new member can message the sibling that applied the commit without an
+    // `UpdatePath`.
     let processed = send_and_process_app_message(
         &mut charly_main,
         &charly_provider,

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -2506,19 +2506,19 @@ fn vc_binding_carries_forward_across_foreign_commits() {
     }
 }
 
-/// A virtual client issues a Commit *without* an `UpdatePath` (an add-only
+/// A virtual client issues a Commit *without* an UpdatePath (an add-only
 /// commit) and a sibling emulator client applies it.
 ///
 ///   * `alice_a` and `alice_b` are two emulator clients of one virtual client,
 ///     sharing a single leaf in a higher-level group that also contains `bob`.
 ///   * `alice_a` adds `charly` with `add_members_without_update`, producing a
-///     commit with no `UpdatePath`. A Commit without an `UpdatePath` cannot
+///     commit with no UpdatePath. A Commit without an UpdatePath cannot
 ///     carry a virtual-clients `DerivationInfo`, so on shape alone it is
 ///     indistinguishable from `alice_a`'s own commit echoed back.
 ///   * `alice_b` (the sibling) processes it. Because the group's current epoch
 ///     is bound to the emulation epoch and `alice_b` holds no pending commit of
 ///     its own, the commit is recognized as a sibling's Commit without an
-///     `UpdatePath` and staged as a regular commit rather than rejected as a
+///     UpdatePath and staged as a regular commit rather than rejected as a
 ///     mismatched own commit. `bob` processes it through the ordinary path.
 ///   * All four parties converge on the same epoch authenticator, and an
 ///     application message round-trips from the new member to the sibling.
@@ -2612,7 +2612,7 @@ fn vc_sibling_applies_commit_without_update_path() {
         "both Alice clients must share the higher-level leaf"
     );
 
-    // alice_a issues a Commit without an `UpdatePath`: an add-only commit for
+    // alice_a issues a Commit without an UpdatePath: an add-only commit for
     // charly.
     let (charly_credential, charly_signer) = new_credential(
         &charly_provider,
@@ -2644,7 +2644,7 @@ fn vc_sibling_applies_commit_without_update_path() {
         .merge_pending_commit(&alice_a_provider)
         .expect("alice_a merge add without an UpdatePath");
 
-    // The sibling (alice_b) applies alice_a's Commit without an `UpdatePath`. It
+    // The sibling (alice_b) applies alice_a's Commit without an UpdatePath. It
     // is staged as a regular commit, not surfaced as an own pending commit.
     let processed = alice_b_main
         .process_message(
@@ -2697,7 +2697,7 @@ fn vc_sibling_applies_commit_without_update_path() {
     assert_eq!(charly_main.epoch_authenticator(), authenticator);
 
     // The new member can message the sibling that applied the commit without an
-    // `UpdatePath`.
+    // UpdatePath.
     let processed = send_and_process_app_message(
         &mut charly_main,
         &charly_provider,

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -2505,3 +2505,209 @@ fn vc_binding_carries_forward_across_foreign_commits() {
         _ => panic!("expected application message"),
     }
 }
+
+/// A virtual client issues a commit *without* a path (an add-only commit) and a
+/// sibling emulator client applies it.
+///
+///   * `alice_a` and `alice_b` are two emulator clients of one virtual client,
+///     sharing a single leaf in a higher-level group that also contains `bob`.
+///   * `alice_a` adds `charly` with `add_members_without_update`, producing a
+///     commit with no `UpdatePath`. A path-less commit cannot carry a
+///     virtual-clients `DerivationInfo`, so on shape alone it is
+///     indistinguishable from `alice_a`'s own commit echoed back.
+///   * `alice_b` (the sibling) processes it. Because the group's current epoch
+///     is bound to the emulation epoch and `alice_b` holds no pending commit of
+///     its own, the commit is recognized as a sibling's path-less commit and
+///     staged as a regular commit rather than rejected as a mismatched own
+///     commit. `bob` processes it through the ordinary path.
+///   * All four parties converge on the same epoch authenticator, and an
+///     application message round-trips from the new member to the sibling.
+#[openmls_test]
+fn vc_sibling_applies_pathless_commit() {
+    use openmls::credentials::{BasicCredential, CredentialWithKey};
+
+    let alice_a_provider = Provider::default();
+    let alice_b_provider = Provider::default();
+    let bob_provider = Provider::default();
+    let charly_provider = Provider::default();
+
+    // The virtual client's shared signature key and credential, stored on both
+    // emulator clients so either can sign for the shared higher-level leaf.
+    let vc_signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).expect("vc signer");
+    vc_signer
+        .store(alice_a_provider.storage())
+        .expect("store vc signer on alice_a");
+    vc_signer
+        .store(alice_b_provider.storage())
+        .expect("store vc signer on alice_b");
+    let vc_credential = CredentialWithKey {
+        credential: BasicCredential::new(b"Alice (VC)".to_vec()).into(),
+        signature_key: vc_signer.public().into(),
+    };
+
+    // alice_a founds the higher-level group and adds bob.
+    let mut alice_a_main = new_vc_main_group(
+        ciphersuite,
+        &alice_a_provider,
+        &vc_signer,
+        vc_credential.clone(),
+    );
+    let (bob_credential, bob_signer) =
+        new_credential(&bob_provider, b"Bob", ciphersuite.signature_algorithm());
+    let bob_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .build(ciphersuite, &bob_provider, &bob_signer, bob_credential)
+        .expect("bob KP build")
+        .key_package()
+        .to_owned();
+    let (_, welcome, _) = alice_a_main
+        .add_members(&alice_a_provider, &vc_signer, &[bob_kp])
+        .expect("alice_a add bob");
+    alice_a_main
+        .merge_pending_commit(&alice_a_provider)
+        .expect("alice_a merge add bob");
+    let mut bob_main = StagedWelcome::new_from_welcome(
+        &bob_provider,
+        &vc_join_config(),
+        welcome.into_welcome().expect("welcome"),
+        Some(alice_a_main.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(&bob_provider))
+    .expect("bob join");
+
+    // alice_b joins as a sibling emulator and resyncs into the higher-level
+    // group, so both Alice clients share `own_leaf_index`.
+    let (siblings, resync_commit) = join_sibling_emulator(
+        ciphersuite,
+        &alice_a_provider,
+        &alice_b_provider,
+        &vc_signer,
+        vc_credential,
+        &alice_a_main,
+        vc_join_config(),
+    );
+    let mut alice_b_main = siblings.alice_b_main;
+
+    for (group, provider) in [
+        (&mut alice_a_main, &alice_a_provider),
+        (&mut bob_main, &bob_provider),
+    ] {
+        let processed = group
+            .process_message(
+                provider,
+                resync_commit.clone().into_protocol_message().unwrap(),
+            )
+            .expect("process resync commit");
+        let staged = match processed.into_content() {
+            ProcessedMessageContent::StagedCommitMessage(s) => *s,
+            _ => panic!("expected staged commit"),
+        };
+        group
+            .merge_staged_commit(provider, staged)
+            .expect("merge resync commit");
+    }
+    assert_eq!(
+        alice_a_main.own_leaf_index(),
+        alice_b_main.own_leaf_index(),
+        "both Alice clients must share the higher-level leaf"
+    );
+
+    // alice_a issues a path-less commit: an add-only commit for charly.
+    let (charly_credential, charly_signer) = new_credential(
+        &charly_provider,
+        b"Charly",
+        ciphersuite.signature_algorithm(),
+    );
+    let charly_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .build(
+            ciphersuite,
+            &charly_provider,
+            &charly_signer,
+            charly_credential,
+        )
+        .expect("charly KP build")
+        .key_package()
+        .to_owned();
+    let (commit, charly_welcome, _) = alice_a_main
+        .add_members_without_update(&alice_a_provider, &vc_signer, &[charly_kp])
+        .expect("alice_a path-less add charly");
+    let staged_pending = alice_a_main
+        .pending_commit()
+        .expect("alice_a has a pending commit");
+    assert!(
+        staged_pending.update_path_leaf_node().is_none(),
+        "the add-only commit must not carry a path"
+    );
+    alice_a_main
+        .merge_pending_commit(&alice_a_provider)
+        .expect("alice_a merge path-less add");
+
+    // The sibling (alice_b) applies alice_a's path-less commit. It is staged as
+    // a regular commit, not surfaced as an own pending commit.
+    let processed = alice_b_main
+        .process_message(
+            &alice_b_provider,
+            commit.clone().into_protocol_message().unwrap(),
+        )
+        .expect("alice_b processes sibling path-less commit");
+    let staged = match processed.into_content() {
+        ProcessedMessageContent::StagedCommitMessage(s) => *s,
+        other => panic!("expected staged commit, got {other:?}"),
+    };
+    assert!(
+        !staged.self_removed(),
+        "a sibling's add-only commit must not remove alice_b"
+    );
+    alice_b_main
+        .merge_staged_commit(&alice_b_provider, staged)
+        .expect("alice_b merge sibling path-less commit");
+
+    // bob applies it through the ordinary path.
+    let processed = bob_main
+        .process_message(&bob_provider, commit.into_protocol_message().unwrap())
+        .expect("bob processes path-less commit");
+    let staged = match processed.into_content() {
+        ProcessedMessageContent::StagedCommitMessage(s) => *s,
+        _ => panic!("expected staged commit"),
+    };
+    bob_main
+        .merge_staged_commit(&bob_provider, staged)
+        .expect("bob merge path-less commit");
+
+    // charly joins from the welcome the add produced.
+    let mut charly_main = StagedWelcome::new_from_welcome(
+        &charly_provider,
+        &vc_join_config(),
+        charly_welcome.into_welcome().expect("charly welcome"),
+        Some(alice_a_main.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(&charly_provider))
+    .expect("charly join");
+
+    // All parties agree on the new epoch.
+    let authenticator = alice_a_main.epoch_authenticator();
+    assert_eq!(
+        alice_b_main.epoch_authenticator(),
+        authenticator,
+        "sibling must converge with the committer"
+    );
+    assert_eq!(bob_main.epoch_authenticator(), authenticator);
+    assert_eq!(charly_main.epoch_authenticator(), authenticator);
+
+    // The new member can message the sibling that applied the path-less commit.
+    let processed = send_and_process_app_message(
+        &mut charly_main,
+        &charly_provider,
+        &charly_signer,
+        &mut alice_b_main,
+        &alice_b_provider,
+        b"hello from charly",
+    );
+    match processed.into_content() {
+        ProcessedMessageContent::ApplicationMessage(msg) => {
+            assert_eq!(msg.into_bytes().as_slice(), b"hello from charly");
+        }
+        _ => panic!("expected application message"),
+    }
+}


### PR DESCRIPTION
This PR allows clients to process and stage their own commits if they don't have a path _and_ don't match the currently pending commit. This is mostly for use in the virtual clients setting.