### PR TITLE
virtual clients: revert derivation epoch retention scheme

### DIFF
--- a/openmls/src/components/vc_commit_data.rs
+++ b/openmls/src/components/vc_commit_data.rs
@@ -1,8 +1,8 @@
 //! Virtual-clients commit data (mls-virtual-clients draft).
 //!
 //! A virtual client attaches this struct to a commit as a Safe AAD item under
-//! [`VC_COMPONENT_ID`]. It tells the sibling emulators which derivation epochs
-//! the author still uses and which actions the commit performs.
+//! [`VC_COMPONENT_ID`]. It tells the sibling emulators which actions the commit
+//! performs.
 //!
 //! ```tls
 //! enum {
@@ -23,28 +23,15 @@
 //! } VirtualClientAction;
 //!
 //! struct {
-//!   opaque epoch_id<V>;
-//! } VcEpochReference;
-//!
-//! struct {
-//!   VcEpochReference in_use_epochs<V>;
-//! } VcEpochUsage;
-//!
-//! struct {
-//!   optional<VcEpochUsage> epoch_usage;
 //!   VirtualClientAction actions<V>;
 //! } VirtualClientCommitData;
 //! ```
 //!
-//! Entries of a [`VcEpochUsage`] are unique and sorted, and a
-//! [`VirtualClientCommitData`] carries at most one `new_derivation_epoch`
-//! action. Both rules are enforced on construction and on deserialization.
+//! A [`VirtualClientCommitData`] carries at most one `new_derivation_epoch`
+//! action. That rule is enforced on construction and on deserialization.
 //!
 //! [`VC_COMPONENT_ID`]: crate::components::vc_derivation_info::VC_COMPONENT_ID
-//! [`VcEpochUsage`]: crate::components::vc_commit_data::VcEpochUsage
 //! [`VirtualClientCommitData`]: crate::components::vc_commit_data::VirtualClientCommitData
