### PR TITLE
fix(vc): use emulation ciphersuite for init key secret expansion

### DIFF
--- a/openmls/src/components/vc_derivation_info.rs
+++ b/openmls/src/components/vc_derivation_info.rs
@@ -574,6 +574,8 @@ pub struct RetainedKeyPackageMaterial {
     pub generation: u32,
     /// Position of this KeyPackage within the batch.
     pub key_package_index: u32,
+    /// The emulation group's ciphersuite.
+    pub emulation_ciphersuite: Ciphersuite,
     /// Per-KeyPackage seed secret from which the init and leaf-encryption keys
     /// are derived at Welcome time.
     pub key_package_seed_secret: KeyPackageSeedSecret,
@@ -704,6 +706,7 @@ pub fn process_vc_key_package_upload<Provider: OpenMlsProvider>(
             leaf_index: upload.leaf_index,
             generation: upload.generation,
             key_package_index: info.key_package_index,
+            emulation_ciphersuite,
             key_package_seed_secret,
         };
         materials.push((info.key_package_ref.clone(), material));
@@ -1212,6 +1215,8 @@ pub(crate) struct VcCommitMaterial {
     pub(crate) operation_secret: OperationSecret,
     /// External init secret carried by an external commit, `None` otherwise.
     pub(crate) external_init_secret: Option<ExternalInitSecret>,
+    /// Ciphersuite of the emulation group.
+    pub(crate) emulation_ciphersuite: Ciphersuite,
 }
 
 /// AEAD plaintext attached to the leaf via the VC component

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -460,7 +460,7 @@ fn build_vc_internal<Provider: OpenMlsProvider>(
         key_package_index,
     )?;
     let leaf_encryption_keypair = key_package_seed
-        .derive_encryption_key_secret(provider.crypto(), ciphersuite)?
+        .derive_encryption_key_secret(provider.crypto(), emulation_ciphersuite)?
         .generate_encryption_key_pair(provider.crypto(), ciphersuite)?;
     let epoch_secret =
         key_package_seed.derive_group_creation_secret(provider.crypto(), ciphersuite)?;

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -1220,7 +1220,7 @@ impl CommitBuilder<'_, Complete, &mut MlsGroup> {
 ///
 /// The `DerivationInfoTbe` wrapping stays in the emulation epoch's
 /// ciphersuite, while the operation secret is expanded under the
-/// higher-level group ciphersuite to produce MLS path material for this
+/// emulation group ciphersuite to produce MLS path material for this
 /// group. The generation was consumed and the advanced tree persisted when
 /// `vc_emulation` was called, so this helper neither allocates nor
 /// persists anything.
@@ -1237,11 +1237,11 @@ fn apply_vc_emulation(
 
     let path_secret = loaded
         .operation_secret
-        .derive_path_generation_secret(crypto, group_ciphersuite)?
+        .derive_path_generation_secret(crypto, emulation_ciphersuite)?
         .into();
     let leaf_encryption_keypair = loaded
         .operation_secret
-        .derive_encryption_key_secret(crypto, group_ciphersuite)?
+        .derive_encryption_key_secret(crypto, emulation_ciphersuite)?
         .generate_encryption_key_pair(crypto, group_ciphersuite)?;
 
     // Wrap the TBE under the per-epoch AEAD key, bound to the new leaf via

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -769,16 +769,16 @@ fn vc_welcome_material<Provider: OpenMlsProvider>(
             VirtualClientsError::StorageError
         })?;
 
-    // The seed was derived under the emulation ciphersuite at
-    // upload-processing time. The init and leaf-encryption keys are derived
-    // from it under the KeyPackage's own (the welcome's) ciphersuite.
+    // The seed and the key secrets expand under the emulation ciphersuite
+    // (pinned in the material), matching the upload side. Only the final
+    // DeriveKeyPair uses the KeyPackage's own (the welcome's) ciphersuite.
     let init_key_pair = material
         .key_package_seed_secret
-        .derive_init_key_secret(crypto, ciphersuite)?
+        .derive_init_key_secret(crypto, material.emulation_ciphersuite)?
         .generate_init_key_pair(crypto, ciphersuite)?;
     let encryption_keypair = material
         .key_package_seed_secret
-        .derive_encryption_key_secret(crypto, ciphersuite)?
+        .derive_encryption_key_secret(crypto, material.emulation_ciphersuite)?
         .generate_encryption_key_pair(crypto, ciphersuite)?;
 
     Ok(Some(VcWelcomeMaterial {
@@ -1152,7 +1152,7 @@ impl MlsGroup {
             key_package_index,
         )?;
         let leaf_keypair = key_package_seed
-            .derive_encryption_key_secret(provider.crypto(), ciphersuite)?
+            .derive_encryption_key_secret(provider.crypto(), emulation_ciphersuite)?
             .generate_encryption_key_pair(provider.crypto(), ciphersuite)?;
         if leaf_keypair.public_key() != creator_leaf.encryption_key() {
             return Err(Error::LeafKeyMismatch);

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -697,6 +697,7 @@ impl MlsGroup {
                 epoch_id: epoch_id.clone(),
                 operation_secret,
                 external_init_secret,
+                emulation_ciphersuite,
             },
         ))
     }

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -320,32 +320,17 @@ impl MlsGroup {
     ) -> Result<StagedCommit, StageCommitError> {
         let ciphersuite = self.ciphersuite();
 
-        // Unbundle the sibling-VC commit material: the per-commit operation
-        // secret recreates the path, the emulation `epoch_id` is recorded on
-        // the staged commit, and the external init secret (external commits
-        // only) feeds the key schedule.
-        #[cfg(feature = "virtual-clients-draft")]
-        let (vc_material, vc_emulation_epoch_id, vc_external_init_secret) = match vc_commit_material
-        {
-            Some(material) => (
-                Some(material.operation_secret),
-                Some(material.epoch_id),
-                material.external_init_secret,
-            ),
-            None => (None, None, None),
-        };
-
         // A sibling-resync external commit is a VC external commit sent by a
         // sibling emulator client to onboard itself into this higher-level
         // group, inline-removing our existing leaf. The receiver-side gate in
         // `process_internal_authenticated_content[_with_app_data_updates]` (see
-        // `is_sibling_vc_commit`) sets `vc_material = Some(_)` only for
+        // `is_sibling_vc_commit`) sets `vc_commit_material = Some(_)` only for
         // own-leaf VC commits and sibling-resync external commits, so here the
         // two-condition check fully identifies the resync case:
         //
-        //   - `vc_material` is `Some`, which after the upstream gate means the
-        //     commit carries a VC derivation-info entry and we hold per-epoch
-        //     state for the referenced `epoch_id`.
+        //   - `vc_commit_material` is `Some`, which after the upstream gate
+        //     means the commit carries a VC derivation-info entry and we hold
+        //     per-epoch state for the referenced `epoch_id`.
         //   - the sender is `NewMemberCommit`, since own-leaf VC commits arrive as
         //     `Sender::Member`, so this disambiguates the two sibling shapes.
         //
@@ -357,7 +342,7 @@ impl MlsGroup {
         // encryption keypairs.
         #[cfg(feature = "virtual-clients-draft")]
         let is_sibling_resync =
-            vc_material.is_some() && matches!(mls_content.sender(), Sender::NewMemberCommit);
+            vc_commit_material.is_some() && matches!(mls_content.sender(), Sender::NewMemberCommit);
         #[cfg(not(feature = "virtual-clients-draft"))]
         let is_sibling_resync = false;
 
@@ -371,7 +356,9 @@ impl MlsGroup {
             apply_proposals_values
                 .external_init_proposal_option
                 .is_some(),
-            vc_external_init_secret.is_some(),
+            vc_commit_material
+                .as_ref()
+                .is_some_and(|material| material.external_init_secret.is_some()),
         )?;
 
         // Determine if Commit has a path
@@ -426,7 +413,7 @@ impl MlsGroup {
                     == self.own_leaf_index()
                     || is_sibling_resync
                 {
-                    let operation_secret = vc_material.ok_or(
+                    let material = vc_commit_material.as_ref().ok_or(
                             crate::components::vc_derivation_info::VirtualClientsError::MissingOperationTree,
                         )?;
                     Some(self.recreate_path_for_own_commit(
@@ -435,7 +422,7 @@ impl MlsGroup {
                         ciphersuite,
                         provider.crypto(),
                         sender_index,
-                        operation_secret,
+                        material,
                     )?)
                 } else {
                     None
@@ -542,7 +529,9 @@ impl MlsGroup {
             commit_secret,
             &serialized_provisional_group_context,
             #[cfg(feature = "virtual-clients-draft")]
-            vc_external_init_secret.as_ref(),
+            vc_commit_material
+                .as_ref()
+                .and_then(|material| material.external_init_secret.as_ref()),
         )?;
         let (provisional_group_secrets, provisional_message_secrets) = epoch_secrets.split_secrets(
             serialized_provisional_group_context,
@@ -599,7 +588,7 @@ impl MlsGroup {
             proposal_queue,
             staged_commit_state,
             #[cfg(feature = "virtual-clients-draft")]
-            vc_emulation_epoch_id,
+            vc_commit_material.map(|material| material.epoch_id),
         );
 
         Ok(staged_commit)
@@ -634,20 +623,28 @@ impl MlsGroup {
         ciphersuite: openmls_traits::types::Ciphersuite,
         crypto: &impl OpenMlsCrypto,
         sender_index: LeafNodeIndex,
-        operation_secret: crate::components::vc_derivation_info::OperationSecret,
+        vc_commit_material: &crate::components::vc_derivation_info::VcCommitMaterial,
     ) -> Result<(Vec<EncryptionKeyPair>, CommitSecret), StageCommitError> {
         use crate::components::vc_derivation_info::VirtualClientsError;
 
-        let path_secret = operation_secret
-            .derive_path_generation_secret(crypto, ciphersuite)?
+        // The path-generation and leaf-encryption key secrets expand from
+        // the operation secret under the emulation group's ciphersuite
+        // (pinned in the material), matching the sender. Only the final
+        // DeriveKeyPair and the path recreation itself run under the
+        // group's ciphersuite.
+        let emulation_ciphersuite = vc_commit_material.emulation_ciphersuite;
+        let path_secret = vc_commit_material
+            .operation_secret
+            .derive_path_generation_secret(crypto, emulation_ciphersuite)?
             .into();
         let (encryption_key_pairs, commit_secret) =
             diff.recreate_path_from_path_secret(crypto, path_secret, sender_index, path.nodes())?;
 
         // Verify that the leaf encryption key in the path matches the one
         // derived from the operation secret.
-        let leaf_keypair = operation_secret
-            .derive_encryption_key_secret(crypto, ciphersuite)?
+        let leaf_keypair = vc_commit_material
+            .operation_secret
+            .derive_encryption_key_secret(crypto, emulation_ciphersuite)?
             .generate_encryption_key_pair(crypto, ciphersuite)?;
         if leaf_keypair.public_key() != path.leaf_node().encryption_key() {
             return Err(VirtualClientsError::EncryptionKeyMismatch.into());

--- a/openmls/src/group/tests_and_kats/tests/mod.rs
+++ b/openmls/src/group/tests_and_kats/tests/mod.rs
@@ -24,4 +24,9 @@ mod key_package_in;
 mod past_secrets;
 mod proposal_validation;
 mod remove_operation;
+#[cfg(all(
+    feature = "virtual-clients-draft",
+    feature = "draft-ietf-mls-pq-ciphersuites"
+))]
+mod virtual_clients;
 mod wire_format_policy;

--- a/openmls/src/group/tests_and_kats/tests/virtual_clients.rs
+++ b/openmls/src/group/tests_and_kats/tests/virtual_clients.rs
@@ -1,0 +1,259 @@
+use openmls_traits::{types::Ciphersuite, OpenMlsProvider};
+use tls_codec::Serialize as _;
+
+use crate::{
+    component::{ComponentId, ComponentType},
+    components::vc_derivation_info::{
+        load_vc_epoch_state_and_tree, EpochId, VirtualClientOperationType, VC_COMPONENT_ID,
+    },
+    credentials::test_utils::new_credential,
+    extensions::{
+        AppDataDictionary, AppDataDictionaryExtension, Extension, ExtensionType, Extensions,
+    },
+    group::{MlsGroup, MlsGroupCreateConfig, PURE_PLAINTEXT_WIRE_FORMAT_POLICY},
+    key_packages::KeyPackage,
+    messages::PathSecret,
+    prelude::{Capabilities, LeafNode},
+};
+
+/// Emulation group suite. Its KDF hash (SHA-384) is wider than the
+/// higher-level group's (SHA-256), so a wrong-suite expansion does not
+/// error out on PRK width -- it silently produces different bytes, which is
+/// exactly what these tests detect.
+const EMULATION_CIPHERSUITE: Ciphersuite =
+    Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519;
+/// Higher-level group suite.
+const GROUP_CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+/// `Capabilities` declaring `AppDataDictionary` support.
+fn vc_capabilities() -> Capabilities {
+    Capabilities::builder()
+        .extensions(vec![ExtensionType::AppDataDictionary])
+        .build()
+}
+
+/// The `AppDataDictionary` leaf-node extension a VC-sending leaf must carry:
+/// an `AppComponents` entry listing `VC_COMPONENT_ID`.
+fn vc_leaf_extensions() -> Extensions<LeafNode> {
+    let supported_components: Vec<u16> = vec![VC_COMPONENT_ID];
+    let app_components_body = supported_components
+        .tls_serialize_detached()
+        .expect("serialize AppComponents body");
+    let mut dictionary = AppDataDictionary::new();
+    dictionary.insert(
+        ComponentId::from(ComponentType::AppComponents),
+        app_components_body,
+    );
+    let ext = Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary));
+    Extensions::from_vec(vec![ext]).expect("build leaf-node Extensions")
+}
+
+fn vc_group_config(ciphersuite: Ciphersuite) -> MlsGroupCreateConfig {
+    MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .capabilities(vc_capabilities())
+        .with_leaf_node_extensions(vc_leaf_extensions())
+        .expect("attach leaf-node extensions")
+        .build()
+}
+
+/// Found a single-member emulation group on `provider` and register an
+/// emulation epoch on it.
+fn registered_emulation_epoch<P: OpenMlsProvider>(provider: &P) -> EpochId {
+    let (credential, signer) = new_credential(
+        provider,
+        b"Emulator",
+        EMULATION_CIPHERSUITE.signature_algorithm(),
+    );
+    let mut emulator_group = MlsGroup::new(
+        provider,
+        &signer,
+        &vc_group_config(EMULATION_CIPHERSUITE),
+        credential,
+    )
+    .expect("create emulation group");
+    emulator_group
+        .register_vc_emulation_epoch(provider.crypto(), provider.storage())
+        .expect("register emulation epoch")
+}
+
+/// A VC commit's update-path material (the leaf encryption key and the
+/// `path_secret` for the first parent node) must expand from the operation
+/// secret under the emulation group's ciphersuite; only the final
+/// `DeriveKeyPair` runs under the higher-level group's ciphersuite.
+#[openmls_test::openmls_test]
+fn vc_commit_path_material_expands_under_emulation_ciphersuite() {
+    let provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let epoch_id = registered_emulation_epoch(provider);
+
+    // Higher-level group: the VC leaf plus one regular member, so the VC
+    // commit's update path contains a parent node.
+    let (alice_credential, alice_signer) = new_credential(
+        provider,
+        b"Alice (VC)",
+        GROUP_CIPHERSUITE.signature_algorithm(),
+    );
+    let mut main_group = MlsGroup::new(
+        provider,
+        &alice_signer,
+        &vc_group_config(GROUP_CIPHERSUITE),
+        alice_credential,
+    )
+    .expect("create main group");
+
+    let (bob_credential, bob_signer) = new_credential(
+        bob_provider,
+        b"Bob",
+        GROUP_CIPHERSUITE.signature_algorithm(),
+    );
+    let bob_key_package = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .build(GROUP_CIPHERSUITE, bob_provider, &bob_signer, bob_credential)
+        .expect("bob KP build")
+        .key_package()
+        .to_owned();
+    main_group
+        .add_members(provider, &alice_signer, &[bob_key_package])
+        .expect("add bob");
+    main_group
+        .merge_pending_commit(provider)
+        .expect("merge add");
+
+    // Reference derivation per spec, from a scratch copy of the operation
+    // tree. The scratch copy advances in memory only and is dropped without
+    // being persisted, so the commit below consumes the same generation.
+    let (state, mut scratch_tree) =
+        load_vc_epoch_state_and_tree(provider, &epoch_id).expect("load vc epoch state");
+    let (emulation_leaf_index, _epoch_encryption_key, emulation_ciphersuite) = state.into_parts();
+    assert_eq!(emulation_ciphersuite, EMULATION_CIPHERSUITE);
+    let (generation, operation_secret) = scratch_tree
+        .next_operation_secret(
+            provider.crypto(),
+            EMULATION_CIPHERSUITE,
+            &epoch_id,
+            emulation_leaf_index,
+            VirtualClientOperationType::LeafNode,
+            main_group.group_id().as_slice(),
+        )
+        .expect("derive reference operation secret");
+    assert_eq!(generation, 0);
+    drop(scratch_tree);
+
+    let expected_leaf_keypair = operation_secret
+        .derive_encryption_key_secret(provider.crypto(), EMULATION_CIPHERSUITE)
+        .expect("derive reference encryption key secret")
+        .generate_encryption_key_pair(provider.crypto(), GROUP_CIPHERSUITE)
+        .expect("generate reference leaf keypair");
+    let expected_parent_keypair = PathSecret::from(
+        operation_secret
+            .derive_path_generation_secret(provider.crypto(), EMULATION_CIPHERSUITE)
+            .expect("derive reference path generation secret"),
+    )
+    .derive_key_pair(provider.crypto(), GROUP_CIPHERSUITE)
+    .expect("derive reference parent keypair");
+
+    // Actual: send the VC commit.
+    main_group
+        .commit_builder()
+        .vc_emulation(provider.crypto(), provider.storage(), epoch_id)
+        .expect("vc_emulation")
+        .load_psks(provider.storage())
+        .expect("load psks")
+        .build(provider.rand(), provider.crypto(), &alice_signer, |_| true)
+        .expect("build vc commit")
+        .stage_commit(provider)
+        .expect("stage vc commit");
+    main_group
+        .merge_pending_commit(provider)
+        .expect("merge vc commit");
+
+    assert_eq!(
+        main_group
+            .own_leaf_node()
+            .expect("own leaf")
+            .encryption_key(),
+        expected_leaf_keypair.public_key(),
+        "the leaf encryption key secret must expand from the operation \
+         secret under the emulation group's ciphersuite"
+    );
+    let ratchet_tree = main_group.export_ratchet_tree();
+    let root = ratchet_tree.parents().next().expect("one parent node");
+    assert_eq!(
+        root.encryption_key(),
+        expected_parent_keypair.public_key(),
+        "the path generation secret must expand from the operation secret \
+         under the emulation group's ciphersuite"
+    );
+}
+
+/// The creator leaf of a VC-created group derives its encryption key from
+/// the per-KeyPackage seed (dedicated `key_package` operation, index 0).
+/// Both the seed and the encryption key secret must expand under the
+/// emulation group's ciphersuite; only the final `DeriveKeyPair` (and the
+/// "Group Creation" epoch secret, per the draft's explicit exception) use
+/// the created group's ciphersuite.
+#[openmls_test::openmls_test]
+fn vc_group_creation_leaf_key_expands_under_emulation_ciphersuite() {
+    let provider = &Provider::default();
+
+    let epoch_id = registered_emulation_epoch(provider);
+
+    // Reference derivation per spec, from a scratch copy of the operation
+    // tree (dropped unpersisted, so the builder consumes the same
+    // generation).
+    let (state, mut scratch_tree) =
+        load_vc_epoch_state_and_tree(provider, &epoch_id).expect("load vc epoch state");
+    let (emulation_leaf_index, _epoch_encryption_key, emulation_ciphersuite) = state.into_parts();
+    assert_eq!(emulation_ciphersuite, EMULATION_CIPHERSUITE);
+    let (generation, operation_secret) = scratch_tree
+        .next_operation_secret(
+            provider.crypto(),
+            EMULATION_CIPHERSUITE,
+            &epoch_id,
+            emulation_leaf_index,
+            VirtualClientOperationType::KeyPackage,
+            b"",
+        )
+        .expect("derive reference operation secret");
+    assert_eq!(generation, 0);
+    drop(scratch_tree);
+
+    let expected_leaf_keypair = operation_secret
+        .derive_key_package_seed_secret(provider.crypto(), EMULATION_CIPHERSUITE, 0)
+        .expect("derive reference key package seed")
+        .derive_encryption_key_secret(provider.crypto(), EMULATION_CIPHERSUITE)
+        .expect("derive reference encryption key secret")
+        .generate_encryption_key_pair(provider.crypto(), GROUP_CIPHERSUITE)
+        .expect("generate reference leaf keypair");
+
+    // Actual: create the higher-level group as the virtual client.
+    let (vc_credential, vc_signer) = new_credential(
+        provider,
+        b"Alice (VC)",
+        GROUP_CIPHERSUITE.signature_algorithm(),
+    );
+    let main_group = MlsGroup::builder()
+        .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(GROUP_CIPHERSUITE)
+        .use_ratchet_tree_extension(true)
+        .with_capabilities(vc_capabilities())
+        .with_leaf_node_extensions(vc_leaf_extensions())
+        .expect("attach leaf-node extensions")
+        .vc_emulation(epoch_id)
+        .build(provider, &vc_signer, vc_credential)
+        .expect("create vc group");
+
+    assert_eq!(
+        main_group
+            .own_leaf_node()
+            .expect("creator leaf")
+            .encryption_key(),
+        expected_leaf_keypair.public_key(),
+        "the creator leaf's encryption key secret must expand from the \
+         per-KeyPackage seed under the emulation group's ciphersuite"
+    );
+}

--- a/openmls/src/key_packages/vc.rs
+++ b/openmls/src/key_packages/vc.rs
@@ -193,19 +193,19 @@ impl VcKeyPackageBatchBuilder {
         resolved_dictionary: &AppDataDictionary,
         key_package_index: u32,
     ) -> Result<(KeyPackageBundle, KeyPackageInfo), KeyPackageNewError> {
-        // Derive the per-index seed under the emulation ciphersuite, then the
-        // init and leaf encryption keys from the seed under the KeyPackage's
-        // own ciphersuite.
+        // Derive the per-index seed and the init and leaf encryption key
+        // secrets under the emulation ciphersuite. Only the final DeriveKeyPair
+        // uses the KeyPackage's own ciphersuite.
         let seed = self.operation_secret.derive_key_package_seed_secret(
             crypto,
             self.emulation_ciphersuite,
             key_package_index,
         )?;
         let init_key_pair = seed
-            .derive_init_key_secret(crypto, ciphersuite)?
+            .derive_init_key_secret(crypto, self.emulation_ciphersuite)?
             .generate_init_key_pair(crypto, ciphersuite)?;
         let encryption_key_pair = seed
-            .derive_encryption_key_secret(crypto, ciphersuite)?
+            .derive_encryption_key_secret(crypto, self.emulation_ciphersuite)?
             .generate_encryption_key_pair(crypto, ciphersuite)?;
 
         // Wrap the TBE bound to the new leaf via its serialized encryption key.


### PR DESCRIPTION
Use the ciphersuite as specified in the draft for the VC derivation info secret expansions. This bug was not caught by the tests, because the ciphersuite of the emulation group in the tests had the same KDF hash as the higher-level group's ciphersuite, so the expansions were silently compatible.