### PR TITLE
virtual clients: derivation epoch liveness tracking for groups

### DIFF
--- a/book/src/virtual_clients.md
+++ b/book/src/virtual_clients.md
@@ -459,9 +459,12 @@ The implementation tracks the draft but does not yet cover everything in it:
   sequence of operations the code already supports.
 - VC Update proposals are not implemented. Only commits and external commits
   emit virtual-client leaves.
-- The `VirtualClientAction` coordination channel over SafeAAD (the draft's
-  `external_join` and `key_package_upload` actions) is not implemented. The
-  transport of the KeyPackage upload is left entirely to the application.
+- The `key_package_upload` action is carried and parsed, but nothing acts on it
+  automatically. The application decides whether to attach it to an
+  emulation-group commit, reads it back with
+  `ProcessedMessage::vc_commit_data()`, and calls
+  `process_vc_key_package_upload` itself. Only the `new_derivation_epoch` action
+  is acted on by the library.
 - Per-epoch state for dead derivation epochs is not garbage collected
   automatically.
 

--- a/compat_tests/src/test_storage_provider.rs
+++ b/compat_tests/src/test_storage_provider.rs
@@ -81,7 +81,9 @@ struct Data {
     // virtual-clients-draft
     vc_derivation_epoch_state: Table,
     vc_emulation_bindings: Table,
+    vc_emulation_binding_epochs: Table,
     registered_vc_derivation_epoch: Table,
+    registered_vc_derivation_epoch_id: Table,
     vc_operation_tree: Table,
     retained_key_package_material: Table,
     retained_key_package_epoch: Table,
@@ -1106,6 +1108,24 @@ macro_rules! impl_storage_provider_virtual_clients_draft {
         }
 
         #[cfg(feature = "virtual-clients-draft")]
+        fn has_vc_emulation_binding_for_epoch<EpochId: traits::VcEpochId<$version>>(
+            &self,
+            epoch_id: &EpochId,
+        ) -> Result<bool, $error> {
+            let data = self.0 .0.lock().unwrap();
+            epoch_has_emulation_binding(epoch_id, &data.vc_emulation_binding_epochs)
+        }
+
+        #[cfg(feature = "virtual-clients-draft")]
+        fn has_registered_vc_derivation_epoch_for_epoch<EpochId: traits::VcEpochId<$version>>(
+            &self,
+            epoch_id: &EpochId,
+        ) -> Result<bool, $error> {
+            let data = self.0 .0.lock().unwrap();
+            epoch_is_referenced(epoch_id, &data.registered_vc_derivation_epoch_id)
+        }
+
+        #[cfg(feature = "virtual-clients-draft")]
         fn write_vc_derivation_epoch_state<
             EpochId: traits::VcEpochId<$version>,
             VcDerivationEpochState: traits::VcDerivationEpochState<$version>,
@@ -1126,29 +1146,39 @@ macro_rules! impl_storage_provider_virtual_clients_draft {
         fn write_vc_emulation_bindings<
             GroupId: traits::GroupId<$version>,
             VcEmulationBindings: traits::VcEmulationBindings<$version>,
+            EpochId: traits::VcEpochId<$version>,
         >(
             &self,
             group_id: &GroupId,
             bindings: &VcEmulationBindings,
+            bound_epochs: &[EpochId],
         ) -> Result<(), $error> {
             let mut data = self.0 .0.lock().unwrap();
-            write(group_id, bindings, &mut data.vc_emulation_bindings)
+            write(group_id, bindings, &mut data.vc_emulation_bindings)?;
+            write_bound_epochs(group_id, bound_epochs, &mut data.vc_emulation_binding_epochs)
         }
 
         #[cfg(feature = "virtual-clients-draft")]
         fn write_registered_vc_derivation_epoch<
             GroupId: traits::GroupId<$version>,
             RegisteredVcDerivationEpoch: traits::RegisteredVcDerivationEpoch<$version>,
+            EpochId: traits::VcEpochId<$version>,
         >(
             &self,
             group_id: &GroupId,
             registered: &RegisteredVcDerivationEpoch,
+            epoch_id: &EpochId,
         ) -> Result<(), $error> {
             let mut data = self.0 .0.lock().unwrap();
             write(
                 group_id,
                 registered,
                 &mut data.registered_vc_derivation_epoch,
+            )?;
+            write_registered_epoch_id(
+                group_id,
+                epoch_id,
+                &mut data.registered_vc_derivation_epoch_id,
             )
         }
 
@@ -1200,18 +1230,16 @@ macro_rules! impl_storage_provider_virtual_clients_draft {
             epoch_id: &EpochId,
         ) -> Result<bool, $error> {
             let mut data = self.0 .0.lock().unwrap();
-            let Data {
-                vc_derivation_epoch_state,
-                vc_operation_tree,
-                retained_key_package_epoch,
-                ..
-            } = &mut *data;
-            delete_vc_state_if_unreferenced(
-                epoch_id,
-                vc_derivation_epoch_state,
-                vc_operation_tree,
-                retained_key_package_epoch,
-            )
+            if epoch_is_referenced(epoch_id, &data.retained_key_package_epoch)?
+                || epoch_is_referenced(epoch_id, &data.registered_vc_derivation_epoch_id)?
+                || epoch_has_emulation_binding(epoch_id, &data.vc_emulation_binding_epochs)?
+            {
+                return Ok(false);
+            }
+            delete(epoch_id, &mut data.vc_derivation_epoch_state)?;
+            delete(epoch_id, &mut data.vc_operation_tree)?;
+
+            Ok(true)
         }
 
         #[cfg(feature = "virtual-clients-draft")]
@@ -1220,7 +1248,8 @@ macro_rules! impl_storage_provider_virtual_clients_draft {
             group_id: &GroupId,
         ) -> Result<(), $error> {
             let mut data = self.0 .0.lock().unwrap();
-            delete(group_id, &mut data.vc_emulation_bindings)
+            delete(group_id, &mut data.vc_emulation_bindings)?;
+            delete(group_id, &mut data.vc_emulation_binding_epochs)
         }
 
         #[cfg(feature = "virtual-clients-draft")]
@@ -1229,7 +1258,8 @@ macro_rules! impl_storage_provider_virtual_clients_draft {
             group_id: &GroupId,
         ) -> Result<(), $error> {
             let mut data = self.0 .0.lock().unwrap();
-            delete(group_id, &mut data.registered_vc_derivation_epoch)
+            delete(group_id, &mut data.registered_vc_derivation_epoch)?;
+            delete(group_id, &mut data.registered_vc_derivation_epoch_id)
         }
 
         #[cfg(feature = "virtual-clients-draft")]
@@ -1468,14 +1498,64 @@ macro_rules! storage_helpers {
             Ok(())
         }
 
-        /// Whether any retained key package material still references `epoch_id`.
+        /// Whether any entry of `references` names `epoch_id`. Serves the
+        /// tables that hold one serialized epoch id per referrer.
         #[cfg(feature = "virtual-clients-draft")]
         fn epoch_is_referenced<EpochId: Key<$version>>(
             epoch_id: &EpochId,
-            epoch_tags: &Table,
+            references: &Table,
         ) -> Result<bool, $err> {
             let serialized = $ser(epoch_id)?;
-            Ok(epoch_tags.values().any(|value| value == &serialized))
+            Ok(references.values().any(|value| value == &serialized))
+        }
+
+        /// Replaces the derivation epoch a group's registration record names.
+        /// The record is opaque, so this entry is what makes it queryable by
+        /// epoch.
+        #[cfg(feature = "virtual-clients-draft")]
+        fn write_registered_epoch_id<GroupId: Key<$version>, EpochId: Key<$version>>(
+            group_id: &GroupId,
+            epoch_id: &EpochId,
+            registered_epoch_ids: &mut Table,
+        ) -> Result<(), $err> {
+            let _ = registered_epoch_ids.insert($ser(group_id)?, $ser(epoch_id)?);
+
+            Ok(())
+        }
+
+        /// Replaces the list of derivation epochs a group's emulation bindings
+        /// bind. The binding record is opaque, so the list is what makes the
+        /// bindings queryable by epoch.
+        #[cfg(feature = "virtual-clients-draft")]
+        fn write_bound_epochs<GroupId: Key<$version>, EpochId: Key<$version>>(
+            group_id: &GroupId,
+            bound_epochs: &[EpochId],
+            bound_epoch_lists: &mut Table,
+        ) -> Result<(), $err> {
+            let mut serialized_epochs = Vec::with_capacity(bound_epochs.len());
+            for epoch_id in bound_epochs {
+                serialized_epochs.push($ser(epoch_id)?);
+            }
+            let _ = bound_epoch_lists.insert($ser(group_id)?, $ser(&serialized_epochs)?);
+
+            Ok(())
+        }
+
+        /// Whether the emulation bindings of any group still bind `epoch_id`.
+        #[cfg(feature = "virtual-clients-draft")]
+        fn epoch_has_emulation_binding<EpochId: Key<$version>>(
+            epoch_id: &EpochId,
+            bound_epoch_lists: &Table,
+        ) -> Result<bool, $err> {
+            let serialized = $ser(epoch_id)?;
+            for value in bound_epoch_lists.values() {
+                let bound_epochs: Vec<Vec<u8>> = $de(value)?;
+                if bound_epochs.contains(&serialized) {
+                    return Ok(true);
+                }
+            }
+
+            Ok(false)
         }
 
         /// Writes an advanced operation tree together with the retained key package
@@ -1503,25 +1583,6 @@ macro_rules! storage_helpers {
             }
 
             Ok(())
-        }
-
-        /// Deletes the derivation epoch state and operation tree for
-        /// `epoch_id` if no retained key package material still references it.
-        #[cfg(feature = "virtual-clients-draft")]
-        fn delete_vc_state_if_unreferenced<EpochId: Key<$version>>(
-            epoch_id: &EpochId,
-            epoch_states: &mut Table,
-            operation_trees: &mut Table,
-            epoch_tags: &Table,
-        ) -> Result<bool, $err> {
-            let serialized = $ser(epoch_id)?;
-            if epoch_tags.values().any(|value| value == &serialized) {
-                return Ok(false);
-            }
-            let _ = epoch_states.remove(&serialized);
-            let _ = operation_trees.remove(&serialized);
-
-            Ok(true)
         }
     };
 }

