### PR TITLE
feat: allow AppDataUpdate proposals in external commits

### DIFF
--- a/openmls/src/group/mls_group/commit_builder/external_commits.rs
+++ b/openmls/src/group/mls_group/commit_builder/external_commits.rs
@@ -340,6 +340,18 @@ impl<'a> CommitBuilder<'a, Initial, MlsGroup> {
             .extend(proposals.into_iter().map(Proposal::psk));
         self
     }
+
+    /// Adds an AppDataUpdateProposal.
+    #[cfg(feature = "extensions-draft")]
+    pub fn add_app_data_update_proposal(
+        mut self,
+        proposal: crate::messages::proposals::AppDataUpdateProposal,
+    ) -> Self {
+        self.stage
+            .own_proposals
+            .push(Proposal::AppDataUpdate(Box::new(proposal)));
+        self
+    }
 }
 
 // Impls that apply only to external commits.

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -531,6 +531,7 @@ impl PublicGroup {
     ///  - ValSem240: External Commit, inline Proposals: There MUST be at least one ExternalInit proposal.
     ///  - ValSem241: External Commit, inline Proposals: There MUST be at most one ExternalInit proposal.
     ///  - ValSem242: External Commit must only cover inline proposal in allowlist (ExternalInit, Remove, PreSharedKey)
+    ///  - When the `extensions-draft` feature is enabled, AppDataUpdate proposal is allowed additionally.
     pub(crate) fn validate_external_commit(
         &self,
         proposal_queue: &ProposalQueue,
@@ -551,13 +552,15 @@ impl PublicGroup {
         // [valn0404](https://validation.openmls.tech/#valn0404)
         let contains_denied_proposal = proposal_queue.queued_proposals().any(|p| {
             let is_inline = p.proposal_or_ref_type() == ProposalOrRefType::Proposal;
-            let is_allowed_type = matches!(
-                p.proposal(),
+            let is_allowed_type = match p.proposal() {
                 Proposal::ExternalInit(_)
-                    | Proposal::Remove(_)
-                    | Proposal::PreSharedKey(_)
-                    | Proposal::Custom(_)
-            );
+                | Proposal::Remove(_)
+                | Proposal::PreSharedKey(_)
+                | Proposal::Custom(_) => true,
+                #[cfg(feature = "extensions-draft")]
+                Proposal::AppDataUpdate(_) => true,
+                _ => false,
+            };
             is_inline && !is_allowed_type
         });
         if contains_denied_proposal {

--- a/openmls/src/group/tests_and_kats/tests/app_data_update_proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/app_data_update_proposal_validation.rs
@@ -1,5 +1,8 @@
 use crate::component::*;
 use crate::extensions::*;
+use crate::group::tests_and_kats::utils::{
+    generate_credential_with_key, CredentialWithKeyAndSigner,
+};
 use crate::prelude::*;
 use crate::test_utils::{frankenstein::*, single_group_test_framework::*};
 use openmls_test::openmls_test;
@@ -776,6 +779,210 @@ fn test_process_with_wrong_app_data_updates() {
             );
         }
     }
+}
+
+/// Test that an AppDataUpdate proposal is allowed as an inline proposal in an external commit.
+#[openmls_test]
+fn test_external_commit_with_app_data_update_proposal() {
+    let alice_provider = &Provider::default();
+    let charlie_provider = &Provider::default();
+
+    let CredentialWithKeyAndSigner {
+        credential_with_key: alice_credential_with_key,
+        signer: alice_signer,
+    } = generate_credential_with_key(
+        b"alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    let CredentialWithKeyAndSigner {
+        credential_with_key: charlie_credential_with_key,
+        signer: charlie_signer,
+    } = generate_credential_with_key(
+        b"charlie".into(),
+        ciphersuite.signature_algorithm(),
+        charlie_provider,
+    );
+
+    // Members must support the AppDataDictionary extension and the AppDataUpdate proposal for the
+    // group to allow committing AppDataUpdate proposals.
+    let capabilities = Capabilities::new(
+        None,
+        None,
+        Some(&[ExtensionType::AppDataDictionary]),
+        Some(&[ProposalType::AppDataUpdate]),
+        None,
+    );
+
+    let required_capabilities_extension =
+        Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
+            &[ExtensionType::AppDataDictionary],
+            &[ProposalType::AppDataUpdate],
+            &[],
+        ));
+
+    let mut alice_group = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .with_wire_format_policy(crate::group::PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .with_capabilities(capabilities.clone())
+        .with_group_context_extensions(Extensions::single(required_capabilities_extension).unwrap())
+        .build(alice_provider, &alice_signer, alice_credential_with_key)
+        .unwrap();
+
+    // Alice sets an initial entry in the group's AppDataDictionary, so that Charlie's external
+    // commit joins a group with a non-empty dictionary.
+    let mut stage = alice_group
+        .commit_builder()
+        .add_proposals(vec![Proposal::AppDataUpdate(Box::new(
+            AppDataUpdateProposal::update(0xf042, b"alice"),
+        ))])
+        .load_psks(alice_provider.storage())
+        .unwrap();
+
+    let mut updater = stage.app_data_dictionary_updater();
+    for proposal in stage.app_data_update_proposals() {
+        if let AppDataUpdateOperation::Update(data) = proposal.operation() {
+            updater.set(ComponentData::from_parts(
+                proposal.component_id(),
+                data.clone(),
+            ));
+        }
+    }
+    stage.with_app_data_dictionary_updates(updater.changes());
+
+    stage
+        .build(
+            alice_provider.rand(),
+            alice_provider.crypto(),
+            &alice_signer,
+            |_| true,
+        )
+        .unwrap()
+        .stage_commit(alice_provider)
+        .unwrap();
+
+    alice_group.merge_pending_commit(alice_provider).unwrap();
+
+    assert_eq!(
+        alice_group
+            .extensions()
+            .app_data_dictionary()
+            .unwrap()
+            .dictionary()
+            .get(&0xf042),
+        Some(b"alice".as_slice())
+    );
+
+    // Alice exports a group info for Charlie to join externally.
+    let verifiable_group_info = alice_group
+        .export_group_info(alice_provider.crypto(), &alice_signer, false)
+        .unwrap()
+        .into_verifiable_group_info()
+        .unwrap();
+
+    // Charlie can inspect the (unverified) AppDataDictionary via the group context before deciding
+    // what to include in the AppDataUpdate proposal of the external commit.
+    assert_eq!(
+        verifiable_group_info
+            .group_context()
+            .app_data_dict()
+            .unwrap()
+            .get(&0xf042),
+        Some(b"alice".as_slice())
+    );
+
+    let tree_option = alice_group.export_ratchet_tree();
+
+    // Charlie joins externally and includes an AppDataUpdate proposal as an inline proposal of the
+    // external commit. This must be allowed by `validate_external_commit`.
+    let mut stage = MlsGroup::external_commit_builder()
+        .with_ratchet_tree(tree_option.into())
+        .build_group(
+            charlie_provider,
+            verifiable_group_info,
+            charlie_credential_with_key.clone(),
+        )
+        .unwrap()
+        .leaf_node_parameters(
+            LeafNodeParameters::builder()
+                .with_capabilities(capabilities)
+                .build(),
+        )
+        .add_app_data_update_proposal(AppDataUpdateProposal::update(0xf043, b"charlie"))
+        .load_psks(charlie_provider.storage())
+        .unwrap();
+
+    let mut charlie_updater = stage.app_data_dictionary_updater();
+    for proposal in stage.app_data_update_proposals() {
+        if let AppDataUpdateOperation::Update(data) = proposal.operation() {
+            charlie_updater.set(ComponentData::from_parts(
+                proposal.component_id(),
+                data.clone(),
+            ));
+        }
+    }
+    stage.with_app_data_dictionary_updates(charlie_updater.changes());
+
+    let (charlie_group, commit_message_bundle) = stage
+        .build(
+            charlie_provider.rand(),
+            charlie_provider.crypto(),
+            &charlie_signer,
+            |_| true,
+        )
+        .unwrap()
+        .finalize(charlie_provider)
+        .unwrap();
+
+    // Charlie's view of the AppDataDictionary contains both Alice's and Charlie's entries.
+    let charlie_dict = charlie_group
+        .extensions()
+        .app_data_dictionary()
+        .unwrap()
+        .dictionary();
+    assert_eq!(charlie_dict.get(&0xf042), Some(b"alice".as_slice()));
+    assert_eq!(charlie_dict.get(&0xf043), Some(b"charlie".as_slice()));
+
+    // Alice processes Charlie's external commit, which carries the AppDataUpdate proposal inline.
+    let plaintext = commit_message_bundle
+        .into_commit()
+        .into_protocol_message()
+        .unwrap();
+
+    let unverified_message = alice_group
+        .unprotect_message(alice_provider, plaintext)
+        .unwrap();
+
+    let mut alice_updater = alice_group.app_data_dictionary_updater();
+    alice_updater.set(ComponentData::from_parts(
+        0xf043,
+        b"charlie".to_vec().into(),
+    ));
+
+    let processed_message = alice_group
+        .process_unverified_message_with_app_data_updates(
+            alice_provider,
+            unverified_message,
+            alice_updater.changes(),
+        )
+        .unwrap();
+
+    let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+        processed_message.into_content()
+    else {
+        panic!("Expected a staged commit message.");
+    };
+    alice_group
+        .merge_staged_commit(alice_provider, *staged_commit)
+        .unwrap();
+
+    let alice_dict = alice_group
+        .extensions()
+        .app_data_dictionary()
+        .unwrap()
+        .dictionary();
+    assert_eq!(alice_dict, charlie_dict);
 }
 
 /// Test that standalone AppDataUpdate proposals can be processed normally

--- a/openmls/src/messages/group_info.rs
+++ b/openmls/src/messages/group_info.rs
@@ -123,6 +123,11 @@ impl VerifiableGroupInfo {
     pub fn epoch(&self) -> GroupEpoch {
         self.payload.group_context.epoch()
     }
+
+    /// Get (unverified) group context of the verifiable group info.
+    pub fn group_context(&self) -> &GroupContext {
+        &self.payload.group_context
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Such proposals are allowed in external commits when the `extensions-draft` feature is enabled.

Additionally, add a getter for the group context in the verifiable group info.