### PR TITLE
fix: don't count the proposal type twice in FrankenProposal's length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- [#2151](https://github.com/openmls/openmls/pull/2151): `FrankenProposal::tls_serialized_len` counted the proposal type twice for custom proposals (`test-utils` feature), so it was two bytes too large. Serializing a `FrankenCommit` carrying a custom proposal failed with `tls_codec::Error::LibraryError`.
+
 ## 0.9.0 (2026-08-03)
 
 ### Added

--- a/openmls/src/test_utils/frankenstein/codec.rs
+++ b/openmls/src/test_utils/frankenstein/codec.rs
@@ -80,7 +80,9 @@ impl Size for FrankenProposal {
                 FrankenProposal::AppEphemeral(p) => p.tls_serialized_len(),
                 #[cfg(feature = "extensions-draft")]
                 FrankenProposal::AppDataUpdate(p) => p.tls_serialized_len(),
-                FrankenProposal::Custom(p) => p.tls_serialized_len(),
+                // Only the payload is written; the proposal type is already
+                // accounted for above.
+                FrankenProposal::Custom(p) => p.payload.tls_serialized_len(),
             }
     }
 }
@@ -287,5 +289,105 @@ impl DeserializeBytes for FrankenExtension {
         let mut bytes_ref = bytes;
         let extension = FrankenExtension::tls_deserialize(&mut bytes_ref)?;
         Ok((extension, bytes_ref))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::frankenstein::{
+        FrankenCommit, FrankenCustomProposal, FrankenExternalPsk, FrankenPreSharedKeyId,
+        FrankenPreSharedKeyProposal, FrankenProposalOrRef, FrankenPsk, FrankenReInitProposal,
+        FrankenRemoveProposal,
+    };
+
+    #[cfg(feature = "extensions-draft")]
+    use crate::messages::proposals::AppDataUpdateOperation;
+
+    /// Proposals that can be built without a key package or a leaf node.
+    fn proposals() -> Vec<FrankenProposal> {
+        let proposals = vec![
+            FrankenProposal::Remove(FrankenRemoveProposal { removed: 3 }),
+            FrankenProposal::PreSharedKey(FrankenPreSharedKeyProposal {
+                psk: FrankenPreSharedKeyId {
+                    psk: FrankenPsk::External(FrankenExternalPsk {
+                        psk_id: vec![7, 8].into(),
+                    }),
+                    psk_nonce: vec![9; 32].into(),
+                },
+            }),
+            FrankenProposal::ReInit(FrankenReInitProposal {
+                group_id: vec![1, 2, 3].into(),
+                version: 1,
+                ciphersuite: 1,
+                extensions: vec![FrankenExtension::LastResort],
+            }),
+            FrankenProposal::ExternalInit(FrankenExternalInitProposal {
+                kem_output: vec![4; 32].into(),
+            }),
+            FrankenProposal::GroupContextExtensions(vec![FrankenExtension::Unknown(
+                0xf042,
+                vec![5, 6].into(),
+            )]),
+            FrankenProposal::Custom(FrankenCustomProposal {
+                proposal_type: 0xf001,
+                payload: vec![1, 2, 3, 4].into(),
+            }),
+        ];
+
+        #[cfg(feature = "extensions-draft")]
+        let proposals = {
+            let mut proposals = proposals;
+            proposals.push(FrankenProposal::AppEphemeral(FrankenAppEphemeralProposal {
+                component_id: 0x8001,
+                data: vec![1, 2, 3].into(),
+            }));
+            proposals.push(FrankenProposal::AppDataUpdate(
+                FrankenAppDataUpdateProposal {
+                    component_id: 0x8001,
+                    operation: AppDataUpdateOperation::Update(vec![4, 5, 6].into()),
+                },
+            ));
+            proposals
+        };
+
+        proposals
+    }
+
+    #[test]
+    fn proposal_length_matches_serialization() {
+        for proposal in proposals() {
+            let serialized = proposal.tls_serialize_detached().unwrap();
+            assert_eq!(
+                proposal.tls_serialized_len(),
+                serialized.len(),
+                "wrong length for {proposal:?}"
+            );
+            assert_eq!(
+                FrankenProposal::tls_deserialize_exact(&serialized).unwrap(),
+                proposal
+            );
+        }
+    }
+
+    /// A wrong length breaks any enclosing struct that writes a length prefix,
+    /// so exercise a proposal nested in a commit as well.
+    #[test]
+    fn commit_with_a_custom_proposal_round_trips() {
+        let commit = FrankenCommit {
+            proposals: vec![FrankenProposalOrRef::Proposal(FrankenProposal::Custom(
+                FrankenCustomProposal {
+                    proposal_type: 0xf001,
+                    payload: vec![1, 2, 3, 4].into(),
+                },
+            ))],
+            path: None,
+        };
+
+        let serialized = commit.tls_serialize_detached().unwrap();
+        assert_eq!(
+            FrankenCommit::tls_deserialize_exact(&serialized).unwrap(),
+            commit
+        );
     }
 }


