### PR TITLE
perf: don't create errors in happy path

### DIFF
--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -422,7 +422,7 @@ impl User {
                                     None
                                 }
                             });
-                        user_id.unwrap_or("".to_owned()).as_bytes().to_vec()
+                        user_id.unwrap_or_default().into_bytes()
                     }
                 };
                 let conversation_message = ConversationMessage::new(

--- a/compat_tests/Cargo.lock
+++ b/compat_tests/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
  "rand_core 0.9.5",
  "serde",
  "subtle",
- "tls_codec",
+ "tls_codec 0.4.2",
  "zeroize",
 ]
 
@@ -998,7 +998,7 @@ dependencies = [
  "libcrux-sha3",
  "libcrux-traits",
  "rand 0.9.4",
- "tls_codec",
+ "tls_codec 0.4.2",
 ]
 
 [[package]]
@@ -1172,7 +1172,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror",
- "tls_codec",
+ "tls_codec 0.4.2",
  "zeroize",
 ]
 
@@ -1187,7 +1187,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror",
- "tls_codec",
+ "tls_codec 0.5.0",
  "zeroize",
 ]
 
@@ -1206,7 +1206,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror",
- "tls_codec",
+ "tls_codec 0.4.2",
  "zeroize",
 ]
 
@@ -1241,7 +1241,7 @@ dependencies = [
  "openmls_traits 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
- "tls_codec",
+ "tls_codec 0.4.2",
 ]
 
 [[package]]
@@ -1289,7 +1289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e21d8877bacdbc407060df29bf59b145bb886a8fa0099b87ae8067a34b902a13"
 dependencies = [
  "serde",
- "tls_codec",
+ "tls_codec 0.4.2",
 ]
 
 [[package]]
@@ -1297,7 +1297,7 @@ name = "openmls_traits"
 version = "0.5.0"
 dependencies = [
  "serde",
- "tls_codec",
+ "tls_codec 0.5.0",
 ]
 
 [[package]]
@@ -1307,7 +1307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f88ccdd53448dfdbfa5b8da8ba4e527c418fdb966418172bace2e3b41eedd56"
 dependencies = [
  "serde",
- "tls_codec",
+ "tls_codec 0.4.2",
 ]
 
 [[package]]
@@ -1905,7 +1905,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
 dependencies = [
  "serde",
- "tls_codec_derive",
+ "tls_codec_derive 0.4.2",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18cc98286004cea38f717e2b03d990fc774fbfd38a82720de40e5c94365067c8"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "tls_codec_derive 0.5.0",
  "zeroize",
 ]
 
@@ -1914,6 +1926,17 @@ name = "tls_codec_derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674f41dd95f76cdeb005c83f9444e20cf43daebef37cde9e49a9ca6f4e87b423"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/compat_tests/src/storage_tag_check.rs
+++ b/compat_tests/src/storage_tag_check.rs
@@ -197,6 +197,6 @@ impl StorageTags {
         let mut c = TagSerializer { tags: None };
         value.serialize(&mut c)?;
         c.tags
-            .ok_or(StorageTagError::custom("no storage tag could be retrieved"))
+            .ok_or_else(|| StorageTagError::custom("no storage tag could be retrieved"))
     }
 }

