### PR TITLE
Enforce app_data_dictionary immutability for bare GroupContextExtensions proposals

### DIFF
--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -654,11 +654,6 @@ impl PublicGroup {
         &self,
         proposal_queue: &ProposalQueue,
     ) -> Result<(), AppDataUpdateValidationError> {
-        let no_app_data_updates = proposal_queue.app_data_update_proposals().next().is_none();
-        if no_app_data_updates {
-            return Ok(());
-        }
-
         // retrieve the GroupContextExtensions proposal, if available
         let group_context_extension_proposal = proposal_queue
             .filtered_by_type(ProposalType::GroupContextExtensions)
@@ -667,6 +662,51 @@ impl PublicGroup {
                 _ => None,
             })
             .next();
+
+        // From https://datatracker.ietf.org/doc/html/draft-ietf-mls-extensions#section-4.7-6:
+        // When an MLS group contains the AppDataUpdate proposal type in the proposal_types list in
+        // the group's required_capabilities extension, a GroupContextExtensions proposal MUST NOT
+        // add, remove, or modify the app_data_dictionary GroupContext extension. In other words,
+        // when every member of the group supports the AppDataUpdate proposal, a
+        // GroupContextExtensions proposal could be sent to update some other extension(s), but the
+        // app_data_dictionary GroupContext extension, if it exists, is left as it was.
+        //
+        // This is checked *before* the "no AppDataUpdate proposals" early return below: the rule
+        // binds every commit that carries a GroupContextExtensions proposal, including one with no
+        // accompanying AppDataUpdate proposals. Skipping it in that case would let a bare
+        // GroupContextExtensions proposal rewrite the app_data_dictionary directly, bypassing the
+        // AppDataUpdate machinery.
+        //
+        // The rule is treated as active when the group requires AppDataUpdate either before or
+        // after the commit. Reading only the *proposed* required_capabilities would let a sender
+        // evade the check by dropping AppDataUpdate from required_capabilities in the same
+        // proposal; reading only the *current* required_capabilities would skip the migrating
+        // commit that both introduces the dictionary and adds AppDataUpdate.
+        if let Some(group_context_extension) = group_context_extension_proposal {
+            let current_requires_app_data_update = self
+                .group_context()
+                .extensions()
+                .required_capabilities()
+                .map(|rc| rc.proposal_types().contains(&ProposalType::AppDataUpdate))
+                .unwrap_or(false);
+            let proposed_requires_app_data_update = group_context_extension
+                .extensions()
+                .required_capabilities()
+                .map(|rc| rc.proposal_types().contains(&ProposalType::AppDataUpdate))
+                .unwrap_or(false);
+
+            if (current_requires_app_data_update || proposed_requires_app_data_update)
+                && group_context_extension.extensions().app_data_dictionary()
+                    != self.group_context().extensions().app_data_dictionary()
+            {
+                return Err(AppDataUpdateValidationError::CannotUpdateDictionaryDirectly);
+            }
+        }
+
+        let no_app_data_updates = proposal_queue.app_data_update_proposals().next().is_none();
+        if no_app_data_updates {
+            return Ok(());
+        }
 
         // check ordering
         // return an error if an AppDataUpdate appears before a GroupContextExtensions proposal
