### PR TITLE
virtual clients: two-step builder for VC sibling external-commit joins

### DIFF
--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -191,9 +191,9 @@ impl<StorageError> From<ExternalCommitBuilderError<StorageError>>
 
 /// Error joining a higher-level group as a virtual client's sibling emulator
 /// by processing another sibling's external commit
-/// ([`MlsGroup::vc_join_via_sibling_external_commit`]).
+/// ([`VcExternalCommitJoinBuilder`]).
 ///
-/// [`MlsGroup::vc_join_via_sibling_external_commit`]: crate::group::MlsGroup::vc_join_via_sibling_external_commit
+/// [`VcExternalCommitJoinBuilder`]: crate::group::VcExternalCommitJoinBuilder
 #[cfg(feature = "virtual-clients-draft")]
 #[derive(Error, Debug)]
 pub enum VcExternalCommitJoinError<StorageError> {

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -27,6 +27,14 @@ use crate::{
 
 use crate::key_packages::KeyPackage;
 
+#[cfg(feature = "virtual-clients-draft")]
+use crate::{
+    component::ComponentId,
+    framing::mls_auth_content::AuthenticatedContent,
+    group::mls_group::processing::{AppDataDictionaryUpdater, AppDataUpdates},
+    messages::proposals::{AppDataUpdateProposal, AppEphemeralProposal},
+};
+
 impl MlsGroup {
     // === Group creation ===
 
@@ -907,144 +915,11 @@ fn find_and_validate_vc_own_leaf<Provider: OpenMlsProvider>(
 
 #[cfg(feature = "virtual-clients-draft")]
 impl MlsGroup {
-    /// Bootstrap a virtual client's sibling emulator client into a higher-level
-    /// group by processing another sibling's external commit, when this client
-    /// is not yet a member of that group.
-    ///
-    /// The first emulator client joined the higher-level group via an external
-    /// commit. A second emulator client (this one), sharing the same emulation
-    /// epoch (`epoch_id`), reconstructs the resulting group state from that
-    /// commit. It cannot decapsulate the external init secret from the previous
-    /// epoch's `external_secret` (it never held it), so it uses the external
-    /// init secret the committing sibling carried in the commit's
-    /// `DerivationInfoTBE` (mls-virtual-clients draft), and recreates
-    /// the commit path from the shared operation secret tree.
-    ///
-    /// `verifiable_group_info` and `ratchet_tree` describe the higher-level
-    /// group at the epoch *before* the external commit (the ratchet tree may
-    /// instead travel in the GroupInfo's `ratchet_tree` extension).
-    /// `external_commit` is the sibling's external commit. On success the
-    /// returned group sits at the epoch the commit installs, with this client
-    /// on the shared virtual-client leaf.
-    ///
-    /// If the commit carries AppEphemeral proposals by value, their payload
-    /// can be read before calling this function via
-    /// [`PublicMessageIn::unverified_app_ephemeral_proposals`], for example
-    /// to decide how to follow the join. That data is unauthenticated until
-    /// the commit is verified, which this function does.
-    ///
-    /// [`PublicMessageIn::unverified_app_ephemeral_proposals`]:
-    ///     crate::framing::PublicMessageIn::unverified_app_ephemeral_proposals
-    pub fn vc_join_via_sibling_external_commit<Provider: OpenMlsProvider>(
-        provider: &Provider,
-        join_config: &MlsGroupJoinConfig,
-        verifiable_group_info: VerifiableGroupInfo,
-        ratchet_tree: Option<RatchetTreeIn>,
-        external_commit: impl Into<crate::framing::ProtocolMessage>,
-        epoch_id: crate::components::vc_derivation_info::EpochId,
-    ) -> Result<MlsGroup, crate::group::errors::VcExternalCommitJoinError<Provider::StorageError>>
-    {
-        use crate::{
-            framing::Sender,
-            group::config::PastEpochDeletionPolicy,
-            group::errors::{ProcessMessageError, VcExternalCommitJoinError as Error},
-            group::public_group::PublicGroup,
-            prelude::mls_content::FramedContentBody,
-            schedule::{EpochSecrets, InitSecret},
-        };
-
-        // Resolve the prior-epoch ratchet tree (from the GroupInfo extension or
-        // the argument) and rebuild the prior-epoch public group.
-        let ratchet_tree = match verifiable_group_info.extensions().ratchet_tree() {
-            Some(extension) => extension.ratchet_tree().clone(),
-            None => ratchet_tree.ok_or(Error::MissingRatchetTree)?,
-        };
-        let (public_group, _group_info) = PublicGroup::from_ratchet_tree(
-            provider.crypto(),
-            ratchet_tree,
-            verifiable_group_info,
-            ProposalStore::new(),
-            LeafNodeLifetimePolicy::default(),
-        )?;
-
-        // Assemble a transient group at the prior epoch. Its epoch secrets are
-        // never used cryptographically here: the external commit carries the
-        // external init secret and the operation secret tree supplies the path,
-        // so a random init-secret stub is sufficient. The own leaf index is the
-        // leftmost free index, where the committing sibling installs the shared
-        // virtual-client leaf.
-        let ciphersuite = public_group.ciphersuite();
-        let serialized_group_context = public_group
-            .group_context()
-            .tls_serialize_detached()
-            .map_err(LibraryError::missing_bound_check)?;
-        let own_leaf_index = public_group.leftmost_free_index(std::iter::empty())?;
-        let init_secret = InitSecret::random(ciphersuite, provider.rand())
-            .map_err(LibraryError::unexpected_crypto_error)?;
-        let epoch_secrets =
-            EpochSecrets::with_init_secret(provider.crypto(), ciphersuite, init_secret)
-                .map_err(LibraryError::unexpected_crypto_error)?;
-        let (group_epoch_secrets, message_secrets) = epoch_secrets.split_secrets(
-            serialized_group_context,
-            public_group.tree_size(),
-            LeafNodeIndex::new(0u32),
-        );
-        // Do not retain the synthetic prior-epoch secrets used only to stage
-        // this external commit.
-        let message_secrets_store = MessageSecretsStore::new_with_secret(
-            &PastEpochDeletionPolicy::MaxEpochs(0),
-            message_secrets,
-        );
-        let mut group = MlsGroup {
-            mls_group_config: join_config.clone(),
-            own_leaf_nodes: vec![],
-            aad: vec![],
-            #[cfg(feature = "extensions-draft")]
-            safe_aad: crate::framing::SafeAad::empty(),
-            group_state: MlsGroupState::Operational,
-            public_group,
-            group_epoch_secrets,
-            own_leaf_index,
-            message_secrets_store,
-            resumption_psk_store: ResumptionPskStore::new(join_config.number_of_resumption_psks),
-            #[cfg(feature = "extensions-draft")]
-            application_export_tree: None,
-        };
-
-        // Parse and verify the external commit against the prior-epoch group.
-        // A PrivateMessage claiming our own leaf cannot be an external commit.
-        let processing::UnprotectedMessage::Unverified(unverified) =
-            group.unprotect_message(provider, external_commit)?
-        else {
-            return Err(Error::NotAnExternalCommit);
-        };
-        let verified = unverified
-            .verify(group.ciphersuite(), provider.crypto(), group.version())
-            .map_err(ProcessMessageError::from)?;
-        if !matches!(verified.content.sender(), Sender::NewMemberCommit) {
-            return Err(Error::NotAnExternalCommit);
-        }
-        let content = verified.content;
-        let FramedContentBody::Commit(commit) = content.content() else {
-            return Err(Error::NotAnExternalCommit);
-        };
-
-        // Recover the sibling-VC commit material (operation secret + emulation
-        // epoch id + carried external init secret) from the leaf's derivation
-        // info, then stage and merge the commit through the sibling-VC path.
-        let material = group
-            .load_vc_commit_material(provider, commit)?
-            .ok_or(Error::MissingDerivationInfo)?;
-        if material.epoch_id != epoch_id {
-            return Err(Error::EpochIdMismatch);
-        }
-        let staged = group.stage_commit(&content, vec![], vec![], provider, Some(material))?;
-        group.merge_staged_commit(provider, staged)?;
-        group.resize_message_secrets_store(join_config.past_epoch_deletion_policy());
-        group
-            .store(provider.storage())
-            .map_err(Error::StorageError)?;
-        Ok(group)
+    /// Returns a new [`VcExternalCommitJoinBuilder`] for joining a
+    /// higher-level group as a virtual client's sibling emulator client, by
+    /// processing another sibling's external commit.
+    pub fn vc_external_commit_join_builder() -> VcExternalCommitJoinBuilder {
+        VcExternalCommitJoinBuilder::new()
     }
 
     /// Bootstrap a virtual client's sibling emulator client into a higher-level
@@ -1266,6 +1141,352 @@ impl MlsGroup {
             .map_err(Error::StorageError)?;
 
         Ok(mls_group)
+    }
+}
+
+/// Builder for bootstrapping a virtual client's sibling emulator client into
+/// a higher-level group by processing another sibling's external commit,
+/// when this client is not yet a member of that group.
+///
+/// The first emulator client joined the higher-level group via an external
+/// commit. A second emulator client (this one), sharing the same emulation
+/// epoch, reconstructs the resulting group state from that commit.
+///
+/// The join happens in two steps. [`Self::process_commit`] rebuilds the
+/// prior-epoch group and verifies the commit, returning a
+/// [`PendingVcExternalCommitJoin`]. The application inspects the verified
+/// proposals it exposes, resolves any AppDataUpdate proposals, and completes
+/// the join with [`PendingVcExternalCommitJoin::join`].
+#[cfg(feature = "virtual-clients-draft")]
+#[derive(Debug, Default)]
+pub struct VcExternalCommitJoinBuilder {
+    join_config: MlsGroupJoinConfig,
+    ratchet_tree: Option<RatchetTreeIn>,
+    lifetime_policy: LeafNodeLifetimePolicy,
+}
+
+#[cfg(feature = "virtual-clients-draft")]
+impl VcExternalCommitJoinBuilder {
+    /// Creates a new [`VcExternalCommitJoinBuilder`] with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Specifies the configuration to use for the joined group.
+    pub fn with_config(mut self, join_config: MlsGroupJoinConfig) -> Self {
+        self.join_config = join_config;
+        self
+    }
+
+    /// Specifies the prior-epoch ratchet tree. This is only used if the
+    /// ratchet tree is not provided in the [`VerifiableGroupInfo`]
+    /// extensions. A ratchet tree must be provided, either in the
+    /// [`VerifiableGroupInfo`] extensions or via this method.
+    pub fn with_ratchet_tree(mut self, ratchet_tree: RatchetTreeIn) -> Self {
+        self.ratchet_tree = Some(ratchet_tree);
+        self
+    }
+
+    /// Skip the validation of lifetimes in leaf nodes in the ratchet tree.
+    /// Note that only the leaf nodes are checked that were never updated.
+    ///
+    /// By default they are validated.
+    pub fn skip_lifetime_validation(mut self) -> Self {
+        self.lifetime_policy = LeafNodeLifetimePolicy::Skip;
+        self
+    }
+
+    /// Rebuilds the higher-level group at the epoch *before* the external
+    /// commit from `verifiable_group_info` (and the ratchet tree, taken from
+    /// the GroupInfo's `ratchet_tree` extension or
+    /// [`Self::with_ratchet_tree`]), and verifies `external_commit` against
+    /// it: the GroupInfo signature and tree, the commit's signature and
+    /// external-commit shape, and that the commit's derivation info
+    /// references the shared emulation epoch `epoch_id`.
+    ///
+    /// Nothing is consumed or persisted at this point. Dropping the returned
+    /// [`PendingVcExternalCommitJoin`] discards the join without advancing
+    /// the shared operation secret tree.
+    pub fn process_commit<Provider: OpenMlsProvider>(
+        self,
+        provider: &Provider,
+        verifiable_group_info: VerifiableGroupInfo,
+        external_commit: impl Into<crate::framing::ProtocolMessage>,
+        epoch_id: crate::components::vc_derivation_info::EpochId,
+    ) -> Result<
+        PendingVcExternalCommitJoin,
+        crate::group::errors::VcExternalCommitJoinError<Provider::StorageError>,
+    > {
+        use tls_codec::DeserializeBytes as _;
+
+        use crate::{
+            components::vc_derivation_info::{
+                DerivationInfo, VirtualClientsError, VC_COMPONENT_ID,
+            },
+            framing::Sender,
+            group::config::PastEpochDeletionPolicy,
+            group::errors::{ProcessMessageError, VcExternalCommitJoinError as Error},
+            group::mls_group::processing::committed_app_data_update_proposals,
+            group::public_group::PublicGroup,
+            prelude::mls_content::FramedContentBody,
+            schedule::{EpochSecrets, InitSecret},
+        };
+
+        let Self {
+            join_config,
+            ratchet_tree,
+            lifetime_policy,
+        } = self;
+
+        // Resolve the prior-epoch ratchet tree (from the GroupInfo extension
+        // or the builder) and rebuild the prior-epoch public group.
+        let ratchet_tree = match verifiable_group_info.extensions().ratchet_tree() {
+            Some(extension) => extension.ratchet_tree().clone(),
+            None => ratchet_tree.ok_or(Error::MissingRatchetTree)?,
+        };
+        let (public_group, _group_info) = PublicGroup::from_ratchet_tree(
+            provider.crypto(),
+            ratchet_tree,
+            verifiable_group_info,
+            ProposalStore::new(),
+            lifetime_policy,
+        )?;
+
+        // Assemble a transient group at the prior epoch. Its epoch secrets are
+        // never used cryptographically here: the external commit carries the
+        // external init secret and the operation secret tree supplies the path,
+        // so a random init-secret stub is sufficient. The own leaf index is the
+        // leftmost free index, where the committing sibling installs the shared
+        // virtual-client leaf.
+        let ciphersuite = public_group.ciphersuite();
+        let serialized_group_context = public_group
+            .group_context()
+            .tls_serialize_detached()
+            .map_err(LibraryError::missing_bound_check)?;
+        let own_leaf_index = public_group.leftmost_free_index(std::iter::empty())?;
+        let init_secret = InitSecret::random(ciphersuite, provider.rand())
+            .map_err(LibraryError::unexpected_crypto_error)?;
+        let epoch_secrets =
+            EpochSecrets::with_init_secret(provider.crypto(), ciphersuite, init_secret)
+                .map_err(LibraryError::unexpected_crypto_error)?;
+        let (group_epoch_secrets, message_secrets) = epoch_secrets.split_secrets(
+            serialized_group_context,
+            public_group.tree_size(),
+            LeafNodeIndex::new(0u32),
+        );
+        // Do not retain the synthetic prior-epoch secrets used only to stage
+        // this external commit.
+        let message_secrets_store = MessageSecretsStore::new_with_secret(
+            &PastEpochDeletionPolicy::MaxEpochs(0),
+            message_secrets,
+        );
+        let resumption_psk_store = ResumptionPskStore::new(join_config.number_of_resumption_psks);
+        let mut group = MlsGroup {
+            mls_group_config: join_config,
+            own_leaf_nodes: vec![],
+            aad: vec![],
+            #[cfg(feature = "extensions-draft")]
+            safe_aad: crate::framing::SafeAad::empty(),
+            group_state: MlsGroupState::Operational,
+            public_group,
+            group_epoch_secrets,
+            own_leaf_index,
+            message_secrets_store,
+            resumption_psk_store,
+            #[cfg(feature = "extensions-draft")]
+            application_export_tree: None,
+        };
+
+        // Parse and verify the external commit against the prior-epoch group.
+        // A PrivateMessage claiming our own leaf cannot be an external commit.
+        let processing::UnprotectedMessage::Unverified(unverified) =
+            group.unprotect_message(provider, external_commit)?
+        else {
+            return Err(Error::NotAnExternalCommit);
+        };
+        let verified = unverified
+            .verify(group.ciphersuite(), provider.crypto(), group.version())
+            .map_err(ProcessMessageError::from)?;
+        if !matches!(verified.content.sender(), Sender::NewMemberCommit) {
+            return Err(Error::NotAnExternalCommit);
+        }
+        let content = verified.content;
+        let FramedContentBody::Commit(commit) = content.content() else {
+            return Err(Error::NotAnExternalCommit);
+        };
+
+        // Check the commit's derivation info without consuming an operation
+        // secret generation: presence and the emulation epoch binding are
+        // validated here, decryption and the consume-once secret derivation
+        // happen in `PendingVcExternalCommitJoin::join`.
+        let derivation_info_bytes = commit
+            .path
+            .as_ref()
+            .and_then(|path| path.leaf_node().extensions().app_data_dictionary())
+            .and_then(|dict| dict.dictionary().get(&VC_COMPONENT_ID))
+            .ok_or(Error::MissingDerivationInfo)?;
+        let derivation_info = DerivationInfo::tls_deserialize_exact_bytes(derivation_info_bytes)
+            .map_err(|_| VirtualClientsError::DerivationInfoMalformed)?;
+        if derivation_info.epoch_id() != &epoch_id {
+            return Err(Error::EpochIdMismatch);
+        }
+
+        // The AppDataUpdate proposals covered by the commit, for the
+        // application to resolve before completing the join. The transient
+        // group's proposal store is empty, so only by-value proposals
+        // resolve. An external commit cannot reference proposals a
+        // non-member could hold.
+        let app_data_update_proposals =
+            committed_app_data_update_proposals(commit, group.proposal_store());
+
+        Ok(PendingVcExternalCommitJoin {
+            group,
+            content,
+            app_data_update_proposals,
+        })
+    }
+}
+
+/// A verified sibling external commit, ready to be joined. Returned by
+/// [`VcExternalCommitJoinBuilder::process_commit`].
+///
+/// The commit's signature has been verified against the prior-epoch group,
+/// so the proposals exposed here are authenticated. If the commit covers
+/// AppDataUpdate proposals, the application must interpret them (with the
+/// help of [`Self::app_data_dictionary_updater`]) and pass the resulting
+/// [`AppDataUpdates`] to [`Self::join`], exactly as it would for
+/// [`MlsGroup::resolve_app_data_commit`] when processing the same commit as
+/// a member.
+///
+/// Dropping this value discards the join. No operation secret generation is
+/// consumed before [`Self::join`], so a discarded join can be started over
+/// by processing the same commit again.
+#[cfg(feature = "virtual-clients-draft")]
+pub struct PendingVcExternalCommitJoin {
+    /// Transient reconstruction of the group at the prior epoch.
+    group: MlsGroup,
+    /// The verified commit content.
+    content: AuthenticatedContent,
+    /// The by-value AppDataUpdate proposals covered by the commit, sorted by
+    /// component id.
+    app_data_update_proposals: Vec<AppDataUpdateProposal>,
+}
+
+#[cfg(feature = "virtual-clients-draft")]
+impl PendingVcExternalCommitJoin {
+    /// Returns the AppDataUpdate proposals covered by the commit, sorted by
+    /// component id. The application interprets them to compute the
+    /// [`AppDataUpdates`] that [`Self::join`] requires.
+    pub fn app_data_update_proposals(&self) -> impl Iterator<Item = &AppDataUpdateProposal> {
+        self.app_data_update_proposals.iter()
+    }
+
+    /// Returns the AppEphemeral proposals for `component_id` that the commit
+    /// carries by value, in the order they appear in the commit, for example
+    /// to decide how to follow the join. Unlike
+    /// [`PublicMessageIn::unverified_app_ephemeral_proposals`], the returned
+    /// data is authenticated: the commit's signature has been verified.
+    ///
+    /// [`PublicMessageIn::unverified_app_ephemeral_proposals`]:
+    ///     crate::framing::PublicMessageIn::unverified_app_ephemeral_proposals
+    pub fn app_ephemeral_proposals(
+        &self,
+        component_id: ComponentId,
+    ) -> impl Iterator<Item = &AppEphemeralProposal> {
+        use crate::{
+            messages::proposals::{Proposal, ProposalOrRef},
+            prelude::mls_content::FramedContentBody,
+        };
+
+        let proposals = match self.content.content() {
+            FramedContentBody::Commit(commit) => commit.proposals.as_slice(),
+            // `process_commit` only constructs pending joins from commits.
+            _ => &[],
+        };
+        proposals
+            .iter()
+            .filter_map(move |proposal_or_ref| match proposal_or_ref {
+                ProposalOrRef::Proposal(proposal) => match proposal.as_ref() {
+                    Proposal::AppEphemeral(app_ephemeral)
+                        if app_ephemeral.component_id() == component_id =>
+                    {
+                        Some(app_ephemeral.as_ref())
+                    }
+                    _ => None,
+                },
+                ProposalOrRef::Reference(_) => None,
+            })
+    }
+
+    /// Returns a helper for computing the [`AppDataUpdates`], seeded with
+    /// the app data dictionary of the prior-epoch group context.
+    pub fn app_data_dictionary_updater(&self) -> AppDataDictionaryUpdater<'_> {
+        AppDataDictionaryUpdater::new(self.group.context().app_data_dict())
+    }
+
+    /// Completes the join. `app_data_updates` must be `Some` exactly when the
+    /// commit covers AppDataUpdate proposals. Absent updates are rejected
+    /// before the consume-once operation secret generation is spent, so the
+    /// join can be started over. Updates that do not reproduce the committing
+    /// sibling's dictionary fail with a confirmation tag mismatch after the
+    /// generation is consumed, so they should be computed deterministically
+    /// from the proposals rather than guessed.
+    pub fn join<Provider: OpenMlsProvider>(
+        self,
+        provider: &Provider,
+        app_data_updates: Option<AppDataUpdates>,
+    ) -> Result<MlsGroup, crate::group::errors::VcExternalCommitJoinError<Provider::StorageError>>
+    {
+        use crate::{
+            group::errors::{StageCommitError, VcExternalCommitJoinError as Error},
+            group::public_group::errors::ApplyAppDataUpdateError,
+            prelude::mls_content::FramedContentBody,
+        };
+
+        let Self {
+            mut group,
+            content,
+            app_data_update_proposals,
+        } = self;
+
+        // An application that has not resolved the commit's AppDataUpdate
+        // proposals yet is rejected before the operation secret generation
+        // is consumed, so it can compute the updates and process the commit
+        // again. Staging repeats this check. Superfluous updates are only
+        // rejected there.
+        if !app_data_update_proposals.is_empty() && app_data_updates.is_none() {
+            return Err(StageCommitError::ApplyAppDataUpdateError(
+                ApplyAppDataUpdateError::MissingAppDataUpdates,
+            )
+            .into());
+        }
+
+        let FramedContentBody::Commit(commit) = content.content() else {
+            // `process_commit` only constructs pending joins from commits.
+            return Err(LibraryError::custom("pending join without commit content").into());
+        };
+
+        // Recover the sibling-VC commit material (operation secret + emulation
+        // epoch id + carried external init secret) from the leaf's derivation
+        // info, then stage and merge the commit through the sibling-VC path.
+        let material = group
+            .load_vc_commit_material(provider, commit)?
+            .ok_or(Error::MissingDerivationInfo)?;
+        let staged = group.stage_commit_with_app_data_updates(
+            &content,
+            vec![],
+            vec![],
+            app_data_updates,
+            provider,
+            Some(material),
+        )?;
+        group.merge_staged_commit(provider, staged)?;
+        let deletion_policy = group.mls_group_config.past_epoch_deletion_policy().clone();
+        group.resize_message_secrets_store(&deletion_policy);
+        group
+            .store(provider.storage())
+            .map_err(Error::StorageError)?;
+        Ok(group)
     }
 }
 

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -1154,9 +1154,9 @@ impl MlsGroup {
 ///
 /// The join happens in two steps. [`Self::process_commit`] rebuilds the
 /// prior-epoch group and verifies the commit, returning a
-/// [`PendingVcExternalCommitJoin`]. The application inspects the verified
+/// [`StagedVcExternalCommitJoin`]. The application inspects the verified
 /// proposals it exposes, resolves any AppDataUpdate proposals, and completes
-/// the join with [`PendingVcExternalCommitJoin::join`].
+/// the join with [`StagedVcExternalCommitJoin::into_group`].
 #[cfg(feature = "virtual-clients-draft")]
 #[derive(Debug, Default)]
 pub struct VcExternalCommitJoinBuilder {
@@ -1205,7 +1205,7 @@ impl VcExternalCommitJoinBuilder {
     /// references the shared emulation epoch `epoch_id`.
     ///
     /// Nothing is consumed or persisted at this point. Dropping the returned
-    /// [`PendingVcExternalCommitJoin`] discards the join without advancing
+    /// [`StagedVcExternalCommitJoin`] discards the join without advancing
     /// the shared operation secret tree.
     pub fn process_commit<Provider: OpenMlsProvider>(
         self,
@@ -1214,7 +1214,7 @@ impl VcExternalCommitJoinBuilder {
         external_commit: impl Into<crate::framing::ProtocolMessage>,
         epoch_id: crate::components::vc_derivation_info::EpochId,
     ) -> Result<
-        PendingVcExternalCommitJoin,
+        StagedVcExternalCommitJoin,
         crate::group::errors::VcExternalCommitJoinError<Provider::StorageError>,
     > {
         use tls_codec::DeserializeBytes as _;
@@ -1318,7 +1318,7 @@ impl VcExternalCommitJoinBuilder {
         // Check the commit's derivation info without consuming an operation
         // secret generation: presence and the emulation epoch binding are
         // validated here, decryption and the consume-once secret derivation
-        // happen in `PendingVcExternalCommitJoin::join`.
+        // happen in `StagedVcExternalCommitJoin::into_group`.
         let derivation_info_bytes = commit
             .path
             .as_ref()
@@ -1339,10 +1339,11 @@ impl VcExternalCommitJoinBuilder {
         let app_data_update_proposals =
             committed_app_data_update_proposals(commit, group.proposal_store());
 
-        Ok(PendingVcExternalCommitJoin {
+        Ok(StagedVcExternalCommitJoin {
             group,
             content,
             app_data_update_proposals,
+            app_data_updates: None,
         })
     }
 }
@@ -1353,16 +1354,17 @@ impl VcExternalCommitJoinBuilder {
 /// The commit's signature has been verified against the prior-epoch group,
 /// so the proposals exposed here are authenticated. If the commit covers
 /// AppDataUpdate proposals, the application must interpret them (with the
-/// help of [`Self::app_data_dictionary_updater`]) and pass the resulting
-/// [`AppDataUpdates`] to [`Self::join`], exactly as it would for
+/// help of [`Self::app_data_dictionary_updater`]) and supply the resulting
+/// [`AppDataUpdates`] via [`Self::with_app_data_dictionary_updates`] before
+/// calling [`Self::into_group`], exactly as it would for
 /// [`MlsGroup::resolve_app_data_commit`] when processing the same commit as
 /// a member.
 ///
 /// Dropping this value discards the join. No operation secret generation is
-/// consumed before [`Self::join`], so a discarded join can be started over
-/// by processing the same commit again.
+/// consumed before [`Self::into_group`], so a discarded join can be started
+/// over by processing the same commit again.
 #[cfg(feature = "virtual-clients-draft")]
-pub struct PendingVcExternalCommitJoin {
+pub struct StagedVcExternalCommitJoin {
     /// Transient reconstruction of the group at the prior epoch.
     group: MlsGroup,
     /// The verified commit content.
@@ -1370,13 +1372,32 @@ pub struct PendingVcExternalCommitJoin {
     /// The by-value AppDataUpdate proposals covered by the commit, sorted by
     /// component id.
     app_data_update_proposals: Vec<AppDataUpdateProposal>,
+    /// The application-resolved updates for the commit's AppDataUpdate
+    /// proposals, if any.
+    app_data_updates: Option<AppDataUpdates>,
 }
 
 #[cfg(feature = "virtual-clients-draft")]
-impl PendingVcExternalCommitJoin {
+impl StagedVcExternalCommitJoin {
+    /// Returns the [`GroupContext`] of the group at the epoch *before* the
+    /// external commit. The commit's changes (including any AppDataUpdate
+    /// proposals) are not applied to it. The joined group's context is
+    /// available on the [`MlsGroup`] returned by [`Self::into_group`].
+    pub fn prior_group_context(&self) -> &GroupContext {
+        self.group.context()
+    }
+
+    /// Returns an iterator over the [`Member`]s of the group at the epoch
+    /// *before* the external commit. The commit's changes are not applied:
+    /// the committing sibling's virtual-client leaf is absent and members
+    /// the commit inline-removes are still present.
+    pub fn prior_members(&self) -> impl Iterator<Item = Member> + '_ {
+        self.group.members()
+    }
+
     /// Returns the AppDataUpdate proposals covered by the commit, sorted by
     /// component id. The application interprets them to compute the
-    /// [`AppDataUpdates`] that [`Self::join`] requires.
+    /// [`AppDataUpdates`] that [`Self::into_group`] requires.
     pub fn app_data_update_proposals(&self) -> impl Iterator<Item = &AppDataUpdateProposal> {
         self.app_data_update_proposals.iter()
     }
@@ -1389,7 +1410,7 @@ impl PendingVcExternalCommitJoin {
     ///
     /// [`PublicMessageIn::unverified_app_ephemeral_proposals`]:
     ///     crate::framing::PublicMessageIn::unverified_app_ephemeral_proposals
-    pub fn app_ephemeral_proposals(
+    pub fn app_ephemeral_proposals_for_component_id(
         &self,
         component_id: ComponentId,
     ) -> impl Iterator<Item = &AppEphemeralProposal> {
@@ -1400,7 +1421,7 @@ impl PendingVcExternalCommitJoin {
 
         let proposals = match self.content.content() {
             FramedContentBody::Commit(commit) => commit.proposals.as_slice(),
-            // `process_commit` only constructs pending joins from commits.
+            // `process_commit` only constructs staged joins from commits.
             _ => &[],
         };
         proposals
@@ -1424,17 +1445,24 @@ impl PendingVcExternalCommitJoin {
         AppDataDictionaryUpdater::new(self.group.context().app_data_dict())
     }
 
-    /// Completes the join. `app_data_updates` must be `Some` exactly when the
-    /// commit covers AppDataUpdate proposals. Absent updates are rejected
-    /// before the consume-once operation secret generation is spent, so the
-    /// join can be started over. Updates that do not reproduce the committing
-    /// sibling's dictionary fail with a confirmation tag mismatch after the
-    /// generation is consumed, so they should be computed deterministically
-    /// from the proposals rather than guessed.
-    pub fn join<Provider: OpenMlsProvider>(
+    /// Sets the [`AppDataUpdates`] that contain the changes made by the
+    /// commit's AppDataUpdate proposals. Updates must be set exactly when
+    /// the commit covers AppDataUpdate proposals.
+    pub fn with_app_data_dictionary_updates(&mut self, app_data_updates: Option<AppDataUpdates>) {
+        self.app_data_updates = app_data_updates;
+    }
+
+    /// Completes the join and returns the joined [`MlsGroup`]. If the commit
+    /// covers AppDataUpdate proposals, the resolved updates must have been
+    /// set via [`Self::with_app_data_dictionary_updates`]. Absent updates
+    /// are rejected before the consume-once operation secret generation is
+    /// spent, so the join can be started over. Updates that do not reproduce
+    /// the committing sibling's dictionary fail with a confirmation tag
+    /// mismatch after the generation is consumed, so they should be computed
+    /// deterministically from the proposals rather than guessed.
+    pub fn into_group<Provider: OpenMlsProvider>(
         self,
         provider: &Provider,
-        app_data_updates: Option<AppDataUpdates>,
     ) -> Result<MlsGroup, crate::group::errors::VcExternalCommitJoinError<Provider::StorageError>>
     {
         use crate::{
@@ -1447,6 +1475,7 @@ impl PendingVcExternalCommitJoin {
             mut group,
             content,
             app_data_update_proposals,
+            app_data_updates,
         } = self;
 
         // An application that has not resolved the commit's AppDataUpdate
@@ -1462,8 +1491,8 @@ impl PendingVcExternalCommitJoin {
         }
 
         let FramedContentBody::Commit(commit) = content.content() else {
-            // `process_commit` only constructs pending joins from commits.
-            return Err(LibraryError::custom("pending join without commit content").into());
+            // `process_commit` only constructs staged joins from commits.
+            return Err(LibraryError::custom("staged join without commit content").into());
         };
 
         // Recover the sibling-VC commit material (operation secret + emulation

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -9,7 +9,7 @@ use openmls::{
     framing::errors::{MessageDecryptionError, SecretTreeError},
     group::{
         AppDataUpdates, ConfirmMessageError, GroupEpoch, MlsGroup, MlsGroupCreateConfig,
-        MlsGroupJoinConfig, PendingVcExternalCommitJoin, Propose, StageCommitError, StagedWelcome,
+        MlsGroupJoinConfig, Propose, StageCommitError, StagedVcExternalCommitJoin, StagedWelcome,
         VcExternalCommitJoinError, MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY,
         PURE_CIPHERTEXT_WIRE_FORMAT_POLICY, PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
     },
@@ -1658,7 +1658,7 @@ fn vc_second_emulator_client_onboards_via_external_commit() {
             epoch_id_b.clone(),
         )
         .expect("process charly_a's external commit")
-        .join(&charly_b_provider, None)
+        .into_group(&charly_b_provider)
         .expect("charly_b bootstraps by processing charly_a's external commit");
     let err = charly_b_main
         .process_message(
@@ -1966,7 +1966,7 @@ fn vc_sibling_reads_app_ephemeral_from_external_commit() {
             epoch_id_b.clone(),
         )
         .expect("process charly_a's external commit")
-        .join(&charly_b_provider, None)
+        .into_group(&charly_b_provider)
         .expect("charly_b bootstraps by processing charly_a's external commit");
 
     assert!(charly_a_main.is_active() && charly_b_main.is_active());
@@ -2235,13 +2235,13 @@ fn resolve_and_merge_app_data_commit<P: OpenMlsProvider>(
         .expect("merge app data commit");
 }
 
-/// Reads the verified AppDataUpdate proposals from a pending sibling join,
+/// Reads the verified AppDataUpdate proposals from a staged sibling join,
 /// checks they carry the expected payload, and computes the resolved updates
 /// the join needs, the way an application's component logic would.
 fn sibling_resolved_app_data_updates(
-    pending: &PendingVcExternalCommitJoin,
+    staged: &StagedVcExternalCommitJoin,
 ) -> Option<AppDataUpdates> {
-    let proposals: Vec<_> = pending.app_data_update_proposals().collect();
+    let proposals: Vec<_> = staged.app_data_update_proposals().collect();
     assert_eq!(proposals.len(), 1);
     assert_eq!(proposals[0].component_id(), APP_DATA_COMPONENT_ID);
     let AppDataUpdateOperation::Update(payload) = proposals[0].operation() else {
@@ -2251,7 +2251,7 @@ fn sibling_resolved_app_data_updates(
 
     // No dictionary exists in the prior-epoch group context yet, so the
     // component computes the value from the payload alone.
-    let mut updater = pending.app_data_dictionary_updater();
+    let mut updater = staged.app_data_dictionary_updater();
     assert!(updater.old_value(APP_DATA_COMPONENT_ID).is_none());
     updater.set(ComponentData::from_parts(
         APP_DATA_COMPONENT_ID,
@@ -2286,7 +2286,7 @@ fn vc_sibling_external_commit_join_resolves_app_data_updates() {
 
     // charly_b computes the same updates from the verified commit's
     // proposals and completes the join with them.
-    let pending = MlsGroup::vc_external_commit_join_builder()
+    let mut staged = MlsGroup::vc_external_commit_join_builder()
         .with_config(vc_join_config())
         .process_commit(
             &scenario.charly_b_provider,
@@ -2295,10 +2295,18 @@ fn vc_sibling_external_commit_join_resolves_app_data_updates() {
             scenario.epoch_id.clone(),
         )
         .expect("process charly_a's external commit");
-    let updates = sibling_resolved_app_data_updates(&pending);
-    let charly_b_main = pending
-        .join(&scenario.charly_b_provider, updates)
+
+    // The staged join exposes the group state at the epoch before the
+    // commit: Alice and Bob, without the virtual-client leaf.
+    let prior_epoch = staged.prior_group_context().epoch();
+    assert_eq!(staged.prior_members().count(), 2);
+
+    let updates = sibling_resolved_app_data_updates(&staged);
+    staged.with_app_data_dictionary_updates(updates);
+    let charly_b_main = staged
+        .into_group(&scenario.charly_b_provider)
         .expect("charly_b joins with resolved app data updates");
+    assert_eq!(charly_b_main.epoch().as_u64(), prior_epoch.as_u64() + 1);
 
     assert!(charly_a_main.is_active() && charly_b_main.is_active());
     assert_eq!(
@@ -2369,7 +2377,7 @@ fn vc_sibling_external_commit_join_with_app_data_update_and_app_ephemeral() {
 
     // charly_b reads both payloads from the verified commit before deciding
     // to complete the join.
-    let pending = MlsGroup::vc_external_commit_join_builder()
+    let mut staged = MlsGroup::vc_external_commit_join_builder()
         .with_config(vc_join_config())
         .process_commit(
             &scenario.charly_b_provider,
@@ -2378,15 +2386,16 @@ fn vc_sibling_external_commit_join_with_app_data_update_and_app_ephemeral() {
             scenario.epoch_id.clone(),
         )
         .expect("process charly_a's external commit");
-    let app_ephemeral: Vec<_> = pending
-        .app_ephemeral_proposals(APP_EPHEMERAL_COMPONENT_ID)
+    let app_ephemeral: Vec<_> = staged
+        .app_ephemeral_proposals_for_component_id(APP_EPHEMERAL_COMPONENT_ID)
         .collect();
     assert_eq!(app_ephemeral.len(), 1);
     assert_eq!(app_ephemeral[0].data(), APP_EPHEMERAL_DATA);
-    let updates = sibling_resolved_app_data_updates(&pending);
+    let updates = sibling_resolved_app_data_updates(&staged);
+    staged.with_app_data_dictionary_updates(updates);
 
-    let charly_b_main = pending
-        .join(&scenario.charly_b_provider, updates)
+    let charly_b_main = staged
+        .into_group(&scenario.charly_b_provider)
         .expect("charly_b joins a commit carrying AppDataUpdate and AppEphemeral");
 
     assert!(charly_a_main.is_active() && charly_b_main.is_active());
@@ -2425,7 +2434,7 @@ fn vc_sibling_external_commit_join_without_app_data_updates_fails() {
     let (charly_a_main, commit) =
         charly_a_external_commit_with_app_data_update(&scenario, vgi_charly_a, None);
 
-    let pending = MlsGroup::vc_external_commit_join_builder()
+    let staged = MlsGroup::vc_external_commit_join_builder()
         .with_config(vc_join_config())
         .process_commit(
             &scenario.charly_b_provider,
@@ -2434,8 +2443,8 @@ fn vc_sibling_external_commit_join_without_app_data_updates_fails() {
             scenario.epoch_id.clone(),
         )
         .expect("process charly_a's external commit");
-    let err = pending
-        .join(&scenario.charly_b_provider, None)
+    let err = staged
+        .into_group(&scenario.charly_b_provider)
         .expect_err("joining without the resolved updates must fail");
     let VcExternalCommitJoinError::StageCommitError(StageCommitError::ApplyAppDataUpdateError(
         ApplyAppDataUpdateError::MissingAppDataUpdates,
@@ -2447,7 +2456,7 @@ fn vc_sibling_external_commit_join_without_app_data_updates_fails() {
     // The failed attempt did not consume an operation secret generation, so
     // processing the same commit again and joining with the resolved updates
     // succeeds.
-    let pending = MlsGroup::vc_external_commit_join_builder()
+    let mut staged = MlsGroup::vc_external_commit_join_builder()
         .with_config(vc_join_config())
         .process_commit(
             &scenario.charly_b_provider,
@@ -2456,9 +2465,10 @@ fn vc_sibling_external_commit_join_without_app_data_updates_fails() {
             scenario.epoch_id.clone(),
         )
         .expect("process charly_a's external commit again");
-    let updates = sibling_resolved_app_data_updates(&pending);
-    let charly_b_main = pending
-        .join(&scenario.charly_b_provider, updates)
+    let updates = sibling_resolved_app_data_updates(&staged);
+    staged.with_app_data_dictionary_updates(updates);
+    let charly_b_main = staged
+        .into_group(&scenario.charly_b_provider)
         .expect("retry with resolved updates succeeds");
     assert_eq!(
         charly_b_main.epoch_authenticator(),
@@ -2478,7 +2488,7 @@ fn vc_sibling_external_commit_join_with_wrong_app_data_updates_fails() {
     let (_charly_a_main, commit) =
         charly_a_external_commit_with_app_data_update(&scenario, vgi_charly_a, None);
 
-    let pending = MlsGroup::vc_external_commit_join_builder()
+    let mut staged = MlsGroup::vc_external_commit_join_builder()
         .with_config(vc_join_config())
         .process_commit(
             &scenario.charly_b_provider,
@@ -2487,14 +2497,15 @@ fn vc_sibling_external_commit_join_with_wrong_app_data_updates_fails() {
             scenario.epoch_id.clone(),
         )
         .expect("process charly_a's external commit");
-    let mut updater = pending.app_data_dictionary_updater();
+    let mut updater = staged.app_data_dictionary_updater();
     updater.set(ComponentData::from_parts(
         APP_DATA_COMPONENT_ID,
         b"a different value".to_vec().into(),
     ));
     let updates = updater.changes();
-    let err = pending
-        .join(&scenario.charly_b_provider, updates)
+    staged.with_app_data_dictionary_updates(updates);
+    let err = staged
+        .into_group(&scenario.charly_b_provider)
         .expect_err("joining with wrong updates must fail");
     let VcExternalCommitJoinError::StageCommitError(StageCommitError::ConfirmationTagMismatch) =
         err

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "virtual-clients-draft")]
 use openmls::{
+    component::{ComponentData, ComponentId},
     components::vc_derivation_info::{EpochId, VcEmulationBindings, VC_COMPONENT_ID},
     credentials::NewSignerBundle,
     extensions::{
@@ -7,15 +8,22 @@ use openmls::{
     },
     framing::errors::{MessageDecryptionError, SecretTreeError},
     group::{
-        ConfirmMessageError, GroupEpoch, MlsGroup, MlsGroupCreateConfig, MlsGroupJoinConfig,
-        Propose, StagedWelcome, MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY,
+        AppDataUpdates, ConfirmMessageError, GroupEpoch, MlsGroup, MlsGroupCreateConfig,
+        MlsGroupJoinConfig, PendingVcExternalCommitJoin, Propose, StageCommitError, StagedWelcome,
+        VcExternalCommitJoinError, MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY,
         PURE_CIPHERTEXT_WIRE_FORMAT_POLICY, PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
     },
     key_packages::KeyPackage,
+    messages::{
+        group_info::VerifiableGroupInfo,
+        proposals::{
+            AppDataUpdateOperation, AppDataUpdateProposal, AppEphemeralProposal, Proposal,
+        },
+    },
     prelude::{
-        test_utils::new_credential, Capabilities, LeafNode, LeafNodeParameters,
-        ProcessMessageError, ProcessedMessageContent, ProposalOrRefType, ProposalType,
-        ValidationError,
+        test_utils::new_credential, ApplyAppDataUpdateError, Capabilities, LeafNode,
+        LeafNodeParameters, ProcessMessageError, ProcessedMessageContent, ProposalOrRefType,
+        ProposalType, ProtocolMessage, ValidationError,
     },
 };
 use openmls_basic_credential::SignatureKeyPair;
@@ -1455,8 +1463,8 @@ fn vc_sibling_emulator_resyncs_into_higher_level_group_via_external_commit() {
 /// `charly_a` joins the higher-level group (Alice + Bob) via a plain external
 /// commit. Per the mls-virtual-clients draft the commit's leaf carries the
 /// external init secret in its derivation info. `charly_b`, which shares the
-/// emulation epoch but is not a member, calls
-/// [`MlsGroup::vc_join_via_sibling_external_commit`] with the prior-epoch
+/// emulation epoch but is not a member, runs the
+/// [`VcExternalCommitJoinBuilder`] with the prior-epoch
 /// GroupInfo and that commit: it rebuilds the prior-epoch public group,
 /// recreates the commit path from the shared operation secret tree, and uses
 /// the carried external init secret as the new epoch's external init secret
@@ -1641,15 +1649,17 @@ fn vc_second_emulator_client_onboards_via_external_commit() {
         .use_ratchet_tree_extension(true)
         .max_past_epochs(1)
         .build();
-    let mut charly_b_main = MlsGroup::vc_join_via_sibling_external_commit(
-        &charly_b_provider,
-        &bootstrap_join_config,
-        vgi_charly_b,
-        None,
-        charly_a_commit_for_b,
-        epoch_id_b.clone(),
-    )
-    .expect("charly_b bootstraps by processing charly_a's external commit");
+    let mut charly_b_main = MlsGroup::vc_external_commit_join_builder()
+        .with_config(bootstrap_join_config)
+        .process_commit(
+            &charly_b_provider,
+            vgi_charly_b,
+            charly_a_commit_for_b,
+            epoch_id_b.clone(),
+        )
+        .expect("process charly_a's external commit")
+        .join(&charly_b_provider, None)
+        .expect("charly_b bootstraps by processing charly_a's external commit");
     let err = charly_b_main
         .process_message(
             &charly_b_provider,
@@ -1727,8 +1737,8 @@ fn vc_app_ephemeral_capabilities() -> Capabilities {
 ///
 /// `charly_a` joins the higher-level group (Alice + Bob) via an external commit
 /// carrying the proposal. `charly_b` reads the payload out of that commit while
-/// it is still an outsider, then bootstraps into the group with
-/// [`MlsGroup::vc_join_via_sibling_external_commit`]. Alice and Bob find the
+/// it is still an outsider, then bootstraps into the group with the
+/// [`VcExternalCommitJoinBuilder`]. Alice and Bob find the
 /// same payload in the staged commit, and all four parties converge.
 #[openmls_test]
 fn vc_sibling_reads_app_ephemeral_from_external_commit() {
@@ -1947,15 +1957,17 @@ fn vc_sibling_reads_app_ephemeral_from_external_commit() {
         .use_ratchet_tree_extension(true)
         .max_past_epochs(1)
         .build();
-    let charly_b_main = MlsGroup::vc_join_via_sibling_external_commit(
-        &charly_b_provider,
-        &bootstrap_join_config,
-        vgi_charly_b,
-        None,
-        charly_a_commit_for_b,
-        epoch_id_b.clone(),
-    )
-    .expect("charly_b bootstraps by processing charly_a's external commit");
+    let charly_b_main = MlsGroup::vc_external_commit_join_builder()
+        .with_config(bootstrap_join_config)
+        .process_commit(
+            &charly_b_provider,
+            vgi_charly_b,
+            charly_a_commit_for_b,
+            epoch_id_b.clone(),
+        )
+        .expect("process charly_a's external commit")
+        .join(&charly_b_provider, None)
+        .expect("charly_b bootstraps by processing charly_a's external commit");
 
     assert!(charly_a_main.is_active() && charly_b_main.is_active());
     assert_eq!(
@@ -1967,6 +1979,528 @@ fn vc_sibling_reads_app_ephemeral_from_external_commit() {
     assert_eq!(charly_a_main.epoch_authenticator(), auth);
     assert_eq!(alice_main.epoch_authenticator(), auth);
     assert_eq!(bob_main.epoch_authenticator(), auth);
+}
+
+/// The VC capabilities, extended with support for the AppDataUpdate and
+/// AppEphemeral proposal types. All leaves of a group need this before
+/// anyone may commit such proposals.
+fn vc_app_data_update_capabilities() -> Capabilities {
+    Capabilities::builder()
+        .extensions(vec![ExtensionType::AppDataDictionary])
+        .proposals(vec![
+            ProposalType::AppDataUpdate,
+            ProposalType::AppEphemeral,
+        ])
+        .build()
+}
+
+/// The group-context component the AppDataUpdate join tests below bump on
+/// the external commit. The proposal payload deliberately differs from the
+/// resulting dictionary value: the value is computed by the application from
+/// the payload, not copied from it, so the tests prove the applied value
+/// comes from the supplied updates.
+const APP_DATA_COMPONENT_ID: ComponentId = 0xf042;
+const APP_DATA_PROPOSAL_PAYLOAD: &[u8] = b"proposal payload";
+const APP_DATA_DICT_VALUE: &[u8] = b"caller computed value";
+
+/// Scenario for sibling joins of external commits carrying AppDataUpdate
+/// proposals: Alice and Bob form the higher-level group (every leaf supports
+/// the AppDataUpdate and AppEphemeral proposal types), and Charly is a
+/// virtual client with two emulator clients sharing an emulation epoch.
+struct VcAppDataScenario<P: OpenMlsProvider> {
+    alice_provider: P,
+    bob_provider: P,
+    charly_a_provider: P,
+    charly_b_provider: P,
+    alice_main: MlsGroup,
+    alice_signer: SignatureKeyPair,
+    bob_main: MlsGroup,
+    vc_signer: SignatureKeyPair,
+    vc_credential: openmls::credentials::CredentialWithKey,
+    epoch_id: EpochId,
+}
+
+fn vc_app_data_scenario<P: OpenMlsProvider + Default>(
+    ciphersuite: openmls_traits::types::Ciphersuite,
+) -> VcAppDataScenario<P> {
+    let alice_provider = P::default();
+    let bob_provider = P::default();
+    let charly_a_provider = P::default();
+    let charly_b_provider = P::default();
+
+    // Alice founds the higher-level group and adds Bob.
+    let (alice_credential, alice_signer) =
+        new_credential(&alice_provider, b"Alice", ciphersuite.signature_algorithm());
+    let main_group_config = MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .capabilities(vc_app_data_update_capabilities())
+        .with_leaf_node_extensions(vc_leaf_extensions())
+        .expect("attach leaf-node extensions")
+        .build();
+    let mut alice_main = MlsGroup::new(
+        &alice_provider,
+        &alice_signer,
+        &main_group_config,
+        alice_credential,
+    )
+    .expect("create vc main group");
+
+    let (bob_credential, bob_signer) =
+        new_credential(&bob_provider, b"Bob", ciphersuite.signature_algorithm());
+    let bob_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .leaf_node_capabilities(vc_app_data_update_capabilities())
+        .leaf_node_extensions(vc_leaf_extensions())
+        .build(ciphersuite, &bob_provider, &bob_signer, bob_credential)
+        .expect("bob KP build")
+        .key_package()
+        .to_owned();
+    let (_, welcome, _) = alice_main
+        .add_members(&alice_provider, &alice_signer, &[bob_kp])
+        .expect("alice add bob");
+    alice_main
+        .merge_pending_commit(&alice_provider)
+        .expect("alice merge add bob");
+    let bob_main = StagedWelcome::new_from_welcome(
+        &bob_provider,
+        &vc_join_config(),
+        welcome.into_welcome().expect("welcome"),
+        Some(alice_main.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(&bob_provider))
+    .expect("bob join higher-level group");
+
+    // Charly is one virtual client with two emulator clients sharing a
+    // signing identity and an emulation epoch.
+    let (vc_signer, vc_credential) =
+        shared_vc_identity(ciphersuite, &charly_a_provider, &charly_b_provider);
+    let (mut emulator_a, emulator_a_signer) =
+        make_emulator_group(ciphersuite, &charly_a_provider, b"CharlyEmulatorA");
+    let (emulator_b_credential, emulator_b_signer) = new_credential(
+        &charly_b_provider,
+        b"CharlyEmulatorB",
+        ciphersuite.signature_algorithm(),
+    );
+    let emulator_b_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_extensions(vc_leaf_extensions())
+        .build(
+            ciphersuite,
+            &charly_b_provider,
+            &emulator_b_signer,
+            emulator_b_credential,
+        )
+        .expect("charly_b emulator KP build")
+        .key_package()
+        .to_owned();
+    let (_, e_welcome, _) = emulator_a
+        .add_members(&charly_a_provider, &emulator_a_signer, &[emulator_b_kp])
+        .expect("emulator_a add charly_b");
+    emulator_a
+        .merge_pending_commit(&charly_a_provider)
+        .expect("emulator_a merge add");
+    let mut emulator_b = StagedWelcome::new_from_welcome(
+        &charly_b_provider,
+        &vc_join_config(),
+        e_welcome.into_welcome().expect("emulator welcome"),
+        Some(emulator_a.export_ratchet_tree().into()),
+    )
+    .and_then(|s| s.into_group(&charly_b_provider))
+    .expect("charly_b join emulator group");
+    let epoch_id = emulator_a
+        .register_vc_emulation_epoch(charly_a_provider.crypto(), charly_a_provider.storage())
+        .expect("charly_a register vc epoch");
+    let epoch_id_b = emulator_b
+        .register_vc_emulation_epoch(charly_b_provider.crypto(), charly_b_provider.storage())
+        .expect("charly_b register vc epoch");
+    assert_eq!(
+        epoch_id, epoch_id_b,
+        "siblings must derive the same EpochId"
+    );
+
+    VcAppDataScenario {
+        alice_provider,
+        bob_provider,
+        charly_a_provider,
+        charly_b_provider,
+        alice_main,
+        alice_signer,
+        bob_main,
+        vc_signer,
+        vc_credential,
+        epoch_id,
+    }
+}
+
+impl<P: OpenMlsProvider> VcAppDataScenario<P> {
+    /// Exports the prior-epoch GroupInfo (with the ratchet tree carried as an
+    /// extension) for one of the parties consuming it.
+    fn export_prior_epoch_vgi(&self, label: &str) -> VerifiableGroupInfo {
+        use tls_codec::Deserialize as _;
+        let gi = self
+            .alice_main
+            .export_group_info(self.alice_provider.crypto(), &self.alice_signer, true)
+            .unwrap_or_else(|_| panic!("export group info ({label})"));
+        let serialized = gi.tls_serialize_detached().expect("serialize gi");
+        openmls::prelude::MlsMessageIn::tls_deserialize(&mut serialized.as_slice())
+            .expect("deserialize gi")
+            .into_verifiable_group_info()
+            .expect("into vgi")
+    }
+}
+
+/// charly_a joins the higher-level group via an external commit carrying a
+/// by-value AppDataUpdate proposal for [`APP_DATA_COMPONENT_ID`], with the
+/// dictionary value computed by the application, and optionally a by-value
+/// AppEphemeral proposal. Returns charly_a's joined group and the commit for
+/// the other parties to process.
+fn charly_a_external_commit_with_app_data_update<P: OpenMlsProvider>(
+    scenario: &VcAppDataScenario<P>,
+    vgi: VerifiableGroupInfo,
+    app_ephemeral: Option<AppEphemeralProposal>,
+) -> (MlsGroup, openmls::prelude::MlsMessageOut) {
+    let provider = &scenario.charly_a_provider;
+    let mut builder = MlsGroup::external_commit_builder()
+        .with_config(vc_join_config())
+        .build_group(provider, vgi, scenario.vc_credential.clone())
+        .expect("build_group charly_a")
+        .leaf_node_parameters(
+            LeafNodeParameters::builder()
+                .with_capabilities(vc_app_data_update_capabilities())
+                .with_extensions(vc_leaf_extensions())
+                .build(),
+        )
+        .vc_emulation(
+            provider.crypto(),
+            provider.storage(),
+            scenario.epoch_id.clone(),
+        )
+        .expect("vc emulation charly_a")
+        .add_app_data_update_proposal(AppDataUpdateProposal::update(
+            APP_DATA_COMPONENT_ID,
+            APP_DATA_PROPOSAL_PAYLOAD,
+        ));
+    if let Some(proposal) = app_ephemeral {
+        builder = builder.add_proposal(Proposal::AppEphemeral(Box::new(proposal)));
+    }
+    let mut builder = builder.load_psks(provider.storage()).expect("load psks");
+    let mut updater = builder.app_data_dictionary_updater();
+    updater.set(ComponentData::from_parts(
+        APP_DATA_COMPONENT_ID,
+        APP_DATA_DICT_VALUE.to_vec().into(),
+    ));
+    builder.with_app_data_dictionary_updates(updater.changes());
+    let (charly_a_main, bundle) = builder
+        .build(
+            provider.rand(),
+            provider.crypto(),
+            &scenario.vc_signer,
+            |_| true,
+        )
+        .expect("build external commit charly_a")
+        .finalize(provider)
+        .expect("finalize charly_a join");
+    (charly_a_main, bundle.into_commit())
+}
+
+/// Processes `commit` on `group`, resolves the expected AppDataUpdate
+/// proposal for [`APP_DATA_COMPONENT_ID`] to [`APP_DATA_DICT_VALUE`], and
+/// merges the resulting staged commit. This is the regular member-side
+/// resolution flow the sibling join must reproduce.
+fn resolve_and_merge_app_data_commit<P: OpenMlsProvider>(
+    group: &mut MlsGroup,
+    provider: &P,
+    commit: ProtocolMessage,
+) {
+    let processed = group
+        .process_message(provider, commit)
+        .expect("process app data commit");
+    let ProcessedMessageContent::UnresolvedAppDataCommit(unresolved) = processed.into_content()
+    else {
+        panic!("expected an unresolved app data commit");
+    };
+    let mut updater = group.app_data_dictionary_updater();
+    updater.set(ComponentData::from_parts(
+        APP_DATA_COMPONENT_ID,
+        APP_DATA_DICT_VALUE.to_vec().into(),
+    ));
+    let staged = group
+        .stage_app_data_commit(provider, *unresolved, updater.changes())
+        .expect("stage app data commit");
+    group
+        .merge_staged_commit(provider, staged)
+        .expect("merge app data commit");
+}
+
+/// Reads the verified AppDataUpdate proposals from a pending sibling join,
+/// checks they carry the expected payload, and computes the resolved updates
+/// the join needs, the way an application's component logic would.
+fn sibling_resolved_app_data_updates(
+    pending: &PendingVcExternalCommitJoin,
+) -> Option<AppDataUpdates> {
+    let proposals: Vec<_> = pending.app_data_update_proposals().collect();
+    assert_eq!(proposals.len(), 1);
+    assert_eq!(proposals[0].component_id(), APP_DATA_COMPONENT_ID);
+    let AppDataUpdateOperation::Update(payload) = proposals[0].operation() else {
+        panic!("expected an update operation");
+    };
+    assert_eq!(payload.as_slice(), APP_DATA_PROPOSAL_PAYLOAD);
+
+    // No dictionary exists in the prior-epoch group context yet, so the
+    // component computes the value from the payload alone.
+    let mut updater = pending.app_data_dictionary_updater();
+    assert!(updater.old_value(APP_DATA_COMPONENT_ID).is_none());
+    updater.set(ComponentData::from_parts(
+        APP_DATA_COMPONENT_ID,
+        APP_DATA_DICT_VALUE.to_vec().into(),
+    ));
+    updater.changes()
+}
+
+/// A sibling join of an external commit carrying an AppDataUpdate proposal:
+/// the application supplies the resolved updates, the join succeeds, and the
+/// joined group's context matches the committing sibling's byte for byte.
+#[openmls_test]
+fn vc_sibling_external_commit_join_resolves_app_data_updates() {
+    let mut scenario = vc_app_data_scenario::<Provider>(ciphersuite);
+    let vgi_charly_a = scenario.export_prior_epoch_vgi("charly_a");
+    let vgi_charly_b = scenario.export_prior_epoch_vgi("charly_b");
+
+    let (charly_a_main, commit) =
+        charly_a_external_commit_with_app_data_update(&scenario, vgi_charly_a, None);
+
+    // Alice and Bob resolve the commit through the regular member flow.
+    resolve_and_merge_app_data_commit(
+        &mut scenario.alice_main,
+        &scenario.alice_provider,
+        commit.clone().into_protocol_message().expect("commit"),
+    );
+    resolve_and_merge_app_data_commit(
+        &mut scenario.bob_main,
+        &scenario.bob_provider,
+        commit.clone().into_protocol_message().expect("commit"),
+    );
+
+    // charly_b computes the same updates from the verified commit's
+    // proposals and completes the join with them.
+    let pending = MlsGroup::vc_external_commit_join_builder()
+        .with_config(vc_join_config())
+        .process_commit(
+            &scenario.charly_b_provider,
+            vgi_charly_b,
+            commit.into_protocol_message().expect("commit"),
+            scenario.epoch_id.clone(),
+        )
+        .expect("process charly_a's external commit");
+    let updates = sibling_resolved_app_data_updates(&pending);
+    let charly_b_main = pending
+        .join(&scenario.charly_b_provider, updates)
+        .expect("charly_b joins with resolved app data updates");
+
+    assert!(charly_a_main.is_active() && charly_b_main.is_active());
+    assert_eq!(
+        charly_b_main.own_leaf_index(),
+        charly_a_main.own_leaf_index(),
+        "the bootstrapped sibling must land on the shared VC leaf"
+    );
+    let auth = charly_b_main.epoch_authenticator();
+    assert_eq!(charly_a_main.epoch_authenticator(), auth);
+    assert_eq!(scenario.alice_main.epoch_authenticator(), auth);
+    assert_eq!(scenario.bob_main.epoch_authenticator(), auth);
+
+    // The joined group's context matches the committing sibling's byte for
+    // byte, and its dictionary carries the caller-computed value.
+    assert_eq!(
+        charly_b_main
+            .export_group_context()
+            .tls_serialize_detached()
+            .expect("serialize charly_b context"),
+        charly_a_main
+            .export_group_context()
+            .tls_serialize_detached()
+            .expect("serialize charly_a context"),
+    );
+    let dictionary = charly_b_main
+        .export_group_context()
+        .extensions()
+        .app_data_dictionary()
+        .expect("joined context carries the dictionary")
+        .dictionary();
+    assert_eq!(
+        dictionary.get(&APP_DATA_COMPONENT_ID),
+        Some(APP_DATA_DICT_VALUE)
+    );
+}
+
+/// An external commit carrying both an AppDataUpdate proposal and a by-value
+/// AppEphemeral proposal: the sibling reads both payloads while still an
+/// outsider and the join succeeds with the resolved updates.
+#[openmls_test]
+fn vc_sibling_external_commit_join_with_app_data_update_and_app_ephemeral() {
+    const APP_EPHEMERAL_COMPONENT_ID: ComponentId = 7;
+    const APP_EPHEMERAL_DATA: &[u8] = b"wrapped key material";
+
+    let mut scenario = vc_app_data_scenario::<Provider>(ciphersuite);
+    let vgi_charly_a = scenario.export_prior_epoch_vgi("charly_a");
+    let vgi_charly_b = scenario.export_prior_epoch_vgi("charly_b");
+
+    let (charly_a_main, commit) = charly_a_external_commit_with_app_data_update(
+        &scenario,
+        vgi_charly_a,
+        Some(AppEphemeralProposal::new(
+            APP_EPHEMERAL_COMPONENT_ID,
+            APP_EPHEMERAL_DATA.to_vec(),
+        )),
+    );
+
+    resolve_and_merge_app_data_commit(
+        &mut scenario.alice_main,
+        &scenario.alice_provider,
+        commit.clone().into_protocol_message().expect("commit"),
+    );
+    resolve_and_merge_app_data_commit(
+        &mut scenario.bob_main,
+        &scenario.bob_provider,
+        commit.clone().into_protocol_message().expect("commit"),
+    );
+
+    // charly_b reads both payloads from the verified commit before deciding
+    // to complete the join.
+    let pending = MlsGroup::vc_external_commit_join_builder()
+        .with_config(vc_join_config())
+        .process_commit(
+            &scenario.charly_b_provider,
+            vgi_charly_b,
+            commit.into_protocol_message().expect("commit"),
+            scenario.epoch_id.clone(),
+        )
+        .expect("process charly_a's external commit");
+    let app_ephemeral: Vec<_> = pending
+        .app_ephemeral_proposals(APP_EPHEMERAL_COMPONENT_ID)
+        .collect();
+    assert_eq!(app_ephemeral.len(), 1);
+    assert_eq!(app_ephemeral[0].data(), APP_EPHEMERAL_DATA);
+    let updates = sibling_resolved_app_data_updates(&pending);
+
+    let charly_b_main = pending
+        .join(&scenario.charly_b_provider, updates)
+        .expect("charly_b joins a commit carrying AppDataUpdate and AppEphemeral");
+
+    assert!(charly_a_main.is_active() && charly_b_main.is_active());
+    assert_eq!(
+        charly_b_main.own_leaf_index(),
+        charly_a_main.own_leaf_index(),
+        "the bootstrapped sibling must land on the shared VC leaf"
+    );
+    let auth = charly_b_main.epoch_authenticator();
+    assert_eq!(charly_a_main.epoch_authenticator(), auth);
+    assert_eq!(scenario.alice_main.epoch_authenticator(), auth);
+    assert_eq!(scenario.bob_main.epoch_authenticator(), auth);
+    assert_eq!(
+        charly_b_main
+            .export_group_context()
+            .tls_serialize_detached()
+            .expect("serialize charly_b context"),
+        charly_a_main
+            .export_group_context()
+            .tls_serialize_detached()
+            .expect("serialize charly_a context"),
+    );
+}
+
+/// Without the resolved updates, a sibling join of an external commit
+/// carrying an AppDataUpdate proposal fails cleanly before consuming an
+/// operation secret generation, so the sibling can compute the updates and
+/// join by processing the same commit again.
+#[openmls_test]
+fn vc_sibling_external_commit_join_without_app_data_updates_fails() {
+    let scenario = vc_app_data_scenario::<Provider>(ciphersuite);
+    let vgi_charly_a = scenario.export_prior_epoch_vgi("charly_a");
+    let vgi_first_attempt = scenario.export_prior_epoch_vgi("charly_b first attempt");
+    let vgi_retry = scenario.export_prior_epoch_vgi("charly_b retry");
+
+    let (charly_a_main, commit) =
+        charly_a_external_commit_with_app_data_update(&scenario, vgi_charly_a, None);
+
+    let pending = MlsGroup::vc_external_commit_join_builder()
+        .with_config(vc_join_config())
+        .process_commit(
+            &scenario.charly_b_provider,
+            vgi_first_attempt,
+            commit.clone().into_protocol_message().expect("commit"),
+            scenario.epoch_id.clone(),
+        )
+        .expect("process charly_a's external commit");
+    let err = pending
+        .join(&scenario.charly_b_provider, None)
+        .expect_err("joining without the resolved updates must fail");
+    let VcExternalCommitJoinError::StageCommitError(StageCommitError::ApplyAppDataUpdateError(
+        ApplyAppDataUpdateError::MissingAppDataUpdates,
+    )) = err
+    else {
+        panic!("expected MissingAppDataUpdates, got {err:?}");
+    };
+
+    // The failed attempt did not consume an operation secret generation, so
+    // processing the same commit again and joining with the resolved updates
+    // succeeds.
+    let pending = MlsGroup::vc_external_commit_join_builder()
+        .with_config(vc_join_config())
+        .process_commit(
+            &scenario.charly_b_provider,
+            vgi_retry,
+            commit.into_protocol_message().expect("commit"),
+            scenario.epoch_id.clone(),
+        )
+        .expect("process charly_a's external commit again");
+    let updates = sibling_resolved_app_data_updates(&pending);
+    let charly_b_main = pending
+        .join(&scenario.charly_b_provider, updates)
+        .expect("retry with resolved updates succeeds");
+    assert_eq!(
+        charly_b_main.epoch_authenticator(),
+        charly_a_main.epoch_authenticator()
+    );
+}
+
+/// Updates that do not reproduce the committing sibling's dictionary fail
+/// the join at the confirmation tag check instead of installing a diverged
+/// group context.
+#[openmls_test]
+fn vc_sibling_external_commit_join_with_wrong_app_data_updates_fails() {
+    let scenario = vc_app_data_scenario::<Provider>(ciphersuite);
+    let vgi_charly_a = scenario.export_prior_epoch_vgi("charly_a");
+    let vgi_charly_b = scenario.export_prior_epoch_vgi("charly_b");
+
+    let (_charly_a_main, commit) =
+        charly_a_external_commit_with_app_data_update(&scenario, vgi_charly_a, None);
+
+    let pending = MlsGroup::vc_external_commit_join_builder()
+        .with_config(vc_join_config())
+        .process_commit(
+            &scenario.charly_b_provider,
+            vgi_charly_b,
+            commit.into_protocol_message().expect("commit"),
+            scenario.epoch_id.clone(),
+        )
+        .expect("process charly_a's external commit");
+    let mut updater = pending.app_data_dictionary_updater();
+    updater.set(ComponentData::from_parts(
+        APP_DATA_COMPONENT_ID,
+        b"a different value".to_vec().into(),
+    ));
+    let updates = updater.changes();
+    let err = pending
+        .join(&scenario.charly_b_provider, updates)
+        .expect_err("joining with wrong updates must fail");
+    let VcExternalCommitJoinError::StageCommitError(StageCommitError::ConfirmationTagMismatch) =
+        err
+    else {
+        panic!("expected ConfirmationTagMismatch, got {err:?}");
+    };
 }
 
 /// A sibling emulator joins a higher-level group via a virtual client's


### PR DESCRIPTION
Replace MlsGroup::vc_join_via_sibling_external_commit with VcExternalCommitJoinBuilder. process_commit rebuilds the prior-epoch group and verifies the commit, returning a PendingVcExternalCommitJoin that exposes the verified AppDataUpdate and AppEphemeral proposals plus a dictionary updater seeded with the prior-epoch group context. join stages and merges the commit with the application-resolved AppDataUpdates, mirroring the resolve_app_data_commit contract of regular processing.

Previously a commit carrying an AppDataUpdate proposal failed at staging with MissingAppDataUpdates, making the entry point unusable for applications that bump a group-context component on every commit.

The consume-once operation secret derivation now happens in join, and missing updates are rejected before it, so an incomplete join can be retried by processing the same commit again.