--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -263,8 +263,16 @@ const APPLICATION_EXPORT_TREE_LABEL: &[u8] = b"ApplicationExportTree";
 const VC_DERIVATION_EPOCH_STATE_LABEL: &[u8] = b"VcDerivationEpochState";
 #[cfg(feature = "virtual-clients-draft")]
 const VC_EMULATION_BINDING_LABEL: &[u8] = b"VcEmulationBinding";
+// The binding record is opaque, so the epochs it binds are kept next to it as
+// a separate entry that the epoch-liveness scan can read.
+#[cfg(feature = "virtual-clients-draft")]
+const VC_BOUND_EPOCHS_LABEL: &[u8] = b"VcBoundDerivationEpochs";
 #[cfg(feature = "virtual-clients-draft")]
 const REGISTERED_VC_DERIVATION_EPOCH_LABEL: &[u8] = b"RegisteredVcDerivationEpoch";
+// The registration record is opaque, so the epoch it names is kept next to it
+// as a separate entry that the epoch-liveness scan can read.
+#[cfg(feature = "virtual-clients-draft")]
+const VC_REGISTERED_EPOCH_ID_LABEL: &[u8] = b"VcRegisteredDerivationEpochId";
 #[cfg(feature = "virtual-clients-draft")]
 const VC_OPERATION_TREE_LABEL: &[u8] = b"VcOperationTree";
 #[cfg(feature = "virtual-clients-draft")]
