### PR TITLE
Use the leftmost removed leaf for external Commit sender index calculation

### DIFF
--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -295,12 +295,12 @@ impl CommitIn {
                     self_removes_in_store,
                 } => {
                     // We need to determine if it is a a resync or a join.
-                    // Find the first remove proposal and extract the leaf index.
-                    let former_sender_index = proposals.iter().find_map(|p| {
+                    // Use the leftmost removed leaf, matching external-commit construction.
+                    let former_sender_index = proposals.iter().filter_map(|p| {
                         p.as_proposal()
                             .and_then(|p| p.as_remove())
                             .map(|r| r.removed())
-                    });
+                    }).min();
 
                     // Collect the sender indices of SelfRemoves that are part of
                     // this commit.


### PR DESCRIPTION
## Summary

Use the leftmost removed leaf when determining the sender position of an external Commit.

## Problem

The external Commit builder considers all `Remove` proposals and selects the smallest available leaf index. Commit validation on the receiving side previously inspected only the first `Remove` proposal. When multiple Remove proposals were present in an order that did not match their leaf indices, sender and receiver selected different UpdatePath positions, causing valid external Commits to be rejected or applied against the wrong tree position.

## Changes

- Inspect every `Remove` proposal during external Commit validation.
- Select the minimum removed leaf index, matching external Commit construction.

## Testing

The relevant OpenMLS library tests should be run with:

`cargo test -p openmls --lib`
