### PR TITLE
feat: add key package batch builder for virtual clients

### DIFF
--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -690,7 +690,7 @@ impl KeyPackageBuilder {
             builder.add_key_package(
                 self.clone(),
                 ciphersuite,
-                provider,
+                provider.crypto(),
                 signer,
                 credential_with_key.clone(),
             )?;

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -123,6 +123,8 @@ pub mod errors;
 pub mod key_package_in;
 
 mod lifetime;
+#[cfg(feature = "virtual-clients-draft")]
+mod vc;
 
 // Tests
 #[cfg(test)]
@@ -131,6 +133,8 @@ pub(crate) mod tests;
 // Public types
 pub use key_package_in::KeyPackageIn;
 pub use lifetime::Lifetime;
+#[cfg(feature = "virtual-clients-draft")]
+pub use vc::{VcKeyPackageBatch, VcKeyPackageBatchBuilder};
 
 /// The unsigned payload of a key package.
 /// Any modification must happen on this unsigned struct. Use `sign` to get a
@@ -676,245 +680,23 @@ impl KeyPackageBuilder {
         signer: &impl Signer,
         credential_with_key: CredentialWithKey,
         epoch_id: crate::components::vc_derivation_info::EpochId,
-        count: u32,
+        count: usize,
     ) -> Result<VcKeyPackageBatch, KeyPackageNewError> {
-        use crate::components::vc_derivation_info::{
-            EmulationEpochState, VirtualClientOperationType, VirtualClientsError,
-        };
-        use crate::components::vc_operation_tree::OperationSecretTree;
-
-        if ciphersuite.signature_algorithm() != signer.signature_scheme() {
-            return Err(KeyPackageNewError::CiphersuiteSignatureSchemeMismatch);
-        }
-
-        // Reject an empty batch before loading state or consuming a generation.
         if count == 0 {
             return Err(KeyPackageNewError::EmptyBatch);
         }
-
-        // Resolve and validate the leaf configuration once for the whole batch
-        // (it does not depend on the per-KeyPackage index) before consuming a
-        // generation, so a misconfigured leaf fails without burning one.
-        let resolved_dictionary =
-            crate::components::vc_derivation_info::resolve_vc_leaf_dictionary(
-                self.leaf_node_capabilities.as_ref(),
-                self.leaf_node_extensions.as_ref(),
-                None,
-            )?;
-
-        // Allocate a single generation of the key_package operation ratchet
-        // for the whole batch. The advanced tree is held in memory and only
-        // persisted once every KeyPackage has been built, so a failure during
-        // building consumes no generation.
-        let state: EmulationEpochState = provider
-            .storage()
-            .vc_emulation_epoch_state(&epoch_id)
-            .map_err(|e| {
-                log::error!("vc: load emulation epoch state in build_vc_batch failed: {e:?}");
-                VirtualClientsError::StorageError
-            })?
-            .ok_or(VirtualClientsError::MissingEmulationEpochState)?;
-        let mut operation_tree: OperationSecretTree = provider
-            .storage()
-            .vc_operation_tree(&epoch_id)
-            .map_err(|e| {
-                log::error!("vc: load operation tree in build_vc_batch failed: {e:?}");
-                VirtualClientsError::StorageError
-            })?
-            .ok_or(VirtualClientsError::MissingOperationTree)?;
-        let (emulation_leaf_index, epoch_encryption_key, emulation_ciphersuite) =
-            state.into_parts();
-
-        // The operation context for KeyPackage operations is empty, since a
-        // KeyPackage is not tied to a higher-level group at build time.
-        let (generation, operation_secret) = operation_tree.next_operation_secret(
-            provider.crypto(),
-            emulation_ciphersuite,
-            &epoch_id,
-            emulation_leaf_index,
-            VirtualClientOperationType::KeyPackage,
-            b"",
-        )?;
-
-        let batch_ctx = VcBatchContext {
-            ciphersuite,
-            epoch_id,
-            emulation_ciphersuite,
-            epoch_encryption_key,
-            emulation_leaf_index,
-            generation,
-            operation_secret,
-            resolved_dictionary,
-        };
-
-        let mut key_packages = Vec::with_capacity(count as usize);
-        for key_package_index in 0..count {
-            let entry = self.build_vc_key_package_for_index(
+        let mut builder = VcKeyPackageBatchBuilder::with_capacity(provider, epoch_id, count)?;
+        for _ in 0..count {
+            builder.add_key_package(
+                self.clone(),
+                ciphersuite,
                 provider,
                 signer,
                 credential_with_key.clone(),
-                &batch_ctx,
-                key_package_index,
             )?;
-            key_packages.push(entry);
         }
-
-        // Persist the advanced operation tree before the KeyPackages it backs.
-        // If a KeyPackage write fails after this, the burned generation is
-        // harmless, but writing KeyPackages first would let the next batch
-        // reuse the same key material under an unconsumed generation.
-        provider
-            .storage()
-            .write_vc_operation_tree(&batch_ctx.epoch_id, &operation_tree)
-            .map_err(|e| {
-                log::error!("vc: persist advanced operation tree in build_vc_batch failed: {e:?}");
-                VirtualClientsError::StorageError
-            })?;
-        for (full_kp, info) in &key_packages {
-            provider
-                .storage()
-                .write_key_package(&info.key_package_ref, full_kp)
-                .map_err(|_| KeyPackageNewError::StorageError)?;
-        }
-
-        Ok(VcKeyPackageBatch {
-            generation,
-            key_packages,
-        })
+        builder.finalize(provider)
     }
-
-    /// Derive and build a single KeyPackage at `key_package_index` from the
-    /// batch's shared `operation_secret`. Used by [`Self::build_vc_batch`].
-    #[cfg(feature = "virtual-clients-draft")]
-    fn build_vc_key_package_for_index(
-        &self,
-        provider: &impl OpenMlsProvider,
-        signer: &impl Signer,
-        credential_with_key: CredentialWithKey,
-        batch_ctx: &VcBatchContext,
-        key_package_index: u32,
-    ) -> Result<
-        (
-            KeyPackageBundle,
-            crate::components::vc_derivation_info::KeyPackageInfo,
-        ),
-        KeyPackageNewError,
-    > {
-        use crate::components::vc_derivation_info::{
-            DerivationInfo, DerivationInfoTbe, KeyPackageInfo, VirtualClientsError,
-        };
-        use tls_codec::Serialize as _;
-
-        let ciphersuite = batch_ctx.ciphersuite;
-
-        // Derive the per-index seed under the emulation ciphersuite, then the
-        // init and leaf encryption keys from the seed under the KeyPackage's
-        // own ciphersuite.
-        let seed = batch_ctx.operation_secret.derive_key_package_seed_secret(
-            provider.crypto(),
-            batch_ctx.emulation_ciphersuite,
-            key_package_index,
-        )?;
-        let init_key_pair = seed
-            .derive_init_key_secret(provider.crypto(), ciphersuite)?
-            .generate_init_key_pair(provider.crypto(), ciphersuite)?;
-        let encryption_key_pair = seed
-            .derive_encryption_key_secret(provider.crypto(), ciphersuite)?
-            .generate_encryption_key_pair(provider.crypto(), ciphersuite)?;
-
-        // Wrap the TBE bound to the new leaf via its serialized encryption key.
-        // The leaf dictionary was resolved and validated once for the whole
-        // batch, so reuse a clone here.
-        let resolved_dictionary = batch_ctx.resolved_dictionary.clone();
-        let leaf_encryption_key = encryption_key_pair
-            .public_key()
-            .tls_serialize_detached()
-            .map_err(VirtualClientsError::from)?;
-        let tbe = DerivationInfoTbe::KeyPackage {
-            leaf_index: batch_ctx.emulation_leaf_index,
-            generation: batch_ctx.generation,
-            key_package_index,
-        };
-        let derivation_info = DerivationInfo::encrypt(
-            provider.crypto(),
-            batch_ctx.emulation_ciphersuite,
-            &batch_ctx.epoch_encryption_key,
-            batch_ctx.epoch_id.clone(),
-            &leaf_encryption_key,
-            &tbe,
-        )?;
-        let derivation_info_bytes = derivation_info
-            .tls_serialize_detached()
-            .map_err(VirtualClientsError::from)?;
-        let mut builder = self.clone();
-        builder.ensure_last_resort();
-        let leaf_node_extensions = crate::components::vc_derivation_info::merge_vc_derivation_info(
-            builder.leaf_node_extensions.as_ref(),
-            resolved_dictionary,
-            derivation_info_bytes,
-        )
-        .map_err(KeyPackageNewError::LibraryError)?;
-
-        let leaf_node_params = KeyPackageLeafNodeParams {
-            lifetime: builder.key_package_lifetime.unwrap_or_default(),
-            capabilities: builder.leaf_node_capabilities.unwrap_or_default(),
-            extensions: leaf_node_extensions,
-        };
-        let (key_package, encryption_key_pair) = KeyPackage::new_from_vc_keys(
-            ciphersuite,
-            signer,
-            credential_with_key,
-            builder.key_package_extensions.unwrap_or_default(),
-            leaf_node_params,
-            init_key_pair.public.into(),
-            encryption_key_pair,
-        )?;
-
-        let key_package_ref = key_package.hash_ref(provider.crypto())?;
-        let full_kp = KeyPackageBundle {
-            key_package,
-            private_init_key: init_key_pair.private,
-            private_encryption_key: encryption_key_pair.private_key().clone(),
-        };
-
-        Ok((
-            full_kp,
-            KeyPackageInfo {
-                key_package_ref,
-                key_package_index,
-            },
-        ))
-    }
-}
-
-/// Shared inputs for building each KeyPackage in a `build_vc_batch` call:
-/// the batch's single operation secret plus the epoch material every
-/// KeyPackage in the batch derives against.
-#[cfg(feature = "virtual-clients-draft")]
-struct VcBatchContext {
-    ciphersuite: Ciphersuite,
-    epoch_id: crate::components::vc_derivation_info::EpochId,
-    emulation_ciphersuite: Ciphersuite,
-    epoch_encryption_key: crate::components::vc_derivation_info::EpochEncryptionKey,
-    emulation_leaf_index: crate::binary_tree::LeafNodeIndex,
-    generation: u32,
-    operation_secret: crate::components::vc_derivation_info::OperationSecret,
-    resolved_dictionary: crate::extensions::AppDataDictionary,
-}
-
-/// The result of [`KeyPackageBuilder::build_vc_batch`]: the single
-/// `key_package` operation generation the batch consumed, and one
-/// `(KeyPackageBundle, KeyPackageInfo)` per KeyPackage built.
-#[cfg(feature = "virtual-clients-draft")]
-#[derive(Debug)]
-pub struct VcKeyPackageBatch {
-    /// The `key_package` operation generation consumed for the whole batch.
-    pub generation: u32,
-    /// One entry per KeyPackage built, in batch-index order. Never empty.
-    pub key_packages: Vec<(
-        KeyPackageBundle,
-        crate::components::vc_derivation_info::KeyPackageInfo,
-    )>,
 }
 
 /// A [`KeyPackageBundle`] contains a [`KeyPackage`] and the init and encryption

--- a/openmls/src/key_packages/vc.rs
+++ b/openmls/src/key_packages/vc.rs
@@ -1,7 +1,8 @@
 //! Key package facilities for virtual clients
 
 use openmls_traits::{
-    signatures::Signer, storage::StorageProvider, types::Ciphersuite, OpenMlsProvider,
+    crypto::OpenMlsCrypto, signatures::Signer, storage::StorageProvider, types::Ciphersuite,
+    OpenMlsProvider,
 };
 use tls_codec::Serialize;
 
@@ -113,7 +114,7 @@ impl VcKeyPackageBatchBuilder {
         &mut self,
         builder: KeyPackageBuilder,
         ciphersuite: Ciphersuite,
-        provider: &impl OpenMlsProvider,
+        crypto: &impl OpenMlsCrypto,
         signer: &impl Signer,
         credential_with_key: CredentialWithKey,
     ) -> Result<&KeyPackageInfo, KeyPackageNewError> {
@@ -132,7 +133,7 @@ impl VcKeyPackageBatchBuilder {
         self.key_packages.push(self.build_vc_key_package_for_index(
             builder,
             ciphersuite,
-            provider,
+            crypto,
             signer,
             credential_with_key,
             &resolved_dictionary,
@@ -186,7 +187,7 @@ impl VcKeyPackageBatchBuilder {
         &self,
         mut builder: KeyPackageBuilder,
         ciphersuite: Ciphersuite,
-        provider: &impl OpenMlsProvider,
+        crypto: &impl OpenMlsCrypto,
         signer: &impl Signer,
         credential_with_key: CredentialWithKey,
         resolved_dictionary: &AppDataDictionary,
@@ -196,16 +197,16 @@ impl VcKeyPackageBatchBuilder {
         // init and leaf encryption keys from the seed under the KeyPackage's
         // own ciphersuite.
         let seed = self.operation_secret.derive_key_package_seed_secret(
-            provider.crypto(),
+            crypto,
             self.emulation_ciphersuite,
             key_package_index,
         )?;
         let init_key_pair = seed
-            .derive_init_key_secret(provider.crypto(), ciphersuite)?
-            .generate_init_key_pair(provider.crypto(), ciphersuite)?;
+            .derive_init_key_secret(crypto, ciphersuite)?
+            .generate_init_key_pair(crypto, ciphersuite)?;
         let encryption_key_pair = seed
-            .derive_encryption_key_secret(provider.crypto(), ciphersuite)?
-            .generate_encryption_key_pair(provider.crypto(), ciphersuite)?;
+            .derive_encryption_key_secret(crypto, ciphersuite)?
+            .generate_encryption_key_pair(crypto, ciphersuite)?;
 
         // Wrap the TBE bound to the new leaf via its serialized encryption key.
         // The leaf dictionary was resolved and validated once for the whole
@@ -220,7 +221,7 @@ impl VcKeyPackageBatchBuilder {
             key_package_index,
         };
         let derivation_info = DerivationInfo::encrypt(
-            provider.crypto(),
+            crypto,
             self.emulation_ciphersuite,
             &self.epoch_encryption_key,
             self.epoch_id.clone(),
@@ -253,7 +254,7 @@ impl VcKeyPackageBatchBuilder {
             encryption_key_pair,
         )?;
 
-        let key_package_ref = key_package.hash_ref(provider.crypto())?;
+        let key_package_ref = key_package.hash_ref(crypto)?;
         let full_kp = KeyPackageBundle {
             key_package,
             private_init_key: init_key_pair.private,

--- a/openmls/src/key_packages/vc.rs
+++ b/openmls/src/key_packages/vc.rs
@@ -1,0 +1,271 @@
+//! Key package facilities for virtual clients
+
+use openmls_traits::{
+    signatures::Signer, storage::StorageProvider, types::Ciphersuite, OpenMlsProvider,
+};
+use tls_codec::Serialize;
+
+use crate::{
+    binary_tree::LeafNodeIndex,
+    components::{
+        vc_derivation_info::{
+            load_vc_epoch_state_and_tree, merge_vc_derivation_info, resolve_vc_leaf_dictionary,
+            DerivationInfo, DerivationInfoTbe, EpochEncryptionKey, EpochId, KeyPackageInfo,
+            OperationSecret, VirtualClientOperationType, VirtualClientsError,
+        },
+        vc_operation_tree::OperationSecretTree,
+    },
+    credentials::CredentialWithKey,
+    extensions::AppDataDictionary,
+    key_packages::{
+        errors::KeyPackageNewError, KeyPackage, KeyPackageBuilder, KeyPackageBundle,
+        KeyPackageLeafNodeParams,
+    },
+};
+
+/// A batch of virtual-client KeyPackages a sibling can reproduce.
+///
+/// Build from a single epoch id and generation.
+#[derive(Debug)]
+pub struct VcKeyPackageBatch {
+    /// The `key_package` operation generation consumed for the whole batch.
+    pub generation: u32,
+    /// One entry per KeyPackage built, in batch-index order. Never empty.
+    pub key_packages: Vec<(
+        KeyPackageBundle,
+        crate::components::vc_derivation_info::KeyPackageInfo,
+    )>,
+}
+
+/// A builder for a batch of virtual-client KeyPackages a sibling can reproduce.
+///
+/// Allows to build heterogeneous batch of key packages, e.g. non-last-resort and last-restort, or
+/// packages with different ciphersuits. Return the batch on [`Self::finalize`]. Dropping the
+/// builder without calling `finalize` burns no generation.
+#[derive(Debug)]
+pub struct VcKeyPackageBatchBuilder {
+    epoch_id: EpochId,
+    /// Ciphersuite of the emulation group
+    emulation_ciphersuite: Ciphersuite,
+    epoch_encryption_key: EpochEncryptionKey,
+    emulation_leaf_index: LeafNodeIndex,
+    generation: u32,
+    operation_secret: OperationSecret,
+    /// Advanced in memory by new()
+    ///
+    /// Only persisted in finalize(), so dropped builder burns not generation.
+    operation_tree: OperationSecretTree,
+    key_packages: Vec<(KeyPackageBundle, KeyPackageInfo)>,
+}
+
+impl VcKeyPackageBatchBuilder {
+    /// Load emulation epoch and allocate the next generation of the key package operation ratchet.
+    ///
+    /// Nothing is persisted yet. Dropping the builder without calling `finalize` burns no
+    /// generation.
+    pub fn new(
+        provider: &impl OpenMlsProvider,
+        epoch_id: EpochId,
+    ) -> Result<Self, KeyPackageNewError> {
+        Self::with_capacity(provider, epoch_id, 0)
+    }
+
+    /// Same as [`Self::new`], but with a capacity hint for the number of key packages.
+    pub fn with_capacity(
+        provider: &impl OpenMlsProvider,
+        epoch_id: EpochId,
+        capacity: usize,
+    ) -> Result<Self, KeyPackageNewError> {
+        let (state, mut operation_tree) = load_vc_epoch_state_and_tree(provider, &epoch_id)?;
+        let (emulation_leaf_index, epoch_encryption_key, emulation_ciphersuite) =
+            state.into_parts();
+        let (generation, operation_secret) = operation_tree.next_operation_secret(
+            provider.crypto(),
+            emulation_ciphersuite,
+            &epoch_id,
+            emulation_leaf_index,
+            VirtualClientOperationType::KeyPackage,
+            b"",
+        )?;
+        Ok(Self {
+            epoch_id,
+            emulation_ciphersuite,
+            epoch_encryption_key,
+            emulation_leaf_index,
+            generation,
+            operation_secret,
+            operation_tree,
+            key_packages: Vec::with_capacity(capacity),
+        })
+    }
+
+    /// Build one key package at the next index.
+    ///
+    /// The key package builder carries the per-step config: key package extensions (incl. last
+    /// resort), leaf node extensions, capabilities, lifetime.
+    ///
+    /// If building fails, the builder is left in a valid state:
+    ///
+    /// - No storage is touched
+    /// - No generation is burned
+    /// - The failed index isn't consumed
+    pub fn add_key_package(
+        &mut self,
+        builder: KeyPackageBuilder,
+        ciphersuite: Ciphersuite,
+        provider: &impl OpenMlsProvider,
+        signer: &impl Signer,
+        credential_with_key: CredentialWithKey,
+    ) -> Result<&KeyPackageInfo, KeyPackageNewError> {
+        if ciphersuite.signature_algorithm() != signer.signature_scheme() {
+            return Err(KeyPackageNewError::CiphersuiteSignatureSchemeMismatch);
+        }
+
+        // Resolve and validate the leaf configuration
+        let resolved_dictionary = resolve_vc_leaf_dictionary(
+            builder.leaf_node_capabilities.as_ref(),
+            builder.leaf_node_extensions.as_ref(),
+            None,
+        )?;
+
+        let key_package_index = self.key_packages.len() as u32;
+        self.key_packages.push(self.build_vc_key_package_for_index(
+            builder,
+            ciphersuite,
+            provider,
+            signer,
+            credential_with_key,
+            &resolved_dictionary,
+            key_package_index,
+        )?);
+
+        let (_, info) = self.key_packages.last().expect("logic error: just pushed");
+        Ok(info)
+    }
+
+    /// Finalize the batch.
+    ///
+    /// Persists the operation tree and the key packages. The operation is not atomic. On failure,
+    /// the generation should be considered as burned. Few orphaned key packages may be left in
+    /// storage.
+    pub fn finalize(
+        self,
+        provider: &impl OpenMlsProvider,
+    ) -> Result<VcKeyPackageBatch, KeyPackageNewError> {
+        if self.key_packages.is_empty() {
+            return Err(KeyPackageNewError::EmptyBatch);
+        }
+
+        // Persist the advanced operation tree before the KeyPackages it backs.
+        // If a KeyPackage write fails after this, the burned generation is
+        // harmless, but writing KeyPackages first would let the next batch
+        // reuse the same key material under an unconsumed generation.
+        provider
+            .storage()
+            .write_vc_operation_tree(&self.epoch_id, &self.operation_tree)
+            .map_err(|e| {
+                log::error!("vc: persist advanced operation tree in build_vc_batch failed: {e:?}");
+                VirtualClientsError::StorageError
+            })?;
+        for (full_kp, info) in &self.key_packages {
+            provider
+                .storage()
+                .write_key_package(&info.key_package_ref, full_kp)
+                .map_err(|_| KeyPackageNewError::StorageError)?;
+        }
+
+        Ok(VcKeyPackageBatch {
+            generation: self.generation,
+            key_packages: self.key_packages,
+        })
+    }
+
+    /// Derive and build a single KeyPackage at `key_package_index`
+    #[expect(clippy::too_many_arguments)]
+    fn build_vc_key_package_for_index(
+        &self,
+        mut builder: KeyPackageBuilder,
+        ciphersuite: Ciphersuite,
+        provider: &impl OpenMlsProvider,
+        signer: &impl Signer,
+        credential_with_key: CredentialWithKey,
+        resolved_dictionary: &AppDataDictionary,
+        key_package_index: u32,
+    ) -> Result<(KeyPackageBundle, KeyPackageInfo), KeyPackageNewError> {
+        // Derive the per-index seed under the emulation ciphersuite, then the
+        // init and leaf encryption keys from the seed under the KeyPackage's
+        // own ciphersuite.
+        let seed = self.operation_secret.derive_key_package_seed_secret(
+            provider.crypto(),
+            self.emulation_ciphersuite,
+            key_package_index,
+        )?;
+        let init_key_pair = seed
+            .derive_init_key_secret(provider.crypto(), ciphersuite)?
+            .generate_init_key_pair(provider.crypto(), ciphersuite)?;
+        let encryption_key_pair = seed
+            .derive_encryption_key_secret(provider.crypto(), ciphersuite)?
+            .generate_encryption_key_pair(provider.crypto(), ciphersuite)?;
+
+        // Wrap the TBE bound to the new leaf via its serialized encryption key.
+        // The leaf dictionary was resolved and validated once for the whole
+        // batch, so reuse a clone here.
+        let leaf_encryption_key = encryption_key_pair
+            .public_key()
+            .tls_serialize_detached()
+            .map_err(VirtualClientsError::from)?;
+        let tbe = DerivationInfoTbe::KeyPackage {
+            leaf_index: self.emulation_leaf_index,
+            generation: self.generation,
+            key_package_index,
+        };
+        let derivation_info = DerivationInfo::encrypt(
+            provider.crypto(),
+            self.emulation_ciphersuite,
+            &self.epoch_encryption_key,
+            self.epoch_id.clone(),
+            &leaf_encryption_key,
+            &tbe,
+        )?;
+        let derivation_info_bytes = derivation_info
+            .tls_serialize_detached()
+            .map_err(VirtualClientsError::from)?;
+        builder.ensure_last_resort();
+        let leaf_node_extensions = merge_vc_derivation_info(
+            builder.leaf_node_extensions.as_ref(),
+            resolved_dictionary.clone(),
+            derivation_info_bytes,
+        )
+        .map_err(KeyPackageNewError::LibraryError)?;
+
+        let leaf_node_params = KeyPackageLeafNodeParams {
+            lifetime: builder.key_package_lifetime.unwrap_or_default(),
+            capabilities: builder.leaf_node_capabilities.unwrap_or_default(),
+            extensions: leaf_node_extensions,
+        };
+        let (key_package, encryption_key_pair) = KeyPackage::new_from_vc_keys(
+            ciphersuite,
+            signer,
+            credential_with_key,
+            builder.key_package_extensions.unwrap_or_default(),
+            leaf_node_params,
+            init_key_pair.public.into(),
+            encryption_key_pair,
+        )?;
+
+        let key_package_ref = key_package.hash_ref(provider.crypto())?;
+        let full_kp = KeyPackageBundle {
+            key_package,
+            private_init_key: init_key_pair.private,
+            private_encryption_key: encryption_key_pair.private_key().clone(),
+        };
+
+        Ok((
+            full_kp,
+            KeyPackageInfo {
+                key_package_ref,
+                key_package_index,
+            },
+        ))
+    }
+}

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -1935,7 +1935,7 @@ fn vc_batch_key_packages_join_in_any_order() {
     );
 
     // One batch of 40 KeyPackages, larger than OUT_OF_ORDER_TOLERANCE (32).
-    let count: u32 = 40;
+    let count = 40;
     let batch = KeyPackage::builder()
         .leaf_node_capabilities(vc_capabilities())
         .leaf_node_extensions(vc_leaf_extensions())


### PR DESCRIPTION
The newly added `VcKeyPackageBatchBuilder` allows to build heterogeneous batches of key packages. Build the batch on `finalize`. Dropping the builder without calling `finalize` burns no generation.