### PR TITLE
Add `with_aad` method to CommitBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#2184](https://github.com/openmls/openmls/pull/2184): Added `PreSharedKeyProposal::psk`, a getter for the `PreSharedKeyId` of a `PreSharedKey` proposal.
 - [#2167](https://github.com/openmls/openmls/pull/2167): Added `PublicGroup::validate_key_package_for_add`, which checks whether a single `KeyPackage` is eligible to be added to the group without building a commit. Applications adding several members at once can use it to filter out candidates that a commit would reject, and to report which candidate was rejected and why. Uniqueness of the signature, init and encryption keys is not covered, since it can only be decided for a full set of proposals.
+- [#2175](https://github.com/openmls/openmls/pull/2175): Added `CommitBuilder::with_aad`, which allows setting the AAD used for the commit.
 
 ## 0.9.0 (2026-08-25)
 

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -97,7 +97,6 @@ use super::HandshakeConfirmationData;
 
 #[derive(Debug)]
 struct ExternalCommitInfo {
-    aad: Vec<u8>,
     /// The authoritative credential and signature key for the external
     /// committer's leaf. `build_internal` folds it into the leaf node
     /// parameters and rejects parameters that pin a different credential.
@@ -120,6 +119,9 @@ pub struct Initial {
     leaf_node_parameters: LeafNodeParameters,
     external_commit_info: Option<ExternalCommitInfo>,
 
+    /// The bare AAD to use for this commit. If it is set, the one from the group is ignored and left untouched.
+    bare_aad: Option<Vec<u8>>,
+
     /// Whether or not to clear the proposal queue of the group when staging the commit. Needs to
     /// be done when we include the commits that have already been queued.
     consume_proposal_store: bool,
@@ -133,6 +135,7 @@ impl Default for Initial {
             leaf_node_parameters: LeafNodeParameters::default(),
             own_proposals: vec![],
             external_commit_info: None,
+            bare_aad: None,
         }
     }
 }
@@ -151,6 +154,9 @@ pub struct LoadedPsks {
 
     /// The GroupInfo creation config
     group_info_config: GroupInfoConfig,
+
+    /// The AAD to use for this commit. If it is set, the one from the group is ignored and left untouched.
+    bare_aad: Option<Vec<u8>>,
 
     #[cfg(feature = "extensions-draft")]
     app_data_dictionary_updates: Option<AppDataUpdates>,
@@ -372,6 +378,12 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
     /// self-update takes place.
     pub fn leaf_node_parameters(mut self, leaf_node_parameters: LeafNodeParameters) -> Self {
         self.stage.leaf_node_parameters = leaf_node_parameters;
+        self
+    }
+
+    /// The AAD to use for this commit. If it is set, the one from the group is ignored and left untouched.
+    pub fn with_aad(mut self, aad: Vec<u8>) -> Self {
+        self.stage.bare_aad = Some(aad);
         self
     }
 
@@ -610,6 +622,7 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, Initial, G> {
                         force_self_update: stage.force_self_update,
                         leaf_node_parameters: stage.leaf_node_parameters,
                         consume_proposal_store: stage.consume_proposal_store,
+                        bare_aad: stage.bare_aad,
                         group_info_config,
                         external_commit_info: stage.external_commit_info,
                         #[cfg(feature = "extensions-draft")]
@@ -1029,31 +1042,33 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, LoadedPsks, G> {
             path: path_computation_result.encrypted_path,
         };
 
-        let (outgoing_aad, wire_format): (Vec<u8>, WireFormat) =
-            match &cur_stage.external_commit_info {
-                None => (
-                    group.outgoing_authenticated_data()?,
-                    group.outgoing_wire_format(),
-                ),
-                Some(ExternalCommitInfo { aad, .. }) => {
-                    // The spec requires the SafeAAD prefix even with zero items
-                    // when the target GroupContext has `safe_aad` present, so a
-                    // bare `aad` would be rejected by SafeAAD-aware receivers.
-                    // The joining group carries no application-staged items, so
-                    // the prefix is empty unless the builder staged the
-                    // virtual-clients marker.
-                    #[cfg(feature = "extensions-draft")]
-                    let aad_bytes = if group.context().safe_aad_required() {
-                        crate::framing::safe_aad::assemble_authenticated_data(&group.safe_aad, aad)
-                            .map_err(|_| LibraryError::custom("SafeAad serialization failed"))?
-                    } else {
-                        aad.clone()
-                    };
-                    #[cfg(not(feature = "extensions-draft"))]
-                    let aad_bytes = aad.clone();
-                    (aad_bytes, WireFormat::PublicMessage)
-                }
+        let wire_format = if cur_stage.external_commit_info.is_some() {
+            WireFormat::PublicMessage
+        } else {
+            group.outgoing_wire_format()
+        };
+
+        let outgoing_aad = if let Some(aad) = cur_stage.bare_aad {
+            // The spec requires the SafeAAD prefix even with zero items
+            // when the target GroupContext has `safe_aad` present, so a
+            // bare `aad` would be rejected by SafeAAD-aware receivers.
+            // The joining group carries no application-staged items, so
+            // the prefix is empty unless the builder staged the
+            // virtual-clients marker.
+            #[cfg(feature = "extensions-draft")]
+            let aad_bytes = if group.context().safe_aad_required() {
+                crate::framing::safe_aad::assemble_authenticated_data(&group.safe_aad, &aad)
+                    .map_err(|_| LibraryError::custom("SafeAad serialization failed"))?
+            } else {
+                aad.clone()
             };
+
+            #[cfg(not(feature = "extensions-draft"))]
+            let aad_bytes = aad.clone();
+            aad_bytes
+        } else {
+            group.outgoing_authenticated_data()?
+        };
 
         let framing_parameters = FramingParameters::new(&outgoing_aad, wire_format);
 

--- a/openmls/src/group/mls_group/commit_builder/external_commits.rs
+++ b/openmls/src/group/mls_group/commit_builder/external_commits.rs
@@ -344,10 +344,10 @@ impl ExternalCommitBuilder {
         let mut commit_builder = CommitBuilder::<'_, Initial, MlsGroup>::new(mls_group);
 
         commit_builder.stage.force_self_update = true;
+        commit_builder.stage.bare_aad = Some(aad);
         commit_builder.stage.external_commit_info = Some(ExternalCommitInfo {
             wire_format_policy: original_wire_format_policy,
             credential: credential_with_key,
-            aad,
         });
 
         Ok(commit_builder)

--- a/openmls/src/group/mls_group/tests_and_kats/tests/commit_builder_aad.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/commit_builder_aad.rs
@@ -56,8 +56,8 @@ fn commit_builder_with_aad() {
         .commit()
         .tls_serialize_detached()
         .expect("serialization should succeed");
-    let msg_in = MlsMessageIn::tls_deserialize(&mut &wire_msg[..])
-        .expect("deserialization should succeed");
+    let msg_in =
+        MlsMessageIn::tls_deserialize(&mut &wire_msg[..]).expect("deserialization should succeed");
     let protocol_message = msg_in
         .try_into_protocol_message()
         .expect("should be a protocol message");

--- a/openmls/src/group/mls_group/tests_and_kats/tests/commit_builder_aad.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/commit_builder_aad.rs
@@ -1,0 +1,75 @@
+//! Test for CommitBuilder AAD support via `with_aad`.
+
+use openmls_test::openmls_test;
+use tls_codec::{Deserialize, Serialize};
+
+use crate::{
+    framing::MlsMessageIn,
+    group::{GroupId, MlsGroupCreateConfig, PURE_PLAINTEXT_WIRE_FORMAT_POLICY},
+    test_utils::single_group_test_framework::{AddMemberConfig, CorePartyState, GroupState},
+};
+
+/// Test that a regular commit built with `with_aad` carries the AAD through to receivers.
+///
+/// 1. Create Alice and Bob in a plaintext group.
+/// 2. Alice builds a commit with `with_aad(b"hello aad")`.
+/// 3. Bob processes the commit and observes the AAD on the `ProcessedMessage`.
+#[openmls_test]
+fn commit_builder_with_aad() {
+    let alice_party = CorePartyState::<Provider>::new("alice");
+    let bob_party = CorePartyState::<Provider>::new("bob");
+
+    let alice_pre_group = alice_party.generate_pre_group(ciphersuite);
+    let bob_pre_group = bob_party.generate_pre_group(ciphersuite);
+
+    let create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .use_ratchet_tree_extension(true)
+        .build();
+    let join_config = create_config.join_config().clone();
+
+    let group_id = GroupId::from_slice(b"test-commit-builder-aad");
+    let mut group_state =
+        GroupState::new_from_party(group_id, alice_pre_group, create_config).unwrap();
+
+    group_state
+        .add_member(AddMemberConfig {
+            adder: "alice",
+            addees: vec![bob_pre_group],
+            join_config,
+            tree: None,
+        })
+        .expect("Could not add member");
+
+    let aad_payload = b"hello aad".to_vec();
+
+    // Alice builds a commit carrying custom AAD.
+    let [alice] = group_state.members_mut(&["alice"]);
+    let bundle = alice
+        .build_commit_and_stage(|builder| builder.with_aad(aad_payload.clone()))
+        .expect("building a commit with AAD should succeed");
+
+    // Bob processes the commit and checks the AAD.
+    let [bob] = group_state.members_mut(&["bob"]);
+    let wire_msg = bundle
+        .commit()
+        .tls_serialize_detached()
+        .expect("serialization should succeed");
+    let msg_in = MlsMessageIn::tls_deserialize(&mut &wire_msg[..])
+        .expect("deserialization should succeed");
+    let protocol_message = msg_in
+        .try_into_protocol_message()
+        .expect("should be a protocol message");
+
+    let processed = bob
+        .group
+        .process_message(&bob.party.core_state.provider, protocol_message)
+        .expect("Bob should be able to process Alice's commit");
+
+    assert_eq!(
+        processed.aad(),
+        aad_payload.as_slice(),
+        "the AAD on the processed message should match what Alice set"
+    );
+}

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mod.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Test and Known Answer Test (KAT) modules for the MLS group.
 
+mod commit_builder_aad;
 mod commit_builder_leaf_node_validation;
 mod external_init;
 mod mls_group;


### PR DESCRIPTION
This PR add a method `with_aad` to the commit builder. This way, the caller can set the AAD for the commit, which completely bypasses the value controlled by `MlsGroup::set_aad`.

Even before this change, external commits had a way to set the AAD this way. The external commit builder code was extended to also use the new member `bare_aad` of the CommitBuilder phase structs.

I don't think we need to rush this in before the release.