### PR TITLE
Fix `MemoryStorage::clear_proposal_queue` leaving orphaned proposal data

### DIFF
--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -874,7 +874,8 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         for proposal_ref in proposal_refs {
             // Delete all proposals.
             let key = serde_json::to_vec(&(group_id, proposal_ref))?;
-            values.remove(&key);
+            let storage_key = build_key_from_vec::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, key);
+            values.remove(&storage_key);
         }
 
         // Delete the proposal refs from the store.

--- a/memory_storage/tests/proposals.rs
+++ b/memory_storage/tests/proposals.rs
@@ -74,4 +74,7 @@ fn read_write_delete() {
 
     let proposals_read: Vec<(ProposalRef, Proposal)> = storage.queued_proposals(&group_id).unwrap();
     assert!(proposals_read.is_empty());
+
+    // Clearing the queue must also remove the proposal values, not only their refs.
+    assert!(storage.values.read().unwrap().is_empty());
 }


### PR DESCRIPTION
## Summary

Fix `MemoryStorage::clear_proposal_queue` so that queued proposal values are actually removed from the backing store.

## Problem

The queue stores proposal values under a key containing the storage label and version suffix. `clear_proposal_queue` attempted to remove only the serialized proposal identifier, so the stored values remained as unreachable entries after the reference list was deleted. Repeated queue cleanup could therefore cause unbounded memory growth and persisted storage bloat.

## Changes

- Build the complete `QUEUED_PROPOSAL_LABEL` storage key before removing each proposal.
- Add a regression assertion that the backing `MemoryStorage` is empty after queue cleanup.

## Testing

`cargo test -p openmls_memory_storage --test proposals read_write_delete`
