### PR TITLE
virtual clients: epoch-scoped message confirmation

### DIFF
--- a/book/src/virtual_clients.md
+++ b/book/src/virtual_clients.md
@@ -198,7 +198,7 @@ size, and encrypts it with a small-space PRP keyed from `reuse_guard_secret`.
 Once the Delivery Service accepts the message, drop the retained key:
 
 ```rust,no_run,noplayground
-main_group.confirm_message(provider.storage(), unconfirmed.generation)?;
+main_group.confirm_message(provider.storage(), unconfirmed.epoch, unconfirmed.generation)?;
 ```
 
 If the Delivery Service reports a collision, the sibling won that generation.

--- a/book/src/virtual_clients.md
+++ b/book/src/virtual_clients.md
@@ -198,7 +198,7 @@ size, and encrypts it with a small-space PRP keyed from `reuse_guard_secret`.
 Once the Delivery Service accepts the message, drop the retained key:
 
 ```rust,no_run,noplayground
-main_group.confirm_message(provider.storage(), unconfirmed.epoch, unconfirmed.generation)?;
+main_group.confirm_application_message(provider.storage(), unconfirmed.epoch, unconfirmed.generation)?;
 ```
 
 If the Delivery Service reports a collision, the sibling won that generation.
@@ -208,7 +208,8 @@ the retained key for that generation, so no explicit cleanup is needed. Then
 call `create_unconfirmed_message` again to re-encrypt from the ratchet head.
 There is no explicit discard call. A retained unconfirmed key is, from the
 receiving side, the same as a skipped-generation key. It is cleaned up by
-`confirm_message`, by decrypting a sibling's message at that generation, or by
+`confirm_application_message`, by decrypting a sibling's message at that
+generation, or by
 aging out under bounded retention.
 
 On the receiving side, `process_message` inverts the reuse guard PRP and