-
-use std::cmp::Ordering;
 
 use tls_codec::{
     DeserializeBytes as TlsDeserializeBytesTrait, Serialize as TlsSerializeTrait,
@@ -52,20 +39,13 @@ use tls_codec::{
 };
 
 use crate::{
-    components::vc_derivation_info::{EpochId, KeyPackageUpload, VC_COMPONENT_ID},
+    components::vc_derivation_info::{KeyPackageUpload, VC_COMPONENT_ID},
     framing::{SafeAad, SafeAadItem},
 };
 
 /// Errors that can occur when building or parsing a [`VirtualClientCommitData`].
 #[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
 pub enum VcCommitDataError {
-    /// Two [`VcEpochReference`] entries carry the same `epoch_id`.
-    #[error("duplicate epoch id in VcEpochUsage")]
-    DuplicateEpochId,
-    /// Entries are not sorted in strictly-increasing order by the TLS
-    /// serialization of `epoch_id`.
-    #[error("VcEpochUsage entries are not sorted by the serialized epoch id in increasing order")]
-    EpochsNotSortedAscending,
     /// More than one `new_derivation_epoch` action is present.
     #[error("VirtualClientCommitData carries more than one new_derivation_epoch action")]
     MultipleNewDerivationEpochs,
@@ -92,146 +72,20 @@ pub enum VirtualClientAction {
     NewDerivationEpoch,
 }
 
-/// A reference to a derivation epoch by its [`EpochId`].
-#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
-pub struct VcEpochReference {
-    epoch_id: EpochId,
-}
-
-impl VcEpochReference {
-    /// The referenced epoch.
-    pub fn epoch_id(&self) -> &EpochId {
-        &self.epoch_id
-    }
-}
-
-impl From<EpochId> for VcEpochReference {
-    fn from(epoch_id: EpochId) -> Self {
-        Self { epoch_id }
-    }
-}
-
-impl From<VcEpochReference> for EpochId {
-    fn from(reference: VcEpochReference) -> Self {
-        reference.epoch_id
-    }
-}
-
-/// The set of derivation epochs the author of a commit still uses.
-///
-/// Entries are unique and sorted by the TLS serialization of their `epoch_id`.
-/// That order is a canonical encoding rule only. It says nothing about the
-/// order in which the derivation epochs were created or should be used.
-#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsSize)]
-pub struct VcEpochUsage {
-    in_use_epochs: Vec<VcEpochReference>,
-}
-
-impl VcEpochUsage {
-    /// Build a usage declaration covering `epoch_ids`.
-    ///
-    /// The epochs are a set, so the caller may pass them in any order and may
-    /// repeat them. Duplicates are dropped and the entries are put into the
-    /// canonical order.
-    pub fn new(epoch_ids: impl IntoIterator<Item = EpochId>) -> Result<Self, VcCommitDataError> {
-        let mut keyed = epoch_ids
-            .into_iter()
-            .map(|epoch_id| Ok((epoch_id.tls_serialize_detached()?, epoch_id)))
-            .collect::<Result<Vec<_>, tls_codec::Error>>()?;
-        keyed.sort_by(|(left, _), (right, _)| left.cmp(right));
-        keyed.dedup_by(|(left, _), (right, _)| left == right);
-        Ok(Self {
-            in_use_epochs: keyed
-                .into_iter()
-                .map(|(_, epoch_id)| VcEpochReference::from(epoch_id))
-                .collect(),
-        })
-    }
-
-    /// Build a usage declaration covering no epoch at all.
-    ///
-    /// This is not the same as omitting the declaration: it retires every epoch
-    /// the author declared before.
-    pub fn empty() -> Self {
-        Self {
-            in_use_epochs: Vec::new(),
-        }
-    }
-
-    /// The entries in canonical order.
-    pub fn in_use_epochs(&self) -> &[VcEpochReference] {
-        &self.in_use_epochs
-    }
-
-    /// The referenced epochs in canonical order.
-    pub fn epoch_ids(&self) -> impl Iterator<Item = &EpochId> {
-        self.in_use_epochs.iter().map(VcEpochReference::epoch_id)
-    }
-
-    /// Returns true if no epoch is declared as in use.
-    pub fn is_empty(&self) -> bool {
-        self.in_use_epochs.is_empty()
-    }
-
-    fn from_entries(entries: Vec<VcEpochReference>) -> Result<Self, VcCommitDataError> {
-        let mut previous: Option<Vec<u8>> = None;
-        for entry in &entries {
-            let current = entry.epoch_id.tls_serialize_detached()?;
-            if let Some(previous) = &previous {
-                match current.cmp(previous) {
-                    Ordering::Equal => return Err(VcCommitDataError::DuplicateEpochId),
-                    Ordering::Less => return Err(VcCommitDataError::EpochsNotSortedAscending),
-                    Ordering::Greater => {}
-                }
-            }
-            previous = Some(current);
-        }
-        Ok(Self {
-            in_use_epochs: entries,
-        })
-    }
-}
-
-impl TlsDeserializeBytesTrait for VcEpochUsage {
-    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
-        let (entries, rest) = Vec::<VcEpochReference>::tls_deserialize_bytes(bytes)?;
-        let usage = VcEpochUsage::from_entries(entries)
-            .map_err(|err| tls_codec::Error::DecodingError(err.to_string()))?;
-        Ok((usage, rest))
-    }
-}
-
 /// What a virtual client tells its siblings about a commit it authored.
 #[derive(Debug, PartialEq, TlsSerialize, TlsSize)]
 pub struct VirtualClientCommitData {
-    epoch_usage: Option<VcEpochUsage>,
     actions: Vec<VirtualClientAction>,
 }
 
 impl VirtualClientCommitData {
     /// Assemble the commit data.
     ///
-    /// Pass `None` for `epoch_usage` to leave the author's previous declaration
-    /// in place, and `Some(VcEpochUsage::empty())` to replace it with the empty
-    /// set.
-    ///
     /// Returns an error if `actions` holds more than one
     /// [`VirtualClientAction::NewDerivationEpoch`].
-    pub fn new(
-        epoch_usage: Option<VcEpochUsage>,
-        actions: Vec<VirtualClientAction>,
-    ) -> Result<Self, VcCommitDataError> {
+    pub fn new(actions: Vec<VirtualClientAction>) -> Result<Self, VcCommitDataError> {
         Self::validate(&actions)?;
-        Ok(Self {
-            epoch_usage,
-            actions,
-        })
-    }
-
-    /// The author's epoch usage declaration, or `None` if the commit does not
-    /// restate it.
-    pub fn epoch_usage(&self) -> Option<&VcEpochUsage> {
-        self.epoch_usage.as_ref()
+        Ok(Self { actions })
     }
 
     /// All actions the commit performs.
@@ -299,9 +153,8 @@ impl VirtualClientCommitData {
 
 impl TlsDeserializeBytesTrait for VirtualClientCommitData {
     fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
-        let (epoch_usage, rest) = Option::<VcEpochUsage>::tls_deserialize_bytes(bytes)?;
-        let (actions, rest) = Vec::<VirtualClientAction>::tls_deserialize_bytes(rest)?;
-        let commit_data = VirtualClientCommitData::new(epoch_usage, actions)
+        let (actions, rest) = Vec::<VirtualClientAction>::tls_deserialize_bytes(bytes)?;
+        let commit_data = VirtualClientCommitData::new(actions)
             .map_err(|err| tls_codec::Error::DecodingError(err.to_string()))?;
         Ok((commit_data, rest))
     }
@@ -313,8 +166,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        binary_tree::LeafNodeIndex, ciphersuite::hash_ref::KeyPackageRef,
-        components::vc_derivation_info::KeyPackageInfo,
+        binary_tree::LeafNodeIndex,
+        ciphersuite::hash_ref::KeyPackageRef,
+        components::vc_derivation_info::{EpochId, KeyPackageInfo},
     };
 
     const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
@@ -344,15 +198,10 @@ mod tests {
     }
 
     fn full_commit_data() -> VirtualClientCommitData {
-        let usage = VcEpochUsage::new([epoch_id(b"aaa"), epoch_id(b"bb"), epoch_id(b"cccc")])
-            .expect("epoch ids must serialize");
-        VirtualClientCommitData::new(
-            Some(usage),
-            vec![
-                VirtualClientAction::KeyPackageUpload(key_package_upload()),
-                VirtualClientAction::NewDerivationEpoch,
-            ],
-        )
+        VirtualClientCommitData::new(vec![
+            VirtualClientAction::KeyPackageUpload(key_package_upload()),
+            VirtualClientAction::NewDerivationEpoch,
+        ])
         .expect("one new_derivation_epoch action is valid")
     }
 
@@ -370,45 +219,14 @@ mod tests {
             parsed.key_package_uploads().collect::<Vec<_>>(),
             vec![&key_package_upload()]
         );
-        assert_eq!(
-            parsed.epoch_usage().unwrap().in_use_epochs().len(),
-            3,
-            "all three epochs are distinct"
-        );
-    }
-
-    #[test]
-    fn vc_commit_data_absent_and_empty_epoch_usage_differ() {
-        let absent = VirtualClientCommitData::new(None, Vec::new()).unwrap();
-        let empty = VirtualClientCommitData::new(Some(VcEpochUsage::empty()), Vec::new()).unwrap();
-
-        let absent_bytes = absent.tls_serialize_detached().unwrap();
-        let empty_bytes = empty.tls_serialize_detached().unwrap();
-
-        // `optional<>` prefixes the value with 0 for absent and 1 for present.
-        // The present-but-empty case then adds the empty entry vector.
-        assert_eq!(absent_bytes, vec![0x00, 0x00]);
-        assert_eq!(empty_bytes, vec![0x01, 0x00, 0x00]);
-
-        let parsed_absent =
-            VirtualClientCommitData::tls_deserialize_exact_bytes(&absent_bytes).unwrap();
-        let parsed_empty =
-            VirtualClientCommitData::tls_deserialize_exact_bytes(&empty_bytes).unwrap();
-
-        assert_eq!(parsed_absent.epoch_usage(), None);
-        assert_eq!(parsed_empty.epoch_usage(), Some(&VcEpochUsage::empty()));
-        assert!(parsed_empty.epoch_usage().unwrap().is_empty());
     }
 
     #[test]
     fn vc_commit_data_new_rejects_two_new_derivation_epochs() {
-        let err = VirtualClientCommitData::new(
-            None,
-            vec![
-                VirtualClientAction::NewDerivationEpoch,
-                VirtualClientAction::NewDerivationEpoch,
-            ],
-        )
+        let err = VirtualClientCommitData::new(vec![
+            VirtualClientAction::NewDerivationEpoch,
+            VirtualClientAction::NewDerivationEpoch,
+        ])
         .unwrap_err();
 
         assert_eq!(err, VcCommitDataError::MultipleNewDerivationEpochs);
@@ -416,9 +234,9 @@ mod tests {
 
     #[test]
     fn vc_commit_data_deserialize_rejects_two_new_derivation_epochs() {
-        // Hand-craft bytes the constructor would refuse to produce: absent
-        // epoch usage followed by two `new_derivation_epoch` actions.
-        let raw_bytes = vec![0x00, 0x02, 0x02, 0x02];
+        // Hand-craft bytes the constructor would refuse to produce: two
+        // `new_derivation_epoch` actions.
+        let raw_bytes = vec![0x02, 0x02, 0x02];
 
         let err = VirtualClientCommitData::tls_deserialize_exact_bytes(&raw_bytes).unwrap_err();
         match err {
@@ -428,70 +246,6 @@ mod tests {
             ),
             other => panic!("unexpected error variant: {other:?}"),
         }
-    }
-
-    #[test]
-    fn vc_epoch_usage_new_sorts_and_dedups() {
-        let usage = VcEpochUsage::new([
-            epoch_id(b"cccc"),
-            epoch_id(b"aaa"),
-            epoch_id(b"bb"),
-            epoch_id(b"aaa"),
-        ])
-        .unwrap();
-
-        let epochs: Vec<&[u8]> = usage.epoch_ids().map(EpochId::as_bytes).collect();
-        // Sorting compares the TLS serializations, which start with the length
-        // prefix, so the shorter id sorts first regardless of its content.
-        assert_eq!(epochs, vec![b"bb".as_slice(), b"aaa", b"cccc"]);
-    }
-
-    #[test]
-    fn vc_epoch_usage_deserialize_rejects_unsorted() {
-        let entries: Vec<VcEpochReference> = vec![
-            epoch_id(b"cccc").into(),
-            epoch_id(b"aaa").into(),
-            epoch_id(b"bb").into(),
-        ];
-        let raw_bytes = entries.tls_serialize_detached().unwrap();
-
-        let err = VcEpochUsage::tls_deserialize_exact_bytes(&raw_bytes).unwrap_err();
-        match err {
-            tls_codec::Error::DecodingError(message) => assert!(
-                message.contains("not sorted"),
-                "unexpected error message: {message}"
-            ),
-            other => panic!("unexpected error variant: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn vc_epoch_usage_deserialize_rejects_duplicates() {
-        let entries: Vec<VcEpochReference> =
-            vec![epoch_id(b"same").into(), epoch_id(b"same").into()];
-        let raw_bytes = entries.tls_serialize_detached().unwrap();
-
-        let err = VcEpochUsage::tls_deserialize_exact_bytes(&raw_bytes).unwrap_err();
-        match err {
-            tls_codec::Error::DecodingError(message) => assert!(
-                message.contains("duplicate"),
-                "unexpected error message: {message}"
-            ),
-            other => panic!("unexpected error variant: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn vc_epoch_usage_sorting_compares_serializations() {
-        // A 64-byte id needs a two-byte length prefix, a 63-byte id one byte,
-        // so the longer id sorts last even though its content byte is smaller.
-        let short = epoch_id(&[0xff; 63]);
-        let long = epoch_id(&[0x00; 64]);
-
-        let usage = VcEpochUsage::new([long.clone(), short.clone()]).unwrap();
-
-        let epochs: Vec<&EpochId> = usage.epoch_ids().collect();
-        assert_eq!(epochs, vec![&short, &long]);
     }
 
     #[test]

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -1414,7 +1414,7 @@ fn stage_vc_new_derivation_epoch(group: &mut MlsGroup) -> Result<(), CreateCommi
     }
 
     let mut commit_data = staged_vc_commit_data(group)?
-        .map_or_else(|| VirtualClientCommitData::new(None, Vec::new()), Ok)?;
+        .map_or_else(|| VirtualClientCommitData::new(Vec::new()), Ok)?;
     commit_data.require_new_derivation_epoch();
     group.safe_aad.upsert(commit_data.to_safe_aad_item()?);
     Ok(())

--- a/openmls/src/group/tests_and_kats/tests/virtual_clients.rs
+++ b/openmls/src/group/tests_and_kats/tests/virtual_clients.rs
@@ -6,7 +6,7 @@ use crate::{
     ciphersuite::Secret,
     component::{ComponentId, ComponentType, ComponentsList},
     components::{
-        vc_commit_data::{VcEpochUsage, VirtualClientAction, VirtualClientCommitData},
+        vc_commit_data::{VirtualClientAction, VirtualClientCommitData},
         vc_derivation_info::{
             load_vc_epoch_state_and_tree, register_vc_derivation_epoch, EpochId,
             RegisteredVcDerivationEpoch, VcDerivationEpochParams, VirtualClientOperationType,
@@ -383,16 +383,8 @@ fn vc_commit_data_travels_in_commit_safe_aad() {
     let (mut alice_group, mut bob_group, alice_signer) =
         safe_aad_group_pair(alice_provider, bob_provider);
 
-    let epoch_usage = VcEpochUsage::new([
-        EpochId::new(b"second declared epoch".to_vec()),
-        EpochId::new(b"first declared epoch".to_vec()),
-    ])
-    .expect("epoch ids must serialize");
-    let commit_data = VirtualClientCommitData::new(
-        Some(epoch_usage),
-        vec![VirtualClientAction::NewDerivationEpoch],
-    )
-    .expect("one new_derivation_epoch action is valid");
+    let commit_data = VirtualClientCommitData::new(vec![VirtualClientAction::NewDerivationEpoch])
+        .expect("one new_derivation_epoch action is valid");
 
     alice_group
         .set_safe_aad(vec![commit_data

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -5882,9 +5882,7 @@ fn malformed_vc_commit_data_is_rejected_by_emulation_group() {
 /// keeps the rest of the application's commit data intact.
 #[openmls_test]
 fn app_staged_vc_marker_refreshes_vc_derivation_epoch() {
-    use openmls::components::vc_commit_data::{
-        VcEpochUsage, VirtualClientAction, VirtualClientCommitData,
-    };
+    use openmls::components::vc_commit_data::{VirtualClientAction, VirtualClientCommitData};
 
     let provider_a = Provider::default();
     let provider_b = Provider::default();
@@ -5895,11 +5893,8 @@ fn app_staged_vc_marker_refreshes_vc_derivation_epoch() {
 
     // The application stages the marker itself and does not call
     // `new_derivation_epoch`.
-    let commit_data = VirtualClientCommitData::new(
-        Some(VcEpochUsage::new([before.clone()]).expect("epoch ids must serialize")),
-        vec![VirtualClientAction::NewDerivationEpoch],
-    )
-    .expect("one new_derivation_epoch action is valid");
+    let commit_data = VirtualClientCommitData::new(vec![VirtualClientAction::NewDerivationEpoch])
+        .expect("one new_derivation_epoch action is valid");
     emulator_a
         .set_safe_aad(vec![commit_data
             .to_safe_aad_item()


### PR DESCRIPTION
The PR at the spec-level has changed to remove the retention scheme. Derivation epochs are still there, so this PR preserves them. This PR doesn't fully implement the spec yet, it just rolls back the previous changes.