@@ -688,32 +728,6 @@ impl PublicGroup {
             .any(|proposal_type| proposal_type == ProposalType::GroupContextExtensions)
         {
             return Err(AppDataUpdateValidationError::IncorrectOrder);
-        }
-
-        if let Some(group_context_extension) = group_context_extension_proposal {
-            let required_capabilities_contain_app_data_update_proposal = group_context_extension
-                .extensions()
-                .required_capabilities()
-                .map(|required_capabilities| {
-                    required_capabilities
-                        .proposal_types()
-                        .contains(&ProposalType::AppDataUpdate)
-                })
-                .unwrap_or(false);
-
-            // From https://datatracker.ietf.org/doc/html/draft-ietf-mls-extensions#section-4.7-6:
-            // When an MLS group contains the AppDataUpdate proposal type in the proposal_types list in
-            // the group's required_capabilities extension, a GroupContextExtensions proposal MUST NOT
-            // add, remove, or modify the app_data_dictionary GroupContext extension. In other words,
-            // when every member of the group supports the AppDataUpdate proposal, a
-            // GroupContextExtensions proposal could be sent to update some other extension(s), but the
-            // app_data_dictionary GroupContext extension, if it exists, is left as it was.
-            if required_capabilities_contain_app_data_update_proposal
-                && group_context_extension.extensions().app_data_dictionary()
-                    != self.group_context().extensions().app_data_dictionary()
-            {
-                return Err(AppDataUpdateValidationError::CannotUpdateDictionaryDirectly);
-            }
         }
 
         // From the draft:

--- a/openmls/src/group/tests_and_kats/tests/app_data_update_proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/app_data_update_proposal_validation.rs
@@ -184,6 +184,57 @@ fn test_group_context_update_dictionary() {
 }
 
 /// Commit creation:
+/// Regression: a GroupContextExtensions proposal that modifies the AppDataDictionary MUST be
+/// rejected even when the commit carries NO AppDataUpdate proposals. Otherwise a bare
+/// GroupContextExtensions proposal bypasses the AppDataUpdate machinery and rewrites the
+/// dictionary directly, in violation of draft-ietf-mls-extensions §4.7-6.
+#[openmls_test]
+fn test_group_context_update_dictionary_without_app_data_update() {
+    // Set up parties
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let bob_party = CorePartyState::<Provider>::new("bob");
+
+    let mut group_state = setup(&alice_party, &bob_party, ciphersuite, true);
+
+    let [alice] = group_state.members_mut(&["alice"]);
+
+    let required_capabilities_extension =
+        Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
+            &[ExtensionType::AppDataDictionary],
+            &[ProposalType::AppDataUpdate],
+            &[],
+        ));
+
+    let dictionary_extension = Extension::AppDataDictionary(AppDataDictionaryExtension::default());
+
+    // Bare GroupContextExtensions proposal that touches the dictionary, with NO accompanying
+    // AppDataUpdate proposal.
+    alice
+        .group
+        .propose_group_context_extensions(
+            &alice_party.provider,
+            Extensions::from_vec(vec![required_capabilities_extension, dictionary_extension])
+                .unwrap(),
+            &alice.party.signer,
+        )
+        .unwrap();
+
+    let err = alice
+        .group
+        .commit_to_pending_proposals(&alice_party.provider, &alice.party.signer)
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        CommitToPendingProposalsError::CreateCommitError(
+            CreateCommitError::AppDataUpdateValidationError(
+                AppDataUpdateValidationError::CannotUpdateDictionaryDirectly
+            )
+        )
+    );
+}
+
+/// Commit creation:
 /// Test the case where a GroupContextExtensionProposal updates the AppDataDictionary after
 /// removing AppDataUpdate from the required capabilities.
 #[openmls_test]


### PR DESCRIPTION
## What

`validate_app_data_update_proposals_and_group_context` enforces
[draft-ietf-mls-extensions §4.7-6](https://datatracker.ietf.org/doc/html/draft-ietf-mls-extensions#section-4.7-6):
once a group's `required_capabilities` include the `AppDataUpdate` proposal type,
a `GroupContextExtensions` proposal MUST NOT add, remove, or modify the
`app_data_dictionary` extension.

Today that check sits **after** an early return:

```rust
let no_app_data_updates = proposal_queue.app_data_update_proposals().next().is_none();
if no_app_data_updates {
    return Ok(());
}
// ... CannotUpdateDictionaryDirectly check ...
```

So the rule is only enforced when the commit *also* carries at least one
`AppDataUpdate` proposal. A **bare** `GroupContextExtensions` proposal — one with
no accompanying `AppDataUpdate` proposals — skips the check entirely and can
rewrite `app_data_dictionary` directly, bypassing the `AppDataUpdate` machinery
(and any application-level validation layered on it). On a group whose members
all support `AppDataUpdate`, any member can thereby overwrite arbitrary
components of the dictionary.

## Fix

Hoist the dictionary-immutability check **above** the early return, so it binds
every commit that carries a `GroupContextExtensions` proposal regardless of
whether `AppDataUpdate` proposals accompany it.

The rule is treated as active when the group requires `AppDataUpdate` **before or
after** the commit:

- Reading only the *proposed* `required_capabilities` would let a sender evade
  the check by dropping `AppDataUpdate` from `required_capabilities` in the same
  proposal.
- Reading only the *current* `required_capabilities` would incorrectly flag the
  migrating commit that both introduces the dictionary and adds `AppDataUpdate`.

The ordering and duplicate-`AppDataUpdate` checks remain after the early return,
where they belong (they are only meaningful when `AppDataUpdate` proposals are
present).

## Tests

Adds `test_group_context_update_dictionary_without_app_data_update`: a bare
`GroupContextExtensions` proposal that touches the dictionary with no
accompanying `AppDataUpdate` proposal must be rejected with
`CannotUpdateDictionaryDirectly`. The three existing tests in
`app_data_update_proposal_validation.rs` (`update_dictionary`, `wrong_order`,
`after_deactivating`) are unaffected — `validate_group_context_extensions_proposal`
runs first, so the `ExtensionNotInRequiredCapabilities` path is preserved.

Runs under `--features extensions-draft,extensions-draft-test-dependencies`.
