### PR TITLE
virtual clients: surface own commit echo as OwnPendingCommit

### DIFF
--- a/delivery-service/ds/src/main.rs
+++ b/delivery-service/ds/src/main.rs
@@ -264,7 +264,7 @@ async fn send_welcome(State(data): State<Arc<DsData>>, body: Bytes) -> Response 
     let mut clients = data.clients.lock();
     for secret in welcome.secrets().iter() {
         let key_package_hash = &secret.new_member();
-        for (_client_name, client) in clients.iter_mut() {
+        for client in clients.values_mut() {
             match client
                 .reserved_key_pkg_hash
                 .take(key_package_hash.as_slice())

--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -125,7 +125,7 @@ impl MemoryStorage {
         list.push(value);
 
         // write back, reusing the old buffer
-        list_bytes.truncate(0);
+        list_bytes.clear();
         serde_json::to_writer(list_bytes, &list)?;
 
         Ok(())
@@ -154,7 +154,7 @@ impl MemoryStorage {
         }
 
         // write back, reusing the old buffer
-        list_bytes.truncate(0);
+        list_bytes.clear();
         serde_json::to_writer(list_bytes, &list)?;
 
         Ok(())

--- a/openmls/src/ciphersuite/secret.rs
+++ b/openmls/src/ciphersuite/secret.rs
@@ -149,7 +149,7 @@ impl Secret {
         let full_label = format!("MLS 1.0 {label}");
         log::trace!(
             "KDF expand with label \"{}\" and {:?} with context {:x?}",
-            &full_label,
+            full_label,
             ciphersuite,
             context
         );

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -616,7 +616,11 @@ pub enum ProcessedMessageContent {
     /// [`OwnPrivateMessage`](Self::OwnPrivateMessage). The exception is the
     /// `virtual-clients-draft` feature, where an own private Commit whose
     /// encryption secret is still retained (not yet confirmed) decrypts and
-    /// can produce this variant as well.
+    /// can produce this variant as well. Under that feature the pending-commit
+    /// match is checked before any sibling-commit (virtual clients) material is
+    /// loaded, so an own Commit fanned back by the delivery service surfaces as
+    /// `OwnPendingCommit` without consuming an operation-secret generation from
+    /// the emulation epoch's operation secret tree.
     OwnPendingCommit,
     /// A PrivateMessage whose sender data claims this client's own leaf index,
     /// i.e. a message this client authored that the delivery service fanned

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -920,15 +920,18 @@ impl MlsGroup {
                 //   auto-Remove targets our previous leaf, so we are the
                 //   sibling being resynced.
                 #[cfg(feature = "virtual-clients-draft")]
-                let vc_commit_material =
-                    if is_sibling_vc_commit(commit, &sender, self.own_leaf_index()) {
-                        self.load_vc_commit_material(provider, commit)?
-                    } else {
-                        None
-                    };
+                let (vc_commit_material, is_own_commit) = {
+                    let vc_commit_material =
+                        if is_sibling_vc_commit(commit, &sender, self.own_leaf_index()) {
+                            self.load_vc_commit_material(provider, commit)?
+                        } else {
+                            None
+                        };
 
-                #[cfg(feature = "virtual-clients-draft")]
-                let is_own_commit = is_own_commit && vc_commit_material.is_none();
+                    let is_own_commit = is_own_commit && vc_commit_material.is_none();
+
+                    (vc_commit_material, is_own_commit)
+                };
 
                 // An own Commit that did not match the pending commit above
                 // cannot be staged when it carries an UpdatePath: we cannot

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -877,32 +877,8 @@ impl MlsGroup {
                 }
             }
             FramedContentBody::Commit(commit) => {
-                // Load virtual-client derivation info when this commit was
-                // authored by a sibling emulator through a leaf shared with us.
-                // A Commit with an UpdatePath carrying this material is staged
-                // via the VC path below rather than treated as our own (see the
-                // own-commit handling further down). The receiver only loads it
-                // when the commit shape lets it identify itself as a sibling:
-                //
-                // * `Sender::Member(idx)` with `idx == own_leaf_index`: the
-                //   sender committed through our shared higher-level leaf, so
-                //   we are a sibling.
-                // * `Sender::NewMemberCommit` with an inline `Remove(own_leaf)`:
-                //   the sender is a sibling joining externally and the
-                //   auto-Remove targets our previous leaf, so we are the
-                //   sibling being resynced.
-                #[cfg(feature = "virtual-clients-draft")]
-                let vc_commit_material =
-                    if is_sibling_vc_commit(commit, &sender, self.own_leaf_index()) {
-                        self.load_vc_commit_material(provider, commit)?
-                    } else {
-                        None
-                    };
-
                 let is_own_commit =
                     matches!(&sender, Sender::Member(member) if member == &self.own_leaf_index());
-                #[cfg(feature = "virtual-clients-draft")]
-                let is_own_commit = is_own_commit && vc_commit_material.is_none();
 
                 if is_own_commit {
                     let received_tag = content
@@ -924,16 +900,45 @@ impl MlsGroup {
                             emulator_sender_leaf_index,
                         ));
                     }
-                    // Not our pending commit. We cannot decrypt a path we
-                    // encrypted to the other members, so a Commit with an
-                    // UpdatePath is unprocessable. A Commit without an
-                    // UpdatePath carries no author-private material and falls
-                    // through to staging (a sibling's Commit without an
-                    // UpdatePath, or our own commit replayed after the pending
-                    // commit was cleared).
-                    if commit.path.is_some() {
-                        return Err(StageCommitError::OwnCommitMismatch.into());
-                    }
+                }
+
+                // Load virtual-client derivation info when this commit was
+                // authored by a sibling emulator through a leaf shared with us.
+                // The pending-commit match above already ran, so an own commit
+                // echoed back by the delivery service never reaches this load
+                // and no operation-secret generation is consumed for it. A
+                // sibling's commit never matches our pending commit's
+                // confirmation tag, so sibling commits still take this path.
+                // The receiver only loads the material when the commit shape
+                // lets it identify itself as a sibling:
+                //
+                // * `Sender::Member(idx)` with `idx == own_leaf_index`: the
+                //   sender committed through our shared higher-level leaf, so
+                //   we are a sibling.
+                // * `Sender::NewMemberCommit` with an inline `Remove(own_leaf)`:
+                //   the sender is a sibling joining externally and the
+                //   auto-Remove targets our previous leaf, so we are the
+                //   sibling being resynced.
+                #[cfg(feature = "virtual-clients-draft")]
+                let vc_commit_material =
+                    if is_sibling_vc_commit(commit, &sender, self.own_leaf_index()) {
+                        self.load_vc_commit_material(provider, commit)?
+                    } else {
+                        None
+                    };
+
+                #[cfg(feature = "virtual-clients-draft")]
+                let is_own_commit = is_own_commit && vc_commit_material.is_none();
+
+                // An own Commit that did not match the pending commit above
+                // cannot be staged when it carries an UpdatePath: we cannot
+                // decrypt a path we encrypted to the other members. A Commit
+                // without an UpdatePath carries no author-private material and
+                // falls through to staging (a sibling's Commit without an
+                // UpdatePath, or our own commit replayed after the pending
+                // commit was cleared).
+                if is_own_commit && commit.path.is_some() {
+                    return Err(StageCommitError::OwnCommitMismatch.into());
                 }
 
                 // A commit covering AppDataUpdate proposals cannot be staged

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -2990,6 +2990,175 @@ fn vc_sibling_applies_commit_without_update_path() {
     }
 }
 
+/// Regression test: a virtual client's own VC commit fanned back by the
+/// delivery service must surface as `OwnPendingCommit`, not fail while loading
+/// sibling-commit material.
+///
+/// alice_a and alice_b are sibling emulators sharing the higher-level leaf and
+/// one emulation epoch, in a group that also holds the regular member bob.
+/// alice_a builds a VC commit and, before merging it, processes the copy the
+/// delivery service echoed back. The commit is framed as
+/// `Sender::Member(own_leaf_index)` with an UpdatePath carrying VC material, so
+/// its shape is indistinguishable from a sibling's commit. Because it matches
+/// alice_a's pending commit it must be reported as `OwnPendingCommit` without
+/// consuming an operation-secret generation. Before the fix this failed with
+/// `VirtualClientsError::OperationGenerationConsumed`.
+#[openmls_test]
+fn vc_own_commit_echo_surfaces_as_own_pending_commit() {
+    let alice_a_provider = Provider::default();
+    let alice_b_provider = Provider::default();
+    let bob_provider = Provider::default();
+
+    let (vc_signer, vc_credential) =
+        shared_vc_identity(ciphersuite, &alice_a_provider, &alice_b_provider);
+
+    // alice_a founds the higher-level group and adds bob.
+    let mut alice_a_main = new_vc_main_group(
+        ciphersuite,
+        &alice_a_provider,
+        &vc_signer,
+        vc_credential.clone(),
+    );
+    let (bob_credential, bob_signer) =
+        new_credential(&bob_provider, b"Bob", ciphersuite.signature_algorithm());
+    let bob_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .build(ciphersuite, &bob_provider, &bob_signer, bob_credential)
+        .expect("bob KP build")
+        .key_package()
+        .to_owned();
+    let (_, welcome, _) = alice_a_main
+        .add_members(&alice_a_provider, &vc_signer, &[bob_kp])
+        .expect("alice_a add bob");
+    alice_a_main
+        .merge_pending_commit(&alice_a_provider)
+        .expect("alice_a merge add bob");
+    let mut bob_main = StagedWelcome::new_from_welcome(
+        &bob_provider,
+        &vc_join_config(),
+        welcome.into_welcome().expect("welcome"),
+        Some(alice_a_main.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(&bob_provider))
+    .expect("bob join");
+
+    // alice_b joins as a sibling emulator and resyncs into the higher-level
+    // group, so both Alice clients share `own_leaf_index` and the same
+    // emulation epoch.
+    let (siblings, resync_commit) = join_sibling_emulator(
+        ciphersuite,
+        &alice_a_provider,
+        &alice_b_provider,
+        &vc_signer,
+        vc_credential,
+        &alice_a_main,
+        vc_join_config(),
+    );
+    let mut alice_b_main = siblings.alice_b_main;
+    let epoch_id = siblings.epoch_id;
+
+    for (group, provider) in [
+        (&mut alice_a_main, &alice_a_provider),
+        (&mut bob_main, &bob_provider),
+    ] {
+        process_and_merge_commit(group, provider, resync_commit.clone());
+    }
+    assert_eq!(
+        alice_a_main.own_leaf_index(),
+        alice_b_main.own_leaf_index(),
+        "both Alice clients must share the higher-level leaf"
+    );
+
+    // alice_a builds a VC commit on the shared emulation epoch but does not
+    // merge it, so it is still her pending commit when the delivery service
+    // fans the copy back to her.
+    let bundle = alice_a_main
+        .commit_builder()
+        .vc_emulation(
+            alice_a_provider.crypto(),
+            alice_a_provider.storage(),
+            epoch_id.clone(),
+        )
+        .expect("alice_a bind commit to emulation epoch")
+        .load_psks(alice_a_provider.storage())
+        .expect("alice_a load psks")
+        .build(
+            alice_a_provider.rand(),
+            alice_a_provider.crypto(),
+            &vc_signer,
+            |_| true,
+        )
+        .expect("alice_a build vc commit")
+        .stage_commit(&alice_a_provider)
+        .expect("alice_a stage vc commit");
+    let commit = bundle.into_commit();
+
+    // alice_a processes her own commit echoed back. It is framed like a
+    // sibling's VC commit, but it matches her pending commit and must surface
+    // as `OwnPendingCommit` without consuming an operation-secret generation.
+    let processed = alice_a_main
+        .process_message(
+            &alice_a_provider,
+            commit.clone().into_protocol_message().unwrap(),
+        )
+        .expect("alice_a processes her own fanned-back vc commit");
+    assert!(matches!(
+        processed.into_content(),
+        ProcessedMessageContent::OwnPendingCommit
+    ));
+    alice_a_main
+        .merge_pending_commit(&alice_a_provider)
+        .expect("alice_a merge her own vc commit");
+
+    // The sibling and bob apply the same commit through the ordinary staging
+    // path.
+    let processed = alice_b_main
+        .process_message(
+            &alice_b_provider,
+            commit.clone().into_protocol_message().unwrap(),
+        )
+        .expect("alice_b processes sibling vc commit");
+    let staged = match processed.into_content() {
+        ProcessedMessageContent::StagedCommitMessage(s) => *s,
+        other => panic!("expected staged commit, got {other:?}"),
+    };
+    alice_b_main
+        .merge_staged_commit(&alice_b_provider, staged)
+        .expect("alice_b merge sibling vc commit");
+    process_and_merge_commit(&mut bob_main, &bob_provider, commit);
+
+    let authenticator = alice_a_main.epoch_authenticator();
+    assert_eq!(
+        alice_b_main.epoch_authenticator(),
+        authenticator,
+        "sibling must converge with the committer"
+    );
+    assert_eq!(
+        bob_main.epoch_authenticator(),
+        authenticator,
+        "bob must converge with the committer"
+    );
+
+    // A second VC commit on the same emulation epoch, this time from alice_b,
+    // proves the operation secret tree stayed healthy after the echo.
+    let second_commit =
+        send_vc_commit_with_epoch(&mut alice_b_main, &alice_b_provider, &vc_signer, epoch_id);
+    process_and_merge_commit(&mut alice_a_main, &alice_a_provider, second_commit.clone());
+    process_and_merge_commit(&mut bob_main, &bob_provider, second_commit);
+
+    let authenticator = alice_b_main.epoch_authenticator();
+    assert_eq!(
+        alice_a_main.epoch_authenticator(),
+        authenticator,
+        "committer's sibling must converge after the second commit"
+    );
+    assert_eq!(
+        bob_main.epoch_authenticator(),
+        authenticator,
+        "bob must converge after the second commit"
+    );
+}
+
 /// Set up two sibling emulator clients sharing one emulation group and epoch.
 /// `alice_a` founds the emulation group, `alice_b` joins it via Welcome, and
 /// both register the same emulation epoch, so both hold its


### PR DESCRIPTION
Processing a commit checked for sibling VC material before checking whether the commit matches the group's pending commit. Since an own commit fanned back by the DS has the same shape as a sibling's commit (Sender::Member(own_leaf) with VC derivation info on the path leaf), load_vc_commit_material re-derived the operation secret the sender had already consumed at send time and processing failed with OperationGenerationConsumed, making OwnPendingCommit unreachable for VC commits.

Check the pending-commit match first, so an own commit echo surfaces as OwnPendingCommit without touching the operation secret tree. Sibling commits never match the pending commit's confirmation tag and still take the VC staging path.