### PR TITLE
fix(bench): restore benchmarks and compare crypto providers

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Benchmarks
-        run: cargo bench -p openmls --verbose
+        run: cargo bench -p openmls --verbose --features=libcrux-provider
 
       - name: Large groups
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,7 @@ dependencies = [
  "num-traits",
  "oorandom",
  "page_size",
+ "plotters",
  "regex",
  "serde",
  "serde_json",
@@ -2851,6 +2852,34 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "poly1305"

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -160,7 +160,10 @@ fork-resolution = []
 unchecked-conversions = []
 
 [dev-dependencies]
-criterion = { version = "^0.8", default-features = false }       # need to disable default features for wasm
+criterion = { version = "^0.8", default-features = false, features = [
+    "plotters",
+    "html_reports",
+] }
 hex = { version = "0.4", features = ["serde"] }
 lazy_static = "1.4"
 openmls_traits = { workspace = true, features = ["test-utils"] }
@@ -187,9 +190,6 @@ web-time = "1.1"
 [[bench]]
 name = "benchmark"
 harness = false
-# Uses the libcrux provider directly, so skip the build when that
-# provider is not enabled (e.g. on the default test build).
-required-features = ["libcrux-provider"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/openmls/benches/benchmark.rs
+++ b/openmls/benches/benchmark.rs
@@ -3,293 +3,332 @@ extern crate criterion;
 extern crate openmls;
 extern crate rand;
 
-use criterion::Criterion;
+use criterion::{measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion};
 use openmls::prelude::*;
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::{crypto::OpenMlsCrypto, OpenMlsProvider};
 
-fn criterion_key_package(c: &mut Criterion, provider: &impl OpenMlsProvider) {
-    for &ciphersuite in provider.crypto().supported_ciphersuites().iter() {
-        c.bench_function(
-            &format!("KeyPackage create bundle with ciphersuite: {ciphersuite:?}"),
-            move |b| {
-                b.iter_with_setup(
-                    || {
-                        let credential = BasicCredential::new(vec![1, 2, 3]);
-                        let signer =
-                            SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
-                        let credential_with_key = CredentialWithKey {
-                            credential: credential.into(),
-                            signature_key: signer.to_public_vec().into(),
-                        };
+/// Identifies one measurement point of a benchmark group by the two dimensions
+/// we vary: the crypto provider and the ciphersuite.
+fn bench_id(provider_name: &str, ciphersuite: Ciphersuite) -> BenchmarkId {
+    BenchmarkId::new(provider_name, format!("{ciphersuite:?}"))
+}
 
-                        (credential_with_key, signer)
-                    },
-                    |(credential_with_key, signer)| {
-                        let _key_package = KeyPackage::builder()
-                            .build(ciphersuite, provider, &signer, credential_with_key)
-                            .expect("An unexpected error occurred.");
-                    },
-                );
-            },
-        );
+fn criterion_key_package(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    provider_name: &str,
+    provider: &impl OpenMlsProvider,
+) {
+    for &ciphersuite in provider.crypto().supported_ciphersuites().iter() {
+        group.bench_function(bench_id(provider_name, ciphersuite), move |b| {
+            b.iter_with_setup(
+                || {
+                    let credential = BasicCredential::new(vec![1, 2, 3]);
+                    let signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+                    let credential_with_key = CredentialWithKey {
+                        credential: credential.into(),
+                        signature_key: signer.to_public_vec().into(),
+                    };
+
+                    (credential_with_key, signer)
+                },
+                |(credential_with_key, signer)| {
+                    let _key_package = KeyPackage::builder()
+                        .build(ciphersuite, provider, &signer, credential_with_key)
+                        .expect("An unexpected error occurred.");
+                },
+            );
+        });
     }
 }
 
-fn create_welcome(c: &mut Criterion, provider: &impl OpenMlsProvider) {
+fn create_welcome(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    provider_name: &str,
+    provider: &impl OpenMlsProvider,
+) {
     for &ciphersuite in provider.crypto().supported_ciphersuites().iter() {
-        c.bench_function(
-            &format!("Create a welcome message with ciphersuite: {ciphersuite:?}"),
-            move |b| {
-                b.iter_with_setup(
-                    || {
-                        let alice_credential = BasicCredential::new("Alice".into());
-                        let alice_signer =
-                            SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
-                        let alice_credential_with_key = CredentialWithKey {
-                            credential: alice_credential.into(),
-                            signature_key: alice_signer.to_public_vec().into(),
-                        };
+        group.bench_function(bench_id(provider_name, ciphersuite), move |b| {
+            b.iter_with_setup(
+                || {
+                    let alice_credential = BasicCredential::new("Alice".into());
+                    let alice_signer =
+                        SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+                    let alice_credential_with_key = CredentialWithKey {
+                        credential: alice_credential.into(),
+                        signature_key: alice_signer.to_public_vec().into(),
+                    };
 
-                        let bob_credential = BasicCredential::new("Bob".into());
-                        let bob_signer =
-                            SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
-                        let bob_credential_with_key = CredentialWithKey {
-                            credential: bob_credential.into(),
-                            signature_key: bob_signer.to_public_vec().into(),
-                        };
-                        let bob_key_package = KeyPackage::builder()
-                            .build(
-                                ciphersuite,
-                                provider,
-                                &bob_signer,
-                                bob_credential_with_key.clone(),
-                            )
-                            .expect("An unexpected error occurred.");
-
-                        let mls_group_create_config = MlsGroupCreateConfig::builder()
-                            .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-                            .ciphersuite(ciphersuite)
-                            .build();
-
-                        // === Alice creates a group ===
-                        let alice_group = MlsGroup::new(
+                    let bob_credential = BasicCredential::new("Bob".into());
+                    let bob_signer =
+                        SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+                    let bob_credential_with_key = CredentialWithKey {
+                        credential: bob_credential.into(),
+                        signature_key: bob_signer.to_public_vec().into(),
+                    };
+                    let bob_key_package = KeyPackage::builder()
+                        .build(
+                            ciphersuite,
                             provider,
-                            &alice_signer,
-                            &mls_group_create_config,
-                            alice_credential_with_key.clone(),
+                            &bob_signer,
+                            bob_credential_with_key.clone(),
                         )
                         .expect("An unexpected error occurred.");
 
-                        (alice_signer, alice_group, bob_key_package)
-                    },
-                    |(alice_signer, mut alice_group, bob_key_package)| {
-                        let _welcome = match alice_group.add_members(
-                            provider,
-                            &alice_signer,
-                            core::slice::from_ref(bob_key_package.key_package()),
-                        ) {
-                            Ok((_, welcome, _)) => welcome,
-                            Err(e) => panic!("Could not add member to group: {e:?}"),
-                        };
-                    },
-                );
-            },
-        );
+                    let mls_group_create_config = MlsGroupCreateConfig::builder()
+                        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+                        .ciphersuite(ciphersuite)
+                        .build();
+
+                    // === Alice creates a group ===
+                    let alice_group = MlsGroup::new(
+                        provider,
+                        &alice_signer,
+                        &mls_group_create_config,
+                        alice_credential_with_key.clone(),
+                    )
+                    .expect("An unexpected error occurred.");
+
+                    (alice_signer, alice_group, bob_key_package)
+                },
+                |(alice_signer, mut alice_group, bob_key_package)| {
+                    let _welcome = match alice_group.add_members(
+                        provider,
+                        &alice_signer,
+                        core::slice::from_ref(bob_key_package.key_package()),
+                    ) {
+                        Ok((_, welcome, _)) => welcome,
+                        Err(e) => panic!("Could not add member to group: {e:?}"),
+                    };
+                },
+            );
+        });
     }
 }
 
-fn join_group(c: &mut Criterion, provider: &impl OpenMlsProvider) {
+fn join_group(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    provider_name: &str,
+    provider: &impl OpenMlsProvider,
+) {
     for &ciphersuite in provider.crypto().supported_ciphersuites().iter() {
-        c.bench_function(
-            &format!("Join a group with ciphersuite: {ciphersuite:?}"),
-            move |b| {
-                b.iter_with_setup(
-                    || {
-                        let alice_credential = BasicCredential::new("Alice".into());
-                        let alice_signer =
-                            SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
-                        let alice_credential_with_key = CredentialWithKey {
-                            credential: alice_credential.into(),
-                            signature_key: alice_signer.to_public_vec().into(),
-                        };
+        group.bench_function(bench_id(provider_name, ciphersuite), move |b| {
+            b.iter_with_setup(
+                || {
+                    let alice_credential = BasicCredential::new("Alice".into());
+                    let alice_signer =
+                        SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+                    let alice_credential_with_key = CredentialWithKey {
+                        credential: alice_credential.into(),
+                        signature_key: alice_signer.to_public_vec().into(),
+                    };
 
-                        let bob_credential = BasicCredential::new("Bob".into());
-                        let bob_signer =
-                            SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
-                        let bob_credential_with_key = CredentialWithKey {
-                            credential: bob_credential.into(),
-                            signature_key: bob_signer.to_public_vec().into(),
-                        };
-                        let bob_key_package = KeyPackage::builder()
-                            .build(
-                                ciphersuite,
-                                provider,
-                                &bob_signer,
-                                bob_credential_with_key.clone(),
-                            )
-                            .expect("An unexpected error occurred.");
-
-                        let mls_group_create_config = MlsGroupCreateConfig::builder()
-                            .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-                            .ciphersuite(ciphersuite)
-                            .build();
-
-                        // === Alice creates a group ===
-                        let mut alice_group = MlsGroup::new(
+                    let bob_credential = BasicCredential::new("Bob".into());
+                    let bob_signer =
+                        SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+                    let bob_credential_with_key = CredentialWithKey {
+                        credential: bob_credential.into(),
+                        signature_key: bob_signer.to_public_vec().into(),
+                    };
+                    let bob_key_package = KeyPackage::builder()
+                        .build(
+                            ciphersuite,
                             provider,
-                            &alice_signer,
-                            &mls_group_create_config,
-                            alice_credential_with_key.clone(),
+                            &bob_signer,
+                            bob_credential_with_key.clone(),
                         )
                         .expect("An unexpected error occurred.");
 
-                        let welcome = match alice_group.add_members(
-                            provider,
-                            &alice_signer,
-                            core::slice::from_ref(bob_key_package.key_package()),
-                        ) {
-                            Ok((_, welcome, _)) => welcome,
-                            Err(e) => panic!("Could not add member to group: {e:?}"),
-                        };
+                    let mls_group_create_config = MlsGroupCreateConfig::builder()
+                        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+                        .ciphersuite(ciphersuite)
+                        .build();
 
-                        alice_group
-                            .merge_pending_commit(provider)
-                            .expect("error merging pending commit");
+                    // === Alice creates a group ===
+                    let mut alice_group = MlsGroup::new(
+                        provider,
+                        &alice_signer,
+                        &mls_group_create_config,
+                        alice_credential_with_key.clone(),
+                    )
+                    .expect("An unexpected error occurred.");
 
-                        (alice_group, mls_group_create_config, welcome)
-                    },
-                    |(alice_group, mls_group_create_config, welcome)| {
-                        let welcome: MlsMessageIn = welcome.into();
-                        let welcome = welcome
-                            .into_welcome()
-                            .expect("expected the message to be a welcome message");
-                        let processed_welcome = ProcessedWelcome::new_from_welcome(
-                            provider,
-                            mls_group_create_config.join_config(),
-                            welcome,
-                        )
+                    let welcome = match alice_group.add_members(
+                        provider,
+                        &alice_signer,
+                        core::slice::from_ref(bob_key_package.key_package()),
+                    ) {
+                        Ok((_, welcome, _)) => welcome,
+                        Err(e) => panic!("Could not add member to group: {e:?}"),
+                    };
+
+                    alice_group
+                        .merge_pending_commit(provider)
+                        .expect("error merging pending commit");
+
+                    (alice_group, mls_group_create_config, welcome)
+                },
+                |(alice_group, mls_group_create_config, welcome)| {
+                    let welcome: MlsMessageIn = welcome.into();
+                    let welcome = welcome
+                        .into_welcome()
+                        .expect("expected the message to be a welcome message");
+                    let processed_welcome = ProcessedWelcome::new_from_welcome(
+                        provider,
+                        mls_group_create_config.join_config(),
+                        welcome,
+                    )
+                    .unwrap();
+                    let _bob_group = JoinBuilder::new(provider, processed_welcome)
+                        .with_ratchet_tree(alice_group.export_ratchet_tree().into())
+                        .replace_old_group()
+                        .build()
+                        .unwrap()
+                        .into_group(provider)
                         .unwrap();
-                        let _bob_group = JoinBuilder::new(provider, processed_welcome)
-                            .with_ratchet_tree(alice_group.export_ratchet_tree().into())
-                            .replace_old_group()
-                            .build()
-                            .unwrap()
-                            .into_group(provider)
-                            .unwrap();
-                    },
-                );
-            },
-        );
+                },
+            );
+        });
     }
 }
 
-fn create_commit(c: &mut Criterion, provider: &impl OpenMlsProvider) {
+fn create_commit(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    provider_name: &str,
+    provider: &impl OpenMlsProvider,
+) {
     for &ciphersuite in provider.crypto().supported_ciphersuites().iter() {
-        c.bench_function(
-            &format!("Create a commit with ciphersuite: {ciphersuite:?}"),
-            move |b| {
-                b.iter_with_setup(
-                    || {
-                        let alice_credential = BasicCredential::new("Alice".into());
-                        let alice_signer =
-                            SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
-                        let alice_credential_with_key = CredentialWithKey {
-                            credential: alice_credential.into(),
-                            signature_key: alice_signer.to_public_vec().into(),
-                        };
+        group.bench_function(bench_id(provider_name, ciphersuite), move |b| {
+            b.iter_with_setup(
+                || {
+                    let alice_credential = BasicCredential::new("Alice".into());
+                    let alice_signer =
+                        SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+                    let alice_credential_with_key = CredentialWithKey {
+                        credential: alice_credential.into(),
+                        signature_key: alice_signer.to_public_vec().into(),
+                    };
 
-                        let bob_credential = BasicCredential::new("Bob".into());
-                        let bob_signer =
-                            SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
-                        let bob_credential_with_key = CredentialWithKey {
-                            credential: bob_credential.into(),
-                            signature_key: bob_signer.to_public_vec().into(),
-                        };
-                        let bob_key_package = KeyPackage::builder()
-                            .build(
-                                ciphersuite,
-                                provider,
-                                &bob_signer,
-                                bob_credential_with_key.clone(),
-                            )
-                            .expect("An unexpected error occurred.");
-
-                        let mls_group_create_config = MlsGroupCreateConfig::builder()
-                            .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-                            .ciphersuite(ciphersuite)
-                            .build();
-
-                        // === Alice creates a group ===
-                        let mut alice_group = MlsGroup::new(
+                    let bob_credential = BasicCredential::new("Bob".into());
+                    let bob_signer =
+                        SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+                    let bob_credential_with_key = CredentialWithKey {
+                        credential: bob_credential.into(),
+                        signature_key: bob_signer.to_public_vec().into(),
+                    };
+                    let bob_key_package = KeyPackage::builder()
+                        .build(
+                            ciphersuite,
                             provider,
-                            &alice_signer,
-                            &mls_group_create_config,
-                            alice_credential_with_key.clone(),
+                            &bob_signer,
+                            bob_credential_with_key.clone(),
                         )
                         .expect("An unexpected error occurred.");
 
-                        let welcome = match alice_group.add_members(
-                            provider,
-                            &alice_signer,
-                            core::slice::from_ref(bob_key_package.key_package()),
-                        ) {
-                            Ok((_, welcome, _)) => welcome,
-                            Err(e) => panic!("Could not add member to group: {e:?}"),
-                        };
+                    let mls_group_create_config = MlsGroupCreateConfig::builder()
+                        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+                        .ciphersuite(ciphersuite)
+                        .build();
 
-                        alice_group
-                            .merge_pending_commit(provider)
-                            .expect("error merging pending commit");
+                    // === Alice creates a group ===
+                    let mut alice_group = MlsGroup::new(
+                        provider,
+                        &alice_signer,
+                        &mls_group_create_config,
+                        alice_credential_with_key.clone(),
+                    )
+                    .expect("An unexpected error occurred.");
 
-                        let welcome: MlsMessageIn = welcome.into();
-                        let welcome = welcome
-                            .into_welcome()
-                            .expect("expected the message to be a welcome message");
-                        let processed_welcome = ProcessedWelcome::new_from_welcome(
-                            provider,
-                            mls_group_create_config.join_config(),
-                            welcome,
-                        )
+                    let welcome = match alice_group.add_members(
+                        provider,
+                        &alice_signer,
+                        core::slice::from_ref(bob_key_package.key_package()),
+                    ) {
+                        Ok((_, welcome, _)) => welcome,
+                        Err(e) => panic!("Could not add member to group: {e:?}"),
+                    };
+
+                    alice_group
+                        .merge_pending_commit(provider)
+                        .expect("error merging pending commit");
+
+                    let welcome: MlsMessageIn = welcome.into();
+                    let welcome = welcome
+                        .into_welcome()
+                        .expect("expected the message to be a welcome message");
+                    let processed_welcome = ProcessedWelcome::new_from_welcome(
+                        provider,
+                        mls_group_create_config.join_config(),
+                        welcome,
+                    )
+                    .unwrap();
+                    let bob_group = JoinBuilder::new(provider, processed_welcome)
+                        .with_ratchet_tree(alice_group.export_ratchet_tree().into())
+                        .replace_old_group()
+                        .build()
+                        .unwrap()
+                        .into_group(provider)
                         .unwrap();
-                        let bob_group = JoinBuilder::new(provider, processed_welcome)
-                            .with_ratchet_tree(alice_group.export_ratchet_tree().into())
-                            .replace_old_group()
-                            .build()
-                            .unwrap()
-                            .into_group(provider)
-                            .unwrap();
 
-                        (bob_group, bob_signer)
-                    },
-                    |(mut bob_group, bob_signer)| {
-                        let _ = bob_group
-                            .self_update(provider, &bob_signer, LeafNodeParameters::default())
-                            .unwrap();
+                    (bob_group, bob_signer)
+                },
+                |(mut bob_group, bob_signer)| {
+                    let _ = bob_group
+                        .self_update(provider, &bob_signer, LeafNodeParameters::default())
+                        .unwrap();
 
-                        bob_group
-                            .merge_pending_commit(provider)
-                            .expect("error merging pending commit");
-                    },
-                );
-            },
-        );
+                    bob_group
+                        .merge_pending_commit(provider)
+                        .expect("error merging pending commit");
+                },
+            );
+        });
     }
 }
 
-fn kp_bundle_rust_crypto(c: &mut Criterion) {
-    let provider = &OpenMlsRustCrypto::default();
-    println!("provider: RustCrypto");
-    criterion_key_package(c, provider);
+/// Runs `bench` against a criterion group named `name`.
+///
+/// All providers have to be benchmarked into the same open group: criterion
+/// generates a group's summary plot from the ids collected while the group is
+/// alive.
+fn bench_group(
+    c: &mut Criterion,
+    name: &str,
+    bench: impl FnOnce(&mut BenchmarkGroup<'_, WallTime>),
+) {
+    let mut group = c.benchmark_group(name);
+    bench(&mut group);
+    group.finish();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    kp_bundle_rust_crypto(c);
-    criterion_key_package(c, &openmls_libcrux_crypto::Provider::default());
-    create_welcome(c, &openmls_libcrux_crypto::Provider::default());
-    join_group(c, &openmls_libcrux_crypto::Provider::default());
-    create_commit(c, &openmls_libcrux_crypto::Provider::default());
+    let rust_crypto = OpenMlsRustCrypto::default();
+    #[cfg(feature = "libcrux-provider")]
+    let libcrux = openmls_libcrux_crypto::Provider::default();
+
+    // One group per operation, holding a measurement per provider and
+    // ciphersuite, so the group summary plot compares both dimensions.
+    bench_group(c, "KeyPackage create bundle", |group| {
+        criterion_key_package(group, "RustCrypto", &rust_crypto);
+        #[cfg(feature = "libcrux-provider")]
+        criterion_key_package(group, "libcrux", &libcrux);
+    });
+    bench_group(c, "Create a welcome message", |group| {
+        create_welcome(group, "RustCrypto", &rust_crypto);
+        #[cfg(feature = "libcrux-provider")]
+        create_welcome(group, "libcrux", &libcrux);
+    });
+    bench_group(c, "Join a group", |group| {
+        join_group(group, "RustCrypto", &rust_crypto);
+        #[cfg(feature = "libcrux-provider")]
+        join_group(group, "libcrux", &libcrux);
+    });
+    bench_group(c, "Create a commit", |group| {
+        create_commit(group, "RustCrypto", &rust_crypto);
+        #[cfg(feature = "libcrux-provider")]
+        create_commit(group, "libcrux", &libcrux);
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
The bench target declared `libcrux-provider` as a required feature, and every benchmark only ran against the libcrux provider. Since CI did not enable the feature, `cargo bench` measured nothing at all.

Benchmarks now run against both the RustCrypto and libcrux providers, grouped per operation with provider and ciphersuite as benchmark id dimension, so criterion group summary compares them directly. CI enables `libcrux-provider`, and criterion html reports are turned on.