### PR TITLE
ci: build nightly debug tests with line tables only

### DIFF
--- a/.github/workflows/tests_nightly.yml
+++ b/.github/workflows/tests_nightly.yml
@@ -17,6 +17,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Full debuginfo for the test crate exceeds the memory of the hosted
+  # runners once the ciphersuite matrix is enabled, which gets the debug
+  # jobs killed mid-build. Line tables are enough for panic backtraces.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
 
 jobs:
   tests:


### PR DESCRIPTION
The debug pq-ciphersuites jobs have been killed with SIGTERM (exit 143) on every nightly run since the PQ ciphersuites were enabled for the RustCrypto provider. Building the openmls test crate with full debuginfo and the whole ciphersuite matrix exceeds the memory of the 16 GB hosted runners. This PR restricts dev-profile debuginfo to line tables, which keeps file and line information in panic backtraces but drops the type and variable info that dominates rustc's memory use.