### PR TITLE
Move computation of epoch secrets from StagedWelcome into ProcessedWelcome

### DIFF
--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -18,7 +18,10 @@ use crate::{
     key_packages::errors::{KeyPackageExtensionSupportError, KeyPackageVerifyError},
     messages::{group_info::GroupInfoError, GroupSecretsError},
     prelude::ExtensionType,
-    schedule::{errors::PskError, PreSharedKeyId},
+    schedule::{
+        errors::{KeyScheduleError, PskError},
+        PreSharedKeyId,
+    },
     treesync::errors::*,
 };
 
@@ -106,6 +109,9 @@ pub enum WelcomeError<StorageError> {
     #[cfg(feature = "virtual-clients-draft")]
     #[error(transparent)]
     VirtualClientsError(#[from] crate::components::vc_derivation_info::VirtualClientsError),
+    /// This error indicates that computing the key schedule failed
+    #[error(transparent)]
+    KeySchedule(#[from] KeyScheduleError),
 }
 
 /// External Commit error

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -186,17 +186,22 @@ impl ProcessedWelcome {
 
             PskSecret::new(provider.crypto(), ciphersuite, psks)?
         };
-        let key_schedule = KeySchedule::init(
+
+        // prepare the key schedule
+        let mut key_schedule = KeySchedule::init(
             ciphersuite,
             provider.crypto(),
             &group_secrets.joiner_secret,
             psk_secret,
         )?;
+
+        // derive the keys for decrypting the group info
         let (welcome_key, welcome_nonce) = key_schedule
             .welcome(provider.crypto(), ciphersuite)
             .map_err(|_| LibraryError::custom("Using the key schedule in the wrong state"))?
             .derive_welcome_key_nonce(provider.crypto(), ciphersuite)
             .map_err(LibraryError::unexpected_crypto_error)?;
+
         let verifiable_group_info = VerifiableGroupInfo::try_from_ciphertext(
             &welcome_key,
             &welcome_nonce,
@@ -204,6 +209,16 @@ impl ProcessedWelcome {
             &[],
             provider.crypto(),
         )?;
+
+        let serialized_group_context = verifiable_group_info
+            .group_context()
+            .tls_serialize_detached()
+            .map_err(LibraryError::missing_bound_check)?;
+
+        // TODO #751: Implement PSK
+        key_schedule.add_context(provider.crypto(), &serialized_group_context)?;
+
+        let epoch_secrets = key_schedule.epoch_secrets(provider.crypto(), ciphersuite)?;
 
         // On the bundle path, check the required capabilities and the
         // ciphersuite against the local KeyPackage. On the virtual-client path
@@ -237,7 +252,7 @@ impl ProcessedWelcome {
             mls_group_config: mls_group_config.clone(),
             ciphersuite,
             group_secrets,
-            key_schedule,
+            epoch_secrets,
             verifiable_group_info,
             resumption_psk_store,
             key_material,
@@ -381,19 +396,11 @@ impl ProcessedWelcome {
                 .tls_serialize_detached()
                 .map_err(LibraryError::missing_bound_check)?;
 
-            // TODO #751: Implement PSK
-            self.key_schedule
-                .add_context(provider.crypto(), &serialized_group_context)
-                .map_err(|_| LibraryError::custom("Using the key schedule in the wrong state"))?;
-
             let EpochSecretsResult {
                 epoch_secrets,
                 #[cfg(feature = "extensions-draft")]
                 application_exporter,
-            } = self
-                .key_schedule
-                .epoch_secrets(provider.crypto(), self.ciphersuite)
-                .map_err(|_| LibraryError::custom("Using the key schedule in the wrong state"))?;
+            } = self.epoch_secrets;
 
             let (group_epoch_secrets, message_secrets) = epoch_secrets.split_secrets(
                 serialized_group_context,
@@ -478,6 +485,30 @@ impl ProcessedWelcome {
         };
 
         Ok(staged_welcome)
+    }
+
+    /// Exports a secret from the epoch of the group that is joined
+    /// using this [`ProcessedWelcome`].
+    /// Returns [`ExportSecretError::KeyLengthTooLong`] if the requested
+    /// key length is too long.
+    pub fn export_secret<CryptoProvider: OpenMlsCrypto>(
+        &self,
+        crypto: &CryptoProvider,
+        label: &str,
+        context: &[u8],
+        key_length: usize,
+    ) -> Result<Vec<u8>, ExportSecretError> {
+        if key_length > u16::MAX as usize {
+            log::error!("Got a key that is larger than u16::MAX");
+            return Err(ExportSecretError::KeyLengthTooLong);
+        }
+
+        Ok(self
+            .epoch_secrets
+            .epoch_secrets
+            .exporter_secret()
+            .derive_exported_secret(self.ciphersuite, crypto, label, context, key_length)
+            .map_err(LibraryError::unexpected_crypto_error)?)
     }
 }
 

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -1214,7 +1214,7 @@ pub struct ProcessedWelcome {
     // building the group.
     ciphersuite: Ciphersuite,
     group_secrets: GroupSecrets,
-    key_schedule: crate::schedule::KeySchedule,
+    epoch_secrets: crate::schedule::EpochSecretsResult,
     verifiable_group_info: crate::messages::group_info::VerifiableGroupInfo,
     resumption_psk_store: crate::schedule::psk::store::ResumptionPskStore,
     key_material: WelcomeKeyMaterial,

--- a/openmls/src/schedule/errors.rs
+++ b/openmls/src/schedule/errors.rs
@@ -67,7 +67,7 @@ pub enum PskError {
 
 /// Key schedule state error
 #[derive(Error, Debug, PartialEq, Clone)]
-pub(crate) enum ErrorState {
+pub enum ErrorState {
     /// Expected to be in initial state.
     #[error("Expected to be in initial state.")]
     Init,
@@ -78,7 +78,7 @@ pub(crate) enum ErrorState {
 
 /// Key schedule error
 #[derive(Error, Debug, PartialEq, Clone)]
-pub(crate) enum KeyScheduleError {
+pub enum KeyScheduleError {
     /// See [`LibraryError`] for more details.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),

--- a/openmls/src/schedule/mod.rs
+++ b/openmls/src/schedule/mod.rs
@@ -1126,7 +1126,6 @@ impl EpochSecrets {
     }
 
     /// Exporter secret
-    #[cfg(any(feature = "test-utils", test))]
     pub(crate) fn exporter_secret(&self) -> &ExporterSecret {
         &self.exporter_secret
     }

--- a/openmls/tests/data_next_epoch.rs
+++ b/openmls/tests/data_next_epoch.rs
@@ -267,11 +267,21 @@ fn staged_welcome_export_secret_matches_created_group() {
         )
         .expect("error adding Bob");
 
-    // 6. Bob stages the Welcome
+    // 6. Bob processes the Welcome
     let welcome = welcome_msg.into_welcome().unwrap();
-    let staged_welcome =
-        StagedWelcome::new_from_welcome(&bob_party.provider, &join_config, welcome, None)
-            .expect("error staging welcome");
+
+    let processed_welcome =
+        ProcessedWelcome::new_from_welcome(&bob_party.provider, &join_config, welcome)
+            .expect("error processing welcome");
+
+    // === Capture values from StagedWelcome ===
+    let processed_export = processed_welcome
+        .export_secret(bob_party.provider.crypto(), "test-label", b"ctx", 32)
+        .unwrap();
+
+    let staged_welcome = processed_welcome
+        .into_staged_welcome(&bob_party.provider, None)
+        .expect("error staging welcome");
 
     // === Capture values from StagedWelcome ===
     let staged_export = staged_welcome
@@ -284,6 +294,7 @@ fn staged_welcome_export_secret_matches_created_group() {
         .expect("error creating group");
 
     // === Verify staged values match group values ===
+    assert_eq!(processed_export, staged_export);
     assert_eq!(
         staged_export,
         bob_group


### PR DESCRIPTION
We would like to be able to peek into the export secrets of the joined epoch from the ProcessedWelcome, on top of the StagedWelcome. This allows us to derive exporters before we have the RatchetTree. This allows us to encrypt the RatchetTree with an exporter from the following epoch.