### PR TITLE
Prevent Delivery Service panics on invalid MLS message types

### DIFF
--- a/delivery-service/ds/src/main.rs
+++ b/delivery-service/ds/src/main.rs
@@ -258,7 +258,10 @@ async fn consume_key_package(
 /// clients in the welcome message.
 async fn send_welcome(State(data): State<Arc<DsData>>, body: Bytes) -> Response {
     let welcome_msg = unwrap_data!(MlsMessageIn::tls_deserialize(&mut &body[..]));
-    let welcome = welcome_msg.clone().into_welcome().unwrap();
+    let welcome = match welcome_msg.clone().into_welcome() {
+        Ok(welcome) => welcome,
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
+    };
     log::debug!("Storing welcome message: {welcome_msg:?}");
 
     let mut clients = data.clients.lock();
@@ -293,7 +296,10 @@ async fn msg_send(State(data): State<Arc<DsData>>, body: Bytes) -> Response {
     let mut clients = data.clients.lock();
     let mut groups = data.groups.lock();
 
-    let protocol_msg: ProtocolMessage = group_msg.msg.clone().try_into().unwrap();
+    let protocol_msg: ProtocolMessage = match group_msg.msg.clone().try_into() {
+        Ok(message) => message,
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
+    };
 
     // Reject any handshake message that has an earlier epoch than the one we know
     // about.


### PR DESCRIPTION
## Summary

Return `400 Bad Request` for validly encoded MLS messages with an invalid message type instead of panicking.

## Problem

The Delivery Service used `unwrap()` when converting a decoded `MlsMessageIn` into a Welcome or `ProtocolMessage`. A client could submit a syntactically valid message of the wrong type, causing the request handler to panic and enabling request-level denial of service.

## Changes

- Handle failed `into_welcome()` conversion in `/send/welcome`.
- Handle failed `TryInto<ProtocolMessage>` conversion in `/send/message`.
- Return `400 Bad Request` for both invalid message-type cases.

## Testing

`cargo test -p mls-ds`