@@ -1085,13 +1093,17 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         epoch_id: &EpochId,
     ) -> Result<bool, Self::Error> {
         let serialized_epoch_id = serde_json::to_vec(epoch_id)?;
-        // Hold the write lock across the liveness check and the deletion so a
-        // material stored concurrently cannot be orphaned.
+        // Hold the write lock across the liveness checks and the deletion so a
+        // material, binding, or registration stored concurrently cannot be
+        // orphaned.
         let mut values = self.values.write().unwrap();
-        let referenced = values
-            .iter()
-            .any(|(key, value)| is_epoch_tag(key) && value == &serialized_epoch_id);
-        if referenced {
+        if any_entry_under_label(
+            &values,
+            RETAINED_KEY_PACKAGE_EPOCH_LABEL,
+            &serialized_epoch_id,
+        ) || any_entry_under_label(&values, VC_REGISTERED_EPOCH_ID_LABEL, &serialized_epoch_id)
+            || epoch_has_emulation_binding(&values, &serialized_epoch_id)?
+        {
             return Ok(false);
         }
         let state_key = build_key_from_vec::<CURRENT_VERSION>(
@@ -1109,16 +1121,34 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
     fn write_vc_emulation_bindings<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         VcEmulationBindings: traits::VcEmulationBindings<CURRENT_VERSION>,
+        EpochId: traits::VcEpochId<CURRENT_VERSION>,
     >(
         &self,
         group_id: &GroupId,
         bindings: &VcEmulationBindings,
+        bound_epochs: &[EpochId],
     ) -> Result<(), Self::Error> {
-        self.write::<CURRENT_VERSION>(
+        let serialized_group_id = serde_json::to_vec(group_id)?;
+        let serialized_epochs = bound_epochs
+            .iter()
+            .map(serde_json::to_vec)
+            .collect::<Result<Vec<Vec<u8>>, _>>()?;
+        let record_key = build_key_from_vec::<CURRENT_VERSION>(
             VC_EMULATION_BINDING_LABEL,
-            &serde_json::to_vec(group_id).unwrap(),
-            serde_json::to_vec(bindings).unwrap(),
-        )
+            serialized_group_id.clone(),
+        );
+        let epochs_key =
+            build_key_from_vec::<CURRENT_VERSION>(VC_BOUND_EPOCHS_LABEL, serialized_group_id);
+        let serialized_bindings = serde_json::to_vec(bindings)?;
+        let serialized_epoch_list = serde_json::to_vec(&serialized_epochs)?;
+        // Take the write lock once so the record and the epochs it binds are
+        // written together. The epoch-liveness scan cannot observe one without
+        // the other. The epoch list replaces the previous one, so epochs whose
+        // bindings aged out of the record stop keeping their state alive.
+        let mut values = self.values.write().unwrap();
+        values.insert(record_key, serialized_bindings);
+        values.insert(epochs_key, serialized_epoch_list);
+        Ok(())
     }
 
     #[cfg(feature = "virtual-clients-draft")]
@@ -1142,26 +1172,41 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         &self,
         group_id: &GroupId,
     ) -> Result<(), Self::Error> {
-        self.delete::<CURRENT_VERSION>(
-            VC_EMULATION_BINDING_LABEL,
-            &serde_json::to_vec(group_id).unwrap(),
-        )
+        let serialized_group_id = serde_json::to_vec(group_id)?;
+        self.delete::<CURRENT_VERSION>(VC_EMULATION_BINDING_LABEL, &serialized_group_id)?;
+        self.delete::<CURRENT_VERSION>(VC_BOUND_EPOCHS_LABEL, &serialized_group_id)
     }
 
     #[cfg(feature = "virtual-clients-draft")]
     fn write_registered_vc_derivation_epoch<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         RegisteredVcDerivationEpoch: traits::RegisteredVcDerivationEpoch<CURRENT_VERSION>,
+        EpochId: traits::VcEpochId<CURRENT_VERSION>,
     >(
         &self,
         group_id: &GroupId,
         registered: &RegisteredVcDerivationEpoch,
+        epoch_id: &EpochId,
     ) -> Result<(), Self::Error> {
-        self.write::<CURRENT_VERSION>(
+        let serialized_group_id = serde_json::to_vec(group_id)?;
+        let record_key = build_key_from_vec::<CURRENT_VERSION>(
             REGISTERED_VC_DERIVATION_EPOCH_LABEL,
-            &serde_json::to_vec(group_id).unwrap(),
-            serde_json::to_vec(registered).unwrap(),
-        )
+            serialized_group_id.clone(),
+        );
+        let epoch_key = build_key_from_vec::<CURRENT_VERSION>(
+            VC_REGISTERED_EPOCH_ID_LABEL,
+            serialized_group_id,
+        );
+        let serialized_registration = serde_json::to_vec(registered)?;
+        let serialized_epoch_id = serde_json::to_vec(epoch_id)?;
+        // Take the write lock once so the record and the epoch it names are
+        // written together. The epoch-liveness scan cannot observe one without
+        // the other. The epoch entry replaces the previous one, so the epoch a
+        // new registration supersedes stops keeping its state alive.
+        let mut values = self.values.write().unwrap();
+        values.insert(record_key, serialized_registration);
+        values.insert(epoch_key, serialized_epoch_id);
+        Ok(())
     }
 
     #[cfg(feature = "virtual-clients-draft")]
@@ -1186,10 +1231,9 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         &self,
         group_id: &GroupId,
     ) -> Result<(), Self::Error> {
-        self.delete::<CURRENT_VERSION>(
-            REGISTERED_VC_DERIVATION_EPOCH_LABEL,
-            &serde_json::to_vec(group_id).unwrap(),
-        )
+        let serialized_group_id = serde_json::to_vec(group_id)?;
+        self.delete::<CURRENT_VERSION>(REGISTERED_VC_DERIVATION_EPOCH_LABEL, &serialized_group_id)?;
+        self.delete::<CURRENT_VERSION>(VC_REGISTERED_EPOCH_ID_LABEL, &serialized_group_id)
     }
 
     #[cfg(feature = "virtual-clients-draft")]
@@ -1288,10 +1332,35 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
     ) -> Result<bool, Self::Error> {
         let serialized_epoch_id = serde_json::to_vec(epoch_id)?;
         let values = self.values.read().unwrap();
-        let referenced = values
-            .iter()
-            .any(|(key, value)| is_epoch_tag(key) && value == &serialized_epoch_id);
-        Ok(referenced)
+        Ok(any_entry_under_label(
+            &values,
+            RETAINED_KEY_PACKAGE_EPOCH_LABEL,
+            &serialized_epoch_id,
+        ))
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_vc_emulation_binding_for_epoch<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error> {
+        let serialized_epoch_id = serde_json::to_vec(epoch_id)?;
+        let values = self.values.read().unwrap();
+        Ok(epoch_has_emulation_binding(&values, &serialized_epoch_id)?)
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_registered_vc_derivation_epoch_for_epoch<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error> {
+        let serialized_epoch_id = serde_json::to_vec(epoch_id)?;
+        let values = self.values.read().unwrap();
+        Ok(any_entry_under_label(
+            &values,
+            VC_REGISTERED_EPOCH_ID_LABEL,
+            &serialized_epoch_id,
+        ))
     }
 
     #[cfg(feature = "virtual-clients-draft")]
@@ -1315,10 +1384,40 @@ fn build_key_from_vec<const V: u16>(label: &[u8], key: Vec<u8>) -> Vec<u8> {
     key_out
 }
 
-/// Whether a storage key belongs to a retained-KeyPackage epoch tag entry.
+/// Whether any entry stored under `label` holds exactly `serialized_value`.
+/// The entries that reference a derivation epoch by id are stored this way,
+/// one per referrer, so this answers whether a referrer of that kind is left.
 #[cfg(feature = "virtual-clients-draft")]
-fn is_epoch_tag(storage_key: &[u8]) -> bool {
-    storage_key.starts_with(RETAINED_KEY_PACKAGE_EPOCH_LABEL)
+fn any_entry_under_label(
+    values: &HashMap<Vec<u8>, Vec<u8>>,
+    label: &[u8],
+    serialized_value: &[u8],
+) -> bool {
+    values
+        .iter()
+        .any(|(key, value)| key.starts_with(label) && value == serialized_value)
+}
+
+/// Whether the emulation bindings of any group still bind the derivation epoch
+/// with the given serialized id.
+#[cfg(feature = "virtual-clients-draft")]
+fn epoch_has_emulation_binding(
+    values: &HashMap<Vec<u8>, Vec<u8>>,
+    serialized_epoch_id: &[u8],
+) -> Result<bool, serde_json::Error> {
+    for (key, value) in values.iter() {
+        if !key.starts_with(VC_BOUND_EPOCHS_LABEL) {
+            continue;
+        }
+        let bound_epochs: Vec<Vec<u8>> = serde_json::from_slice(value)?;
+        if bound_epochs
+            .iter()
+            .any(|epoch| epoch == serialized_epoch_id)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Build a key with version and label.

--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -1173,8 +1173,16 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         group_id: &GroupId,
     ) -> Result<(), Self::Error> {
         let serialized_group_id = serde_json::to_vec(group_id)?;
-        self.delete::<CURRENT_VERSION>(VC_EMULATION_BINDING_LABEL, &serialized_group_id)?;
-        self.delete::<CURRENT_VERSION>(VC_BOUND_EPOCHS_LABEL, &serialized_group_id)
+        let record_key = build_key_from_vec::<CURRENT_VERSION>(
+            VC_EMULATION_BINDING_LABEL,
+            serialized_group_id.clone(),
+        );
+        let epochs_key =
+            build_key_from_vec::<CURRENT_VERSION>(VC_BOUND_EPOCHS_LABEL, serialized_group_id);
+        let mut values = self.values.write().unwrap();
+        values.remove(&record_key);
+        values.remove(&epochs_key);
+        Ok(())
     }
 
     #[cfg(feature = "virtual-clients-draft")]

--- a/memory_storage/src/test_store.rs
+++ b/memory_storage/src/test_store.rs
@@ -598,10 +598,12 @@ impl StorageProvider<V_TEST> for MemoryStorage {
     fn write_vc_emulation_bindings<
         GroupId: traits::GroupId<V_TEST>,
         VcEmulationBindings: traits::VcEmulationBindings<V_TEST>,
+        EpochId: traits::VcEpochId<V_TEST>,
     >(
         &self,
         _group_id: &GroupId,
         _bindings: &VcEmulationBindings,
+        _bound_epochs: &[EpochId],
     ) -> Result<(), Self::Error> {
         todo!()
     }
@@ -629,10 +631,12 @@ impl StorageProvider<V_TEST> for MemoryStorage {
     fn write_registered_vc_derivation_epoch<
         GroupId: traits::GroupId<V_TEST>,
         RegisteredVcDerivationEpoch: traits::RegisteredVcDerivationEpoch<V_TEST>,
+        EpochId: traits::VcEpochId<V_TEST>,
     >(
         &self,
         _group_id: &GroupId,
         _registered: &RegisteredVcDerivationEpoch,
+        _epoch_id: &EpochId,
     ) -> Result<(), Self::Error> {
         todo!()
     }
@@ -707,6 +711,22 @@ impl StorageProvider<V_TEST> for MemoryStorage {
 
     #[cfg(feature = "virtual-clients-draft")]
     fn has_retained_key_package_material_for_epoch<EpochId: traits::VcEpochId<V_TEST>>(
+        &self,
+        _epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_vc_emulation_binding_for_epoch<EpochId: traits::VcEpochId<V_TEST>>(
+        &self,
+        _epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_registered_vc_derivation_epoch_for_epoch<EpochId: traits::VcEpochId<V_TEST>>(
         &self,
         _epoch_id: &EpochId,
     ) -> Result<bool, Self::Error> {

--- a/memory_storage/tests/vc_operation_tree.rs
+++ b/memory_storage/tests/vc_operation_tree.rs
@@ -33,6 +33,131 @@ struct TestDerivationState(Vec<u8>);
 impl traits::VcDerivationEpochState<CURRENT_VERSION> for TestDerivationState {}
 impl Entity<CURRENT_VERSION> for TestDerivationState {}
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestGroupId(Vec<u8>);
+impl traits::GroupId<CURRENT_VERSION> for TestGroupId {}
+impl Key<CURRENT_VERSION> for TestGroupId {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestEmulationBindings(Vec<u8>);
+impl traits::VcEmulationBindings<CURRENT_VERSION> for TestEmulationBindings {}
+impl Entity<CURRENT_VERSION> for TestEmulationBindings {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestRegistered(Vec<u8>);
+impl traits::RegisteredVcDerivationEpoch<CURRENT_VERSION> for TestRegistered {}
+impl Entity<CURRENT_VERSION> for TestRegistered {}
+
+/// An emulation group's registration record keeps its epoch's state alive. A
+/// newer registration replaces the projection entry and releases the epoch,
+/// and so does deleting the record.
+#[test]
+fn registration_keeps_epoch_state_alive() {
+    let storage = MemoryStorage::default();
+    let epoch_id = TestEpochId(b"RegisteredEpoch".to_vec());
+    let group_id = TestGroupId(b"emulation-group".to_vec());
+
+    storage
+        .write_vc_derivation_epoch_state(&epoch_id, &TestDerivationState(b"state".to_vec()))
+        .unwrap();
+    assert!(!storage
+        .has_registered_vc_derivation_epoch_for_epoch(&epoch_id)
+        .unwrap());
+
+    storage
+        .write_registered_vc_derivation_epoch(
+            &group_id,
+            &TestRegistered(b"registration".to_vec()),
+            &epoch_id,
+        )
+        .unwrap();
+    assert!(storage
+        .has_registered_vc_derivation_epoch_for_epoch(&epoch_id)
+        .unwrap());
+
+    // Nothing else references the epoch, so the registration alone has to
+    // keep the state.
+    assert!(!storage
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestDerivationState> =
+        storage.vc_derivation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_some());
+
+    // A newer registration supersedes the old epoch and releases it.
+    let newer_epoch_id = TestEpochId(b"NewerEpoch".to_vec());
+    storage
+        .write_registered_vc_derivation_epoch(
+            &group_id,
+            &TestRegistered(b"newer registration".to_vec()),
+            &newer_epoch_id,
+        )
+        .unwrap();
+    assert!(!storage
+        .has_registered_vc_derivation_epoch_for_epoch(&epoch_id)
+        .unwrap());
+    assert!(storage
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestDerivationState> =
+        storage.vc_derivation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_none());
+
+    storage
+        .delete_registered_vc_derivation_epoch(&group_id)
+        .unwrap();
+    assert!(!storage
+        .has_registered_vc_derivation_epoch_for_epoch(&newer_epoch_id)
+        .unwrap());
+}
+
+/// A group bound to a derivation epoch keeps that epoch's state alive, and
+/// dropping the group's bindings releases it.
+#[test]
+fn emulation_binding_keeps_epoch_state_alive() {
+    let storage = MemoryStorage::default();
+    let epoch_id = TestEpochId(b"BoundEpoch".to_vec());
+    let group_id = TestGroupId(b"group".to_vec());
+
+    storage
+        .write_vc_derivation_epoch_state(&epoch_id, &TestDerivationState(b"state".to_vec()))
+        .unwrap();
+    assert!(!storage
+        .has_vc_emulation_binding_for_epoch(&epoch_id)
+        .unwrap());
+
+    storage
+        .write_vc_emulation_bindings(
+            &group_id,
+            &TestEmulationBindings(b"bindings".to_vec()),
+            std::slice::from_ref(&epoch_id),
+        )
+        .unwrap();
+    assert!(storage
+        .has_vc_emulation_binding_for_epoch(&epoch_id)
+        .unwrap());
+
+    // No retained material references the epoch, so the binding alone has to
+    // keep the state.
+    assert!(!storage
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestDerivationState> =
+        storage.vc_derivation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_some());
+
+    storage.delete_vc_emulation_bindings(&group_id).unwrap();
+    assert!(!storage
+        .has_vc_emulation_binding_for_epoch(&epoch_id)
+        .unwrap());
+    assert!(storage
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestDerivationState> =
+        storage.vc_derivation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_none());
+}
+
 /// A batch write stores the operation tree and the retained material, the
 /// material ties the epoch into liveness, and the guarded delete keeps the
 /// epoch state while material references it but removes it afterwards.

--- a/openmls/src/components/vc_derivation_info.rs
+++ b/openmls/src/components/vc_derivation_info.rs
@@ -968,7 +968,7 @@ pub(crate) fn register_vc_derivation_epoch<
             RegisterVcDerivationEpochError::Storage(e)
         })?;
     storage
-        .write_registered_vc_derivation_epoch(group_id, &registered)
+        .write_registered_vc_derivation_epoch(group_id, &registered, &registered.epoch_id)
         .map_err(|e| {
             log::error!("vc: record newest derivation epoch at registration failed: {e:?}");
             RegisterVcDerivationEpochError::Storage(e)
@@ -1003,6 +1003,31 @@ impl VcEmulationBindings {
             }
         }
         None
+    }
+
+    /// The derivation epochs this record binds, without duplicates and in
+    /// order of first appearance. A derivation epoch stays bound while the
+    /// virtual-client LeafNode it produced is active, so the same epoch id
+    /// usually appears under several higher-level epochs.
+    pub fn bound_epoch_ids(&self) -> Vec<EpochId> {
+        let mut epoch_ids = Vec::with_capacity(self.bindings.len());
+        for (_, epoch_id) in &self.bindings {
+            if !epoch_ids.contains(epoch_id) {
+                epoch_ids.push(epoch_id.clone());
+            }
+        }
+        epoch_ids
+    }
+
+    /// Persist this record for `group_id`, together with the derivation epochs
+    /// it binds. Storage keeps the state of a bound epoch alive, so the two
+    /// have to be written from the same record.
+    pub(crate) fn store<Storage: crate::storage::StorageProvider>(
+        &self,
+        storage: &Storage,
+        group_id: &GroupId,
+    ) -> Result<(), Storage::Error> {
+        storage.write_vc_emulation_bindings(group_id, self, &self.bound_epoch_ids())
     }
 
     /// Record `epoch_id` as the binding for `epoch`, keeping at most
@@ -1073,6 +1098,12 @@ impl EpochEncryptionKey {
 /// secret tree and keyed by [`EpochId`]. Bundles everything the library needs
 /// to emit a VC commit for this epoch and to XOR application message nonces
 /// with deterministic reuse guards.
+///
+/// This is the local storage encoding, not the draft's wire struct of the same
+/// name. The draft's version carries the `epoch_id` and the operation secret
+/// tree as fields, both of which are stored separately here and keyed by
+/// [`EpochId`], and calls the leaf count `leaf_count` rather than
+/// `emulation_group_size`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VcDerivationEpochState {
     /// The registering client's leaf index in the emulation group at

--- a/openmls/src/components/vc_derivation_info.rs
+++ b/openmls/src/components/vc_derivation_info.rs
@@ -471,7 +471,17 @@ impl DerivationInfo {
 /// `safe_export_secret(VC_COMPONENT_ID)`, so every emulator client of a virtual
 /// client arrives at the same value for a given derivation epoch.
 #[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TlsSize, TlsSerialize, TlsDeserializeBytes,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    TlsSize,
+    TlsSerialize,
+    TlsDeserializeBytes,
 )]
 pub struct EpochId(VLByteVec);
 
@@ -1006,16 +1016,17 @@ impl VcEmulationBindings {
     }
 
     /// The derivation epochs this record binds, without duplicates and in
-    /// order of first appearance. A derivation epoch stays bound while the
-    /// virtual-client LeafNode it produced is active, so the same epoch id
-    /// usually appears under several higher-level epochs.
+    /// sorted order. A derivation epoch stays bound while the virtual-client
+    /// LeafNode it produced is active, so the same epoch id usually appears
+    /// under several higher-level epochs.
     pub fn bound_epoch_ids(&self) -> Vec<EpochId> {
-        let mut epoch_ids = Vec::with_capacity(self.bindings.len());
-        for (_, epoch_id) in &self.bindings {
-            if !epoch_ids.contains(epoch_id) {
-                epoch_ids.push(epoch_id.clone());
-            }
-        }
+        let mut epoch_ids: Vec<EpochId> = self
+            .bindings
+            .iter()
+            .map(|(_, epoch_id)| epoch_id.clone())
+            .collect();
+        epoch_ids.sort_unstable();
+        epoch_ids.dedup();
         epoch_ids
     }
 

--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -688,9 +688,8 @@ fn build_vc_internal<Provider: OpenMlsProvider>(
         .unwrap_or_default();
     let max_entries = mls_group.message_secrets_store.max_epochs.saturating_add(1);
     bindings.insert(mls_group.epoch(), epoch_id, max_entries);
-    provider
-        .storage()
-        .write_vc_emulation_bindings(&group_id, &bindings)
+    bindings
+        .store(provider.storage(), &group_id)
         .map_err(NewGroupError::StorageError)?;
 
     mls_group

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -1400,9 +1400,8 @@ impl MlsGroup {
             .unwrap_or_default();
         let max_entries = message_secrets_store.max_epochs.saturating_add(1);
         bindings.insert(public_group.group_context().epoch(), epoch_id, max_entries);
-        provider
-            .storage()
-            .write_vc_emulation_bindings(public_group.group_id(), &bindings)
+        bindings
+            .store(provider.storage(), public_group.group_id())
             .map_err(Error::StorageError)?;
 
         let mls_group = MlsGroup {

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -515,9 +515,8 @@ impl MlsGroup {
                 // with the message secrets they are needed for.
                 let max_entries = self.message_secrets_store.max_epochs.saturating_add(1);
                 bindings.insert(staged_commit.epoch(), epoch_id, max_entries);
-                provider
-                    .storage()
-                    .write_vc_emulation_bindings(self.group_id(), &bindings)
+                bindings
+                    .store(provider.storage(), self.group_id())
                     .map_err(|e| {
                         log::error!("vc: persist emulation bindings at merge failed: {e:?}");
                         MergeCommitError::StorageError(e)

--- a/openmls/src/group/mls_group/staged_commit.rs
+++ b/openmls/src/group/mls_group/staged_commit.rs
@@ -726,8 +726,11 @@ impl MlsGroup {
     /// Merges a [StagedCommit] into the group state and optionally return a [`SecretTree`]
     /// from the previous epoch. The secret tree is returned if the Commit does not contain a self removal.
     ///
-    /// This function should not fail and only returns a [`Result`], because it
-    /// might throw a `LibraryError`.
+    /// Beyond a `LibraryError`, this fails on a storage error, and on an
+    /// emulation group it also fails if registering the derivation epoch the
+    /// commit creates fails. The group is already advanced in memory by then,
+    /// and a storage transaction does not roll that back, so a caller that sees
+    /// an error has to discard this group and load it again.
     pub(crate) fn merge_commit<Provider: OpenMlsProvider>(
         &mut self,
         provider: &Provider,

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -3431,14 +3431,53 @@ fn bound_group_fails_closed_when_derivation_state_missing_on_send() {
 
     let epoch_id = newest_epoch(&emulator_group, &provider);
     let _commit_msg = send_vc_commit(&mut alice_group, &emulator_group, &provider, &alice_signer);
+
+    // The group's binding keeps the epoch state alive, so the guarded delete
+    // refuses while the binding is stored.
+    let bindings: VcEmulationBindings = provider
+        .storage()
+        .vc_emulation_bindings(alice_group.group_id())
+        .expect("read emulation bindings")
+        .expect("the VC commit bound the group");
+    assert!(!provider
+        .storage()
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
+        .expect("guarded delete while bound"));
+
+    // Drop the binding. The emulator group's registration record alone still
+    // keeps the epoch state alive.
+    provider
+        .storage()
+        .delete_vc_emulation_bindings(alice_group.group_id())
+        .expect("drop emulation bindings");
+    assert!(!provider
+        .storage()
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
+        .expect("guarded delete while registered"));
+
+    // Drop the registration too, delete the state, then put the binding back.
+    // That leaves the group bound to an epoch whose state is gone, which is
+    // the situation a corrupted or partially restored store can produce.
+    provider
+        .storage()
+        .delete_registered_vc_derivation_epoch(emulator_group.group_id())
+        .expect("drop registered derivation epoch");
     let deleted = provider
         .storage()
         .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
         .expect("delete derivation epoch state");
     assert!(
         deleted,
-        "no retained material, so the epoch state is deleted"
+        "nothing references the epoch, so the epoch state is deleted"
     );
+    provider
+        .storage()
+        .write_vc_emulation_bindings(
+            alice_group.group_id(),
+            &bindings,
+            &bindings.bound_epoch_ids(),
+        )
+        .expect("restore emulation bindings");
 
     let err = alice_group
         .create_message(&provider, &alice_signer, b"must not send")

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -3496,6 +3496,70 @@ fn bound_group_fails_closed_when_derivation_state_missing_on_send() {
     );
 }
 
+#[test]
+fn aged_out_binding_releases_derivation_epoch_state() {
+    let ciphersuite =
+        openmls_traits::types::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let provider = OpenMlsRustCrypto::default();
+    let (alice_credential, alice_signer) =
+        new_credential(&provider, b"Alice", ciphersuite.signature_algorithm());
+
+    let mut alice_group =
+        new_vc_main_group(ciphersuite, &provider, &alice_signer, alice_credential);
+    let (mut emulator_group, emulator_signer) =
+        make_emulator_group(ciphersuite, &provider, b"AliceEmulator", true);
+
+    let epoch_id_one = newest_epoch(&emulator_group, &provider);
+    let _commit = send_vc_commit(&mut alice_group, &emulator_group, &provider, &alice_signer);
+
+    // Start a second derivation epoch on the emulation group. The emulator's
+    // registration record then references only the new epoch, so the group's
+    // binding is all that keeps the first epoch's state alive.
+    let _bundle = emulator_group
+        .commit_builder()
+        .derivation_epoch(true)
+        .force_self_update(true)
+        .load_psks(provider.storage())
+        .expect("load psks")
+        .build(provider.rand(), provider.crypto(), &emulator_signer, |_| {
+            true
+        })
+        .expect("build emulator commit with marker")
+        .stage_commit(&provider)
+        .expect("stage emulator commit with marker");
+    emulator_group
+        .merge_pending_commit(&provider)
+        .expect("emulator merge marker commit");
+    let epoch_id_two = newest_epoch(&emulator_group, &provider);
+    assert_ne!(epoch_id_one, epoch_id_two);
+    assert!(!provider
+        .storage()
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id_one)
+        .expect("guarded delete while bound"));
+
+    // The second VC commit rewrites the bindings. The group retains no past
+    // message secrets, so the record keeps a single entry and the rewrite
+    // drops the first epoch from the bound-epochs list.
+    let _commit = send_vc_commit(&mut alice_group, &emulator_group, &provider, &alice_signer);
+    let bindings: VcEmulationBindings = provider
+        .storage()
+        .vc_emulation_bindings(alice_group.group_id())
+        .expect("read emulation bindings")
+        .expect("emulation bindings present");
+    assert_eq!(bindings.bound_epoch_ids(), vec![epoch_id_two.clone()]);
+
+    // Nothing references the first epoch anymore, so its state is deletable.
+    // The second epoch stays alive through the new binding.
+    assert!(provider
+        .storage()
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id_one)
+        .expect("guarded delete of the aged-out epoch"));
+    assert!(!provider
+        .storage()
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id_two)
+        .expect("guarded delete of the still-bound epoch"));
+}
+
 /// On a group bound to a derivation epoch, `create_unconfirmed_message`
 /// returns a generation ID, and consecutive ratchet generations produce
 /// distinct generation IDs.

--- a/sqlite_storage/migrations/V8__vc_epoch_liveness_projections.sql
+++ b/sqlite_storage/migrations/V8__vc_epoch_liveness_projections.sql
@@ -1,0 +1,29 @@
+-- Projection of the emulation bindings onto the derivation epochs they bind.
+-- One row per (higher-level group, derivation epoch) pair, rewritten whole
+-- whenever the group's binding record is written. The binding record itself is
+-- an opaque blob, so this table is what lets the guarded delete of a
+-- derivation epoch's state find the groups still bound to it and keep the
+-- state alive for them.
+CREATE TABLE vc_emulation_binding_epochs (
+    provider_version INTEGER NOT NULL,
+    group_id BLOB NOT NULL,
+    epoch_id BLOB NOT NULL,
+    PRIMARY KEY (group_id, epoch_id)
+);
+
+-- The guarded delete queries by epoch alone, which the group-first primary key
+-- cannot serve.
+CREATE INDEX vc_emulation_binding_epochs_epoch_id
+    ON vc_emulation_binding_epochs (epoch_id);
+
+-- Projection of the registration record onto the derivation epoch it names,
+-- for the same guarded delete: an emulation group's current epoch must stay
+-- alive even before any higher-level group binds it. The registration record
+-- is an opaque blob, so the epoch id is kept in a column written alongside it.
+-- Rows written before this migration hold NULL and are not represented until
+-- the group registers again.
+ALTER TABLE registered_vc_derivation_epochs
+    ADD COLUMN epoch_id BLOB;
+
+CREATE INDEX registered_vc_derivation_epochs_epoch_id
+    ON registered_vc_derivation_epochs (epoch_id);

--- a/sqlite_storage/src/storage_provider.rs
+++ b/sqlite_storage/src/storage_provider.rs
@@ -777,10 +777,14 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
         epoch_id: &EpochId,
     ) -> Result<bool, Self::Error> {
         // The application should call this within a transaction so the liveness
-        // check and the deletions apply atomically and a material stored
-        // concurrently cannot be orphaned.
+        // checks and the deletions apply atomically and a material, binding,
+        // or registration stored concurrently cannot be orphaned.
         if StorableKeyRef(epoch_id)
             .has_retained_key_package_material_for_epoch::<C>(self.connection.borrow())?
+            || StorableKeyRef(epoch_id)
+                .has_vc_emulation_binding_for_epoch::<C>(self.connection.borrow())?
+            || StorableKeyRef(epoch_id)
+                .has_registered_vc_derivation_epoch_for_epoch::<C>(self.connection.borrow())?
         {
             return Ok(false);
         }
@@ -793,13 +797,19 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
     fn write_vc_emulation_bindings<
         GroupId: traits::GroupId<STORAGE_PROVIDER_VERSION>,
         VcEmulationBindings: traits::VcEmulationBindings<STORAGE_PROVIDER_VERSION>,
+        EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>,
     >(
         &self,
         group_id: &GroupId,
         bindings: &VcEmulationBindings,
+        bound_epochs: &[EpochId],
     ) -> Result<(), Self::Error> {
         crate::vc_secrets::StorableEmulationBindingRef(bindings)
-            .store_vc_emulation_bindings::<C, _>(self.connection.borrow(), group_id)
+            .store_vc_emulation_bindings::<C, _, _>(
+                self.connection.borrow(),
+                group_id,
+                bound_epochs,
+            )
     }
 
     #[cfg(feature = "virtual-clients-draft")]
@@ -826,13 +836,19 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
     fn write_registered_vc_derivation_epoch<
         GroupId: traits::GroupId<STORAGE_PROVIDER_VERSION>,
         RegisteredVcDerivationEpoch: traits::RegisteredVcDerivationEpoch<STORAGE_PROVIDER_VERSION>,
+        EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>,
     >(
         &self,
         group_id: &GroupId,
         registered: &RegisteredVcDerivationEpoch,
+        epoch_id: &EpochId,
     ) -> Result<(), Self::Error> {
         crate::vc_secrets::StorableRegisteredVcDerivationEpochRef(registered)
-            .store_registered_vc_derivation_epoch::<C, _>(self.connection.borrow(), group_id)
+            .store_registered_vc_derivation_epoch::<C, _, _>(
+                self.connection.borrow(),
+                group_id,
+                epoch_id,
+            )
     }
 
     #[cfg(feature = "virtual-clients-draft")]
@@ -934,6 +950,25 @@ impl<C: Codec, ConnectionRef: Borrow<Connection>> StorageProvider<STORAGE_PROVID
     ) -> Result<bool, Self::Error> {
         StorableKeyRef(epoch_id)
             .has_retained_key_package_material_for_epoch::<C>(self.connection.borrow())
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_vc_emulation_binding_for_epoch<EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>>(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error> {
+        StorableKeyRef(epoch_id).has_vc_emulation_binding_for_epoch::<C>(self.connection.borrow())
+    }
+
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_registered_vc_derivation_epoch_for_epoch<
+        EpochId: traits::VcEpochId<STORAGE_PROVIDER_VERSION>,
+    >(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error> {
+        StorableKeyRef(epoch_id)
+            .has_registered_vc_derivation_epoch_for_epoch::<C>(self.connection.borrow())
     }
 
     #[cfg(feature = "virtual-clients-draft")]

--- a/sqlite_storage/src/vc_secrets.rs
+++ b/sqlite_storage/src/vc_secrets.rs
@@ -152,18 +152,15 @@ impl<VcEpochId: VcEpochIdTrait<STORAGE_PROVIDER_VERSION>> StorableKeyRef<'_, VcE
         Ok(())
     }
 
-    pub(super) fn has_retained_key_package_material_for_epoch<C: Codec>(
+    /// Runs an `EXISTS` query that takes this epoch id as `?1` and the
+    /// provider version as `?2`.
+    fn epoch_reference_exists<C: Codec>(
         &self,
         connection: &rusqlite::Connection,
+        exists_query: &str,
     ) -> Result<bool, rusqlite::Error> {
         let Self(epoch_id) = self;
-        let mut stmt = connection.prepare(
-            "SELECT EXISTS(
-                SELECT 1 FROM vc_retained_key_package_material
-                WHERE epoch_id = ?1
-                    AND provider_version = ?2
-            )",
-        )?;
+        let mut stmt = connection.prepare(exists_query)?;
         stmt.query_row(
             params![
                 KeyRefWrapper::<C, VcEpochId>(epoch_id, PhantomData),
@@ -172,11 +169,54 @@ impl<VcEpochId: VcEpochIdTrait<STORAGE_PROVIDER_VERSION>> StorableKeyRef<'_, VcE
             |row| row.get::<_, bool>(0),
         )
     }
+
+    pub(super) fn has_retained_key_package_material_for_epoch<C: Codec>(
+        &self,
+        connection: &rusqlite::Connection,
+    ) -> Result<bool, rusqlite::Error> {
+        self.epoch_reference_exists::<C>(
+            connection,
+            "SELECT EXISTS(
+                SELECT 1 FROM vc_retained_key_package_material
+                WHERE epoch_id = ?1
+                    AND provider_version = ?2
+            )",
+        )
+    }
+
+    pub(super) fn has_vc_emulation_binding_for_epoch<C: Codec>(
+        &self,
+        connection: &rusqlite::Connection,
+    ) -> Result<bool, rusqlite::Error> {
+        self.epoch_reference_exists::<C>(
+            connection,
+            "SELECT EXISTS(
+                SELECT 1 FROM vc_emulation_binding_epochs
+                WHERE epoch_id = ?1
+                    AND provider_version = ?2
+            )",
+        )
+    }
+
+    pub(super) fn has_registered_vc_derivation_epoch_for_epoch<C: Codec>(
+        &self,
+        connection: &rusqlite::Connection,
+    ) -> Result<bool, rusqlite::Error> {
+        self.epoch_reference_exists::<C>(
+            connection,
+            "SELECT EXISTS(
+                SELECT 1 FROM registered_vc_derivation_epochs
+                WHERE epoch_id = ?1
+                    AND provider_version = ?2
+            )",
+        )
+    }
 }
 
 /// Per-epoch bindings from a higher-level group to derivation epochs. One row
-/// per higher-level group, holding the serialized binding record. Written on
-/// every commit merge.
+/// per higher-level group, holding the serialized binding record, plus one row
+/// per bound derivation epoch in `vc_emulation_binding_epochs` so the record
+/// can be queried by epoch. Written on every commit merge.
 pub(super) struct StorableEmulationBindingRef<
     'a,
     VcEmulationBindings: EntityTrait<STORAGE_PROVIDER_VERSION>,
@@ -188,10 +228,12 @@ impl<'a, VcEmulationBindings: EntityTrait<STORAGE_PROVIDER_VERSION>>
     pub(super) fn store_vc_emulation_bindings<
         C: Codec,
         GroupId: GroupIdTrait<STORAGE_PROVIDER_VERSION>,
+        EpochId: VcEpochIdTrait<STORAGE_PROVIDER_VERSION>,
     >(
         &self,
         connection: &rusqlite::Connection,
         group_id: &GroupId,
+        bound_epochs: &[EpochId],
     ) -> Result<(), rusqlite::Error> {
         connection.execute(
             "INSERT INTO vc_emulation_bindings (provider_version, group_id, bindings)
@@ -205,6 +247,31 @@ impl<'a, VcEmulationBindings: EntityTrait<STORAGE_PROVIDER_VERSION>>
                 EntityRefWrapper::<C, _>(self.0, PhantomData)
             ],
         )?;
+        // The record above replaces the previous one wholesale, so the
+        // projection is rebuilt rather than added to. That also drops the
+        // epochs whose bindings aged out of the record.
+        connection.execute(
+            "DELETE FROM vc_emulation_binding_epochs
+            WHERE group_id = ?1
+                AND provider_version = ?2",
+            params![
+                KeyRefWrapper::<C, _>(group_id, PhantomData),
+                STORAGE_PROVIDER_VERSION
+            ],
+        )?;
+        let mut stmt = connection.prepare(
+            "INSERT INTO vc_emulation_binding_epochs (provider_version, group_id, epoch_id)
+            VALUES (?1, ?2, ?3)
+            ON CONFLICT(group_id, epoch_id) DO UPDATE SET
+                provider_version = excluded.provider_version",
+        )?;
+        for epoch_id in bound_epochs {
+            stmt.execute(params![
+                STORAGE_PROVIDER_VERSION,
+                KeyRefWrapper::<C, _>(group_id, PhantomData),
+                KeyRefWrapper::<C, _>(epoch_id, PhantomData)
+            ])?;
+        }
         Ok(())
     }
 }
@@ -251,13 +318,23 @@ impl<GroupId: GroupIdTrait<STORAGE_PROVIDER_VERSION>> StorableKeyRef<'_, GroupId
                 STORAGE_PROVIDER_VERSION
             ],
         )?;
+        connection.execute(
+            "DELETE FROM vc_emulation_binding_epochs
+            WHERE group_id = ?1
+                AND provider_version = ?2",
+            params![
+                KeyRefWrapper::<C, GroupId>(group_id, PhantomData),
+                STORAGE_PROVIDER_VERSION
+            ],
+        )?;
         Ok(())
     }
 }
 
 /// The derivation epoch an emulation group registered for its current group
 /// epoch. One row per emulation group, holding the serialized registration
-/// record. Written when a derivation epoch is registered.
+/// record plus the epoch id it names so the record can be queried by epoch.
+/// Written when a derivation epoch is registered.
 pub(super) struct StorableRegisteredVcDerivationEpochRef<
     'a,
     RegisteredVcDerivationEpoch: EntityTrait<STORAGE_PROVIDER_VERSION>,
@@ -269,21 +346,26 @@ impl<'a, RegisteredVcDerivationEpoch: EntityTrait<STORAGE_PROVIDER_VERSION>>
     pub(super) fn store_registered_vc_derivation_epoch<
         C: Codec,
         GroupId: GroupIdTrait<STORAGE_PROVIDER_VERSION>,
+        EpochId: VcEpochIdTrait<STORAGE_PROVIDER_VERSION>,
     >(
         &self,
         connection: &rusqlite::Connection,
         group_id: &GroupId,
+        epoch_id: &EpochId,
     ) -> Result<(), rusqlite::Error> {
         connection.execute(
-            "INSERT INTO registered_vc_derivation_epochs (provider_version, group_id, registration)
-            VALUES (?1, ?2, ?3)
+            "INSERT INTO registered_vc_derivation_epochs
+                (provider_version, group_id, registration, epoch_id)
+            VALUES (?1, ?2, ?3, ?4)
             ON CONFLICT(group_id) DO UPDATE SET
                 registration = excluded.registration,
+                epoch_id = excluded.epoch_id,
                 provider_version = excluded.provider_version",
             params![
                 STORAGE_PROVIDER_VERSION,
                 KeyRefWrapper::<C, _>(group_id, PhantomData),
-                EntityRefWrapper::<C, _>(self.0, PhantomData)
+                EntityRefWrapper::<C, _>(self.0, PhantomData),
+                KeyRefWrapper::<C, _>(epoch_id, PhantomData)
             ],
         )?;
         Ok(())

--- a/sqlite_storage/tests/vc_operation_tree.rs
+++ b/sqlite_storage/tests/vc_operation_tree.rs
@@ -49,6 +49,131 @@ struct TestDerivationState(Vec<u8>);
 impl traits::VcDerivationEpochState<1> for TestDerivationState {}
 impl Entity<1> for TestDerivationState {}
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestGroupId(Vec<u8>);
+impl traits::GroupId<1> for TestGroupId {}
+impl Key<1> for TestGroupId {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestEmulationBindings(Vec<u8>);
+impl traits::VcEmulationBindings<1> for TestEmulationBindings {}
+impl Entity<1> for TestEmulationBindings {}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+struct TestRegistered(Vec<u8>);
+impl traits::RegisteredVcDerivationEpoch<1> for TestRegistered {}
+impl Entity<1> for TestRegistered {}
+
+/// An emulation group's registration record keeps its epoch's state alive. A
+/// newer registration replaces the projection entry and releases the epoch,
+/// and so does deleting the record.
+#[test]
+fn registration_keeps_epoch_state_alive() {
+    let storage = storage();
+    let epoch_id = TestEpochId(b"RegisteredEpoch".to_vec());
+    let group_id = TestGroupId(b"emulation-group".to_vec());
+
+    storage
+        .write_vc_derivation_epoch_state(&epoch_id, &TestDerivationState(b"state".to_vec()))
+        .unwrap();
+    assert!(!storage
+        .has_registered_vc_derivation_epoch_for_epoch(&epoch_id)
+        .unwrap());
+
+    storage
+        .write_registered_vc_derivation_epoch(
+            &group_id,
+            &TestRegistered(b"registration".to_vec()),
+            &epoch_id,
+        )
+        .unwrap();
+    assert!(storage
+        .has_registered_vc_derivation_epoch_for_epoch(&epoch_id)
+        .unwrap());
+
+    // Nothing else references the epoch, so the registration alone has to
+    // keep the state.
+    assert!(!storage
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestDerivationState> =
+        storage.vc_derivation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_some());
+
+    // A newer registration supersedes the old epoch and releases it.
+    let newer_epoch_id = TestEpochId(b"NewerEpoch".to_vec());
+    storage
+        .write_registered_vc_derivation_epoch(
+            &group_id,
+            &TestRegistered(b"newer registration".to_vec()),
+            &newer_epoch_id,
+        )
+        .unwrap();
+    assert!(!storage
+        .has_registered_vc_derivation_epoch_for_epoch(&epoch_id)
+        .unwrap());
+    assert!(storage
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestDerivationState> =
+        storage.vc_derivation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_none());
+
+    storage
+        .delete_registered_vc_derivation_epoch(&group_id)
+        .unwrap();
+    assert!(!storage
+        .has_registered_vc_derivation_epoch_for_epoch(&newer_epoch_id)
+        .unwrap());
+}
+
+/// A group bound to a derivation epoch keeps that epoch's state alive, and
+/// dropping the group's bindings releases it.
+#[test]
+fn emulation_binding_keeps_epoch_state_alive() {
+    let storage = storage();
+    let epoch_id = TestEpochId(b"BoundEpoch".to_vec());
+    let group_id = TestGroupId(b"group".to_vec());
+
+    storage
+        .write_vc_derivation_epoch_state(&epoch_id, &TestDerivationState(b"state".to_vec()))
+        .unwrap();
+    assert!(!storage
+        .has_vc_emulation_binding_for_epoch(&epoch_id)
+        .unwrap());
+
+    storage
+        .write_vc_emulation_bindings(
+            &group_id,
+            &TestEmulationBindings(b"bindings".to_vec()),
+            std::slice::from_ref(&epoch_id),
+        )
+        .unwrap();
+    assert!(storage
+        .has_vc_emulation_binding_for_epoch(&epoch_id)
+        .unwrap());
+
+    // No retained material references the epoch, so the binding alone has to
+    // keep the state.
+    assert!(!storage
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestDerivationState> =
+        storage.vc_derivation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_some());
+
+    storage.delete_vc_emulation_bindings(&group_id).unwrap();
+    assert!(!storage
+        .has_vc_emulation_binding_for_epoch(&epoch_id)
+        .unwrap());
+    assert!(storage
+        .delete_vc_derivation_epoch_state_if_unreferenced(&epoch_id)
+        .unwrap());
+    let read_state: Option<TestDerivationState> =
+        storage.vc_derivation_epoch_state(&epoch_id).unwrap();
+    assert!(read_state.is_none());
+}
+
 /// A batch write stores the operation tree and the retained material, the
 /// material ties the epoch into liveness, and the guarded delete keeps the
 /// epoch state while material references it but removes it afterwards.
@@ -126,7 +251,6 @@ fn storage() -> openmls_sqlite_storage::SqliteStorageProvider<JsonCodec, Connect
     storage
 }
 
-/// Write, read back, overwrite, and delete an operation secret tree.
 #[test]
 fn operation_tree_read_write_delete() {
     let storage = storage();

--- a/traits/src/storage.rs
+++ b/traits/src/storage.rs
@@ -194,14 +194,22 @@ pub trait StorageProvider<const VERSION: u16> {
     /// group and prunes its own entries in lockstep with the group's
     /// message-secrets retention. A subsequent write replaces any previously
     /// stored record.
+    ///
+    /// `bound_epochs` lists the distinct derivation epochs the record binds,
+    /// so that an implementation can keep a projection from epoch to bound
+    /// group for [`Self::has_vc_emulation_binding_for_epoch`]. A write
+    /// replaces the group's projection rather than adding to it. Record and
+    /// projection must become visible together.
     #[cfg(feature = "virtual-clients-draft")]
     fn write_vc_emulation_bindings<
         GroupId: traits::GroupId<VERSION>,
         VcEmulationBindings: traits::VcEmulationBindings<VERSION>,
+        EpochId: traits::VcEpochId<VERSION>,
     >(
         &self,
         group_id: &GroupId,
         bindings: &VcEmulationBindings,
+        bound_epochs: &[EpochId],
     ) -> Result<(), Self::Error>;
 
     /// Record the derivation epoch an emulation group registered for its
@@ -209,14 +217,22 @@ pub trait StorageProvider<const VERSION: u16> {
     /// repeated call in the same group epoch returns the already-derived
     /// epoch id instead of consuming the forward-secure exporter again. A
     /// subsequent write replaces any previously stored record.
+    ///
+    /// `epoch_id` is the derivation epoch the record names, so that an
+    /// implementation can keep a projection from epoch to registering group
+    /// for [`Self::has_registered_vc_derivation_epoch_for_epoch`]. A write
+    /// replaces the group's projection entry. Record and projection must
+    /// become visible together.
     #[cfg(feature = "virtual-clients-draft")]
     fn write_registered_vc_derivation_epoch<
         GroupId: traits::GroupId<VERSION>,
         RegisteredVcDerivationEpoch: traits::RegisteredVcDerivationEpoch<VERSION>,
+        EpochId: traits::VcEpochId<VERSION>,
     >(
         &self,
         group_id: &GroupId,
         registered: &RegisteredVcDerivationEpoch,
+        epoch_id: &EpochId,
     ) -> Result<(), Self::Error>;
 
     /// Write the per-derivation-epoch Virtual Client Operation Secret Tree
@@ -597,6 +613,32 @@ pub trait StorageProvider<const VERSION: u16> {
         epoch_id: &EpochId,
     ) -> Result<bool, Self::Error>;
 
+    /// Return `true` if the emulation bindings of any higher-level group still
+    /// reference `epoch_id`. Used to keep a derivation epoch's state alive
+    /// while a group bound to it can still protect and deprotect messages
+    /// (see [`Self::delete_vc_derivation_epoch_state_if_unreferenced`]).
+    ///
+    /// The answer covers the `bound_epochs` of the last
+    /// [`Self::write_vc_emulation_bindings`] call of each group.
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_vc_emulation_binding_for_epoch<EpochId: traits::VcEpochId<VERSION>>(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error>;
+
+    /// Return `true` if the registration record of any emulation group still
+    /// names `epoch_id`. Used to keep a derivation epoch's state alive while
+    /// the group that registered it can still operate on it (see
+    /// [`Self::delete_vc_derivation_epoch_state_if_unreferenced`]).
+    ///
+    /// The answer covers the `epoch_id` of the last
+    /// [`Self::write_registered_vc_derivation_epoch`] call of each group.
+    #[cfg(feature = "virtual-clients-draft")]
+    fn has_registered_vc_derivation_epoch_for_epoch<EpochId: traits::VcEpochId<VERSION>>(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<bool, Self::Error>;
+
     //
     //     ---    deleters for group state    ---
     //
@@ -725,7 +767,8 @@ pub trait StorageProvider<const VERSION: u16> {
     ///
     /// Under the `virtual-clients-draft` feature, an implementation must also
     /// delete the retained virtual clients KeyPackage material stored for the
-    /// same reference (see [`Self::delete_retained_key_package_material`]).
+    /// same reference (see `delete_retained_key_package_material`, which only
+    /// exists under that feature).
     /// Deleting non-existent material is a no-op, so this is safe for
     /// KeyPackages that were never uploaded by a virtual client.
     fn delete_key_package<KeyPackageRef: traits::HashReference<VERSION>>(
@@ -751,34 +794,40 @@ pub trait StorageProvider<const VERSION: u16> {
 
     /// Delete all per-epoch state for the given derivation epoch (both the
     /// derivation epoch state and the Virtual Client Operation Secret Tree),
-    /// but only if no retained virtual clients KeyPackage material still
-    /// references it.
+    /// but only if nothing still references it.
+    ///
+    /// Three liveness sources are checked: retained virtual clients
+    /// KeyPackage material
+    /// ([`Self::has_retained_key_package_material_for_epoch`]), the emulation
+    /// bindings of higher-level groups
+    /// ([`Self::has_vc_emulation_binding_for_epoch`]), and the registration
+    /// records of emulation groups
+    /// ([`Self::has_registered_vc_derivation_epoch_for_epoch`]).
     ///
     /// Returns `Ok(true)` if the epoch state was deleted, and `Ok(false)` if
-    /// it was kept because retained material still references the epoch. The
-    /// liveness check and the deletion belong together. Providers do not open
-    /// their own transaction, so an application using a transactional provider
-    /// (such as SQLite) should call this within a transaction, so a material
-    /// stored concurrently cannot be orphaned by a deletion that already
-    /// observed the epoch as unreferenced. The in-memory provider holds its
-    /// write lock across both.
+    /// it was kept because something still references the epoch. The liveness
+    /// checks and the deletion must apply atomically, or a reference stored
+    /// concurrently can be orphaned. Providers do not open their own
+    /// transaction, so an application using a transactional provider should
+    /// call this within one.
     #[cfg(feature = "virtual-clients-draft")]
     fn delete_vc_derivation_epoch_state_if_unreferenced<EpochId: traits::VcEpochId<VERSION>>(
         &self,
         epoch_id: &EpochId,
     ) -> Result<bool, Self::Error>;
 
-    /// Remove the per-epoch emulation bindings of the given group. Called
-    /// when the group is being deleted.
+    /// Remove the per-epoch emulation bindings of the given group, together
+    /// with the group's entries in the epoch projection that backs
+    /// [`Self::has_vc_emulation_binding_for_epoch`].
     #[cfg(feature = "virtual-clients-draft")]
     fn delete_vc_emulation_bindings<GroupId: traits::GroupId<VERSION>>(
         &self,
         group_id: &GroupId,
     ) -> Result<(), Self::Error>;
 
-    /// Remove the registered derivation epoch record of the given group (see
-    /// [`Self::write_registered_vc_derivation_epoch`]). Called when the group
-    /// is being deleted or the member removed itself.
+    /// Remove the registered derivation epoch record of the given group,
+    /// together with the group's entry in the epoch projection that backs
+    /// [`Self::has_registered_vc_derivation_epoch_for_epoch`].
     #[cfg(feature = "virtual-clients-draft")]
     fn delete_registered_vc_derivation_epoch<GroupId: traits::GroupId<VERSION>>(
         &self,


### PR DESCRIPTION
This PR adds some bookkeeping to allows OpenMLS to track which epoch ID is bound to which group. This additional tracking allows OpenMLS to clean up key material from unused, old derivation epochs. That clean-up (bound to an application-defined policy) comes in a follow up.