### PR TITLE
Correct TLS serialized length calculation for `HashSet<Vec<u8>>`

### DIFF
--- a/delivery-service/ds-lib/src/lib.rs
+++ b/delivery-service/ds-lib/src/lib.rs
@@ -34,7 +34,7 @@ mod hashset_codec {
         io::{Read, Write},
     };
 
-    use crate::tls_codec::{self, Deserialize, Serialize};
+    use crate::tls_codec::{self, Deserialize, Serialize, Size};
 
     pub fn tls_serialized_len(hashset: &HashSet<Vec<u8>>) -> usize {
         let payload_len = hashset

--- a/delivery-service/ds-lib/src/lib.rs
+++ b/delivery-service/ds-lib/src/lib.rs
@@ -37,14 +37,17 @@ mod hashset_codec {
     use crate::tls_codec::{self, Deserialize, Serialize};
 
     pub fn tls_serialized_len(hashset: &HashSet<Vec<u8>>) -> usize {
-        let hashset_len = hashset.len();
-        let length_encoding_bytes = match hashset_len {
+        let payload_len = hashset
+            .iter()
+            .map(|value| value.as_slice().tls_serialized_len())
+            .sum::<usize>();
+        let length_encoding_bytes = match payload_len {
             0..=0x3f => 1,
             0x40..=0x3fff => 2,
             0x4000..=0x3fff_ffff => 4,
             _ => 8,
         };
-        hashset_len + length_encoding_bytes
+        payload_len + length_encoding_bytes
     }
 
     pub fn tls_serialize<W>(
@@ -61,6 +64,24 @@ mod hashset_codec {
     pub fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<HashSet<Vec<u8>>, tls_codec::Error> {
         let vec = Vec::<Vec<u8>>::tls_deserialize(bytes)?;
         Ok(vec.into_iter().collect::<HashSet<_>>())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hashset_codec;
+    use std::collections::HashSet;
+
+    #[test]
+    fn hashset_serialized_length_matches_encoding() {
+        let values = HashSet::from([vec![1, 2, 3], vec![4; 64]]);
+        let mut encoded = Vec::new();
+        hashset_codec::tls_serialize(&values, &mut encoded).unwrap();
+
+        assert_eq!(
+            hashset_codec::tls_serialized_len(&values),
+            encoded.len()
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Correct the TLS serialized length calculation for `HashSet<Vec<u8>>` in `ds-lib`.

## Problem

The custom `tls_serialized_len` implementation used the number of set elements as the vector payload length. TLS vector lengths represent serialized bytes, including each element's own length prefix, so the reported size was incorrect for non-empty or variable-length values.

## Changes

- Calculate the payload length from each element's serialized length.
- Select the outer TLS length-prefix width from the payload byte length.
- Add a regression test comparing the reported size with the actual encoded size.

## Testing

`cargo test -p ds-lib`