--- a/interop_client/src/main.rs
+++ b/interop_client/src/main.rs
@@ -369,10 +369,12 @@ impl MlsClient for MlsClientImpl {
         let (my_key_package, _my_credential, my_signature_keys, crypto_provider) =
             pending_key_packages
                 .remove(&request.identity)
-                .ok_or(Status::aborted(format!(
-                    "failed to find key package for identity {:x?}",
-                    request.identity
-                )))?;
+                .ok_or_else(|| {
+                    Status::aborted(format!(
+                        "failed to find key package for identity {:x?}",
+                        request.identity
+                    ))
+                })?;
 
         use openmls_traits::storage::StorageProvider as _;
 
@@ -723,7 +725,7 @@ impl MlsClient for MlsClientImpl {
             let mut pending_state = self.pending_state.lock().unwrap();
             let pending_state = pending_state
                 .get_mut(pending_state_id)
-                .ok_or(Status::internal("Unable to retrieve pending state"))?;
+                .ok_or_else(|| Status::internal("Unable to retrieve pending state"))?;
 
             store(
                 pending_state.0.key_package().ciphersuite(),
@@ -770,7 +772,7 @@ impl MlsClient for MlsClientImpl {
         let key_package = MlsMessageIn::tls_deserialize(&mut request.key_package.as_slice())
             .map_err(|_| Status::aborted("failed to deserialize key package (MlsMessage)"))?
             .into_keypackage()
-            .ok_or(Status::aborted("failed to deserialize key package"))?;
+            .ok_or_else(|| Status::aborted("failed to deserialize key package"))?;
         trace!(
             "   for {:#x?}",
             key_package
@@ -1002,7 +1004,7 @@ impl MlsClient for MlsClientImpl {
                             .map_err(|_| Status::invalid_argument("Invalid key package"))?;
                     let key_package = key_package
                         .into_keypackage()
-                        .ok_or(Status::invalid_argument("Message was not a key package"))?;
+                        .ok_or_else(|| Status::invalid_argument("Message was not a key package"))?;
 
                     group
                         .propose_add_member_by_value(

--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -118,7 +118,7 @@ impl MemoryStorage {
         log::trace!("{}", std::backtrace::Backtrace::capture());
 
         // fetch value from db, falling back to an empty list if doens't exist
-        let list_bytes = values.entry(storage_key).or_insert(b"[]".to_vec());
+        let list_bytes = values.entry(storage_key).or_insert_with(|| b"[]".to_vec());
 
         // parse old value and push new data
         let mut list: Vec<Vec<u8>> = serde_json::from_slice(list_bytes)?;
@@ -145,7 +145,7 @@ impl MemoryStorage {
         log::trace!("{}", std::backtrace::Backtrace::capture());
 
         // fetch value from db, falling back to an empty list if doens't exist
-        let list_bytes = values.entry(storage_key).or_insert(b"[]".to_vec());
+        let list_bytes = values.entry(storage_key).or_insert_with(|| b"[]".to_vec());
 
         // parse old value, find value to delete and remove it from list
         let mut list: Vec<Vec<u8>> = serde_json::from_slice(list_bytes)?;

--- a/openmls/examples/large-groups.rs
+++ b/openmls/examples/large-groups.rs
@@ -484,7 +484,7 @@ mod util {
     ) {
         let mut members = vec![];
 
-        let group_sizes = group_sizes.unwrap_or(generate::GROUP_SIZES.to_vec());
+        let group_sizes = group_sizes.unwrap_or_else(|| generate::GROUP_SIZES.to_vec());
         println!("Generating groups for benchmarks {group_sizes:?}...");
         let mut smaller_groups = None;
         for num in group_sizes.into_iter().sorted() {

--- a/openmls/src/framing/mls_content_in.rs
+++ b/openmls/src/framing/mls_content_in.rs
@@ -160,7 +160,7 @@ impl FramedContentBodyIn {
             ),
             FramedContentBodyIn::Commit(commit_in) => {
                 let sender_context = sender_context
-                    .ok_or(LibraryError::custom("Forgot the commit sender context"))?;
+                    .ok_or_else(|| LibraryError::custom("Forgot the commit sender context"))?;
                 FramedContentBody::Commit(Box::new(commit_in.validate(
                     ciphersuite,
                     crypto,

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -1381,9 +1381,11 @@ impl TryFrom<CommitMessageBundle> for WelcomeCommitMessages {
         let (commit, welcome_opt, group_info) = value.into_messages();
         Ok(Self {
             commit,
-            welcome: welcome_opt.ok_or(LibraryError::custom(
-                "WelcomeCommitMessages must only be used with commits that produce a welcome.",
-            ))?,
+            welcome: welcome_opt.ok_or_else(|| {
+                LibraryError::custom(
+                    "WelcomeCommitMessages must only be used with commits that produce a welcome.",
+                )
+            })?,
             group_info,
         })
     }

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -577,9 +577,7 @@ impl StagedWelcome {
         let sender_index = self.welcome_sender_index();
         self.public_group
             .leaf(sender_index)
-            .ok_or(LibraryError::custom(
-                "no leaf with given welcome sender index exists",
-            ))
+            .ok_or_else(|| LibraryError::custom("no leaf with given welcome sender index exists"))
     }
 
     /// Returns the leaf index of the client in this welcome's [`PublicGroup`].

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -174,9 +174,9 @@ impl MlsGroup {
             .build(provider.rand(), provider.crypto(), signer, |_| true)?
             .stage_commit(provider)?;
 
-        let welcome: MlsMessageOut = bundle.to_welcome_msg().ok_or(LibraryError::custom(
-            "No secrets to generate commit message.",
-        ))?;
+        let welcome: MlsMessageOut = bundle
+            .to_welcome_msg()
+            .ok_or_else(|| LibraryError::custom("No secrets to generate commit message."))?;
         let (commit, _, group_info) = bundle.into_contents();
 
         self.reset_aad();

--- a/openmls/src/group/public_group/builder.rs
+++ b/openmls/src/group/public_group/builder.rs
@@ -74,13 +74,15 @@ impl TempBuilderPG1 {
             } else {
                 (None, None, None)
             };
-        let capabilities = self.capabilities.unwrap_or(Capabilities::new(
-            Some(&[ProtocolVersion::default()]),
-            Some(&[self.ciphersuite]),
-            required_extensions,
-            required_proposals,
-            required_credentials,
-        ));
+        let capabilities = self.capabilities.unwrap_or_else(|| {
+            Capabilities::new(
+                Some(&[ProtocolVersion::default()]),
+                Some(&[self.ciphersuite]),
+                required_extensions,
+                required_proposals,
+                required_credentials,
+            )
+        });
         let (treesync, commit_secret, leaf_keypair) = TreeSync::new(
             provider,
             signer,

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -279,9 +279,11 @@ impl CommitIn {
                         .chain(former_sender_index)
                         .chain(self_removed_indices)
                         .min()
-                        .ok_or(ValidationError::LibraryError(LibraryError::custom(
-                            "The iterator should have at least one element.",
-                        )))?;
+                        .ok_or_else(|| {
+                            ValidationError::LibraryError(LibraryError::custom(
+                                "The iterator should have at least one element.",
+                            ))
+                        })?;
 
                     TreePosition::new(group_id, new_leaf_index)
                 }


### PR DESCRIPTION
In particular, this improves the performance in debug builds because LibraryError::custom captures a backtrace in such builds.