--- a/delivery-service/ds/src/main.rs
+++ b/delivery-service/ds/src/main.rs
@@ -264,7 +264,7 @@ async fn send_welcome(State(data): State<Arc<DsData>>, body: Bytes) -> Response 
     let mut clients = data.clients.lock();
     for secret in welcome.secrets().iter() {
         let key_package_hash = &secret.new_member();
-        for (_client_name, client) in clients.iter_mut() {
+        for client in clients.values_mut() {
             match client
                 .reserved_key_pkg_hash
                 .take(key_package_hash.as_slice())

--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -125,7 +125,7 @@ impl MemoryStorage {
         list.push(value);
 
         // write back, reusing the old buffer
-        list_bytes.truncate(0);
+        list_bytes.clear();
         serde_json::to_writer(list_bytes, &list)?;
 
         Ok(())
@@ -154,7 +154,7 @@ impl MemoryStorage {
         }
 
         // write back, reusing the old buffer
-        list_bytes.truncate(0);
+        list_bytes.clear();
         serde_json::to_writer(list_bytes, &list)?;
 
         Ok(())

--- a/openmls/src/ciphersuite/secret.rs
+++ b/openmls/src/ciphersuite/secret.rs
@@ -149,7 +149,7 @@ impl Secret {
         let full_label = format!("MLS 1.0 {label}");
         log::trace!(
             "KDF expand with label \"{}\" and {:?} with context {:x?}",
-            &full_label,
+            full_label,
             ciphersuite,
             context
         );

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -616,7 +616,11 @@ pub enum ProcessedMessageContent {
     /// [`OwnPrivateMessage`](Self::OwnPrivateMessage). The exception is the
     /// `virtual-clients-draft` feature, where an own private Commit whose
     /// encryption secret is still retained (not yet confirmed) decrypts and
-    /// can produce this variant as well.
+    /// can produce this variant as well. Under that feature the pending-commit
+    /// match is checked before any sibling-commit (virtual clients) material is
+    /// loaded, so an own Commit fanned back by the delivery service surfaces as
+    /// `OwnPendingCommit` without consuming an operation-secret generation from
+    /// the emulation epoch's operation secret tree.
     OwnPendingCommit,
     /// A PrivateMessage whose sender data claims this client's own leaf index,
     /// i.e. a message this client authored that the delivery service fanned

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -640,7 +640,8 @@ pub enum ProcessedMessageContent {
     /// normally. This variant is then only returned in groups that do not
     /// use virtual clients (no emulation state registered for the message's
     /// epoch), when decryption of an own message fails, e.g. because the
-    /// send was already confirmed via `MlsGroup::confirm_message()`.
+    /// send was already confirmed via
+    /// `MlsGroup::confirm_application_message()`.
     OwnPrivateMessage,
     /// A Commit message covering AppDataUpdate proposals.
     ///

--- a/openmls/src/group/mls_group/application.rs
+++ b/openmls/src/group/mls_group/application.rs
@@ -17,9 +17,13 @@ use super::{errors::CreateMessageError, *};
 pub struct UnconfirmedMessage {
     /// The encrypted application message to fan out.
     pub message: MlsMessageOut,
-    /// The ratchet generation used for encryption. Pass it back to
-    /// [`MlsGroup::confirm_message`] once the DS has accepted the message, to
-    /// delete the retained encryption secret.
+    /// The epoch the message was encrypted in. Pass it together with
+    /// `generation` to [`MlsGroup::confirm_message`] once the DS has accepted
+    /// the message, to delete the retained encryption secret.
+    pub epoch: GroupEpoch,
+    /// The ratchet generation used for encryption. Pass it together with
+    /// `epoch` to [`MlsGroup::confirm_message`] once the DS has accepted the
+    /// message, to delete the retained encryption secret.
     pub generation: u32,
     /// The [`GenerationId`] to attach to the fanned-out message, present when
     /// the group is bound to an emulation epoch and `None` otherwise. A
@@ -68,7 +72,7 @@ impl MlsGroup {
     ) -> Result<MlsMessageOut, CreateMessageError<Provider::StorageError>> {
         let (generation, _generation_id, output) =
             self.create_message_internal(provider, signer, message)?;
-        self.confirm_message(provider.storage(), generation)?;
+        self.confirm_message(provider.storage(), self.epoch(), generation)?;
         Ok(output)
     }
 
@@ -181,28 +185,99 @@ impl MlsGroup {
             self.create_message_internal(provider, signer, message)?;
         Ok(UnconfirmedMessage {
             message,
+            epoch: self.epoch(),
             generation,
             generation_id,
         })
     }
 
-    /// Confirms that a message has been successfully sent without a generation
-    /// collision. This deletes the encryption secrets for the given generation.
+    /// Deletes the retained own secret of the given `secret_type` created at
+    /// (`epoch`, `generation`). A confirm call deletes exactly the secret its
+    /// corresponding create call retained, or nothing.
     #[cfg(feature = "virtual-clients-draft")]
-    pub fn confirm_message<Storage: StorageProvider>(
+    fn confirm_own_secret<Storage: StorageProvider>(
         &mut self,
         storage: &Storage,
+        epoch: GroupEpoch,
         generation: u32,
+        secret_type: SecretType,
     ) -> Result<(), ConfirmMessageError<Storage::Error>> {
-        // For now we only support application secrets.
-        let secret_type = SecretType::ApplicationSecret;
-        self.message_secrets_store
-            .message_secrets_mut()
+        // Dispatch on the creation epoch directly rather than through
+        // `message_secrets_for_epoch_mut`, which maps future epochs to the
+        // current tree and would delete a different message's secret.
+        let message_secrets = if epoch > self.context().epoch() {
+            return Err(ConfirmMessageError::FutureEpoch);
+        } else if epoch == self.context().epoch() {
+            self.message_secrets_store.message_secrets_mut()
+        } else {
+            // The retained secret is already gone once its epoch has aged out
+            // of the store, so there is nothing left to delete.
+            let Some(message_secrets) = self.message_secrets_store.secrets_for_epoch_mut(epoch)
+            else {
+                return Ok(());
+            };
+            message_secrets
+        };
+        message_secrets
             .secret_tree_mut()
             .delete_own_secret_for_generation(secret_type, generation)?;
         storage
             .write_message_secrets(self.group_id(), &self.message_secrets_store)
             .map_err(ConfirmMessageError::StorageError)?;
         Ok(())
+    }
+
+    /// Deletes the retained encryption secret of the application message created
+    /// at (`epoch`, `generation`). A confirm call deletes exactly the secret its
+    /// corresponding [`MlsGroup::create_unconfirmed_message`] call retained, or
+    /// nothing.
+    ///
+    /// This is a no-op success when the epoch has aged out of the message
+    /// secrets store, or when the generation's secret is already gone (already
+    /// confirmed, or consumed by processing the message's own echo).
+    ///
+    /// Returns [`ConfirmMessageError::FutureEpoch`] when `epoch` is newer than
+    /// the group's current epoch.
+    ///
+    /// Only confirm once the DS has accepted exactly this message. After a lost
+    /// race against a sibling (the DS rejected the send because of a generation
+    /// collision), the secret must not be confirmed, since it is what decrypts
+    /// the sibling's winning message at the same generation.
+    #[cfg(feature = "virtual-clients-draft")]
+    pub fn confirm_message<Storage: StorageProvider>(
+        &mut self,
+        storage: &Storage,
+        epoch: GroupEpoch,
+        generation: u32,
+    ) -> Result<(), ConfirmMessageError<Storage::Error>> {
+        self.confirm_own_secret(storage, epoch, generation, SecretType::ApplicationSecret)
+    }
+
+    /// Deletes the retained encryption secret of the handshake message (proposal
+    /// or commit) created at (`epoch`, `generation`). A confirm call deletes
+    /// exactly the secret its corresponding create call retained, or nothing.
+    ///
+    /// Proposals and commits draw generations from the same per-epoch handshake
+    /// ratchet, so this single endpoint covers both.
+    ///
+    /// This is a no-op success when the epoch has aged out of the message
+    /// secrets store, or when the generation's secret is already gone (already
+    /// confirmed, or consumed by processing the message's own echo).
+    ///
+    /// Returns [`ConfirmMessageError::FutureEpoch`] when `epoch` is newer than
+    /// the group's current epoch.
+    ///
+    /// Only confirm once the DS has accepted exactly this message. After a lost
+    /// race against a sibling (the DS rejected the send because of a generation
+    /// collision), the secret must not be confirmed, since it is what decrypts
+    /// the sibling's winning message at the same generation.
+    #[cfg(feature = "virtual-clients-draft")]
+    pub fn confirm_handshake_message<Storage: StorageProvider>(
+        &mut self,
+        storage: &Storage,
+        epoch: GroupEpoch,
+        generation: u32,
+    ) -> Result<(), ConfirmMessageError<Storage::Error>> {
+        self.confirm_own_secret(storage, epoch, generation, SecretType::HandshakeSecret)
     }
 }

--- a/openmls/src/group/mls_group/application.rs
+++ b/openmls/src/group/mls_group/application.rs
@@ -18,12 +18,12 @@ pub struct UnconfirmedMessage {
     /// The encrypted application message to fan out.
     pub message: MlsMessageOut,
     /// The epoch the message was encrypted in. Pass it together with
-    /// `generation` to [`MlsGroup::confirm_message`] once the DS has accepted
-    /// the message, to delete the retained encryption secret.
+    /// `generation` to [`MlsGroup::confirm_application_message`] once the DS
+    /// has accepted the message, to delete the retained encryption secret.
     pub epoch: GroupEpoch,
     /// The ratchet generation used for encryption. Pass it together with
-    /// `epoch` to [`MlsGroup::confirm_message`] once the DS has accepted the
-    /// message, to delete the retained encryption secret.
+    /// `epoch` to [`MlsGroup::confirm_application_message`] once the DS has
+    /// accepted the message, to delete the retained encryption secret.
     pub generation: u32,
     /// The [`GenerationId`] to attach to the fanned-out message, present when
     /// the group is bound to an emulation epoch and `None` otherwise. A
@@ -155,16 +155,17 @@ impl MlsGroup {
     }
 
     /// Creates an application message. Encryption secrets are only deleted
-    /// after the message has been confirmed via `confirm_message()`.
+    /// after the message has been confirmed via
+    /// `confirm_application_message()`.
     ///
     /// Returns the ratchet `generation` used for encryption, an optional
     /// [`GenerationId`], and the encrypted message. The `generation` is passed
-    /// back to `confirm_message` to delete the retained encryption secret once
-    /// the DS has accepted the message. The [`GenerationId`] is present when
-    /// the group is bound to an emulation epoch and `None` otherwise. When
-    /// present, the application attaches it to the fanned-out message so a
-    /// strongly-consistent DS can detect generation collisions between
-    /// siblings.
+    /// back to `confirm_application_message` to delete the retained encryption
+    /// secret once the DS has accepted the message. The [`GenerationId`] is
+    /// present when the group is bound to an emulation epoch and `None`
+    /// otherwise. When present, the application attaches it to the fanned-out
+    /// message so a strongly-consistent DS can detect generation collisions
+    /// between siblings.
     ///
     /// Returns `CreateMessageError::MlsGroupStateError::UseAfterEviction` if
     /// the member is no longer part of the group. Returns

--- a/openmls/src/group/mls_group/application.rs
+++ b/openmls/src/group/mls_group/application.rs
@@ -72,7 +72,7 @@ impl MlsGroup {
     ) -> Result<MlsMessageOut, CreateMessageError<Provider::StorageError>> {
         let (generation, _generation_id, output) =
             self.create_message_internal(provider, signer, message)?;
-        self.confirm_message(provider.storage(), self.epoch(), generation)?;
+        self.confirm_application_message(provider.storage(), self.epoch(), generation)?;
         Ok(output)
     }
 
@@ -244,7 +244,7 @@ impl MlsGroup {
     /// collision), the secret must not be confirmed, since it is what decrypts
     /// the sibling's winning message at the same generation.
     #[cfg(feature = "virtual-clients-draft")]
-    pub fn confirm_message<Storage: StorageProvider>(
+    pub fn confirm_application_message<Storage: StorageProvider>(
         &mut self,
         storage: &Storage,
         epoch: GroupEpoch,

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -616,6 +616,9 @@ mod virtual_clients_draft {
         /// See [`SecretTreeError`] for more details.
         #[error(transparent)]
         SecretTreeError(#[from] SecretTreeError),
+        /// The requested epoch is newer than the group's current epoch.
+        #[error("The requested epoch is newer than the group's current epoch.")]
+        FutureEpoch,
         /// Error writing to storage.
         #[error("Error writing to storage: {0}")]
         StorageError(StorageError),
@@ -629,6 +632,11 @@ mod virtual_clients_draft {
                         MessageEncryptionError::SecretTreeError(e),
                     )
                 }
+                // Unreachable: `create_message` confirms at the current epoch,
+                // which never triggers the future-epoch guard.
+                ConfirmMessageError::FutureEpoch => CreateMessageError::LibraryError(
+                    LibraryError::custom("confirm_message reported a future epoch"),
+                ),
                 ConfirmMessageError::StorageError(e) => CreateMessageError::StorageError(e),
             }
         }

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -635,7 +635,7 @@ mod virtual_clients_draft {
                 // Unreachable: `create_message` confirms at the current epoch,
                 // which never triggers the future-epoch guard.
                 ConfirmMessageError::FutureEpoch => CreateMessageError::LibraryError(
-                    LibraryError::custom("confirm_message reported a future epoch"),
+                    LibraryError::custom("confirm_application_message reported a future epoch"),
                 ),
                 ConfirmMessageError::StorageError(e) => CreateMessageError::StorageError(e),
             }

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -920,15 +920,18 @@ impl MlsGroup {
                 //   auto-Remove targets our previous leaf, so we are the
                 //   sibling being resynced.
                 #[cfg(feature = "virtual-clients-draft")]
-                let vc_commit_material =
-                    if is_sibling_vc_commit(commit, &sender, self.own_leaf_index()) {
-                        self.load_vc_commit_material(provider, commit)?
-                    } else {
-                        None
-                    };
+                let (vc_commit_material, is_own_commit) = {
+                    let vc_commit_material =
+                        if is_sibling_vc_commit(commit, &sender, self.own_leaf_index()) {
+                            self.load_vc_commit_material(provider, commit)?
+                        } else {
+                            None
+                        };
 
-                #[cfg(feature = "virtual-clients-draft")]
-                let is_own_commit = is_own_commit && vc_commit_material.is_none();
+                    let is_own_commit = is_own_commit && vc_commit_material.is_none();
+
+                    (vc_commit_material, is_own_commit)
+                };
 
                 // An own Commit that did not match the pending commit above
                 // cannot be staged when it carries an UpdatePath: we cannot

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -877,32 +877,8 @@ impl MlsGroup {
                 }
             }
             FramedContentBody::Commit(commit) => {
-                // Load virtual-client derivation info when this commit was
-                // authored by a sibling emulator through a leaf shared with us.
-                // A Commit with an UpdatePath carrying this material is staged
-                // via the VC path below rather than treated as our own (see the
-                // own-commit handling further down). The receiver only loads it
-                // when the commit shape lets it identify itself as a sibling:
-                //
-                // * `Sender::Member(idx)` with `idx == own_leaf_index`: the
-                //   sender committed through our shared higher-level leaf, so
-                //   we are a sibling.
-                // * `Sender::NewMemberCommit` with an inline `Remove(own_leaf)`:
-                //   the sender is a sibling joining externally and the
-                //   auto-Remove targets our previous leaf, so we are the
-                //   sibling being resynced.
-                #[cfg(feature = "virtual-clients-draft")]
-                let vc_commit_material =
-                    if is_sibling_vc_commit(commit, &sender, self.own_leaf_index()) {
-                        self.load_vc_commit_material(provider, commit)?
-                    } else {
-                        None
-                    };
-
                 let is_own_commit =
                     matches!(&sender, Sender::Member(member) if member == &self.own_leaf_index());
-                #[cfg(feature = "virtual-clients-draft")]
-                let is_own_commit = is_own_commit && vc_commit_material.is_none();
 
                 if is_own_commit {
                     let received_tag = content
@@ -924,16 +900,45 @@ impl MlsGroup {
                             emulator_sender_leaf_index,
                         ));
                     }
-                    // Not our pending commit. We cannot decrypt a path we
-                    // encrypted to the other members, so a Commit with an
-                    // UpdatePath is unprocessable. A Commit without an
-                    // UpdatePath carries no author-private material and falls
-                    // through to staging (a sibling's Commit without an
-                    // UpdatePath, or our own commit replayed after the pending
-                    // commit was cleared).
-                    if commit.path.is_some() {
-                        return Err(StageCommitError::OwnCommitMismatch.into());
-                    }
+                }
+
+                // Load virtual-client derivation info when this commit was
+                // authored by a sibling emulator through a leaf shared with us.
+                // The pending-commit match above already ran, so an own commit
+                // echoed back by the delivery service never reaches this load
+                // and no operation-secret generation is consumed for it. A
+                // sibling's commit never matches our pending commit's
+                // confirmation tag, so sibling commits still take this path.
+                // The receiver only loads the material when the commit shape
+                // lets it identify itself as a sibling:
+                //
+                // * `Sender::Member(idx)` with `idx == own_leaf_index`: the
+                //   sender committed through our shared higher-level leaf, so
+                //   we are a sibling.
+                // * `Sender::NewMemberCommit` with an inline `Remove(own_leaf)`:
+                //   the sender is a sibling joining externally and the
+                //   auto-Remove targets our previous leaf, so we are the
+                //   sibling being resynced.
+                #[cfg(feature = "virtual-clients-draft")]
+                let vc_commit_material =
+                    if is_sibling_vc_commit(commit, &sender, self.own_leaf_index()) {
+                        self.load_vc_commit_material(provider, commit)?
+                    } else {
+                        None
+                    };
+
+                #[cfg(feature = "virtual-clients-draft")]
+                let is_own_commit = is_own_commit && vc_commit_material.is_none();
+
+                // An own Commit that did not match the pending commit above
+                // cannot be staged when it carries an UpdatePath: we cannot
+                // decrypt a path we encrypted to the other members. A Commit
+                // without an UpdatePath carries no author-private material and
+                // falls through to staging (a sibling's Commit without an
+                // UpdatePath, or our own commit replayed after the pending
+                // commit was cleared).
+                if is_own_commit && commit.path.is_some() {
+                    return Err(StageCommitError::OwnCommitMismatch.into());
                 }
 
                 // A commit covering AppDataUpdate proposals cannot be staged

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -6,13 +6,13 @@ use openmls::{
     },
     framing::errors::{MessageDecryptionError, SecretTreeError},
     group::{
-        MlsGroup, MlsGroupCreateConfig, MlsGroupJoinConfig, StagedWelcome,
-        PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+        ConfirmMessageError, GroupEpoch, MlsGroup, MlsGroupCreateConfig, MlsGroupJoinConfig,
+        StagedWelcome, PURE_CIPHERTEXT_WIRE_FORMAT_POLICY, PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
     },
     key_packages::KeyPackage,
     prelude::{
-        test_utils::new_credential, Capabilities, LeafNode, ProcessMessageError,
-        ProcessedMessageContent, ValidationError,
+        test_utils::new_credential, Capabilities, LeafNode, LeafNodeParameters,
+        ProcessMessageError, ProcessedMessageContent, ValidationError,
     },
 };
 use openmls_basic_credential::SignatureKeyPair;
@@ -2082,7 +2082,11 @@ fn processing_own_application_message() {
         .unwrap();
     let ciphertext = unconfirmed.message;
     alice_group
-        .confirm_message(alice_provider.storage(), unconfirmed.generation)
+        .confirm_message(
+            alice_provider.storage(),
+            unconfirmed.epoch,
+            unconfirmed.generation,
+        )
         .unwrap();
 
     let processed_message = alice_group
@@ -2093,6 +2097,340 @@ fn processing_own_application_message() {
         .expect("Expected processing a confirmed message to succeed.");
     assert!(matches!(
         processed_message.into_content(),
+        ProcessedMessageContent::OwnPrivateMessage
+    ));
+}
+
+/// Confirming a message deletes the secret of its own creation epoch, even
+/// after the group has advanced past that epoch, and never the secret of a
+/// different message that happens to share the generation number in a newer
+/// epoch.
+#[openmls_test::openmls_test]
+fn confirm_targets_creation_epoch() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let (alice_credential, alice_signer) =
+        new_credential(alice_provider, b"Alice", ciphersuite.signature_algorithm());
+    let (bob_credential, bob_signer) =
+        new_credential(bob_provider, b"Bob", ciphersuite.signature_algorithm());
+
+    // Alice keeps one past epoch so the secret retained at epoch N survives
+    // into epoch N+1.
+    let mut alice_group = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .max_past_epochs(1)
+        .build(alice_provider, &alice_signer, alice_credential)
+        .expect("alice create group");
+
+    let bob_key_package = KeyPackage::builder()
+        .build(ciphersuite, bob_provider, &bob_signer, bob_credential)
+        .expect("bob KP build")
+        .key_package()
+        .to_owned();
+
+    let (_commit, welcome, _gi) = alice_group
+        .add_members(alice_provider, &alice_signer, &[bob_key_package])
+        .expect("alice add bob");
+    alice_group
+        .merge_pending_commit(alice_provider)
+        .expect("alice merge add");
+
+    let mut bob_group = StagedWelcome::new_from_welcome(
+        bob_provider,
+        &MlsGroupJoinConfig::default(),
+        welcome.into_welcome().unwrap(),
+        Some(alice_group.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(bob_provider))
+    .expect("bob join");
+
+    // Epoch N: Alice creates the first application message of the epoch.
+    let msg1 = alice_group
+        .create_unconfirmed_message(alice_provider, &alice_signer, b"epoch N message")
+        .expect("create msg1");
+
+    // Bob commits, Alice processes and merges, moving to epoch N+1.
+    let bob_commit = bob_group
+        .self_update(bob_provider, &bob_signer, LeafNodeParameters::default())
+        .expect("bob self-update")
+        .into_commit();
+    bob_group
+        .merge_pending_commit(bob_provider)
+        .expect("bob merge self-update");
+    let processed = alice_group
+        .process_message(alice_provider, bob_commit.into_protocol_message().unwrap())
+        .expect("alice process bob commit");
+    let ProcessedMessageContent::StagedCommitMessage(staged) = processed.into_content() else {
+        panic!("expected a staged commit");
+    };
+    alice_group
+        .merge_staged_commit(alice_provider, *staged)
+        .expect("alice merge bob commit");
+
+    // Epoch N+1: Alice creates the first application message of the epoch.
+    let msg2 = alice_group
+        .create_unconfirmed_message(alice_provider, &alice_signer, b"epoch N+1 message")
+        .expect("create msg2");
+
+    assert_ne!(
+        msg1.epoch, msg2.epoch,
+        "the commit must have advanced the epoch"
+    );
+    assert_eq!(
+        msg1.generation, msg2.generation,
+        "both are the first application send of their epoch"
+    );
+
+    // Confirming msg1 at its creation epoch must not touch msg2's secret,
+    // which shares the generation number in the newer epoch.
+    alice_group
+        .confirm_message(alice_provider.storage(), msg1.epoch, msg1.generation)
+        .expect("confirm msg1");
+
+    // msg2's secret is intact, so its echo decrypts.
+    let processed = alice_group
+        .process_message(
+            alice_provider,
+            msg2.message.into_protocol_message().unwrap(),
+        )
+        .expect("process msg2 echo");
+    let ProcessedMessageContent::ApplicationMessage(app) = processed.into_content() else {
+        panic!("expected msg2 to decrypt to an application message");
+    };
+    assert_eq!(app.into_bytes().as_slice(), b"epoch N+1 message");
+
+    // msg1's secret was deleted, so its echo surfaces OwnPrivateMessage.
+    let processed = alice_group
+        .process_message(
+            alice_provider,
+            msg1.message.into_protocol_message().unwrap(),
+        )
+        .expect("process msg1 echo");
+    assert!(matches!(
+        processed.into_content(),
+        ProcessedMessageContent::OwnPrivateMessage
+    ));
+}
+
+/// Confirming a message whose creation epoch has aged out of the message
+/// secrets store is a no-op success.
+#[openmls_test::openmls_test]
+fn confirm_aged_out_epoch_is_noop() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let (alice_credential, alice_signer) =
+        new_credential(alice_provider, b"Alice", ciphersuite.signature_algorithm());
+    let (bob_credential, bob_signer) =
+        new_credential(bob_provider, b"Bob", ciphersuite.signature_algorithm());
+
+    // Default config keeps no past epochs.
+    let mut alice_group = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .build(alice_provider, &alice_signer, alice_credential)
+        .expect("alice create group");
+
+    let bob_key_package = KeyPackage::builder()
+        .build(ciphersuite, bob_provider, &bob_signer, bob_credential)
+        .expect("bob KP build")
+        .key_package()
+        .to_owned();
+
+    let (_commit, welcome, _gi) = alice_group
+        .add_members(alice_provider, &alice_signer, &[bob_key_package])
+        .expect("alice add bob");
+    alice_group
+        .merge_pending_commit(alice_provider)
+        .expect("alice merge add");
+
+    let mut bob_group = StagedWelcome::new_from_welcome(
+        bob_provider,
+        &MlsGroupJoinConfig::default(),
+        welcome.into_welcome().unwrap(),
+        Some(alice_group.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(bob_provider))
+    .expect("bob join");
+
+    let msg = alice_group
+        .create_unconfirmed_message(alice_provider, &alice_signer, b"epoch N message")
+        .expect("create msg");
+
+    // Bob commits, Alice advances to epoch N+1. With no retained past epochs,
+    // the epoch-N secret tree is dropped.
+    let bob_commit = bob_group
+        .self_update(bob_provider, &bob_signer, LeafNodeParameters::default())
+        .expect("bob self-update")
+        .into_commit();
+    bob_group
+        .merge_pending_commit(bob_provider)
+        .expect("bob merge self-update");
+    let processed = alice_group
+        .process_message(alice_provider, bob_commit.into_protocol_message().unwrap())
+        .expect("alice process bob commit");
+    let ProcessedMessageContent::StagedCommitMessage(staged) = processed.into_content() else {
+        panic!("expected a staged commit");
+    };
+    alice_group
+        .merge_staged_commit(alice_provider, *staged)
+        .expect("alice merge bob commit");
+
+    alice_group
+        .confirm_message(alice_provider.storage(), msg.epoch, msg.generation)
+        .expect("confirming an aged-out epoch must be a no-op success");
+}
+
+/// Confirming a message whose secret was already consumed by processing its
+/// own echo is a no-op success.
+#[openmls_test::openmls_test]
+fn confirm_after_processing_own_echo_is_noop() {
+    let alice_provider = &Provider::default();
+
+    let (alice_credential, alice_signer) =
+        new_credential(alice_provider, b"Alice", ciphersuite.signature_algorithm());
+
+    let mut alice_group = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .build(alice_provider, &alice_signer, alice_credential)
+        .expect("alice create group");
+
+    let unconfirmed = alice_group
+        .create_unconfirmed_message(alice_provider, &alice_signer, b"echo me")
+        .expect("create unconfirmed message");
+    let epoch = unconfirmed.epoch;
+    let generation = unconfirmed.generation;
+
+    let processed = alice_group
+        .process_message(
+            alice_provider,
+            unconfirmed.message.into_protocol_message().unwrap(),
+        )
+        .expect("process own echo");
+    let ProcessedMessageContent::ApplicationMessage(app) = processed.into_content() else {
+        panic!("expected the own echo to decrypt");
+    };
+    assert_eq!(app.into_bytes().as_slice(), b"echo me");
+
+    alice_group
+        .confirm_message(alice_provider.storage(), epoch, generation)
+        .expect("confirming an already-consumed generation must be a no-op success");
+}
+
+/// Confirming an epoch newer than the group's current epoch errors.
+#[openmls_test::openmls_test]
+fn confirm_future_epoch_errors() {
+    let alice_provider = &Provider::default();
+
+    let (alice_credential, alice_signer) =
+        new_credential(alice_provider, b"Alice", ciphersuite.signature_algorithm());
+
+    let mut alice_group = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .build(alice_provider, &alice_signer, alice_credential)
+        .expect("alice create group");
+
+    let future_epoch = GroupEpoch::from(alice_group.epoch().as_u64() + 1);
+    let err = alice_group
+        .confirm_message(alice_provider.storage(), future_epoch, 0)
+        .expect_err("confirming a future epoch must error");
+    assert!(matches!(err, ConfirmMessageError::FutureEpoch));
+}
+
+/// A retained own handshake secret decrypts the message's own echo, and
+/// `confirm_handshake_message` deletes it.
+#[openmls_test::openmls_test]
+fn confirm_handshake_message_deletes_retained_secret() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let (alice_credential, alice_signer) =
+        new_credential(alice_provider, b"Alice", ciphersuite.signature_algorithm());
+    let (bob_credential, bob_signer) =
+        new_credential(bob_provider, b"Bob", ciphersuite.signature_algorithm());
+    let (charlie_credential, charlie_signer) = new_credential(
+        alice_provider,
+        b"Charlie",
+        ciphersuite.signature_algorithm(),
+    );
+    let (dave_credential, dave_signer) =
+        new_credential(alice_provider, b"Dave", ciphersuite.signature_algorithm());
+
+    // Pure-ciphertext framing so proposals are sent and accepted as
+    // PrivateMessage.
+    let group_config = MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_CIPHERTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .build();
+    let mut alice_group = MlsGroup::new(
+        alice_provider,
+        &alice_signer,
+        &group_config,
+        alice_credential,
+    )
+    .expect("alice create group");
+
+    let bob_key_package = KeyPackage::builder()
+        .build(ciphersuite, bob_provider, &bob_signer, bob_credential)
+        .expect("bob KP build")
+        .key_package()
+        .to_owned();
+    let (_commit, _welcome, _gi) = alice_group
+        .add_members(alice_provider, &alice_signer, &[bob_key_package])
+        .expect("alice add bob");
+    alice_group
+        .merge_pending_commit(alice_provider)
+        .expect("alice merge add");
+
+    let charlie_key_package = KeyPackage::builder()
+        .build(
+            ciphersuite,
+            alice_provider,
+            &charlie_signer,
+            charlie_credential,
+        )
+        .expect("charlie KP build")
+        .key_package()
+        .to_owned();
+    let dave_key_package = KeyPackage::builder()
+        .build(ciphersuite, alice_provider, &dave_signer, dave_credential)
+        .expect("dave KP build")
+        .key_package()
+        .to_owned();
+
+    let epoch = alice_group.epoch();
+
+    // The first handshake send of this epoch uses generation 0. The send API
+    // does not surface the handshake generation yet.
+    let (proposal_a, _ref_a) = alice_group
+        .propose_add_member(alice_provider, &alice_signer, &charlie_key_package)
+        .expect("propose add charlie");
+
+    // Processing proposal A's own echo without confirming decrypts it, which
+    // proves the own handshake ratchet retains the secret.
+    let processed = alice_group
+        .process_message(alice_provider, proposal_a.into_protocol_message().unwrap())
+        .expect("process proposal A echo");
+    assert!(matches!(
+        processed.into_content(),
+        ProcessedMessageContent::ProposalMessage(_)
+    ));
+
+    // Proposal B uses handshake generation 1.
+    let (proposal_b, _ref_b) = alice_group
+        .propose_add_member(alice_provider, &alice_signer, &dave_key_package)
+        .expect("propose add dave");
+    alice_group
+        .confirm_handshake_message(alice_provider.storage(), epoch, 1)
+        .expect("confirm proposal B");
+
+    // Proposal B's secret was deleted, so its echo surfaces OwnPrivateMessage.
+    let processed = alice_group
+        .process_message(alice_provider, proposal_b.into_protocol_message().unwrap())
+        .expect("process proposal B echo");
+    assert!(matches!(
+        processed.into_content(),
         ProcessedMessageContent::OwnPrivateMessage
     ));
 }
@@ -2121,7 +2459,7 @@ fn unconfirmed_message_decrypts_after_next_message_is_confirmed() {
         .expect("Could not create second message.");
     assert_eq!(second.generation, 1);
     alice_group
-        .confirm_message(alice_provider.storage(), second.generation)
+        .confirm_message(alice_provider.storage(), second.epoch, second.generation)
         .expect("Could not confirm second message.");
 
     let processed_message = alice_group
@@ -2168,7 +2506,7 @@ fn old_unconfirmed_own_message_survives_later_confirmations() {
             )
             .expect("Could not create later unconfirmed message.");
         alice_group
-            .confirm_message(alice_provider.storage(), later.generation)
+            .confirm_message(alice_provider.storage(), later.epoch, later.generation)
             .expect("Could not confirm later message.");
     }
 
@@ -2368,7 +2706,7 @@ fn create_unconfirmed_message_returns_generation_id_when_bound() {
         ciphersuite.hash_length()
     );
     alice_group
-        .confirm_message(provider.storage(), first.generation)
+        .confirm_message(provider.storage(), first.epoch, first.generation)
         .expect("confirm first message");
 
     let second = alice_group

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -2990,6 +2990,175 @@ fn vc_sibling_applies_commit_without_update_path() {
     }
 }
 
+/// Regression test: a virtual client's own VC commit fanned back by the
+/// delivery service must surface as `OwnPendingCommit`, not fail while loading
+/// sibling-commit material.
+///
+/// alice_a and alice_b are sibling emulators sharing the higher-level leaf and
+/// one emulation epoch, in a group that also holds the regular member bob.
+/// alice_a builds a VC commit and, before merging it, processes the copy the
+/// delivery service echoed back. The commit is framed as
+/// `Sender::Member(own_leaf_index)` with an UpdatePath carrying VC material, so
+/// its shape is indistinguishable from a sibling's commit. Because it matches
+/// alice_a's pending commit it must be reported as `OwnPendingCommit` without
+/// consuming an operation-secret generation. Before the fix this failed with
+/// `VirtualClientsError::OperationGenerationConsumed`.
+#[openmls_test]
+fn vc_own_commit_echo_surfaces_as_own_pending_commit() {
+    let alice_a_provider = Provider::default();
+    let alice_b_provider = Provider::default();
+    let bob_provider = Provider::default();
+
+    let (vc_signer, vc_credential) =
+        shared_vc_identity(ciphersuite, &alice_a_provider, &alice_b_provider);
+
+    // alice_a founds the higher-level group and adds bob.
+    let mut alice_a_main = new_vc_main_group(
+        ciphersuite,
+        &alice_a_provider,
+        &vc_signer,
+        vc_credential.clone(),
+    );
+    let (bob_credential, bob_signer) =
+        new_credential(&bob_provider, b"Bob", ciphersuite.signature_algorithm());
+    let bob_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .build(ciphersuite, &bob_provider, &bob_signer, bob_credential)
+        .expect("bob KP build")
+        .key_package()
+        .to_owned();
+    let (_, welcome, _) = alice_a_main
+        .add_members(&alice_a_provider, &vc_signer, &[bob_kp])
+        .expect("alice_a add bob");
+    alice_a_main
+        .merge_pending_commit(&alice_a_provider)
+        .expect("alice_a merge add bob");
+    let mut bob_main = StagedWelcome::new_from_welcome(
+        &bob_provider,
+        &vc_join_config(),
+        welcome.into_welcome().expect("welcome"),
+        Some(alice_a_main.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(&bob_provider))
+    .expect("bob join");
+
+    // alice_b joins as a sibling emulator and resyncs into the higher-level
+    // group, so both Alice clients share `own_leaf_index` and the same
+    // emulation epoch.
+    let (siblings, resync_commit) = join_sibling_emulator(
+        ciphersuite,
+        &alice_a_provider,
+        &alice_b_provider,
+        &vc_signer,
+        vc_credential,
+        &alice_a_main,
+        vc_join_config(),
+    );
+    let mut alice_b_main = siblings.alice_b_main;
+    let epoch_id = siblings.epoch_id;
+
+    for (group, provider) in [
+        (&mut alice_a_main, &alice_a_provider),
+        (&mut bob_main, &bob_provider),
+    ] {
+        process_and_merge_commit(group, provider, resync_commit.clone());
+    }
+    assert_eq!(
+        alice_a_main.own_leaf_index(),
+        alice_b_main.own_leaf_index(),
+        "both Alice clients must share the higher-level leaf"
+    );
+
+    // alice_a builds a VC commit on the shared emulation epoch but does not
+    // merge it, so it is still her pending commit when the delivery service
+    // fans the copy back to her.
+    let bundle = alice_a_main
+        .commit_builder()
+        .vc_emulation(
+            alice_a_provider.crypto(),
+            alice_a_provider.storage(),
+            epoch_id.clone(),
+        )
+        .expect("alice_a bind commit to emulation epoch")
+        .load_psks(alice_a_provider.storage())
+        .expect("alice_a load psks")
+        .build(
+            alice_a_provider.rand(),
+            alice_a_provider.crypto(),
+            &vc_signer,
+            |_| true,
+        )
+        .expect("alice_a build vc commit")
+        .stage_commit(&alice_a_provider)
+        .expect("alice_a stage vc commit");
+    let commit = bundle.into_commit();
+
+    // alice_a processes her own commit echoed back. It is framed like a
+    // sibling's VC commit, but it matches her pending commit and must surface
+    // as `OwnPendingCommit` without consuming an operation-secret generation.
+    let processed = alice_a_main
+        .process_message(
+            &alice_a_provider,
+            commit.clone().into_protocol_message().unwrap(),
+        )
+        .expect("alice_a processes her own fanned-back vc commit");
+    assert!(matches!(
+        processed.into_content(),
+        ProcessedMessageContent::OwnPendingCommit
+    ));
+    alice_a_main
+        .merge_pending_commit(&alice_a_provider)
+        .expect("alice_a merge her own vc commit");
+
+    // The sibling and bob apply the same commit through the ordinary staging
+    // path.
+    let processed = alice_b_main
+        .process_message(
+            &alice_b_provider,
+            commit.clone().into_protocol_message().unwrap(),
+        )
+        .expect("alice_b processes sibling vc commit");
+    let staged = match processed.into_content() {
+        ProcessedMessageContent::StagedCommitMessage(s) => *s,
+        other => panic!("expected staged commit, got {other:?}"),
+    };
+    alice_b_main
+        .merge_staged_commit(&alice_b_provider, staged)
+        .expect("alice_b merge sibling vc commit");
+    process_and_merge_commit(&mut bob_main, &bob_provider, commit);
+
+    let authenticator = alice_a_main.epoch_authenticator();
+    assert_eq!(
+        alice_b_main.epoch_authenticator(),
+        authenticator,
+        "sibling must converge with the committer"
+    );
+    assert_eq!(
+        bob_main.epoch_authenticator(),
+        authenticator,
+        "bob must converge with the committer"
+    );
+
+    // A second VC commit on the same emulation epoch, this time from alice_b,
+    // proves the operation secret tree stayed healthy after the echo.
+    let second_commit =
+        send_vc_commit_with_epoch(&mut alice_b_main, &alice_b_provider, &vc_signer, epoch_id);
+    process_and_merge_commit(&mut alice_a_main, &alice_a_provider, second_commit.clone());
+    process_and_merge_commit(&mut bob_main, &bob_provider, second_commit);
+
+    let authenticator = alice_b_main.epoch_authenticator();
+    assert_eq!(
+        alice_a_main.epoch_authenticator(),
+        authenticator,
+        "committer's sibling must converge after the second commit"
+    );
+    assert_eq!(
+        bob_main.epoch_authenticator(),
+        authenticator,
+        "bob must converge after the second commit"
+    );
+}
+
 /// Set up two sibling emulator clients sharing one emulation group and epoch.
 /// `alice_a` founds the emulation group, `alice_b` joins it via Welcome, and
 /// both register the same emulation epoch, so both hold its

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -2082,7 +2082,7 @@ fn processing_own_application_message() {
         .unwrap();
     let ciphertext = unconfirmed.message;
     alice_group
-        .confirm_message(
+        .confirm_application_message(
             alice_provider.storage(),
             unconfirmed.epoch,
             unconfirmed.generation,
@@ -2185,7 +2185,7 @@ fn confirm_targets_creation_epoch() {
     // Confirming msg1 at its creation epoch must not touch msg2's secret,
     // which shares the generation number in the newer epoch.
     alice_group
-        .confirm_message(alice_provider.storage(), msg1.epoch, msg1.generation)
+        .confirm_application_message(alice_provider.storage(), msg1.epoch, msg1.generation)
         .expect("confirm msg1");
 
     // msg2's secret is intact, so its echo decrypts.
@@ -2277,7 +2277,7 @@ fn confirm_aged_out_epoch_is_noop() {
         .expect("alice merge bob commit");
 
     alice_group
-        .confirm_message(alice_provider.storage(), msg.epoch, msg.generation)
+        .confirm_application_message(alice_provider.storage(), msg.epoch, msg.generation)
         .expect("confirming an aged-out epoch must be a no-op success");
 }
 
@@ -2313,7 +2313,7 @@ fn confirm_after_processing_own_echo_is_noop() {
     assert_eq!(app.into_bytes().as_slice(), b"echo me");
 
     alice_group
-        .confirm_message(alice_provider.storage(), epoch, generation)
+        .confirm_application_message(alice_provider.storage(), epoch, generation)
         .expect("confirming an already-consumed generation must be a no-op success");
 }
 
@@ -2332,7 +2332,7 @@ fn confirm_future_epoch_errors() {
 
     let future_epoch = GroupEpoch::from(alice_group.epoch().as_u64() + 1);
     let err = alice_group
-        .confirm_message(alice_provider.storage(), future_epoch, 0)
+        .confirm_application_message(alice_provider.storage(), future_epoch, 0)
         .expect_err("confirming a future epoch must error");
     assert!(matches!(err, ConfirmMessageError::FutureEpoch));
 }
@@ -2459,7 +2459,7 @@ fn unconfirmed_message_decrypts_after_next_message_is_confirmed() {
         .expect("Could not create second message.");
     assert_eq!(second.generation, 1);
     alice_group
-        .confirm_message(alice_provider.storage(), second.epoch, second.generation)
+        .confirm_application_message(alice_provider.storage(), second.epoch, second.generation)
         .expect("Could not confirm second message.");
 
     let processed_message = alice_group
@@ -2506,7 +2506,7 @@ fn old_unconfirmed_own_message_survives_later_confirmations() {
             )
             .expect("Could not create later unconfirmed message.");
         alice_group
-            .confirm_message(alice_provider.storage(), later.epoch, later.generation)
+            .confirm_application_message(alice_provider.storage(), later.epoch, later.generation)
             .expect("Could not confirm later message.");
     }
 
@@ -2706,7 +2706,7 @@ fn create_unconfirmed_message_returns_generation_id_when_bound() {
         ciphersuite.hash_length()
     );
     alice_group
-        .confirm_message(provider.storage(), first.epoch, first.generation)
+        .confirm_application_message(provider.storage(), first.epoch, first.generation)
         .expect("confirm first message");
 
     let second = alice_group


### PR DESCRIPTION
confirm_message deleted the given generation from the current epoch's own application ratchet. If the group advanced an epoch between create_unconfirmed_message and the confirmation, it either silently no-oped, retaining the old secret forever, or deleted a different message's still-unconfirmed secret that shared the generation number in the new epoch, making a lost race against a sibling undecryptable.

confirm_message now takes the creation epoch, carried on UnconfirmedMessage, and deletes exactly the secret its create call retained, or nothing: aged-out epochs and already-consumed generations are no-op successes, future epochs are rejected. The new confirm_handshake_message applies the same semantics to the handshake ratchet, giving retained own proposal and commit secrets a cleanup path. Proposals and commits share the per-epoch handshake ratchet, so one endpoint covers both.