### PR TITLE
Add `own_leaf_node()` and `own_leaf_index()` APIs to `StagedWelcome`

### DIFF
--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -568,6 +568,16 @@ impl StagedWelcome {
             ))
     }
 
+    /// Returns the leaf index of the client in this welcome's [`PublicGroup`].
+    pub fn own_leaf_index(&self) -> LeafNodeIndex {
+        self.own_leaf_index
+    }
+
+    /// Returns the leaf node of the client in this welcome's [`PublicGroup`].
+    pub fn own_leaf_node(&self) -> Option<&LeafNode> {
+        self.public_group.leaf(self.own_leaf_index())
+    }
+
     /// Get the [`GroupContext`] of this welcome's [`PublicGroup`].
     pub fn group_context(&self) -> &GroupContext {
         self.public_group.group_context()

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -535,6 +535,14 @@ fn staged_join() {
         alice_kpb.key_package().leaf_node().credential()
     );
 
+    // retrieve the own leaf from the staged group for Bob
+    let own_leaf = staged_bob_group
+        .own_leaf_node()
+        .expect("no own leaf index was found");
+
+    // check that the own leaf node matches the leaf node in Bob's key package
+    assert_eq!(own_leaf, bob_kpb.key_package.leaf_node());
+
     let bob_group = staged_bob_group
         .into_group(bob_provider)
         .expect("error turning StagedWelcome into MlsGroup");


### PR DESCRIPTION
- Adds getters for `own_leaf_node()` and `own_leaf_index()` APIs to `StagedWelcome`
- Updates the test that checks the `StagedWelcome::welcome_sender()` API to also check the `own_leaf_node()` API