### PR TITLE
feat: expose a KeyPackage eligibility check on PublicGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `PublicGroup::validate_key_package_for_add`, which checks whether a single `KeyPackage` is eligible to be added to the group without building a commit. Applications adding several members at once can use it to filter out candidates that a commit would reject, and to report which candidate was rejected and why. Uniqueness of the signature, init and encryption keys is not covered, since it can only be decided for a full set of proposals.
 - [#1972](https://github.com/openmls/openmls/pull/1972): Add APIs for time-based deletion of past epoch secrets, and for setting the past epoch deletion policy for an `MlsGroup`.
 - [#2010](https://github.com/openmls/openmls/pull/2010): Added `MlsGroup::propose_self_update_with_new_signer`, a variant of `propose_self_update` that stages an `Update` proposal carrying a new signature key.
 - [#2084](https://github.com/openmls/openmls/pull/2084): Added the `ProcessedMessageContent::OwnPendingCommit` variant, returned when processing a Commit authored by this client that matches the group's pending commit. Callers should merge the pending commit via `MlsGroup::merge_pending_commit()`.

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -376,10 +376,9 @@ impl PublicGroup {
     /// - the ciphersuite and the protocol version match the group,
     /// - the leaf node supports all extensions in the group context,
     /// - the leaf node is valid for this group, which covers its capabilities,
-    ///   the required capabilities of the group, and mutual support of the
-    ///   credential types in use with the existing members.
-    ///
-    /// `validate_lifetimes` determines whether the lifetime of the leaf node is verified.
+    ///   the required capabilities of the group, mutual support of the
+    ///   credential types in use with the existing members, and the lifetime of
+    ///   the leaf node.
     ///
     /// Checks that concern a set of proposals as a whole are not covered. In
     /// particular the signature key, the init key and the encryption key of the
@@ -390,7 +389,6 @@ impl PublicGroup {
     pub fn validate_key_package_for_add(
         &self,
         key_package: &KeyPackage,
-        validate_lifetimes: LeafNodeLifetimePolicy,
     ) -> Result<(), ProposalValidationError> {
         // ValSem105: Check if ciphersuite and version of the group are correct:
         // https://validation.openmls.tech/#valn0201
@@ -414,7 +412,7 @@ impl PublicGroup {
         }
 
         // https://validation.openmls.tech/#valn0202
-        self.validate_leaf_node_inner(key_package.leaf_node(), validate_lifetimes)?;
+        self.validate_leaf_node(key_package.leaf_node())?;
 
         Ok(())
     }

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -20,6 +20,7 @@ use crate::{
         proposal_store::ProposalQueue,
         GroupContextExtensionsProposalValidationError, Member,
     },
+    key_packages::KeyPackage,
     messages::{
         proposals::{Proposal, ProposalOrRefType, ProposalType},
         Commit,
@@ -367,6 +368,57 @@ impl PublicGroup {
             })
     }
 
+    /// Checks whether `key_package` is eligible to be added to this group
+    ///
+    /// This runs the checks that a commit with an Add proposal for
+    /// `key_package` performs on that key package alone:
+    ///
+    /// - the ciphersuite and the protocol version match the group,
+    /// - the leaf node supports all extensions in the group context,
+    /// - the leaf node is valid for this group, which covers its capabilities,
+    ///   the required capabilities of the group, and mutual support of the
+    ///   credential types in use with the existing members.
+    ///
+    /// `validate_lifetimes` determines whether the lifetime of the leaf node is verified.
+    ///
+    /// Checks that concern a set of proposals as a whole are not covered. In
+    /// particular the signature key, the init key and the encryption key of the
+    /// added member have to be unique among the group members and the other
+    /// proposals in the commit, which can only be decided once all proposals are
+    /// known. Passing this check therefore does not guarantee that a commit
+    /// adding `key_package` can be built.
+    pub fn validate_key_package_for_add(
+        &self,
+        key_package: &KeyPackage,
+        validate_lifetimes: LeafNodeLifetimePolicy,
+    ) -> Result<(), ProposalValidationError> {
+        // ValSem105: Check if ciphersuite and version of the group are correct:
+        // https://validation.openmls.tech/#valn0201
+        if key_package.ciphersuite() != self.ciphersuite()
+            || key_package.protocol_version() != self.version()
+        {
+            return Err(ProposalValidationError::InvalidAddProposalCiphersuiteOrVersion);
+        }
+
+        // Check that the leaf node of the added key package supports all extensions in the group
+        // context.
+        // https://validation.openmls.tech/#valn0502
+        let added_leaf_supports_all_group_context_extensions =
+            self.group_context().extensions().iter().all(|extension| {
+                key_package
+                    .leaf_node()
+                    .supports_extension(&extension.extension_type())
+            });
+        if !added_leaf_supports_all_group_context_extensions {
+            return Err(ProposalValidationError::InsufficientCapabilities);
+        }
+
+        // https://validation.openmls.tech/#valn0202
+        self.validate_leaf_node_inner(key_package.leaf_node(), validate_lifetimes)?;
+
+        Ok(())
+    }
+
     /// Validate Add proposals. This function implements the following checks:
     ///  - ValSem105: Add Proposal: Ciphersuite & protocol version must match the group
     pub(crate) fn validate_add_proposals(
@@ -378,31 +430,7 @@ impl PublicGroup {
         // We do the key package validation checks here inline
         // https://validation.openmls.tech/#valn0501
         for add_proposal in add_proposals {
-            // ValSem105: Check if ciphersuite and version of the group are correct:
-            // https://validation.openmls.tech/#valn0201
-            if add_proposal.add_proposal().key_package().ciphersuite() != self.ciphersuite()
-                || add_proposal.add_proposal().key_package().protocol_version() != self.version()
-            {
-                return Err(ProposalValidationError::InvalidAddProposalCiphersuiteOrVersion);
-            }
-
-            // Check that the leaf node of the added key package supports all extensions in the group
-            // context.
-            // https://validation.openmls.tech/#valn0502
-            let added_leaf_supports_all_group_context_extensions =
-                self.group_context().extensions().iter().all(|extension| {
-                    add_proposal
-                        .add_proposal()
-                        .key_package
-                        .leaf_node()
-                        .supports_extension(&extension.extension_type())
-                });
-            if !added_leaf_supports_all_group_context_extensions {
-                return Err(ProposalValidationError::InsufficientCapabilities);
-            }
-
-            // https://validation.openmls.tech/#valn0202
-            self.validate_leaf_node(add_proposal.add_proposal().key_package().leaf_node())?;
+            self.validate_key_package_for_add(add_proposal.add_proposal().key_package())?;
         }
         Ok(())
     }

--- a/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/proposal_validation.rs
@@ -2395,6 +2395,132 @@ fn valsem113() {
     }
 }
 
+// Tests `PublicGroup::validate_key_package_for_add`, which runs the checks of
+// an Add proposal on a single key package. The group used here carries the
+// unknown extension 0xf001 in its group context and requires support for the
+// unknown extension 0xf002 through its required capabilities.
+#[openmls_test::openmls_test]
+fn validate_key_package_for_add() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let group_context_extension_type = ExtensionType::Unknown(0xf001);
+    let required_extension_type = ExtensionType::Unknown(0xf002);
+
+    let capabilities = |ciphersuite, extension_types: Vec<ExtensionType>| {
+        Capabilities::builder()
+            .ciphersuites(vec![ciphersuite])
+            .extensions(extension_types)
+            .build()
+    };
+
+    let group_context_extensions = Extensions::from_vec(vec![
+        Extension::Unknown(0xf001, UnknownExtension(vec![0x01])),
+        Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
+            &[required_extension_type],
+            &[],
+            &[],
+        )),
+    ])
+    .unwrap();
+
+    let alice_credential_with_key_and_signer = generate_credential_with_key(
+        "Alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    let alice_group = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .with_capabilities(capabilities(
+            ciphersuite,
+            vec![group_context_extension_type, required_extension_type],
+        ))
+        .with_group_context_extensions(group_context_extensions)
+        .build(
+            alice_provider,
+            &alice_credential_with_key_and_signer.signer,
+            alice_credential_with_key_and_signer
+                .credential_with_key
+                .clone(),
+        )
+        .unwrap();
+
+    let public_group = alice_group.public_group();
+
+    // Builds a key package for Bob with the given ciphersuite and capabilities.
+    let bob_key_package = |ciphersuite: Ciphersuite, capabilities| {
+        let credential_with_key_and_signer = generate_credential_with_key(
+            "Bob".into(),
+            ciphersuite.signature_algorithm(),
+            bob_provider,
+        );
+
+        KeyPackage::builder()
+            .leaf_node_capabilities(capabilities)
+            .build(
+                ciphersuite,
+                bob_provider,
+                &credential_with_key_and_signer.signer,
+                credential_with_key_and_signer.credential_with_key,
+            )
+            .unwrap()
+    };
+
+    // A key package that supports both extensions is eligible.
+    let eligible = bob_key_package(
+        ciphersuite,
+        capabilities(
+            ciphersuite,
+            vec![group_context_extension_type, required_extension_type],
+        ),
+    );
+    public_group
+        .validate_key_package_for_add(eligible.key_package())
+        .unwrap();
+
+    // A key package for a different ciphersuite is not eligible.
+    let other_ciphersuite = bob_provider
+        .crypto()
+        .supported_ciphersuites()
+        .into_iter()
+        .find(|supported| *supported != ciphersuite)
+        .expect("the provider should support more than one ciphersuite");
+    let wrong_ciphersuite = bob_key_package(
+        other_ciphersuite,
+        capabilities(
+            other_ciphersuite,
+            vec![group_context_extension_type, required_extension_type],
+        ),
+    );
+    assert_eq!(
+        public_group.validate_key_package_for_add(wrong_ciphersuite.key_package()),
+        Err(ProposalValidationError::InvalidAddProposalCiphersuiteOrVersion)
+    );
+
+    // A key package whose leaf node does not support the group context
+    // extension is not eligible.
+    let missing_group_context_extension =
+        bob_key_package(ciphersuite, capabilities(ciphersuite, vec![]));
+    assert_eq!(
+        public_group.validate_key_package_for_add(missing_group_context_extension.key_package()),
+        Err(ProposalValidationError::InsufficientCapabilities)
+    );
+
+    // A key package whose leaf node does not satisfy the required capabilities
+    // of the group is not eligible.
+    let missing_required_capability = bob_key_package(
+        ciphersuite,
+        capabilities(ciphersuite, vec![group_context_extension_type]),
+    );
+    assert_eq!(
+        public_group.validate_key_package_for_add(missing_required_capability.key_package()),
+        Err(ProposalValidationError::LeafNodeValidation(
+            LeafNodeValidationError::UnsupportedExtensions
+        ))
+    );
+}
+
 // --- PreSharedKey Proposals ---
 // TODO(#1354): This is currently not tested because we can't easily create invalid commits.
 /*


### PR DESCRIPTION
Add `PublicGroup::validate_key_package_for_add`, which runs the add proposal checks on a single `KeyPackage`. Applications that add several members at once can now filter out ineligible candidates up front and tell the user who was left out and why. Building a commit does not allow that: `CommitBuilder::build()` is atomic, so one unacceptable KeyPackage fails the whole commit, and the error does not say which KeyPackage was at fault.

The method is the extracted body of the loop in
`validate_add_proposals`, which now calls it once per add proposal. The checks and their order are unchanged. Key uniqueness stays in `validate_key_uniqueness`, since it is about a set of proposals and cannot be decided for a single KeyPackage.