### PR DESCRIPTION
`Size for FrankenProposal` (openmls/src/test_utils/frankenstein/codec.rs:68) starts from `self.proposal_type().tls_serialized_len()`, which is the two byte type tag, and then adds the length of the variant body. For the custom variant it added `p.tls_serialized_len()`, the whole `FrankenCustomProposal`, and that struct carries its own `proposal_type: u16` field alongside the payload. So the tag was counted twice.

`Serialize` writes the tag once and then `p.payload` alone (codec.rs:103), and `Deserialize` reads a `FrankenProposalType` followed by a `VLBytes` (codec.rs:145). Both agree on the wire format. Only `Size` disagreed, by two bytes.

That is enough to break any enclosing struct whose length prefix is derived from `Size`. `FrankenCommit.proposals` is a `Vec<FrankenProposalOrRef>`, so the derived impl writes a prefix computed from `tls_serialized_len` and then serializes the elements. The prefix comes out two bytes longer than the bytes that follow, and `tls_serialize_detached` bails out with a `LibraryError`. A `FrankenCommit` carrying a custom proposal could not be serialized at all.

Repro on unpatched code, using the two tests added here (I backed out the three changed lines in the `Size` impl and put back the old `FrankenProposal::Custom(p) => p.tls_serialized_len(),`):

```
$ cargo test -p openmls --lib frankenstein::codec

running 2 tests
test test_utils::frankenstein::codec::tests::commit_with_a_custom_proposal_round_trips ... FAILED
test test_utils::frankenstein::codec::tests::proposal_length_matches_serialization ... FAILED

failures:

---- test_utils::frankenstein::codec::tests::commit_with_a_custom_proposal_round_trips stdout ----

thread 'test_utils::frankenstein::codec::tests::commit_with_a_custom_proposal_round_trips' (1879012) panicked at openmls/src/test_utils/frankenstein/codec.rs:385:58:
called `Result::unwrap()` on an `Err` value: LibraryError

---- test_utils::frankenstein::codec::tests::proposal_length_matches_serialization stdout ----

thread 'test_utils::frankenstein::codec::tests::proposal_length_matches_serialization' (1879013) panicked at openmls/src/test_utils/frankenstein/codec.rs:359:13:
assertion `left == right` failed: wrong length for Custom(FrankenCustomProposal { proposal_type: 61441, payload: VLBytes { 0x01020304 } })
  left: 9
 right: 7
```

Nine against the seven bytes that actually come out: two for the type tag, one for the `VLBytes` length prefix, four of payload.

## The change

One arm of the `Size` impl now reports `p.payload.tls_serialized_len()` instead of `p.tls_serialized_len()`, which is what `Serialize` writes for that variant. This is the same shape as `Size for Proposal` in openmls/src/messages/codec.rs:21, where the custom arm is already `p.payload().tls_serialized_len()`.

The other option was to leave `Size` alone and have `Serialize` write the whole `FrankenCustomProposal`. That would put a second copy of the proposal type on the wire, inside the payload, which is not the format `Deserialize` reads back and not what the real `Proposal` produces. Franken types exist to build byte-level variations of real messages, so the one that keeps them byte compatible with the real encoder is the right one.

## Side effects

- No public API change and no behaviour change outside the `test-utils` feature. The `Size` impl for `FrankenProposal` is only reachable through `openmls::test_utils::frankenstein`.
- Only the custom variant is affected. Every other arm passes the same value to `Size` and to `Serialize`, so their lengths were already right.
- Bytes produced for custom proposals do not change. Serialization was either failing or, where the length was not used for a prefix, already correct.

## Tests

Both new tests live in a `tests` module at the bottom of the same file, matching what openmls/src/extensions/codec.rs does.

`proposal_length_matches_serialization` builds one of each `FrankenProposal` variant that can be constructed without a key package or a leaf node, checks `tls_serialized_len()` against the length of `tls_serialize_detached()`, and round trips each one. `Add` and `Update` are left out because they wrap a full `FrankenKeyPackage` and `FrankenLeafNode`; both take their body straight from a derived impl, so there is nothing hand written to get wrong there.

`commit_with_a_custom_proposal_round_trips` covers the symptom rather than the arithmetic, since a wrong length only becomes visible once something writes a prefix from it.

## Verification

```
$ cargo test -p openmls --lib frankenstein::codec
running 2 tests
test test_utils::frankenstein::codec::tests::commit_with_a_custom_proposal_round_trips ... ok
test test_utils::frankenstein::codec::tests::proposal_length_matches_serialization ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 273 filtered out; finished in 0.00s

$ cargo test -p openmls --lib
test result: ok. 272 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 71.27s

$ cargo test -p openmls --lib -F extensions-draft,extensions-draft-test-dependencies
test result: ok. 317 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 63.43s

$ cargo test -p openmls --lib -F virtual-clients-draft,virtual-clients-draft-test-dependencies
test result: ok. 353 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 78.80s

$ cargo test -p openmls
# every target green, including the RFC 9420 KAT vectors and the passive client vectors

$ cargo fmt --check     # clean
$ cargo clippy -p openmls --all-targets     # no warnings
```

The two draft feature runs are there because the `Size` impl I touched has `extensions-draft` arms next to the one that changed, and the new test builds those two proposal variants under the same flag.

The CHANGELOG entry links to #2151; happy to renumber if that is off.
