### PR TITLE
Fix minor treemath issues

### DIFF
--- a/book/src/releases/0.9.0.md
+++ b/book/src/releases/0.9.0.md
@@ -41,6 +41,7 @@
 
 ## Fixed
 
+- [#2186](https://github.com/openmls/openmls/pulls/2186): Fix wrong computation of tree node indexes when provided invalid inputs.
 - [#2134](https://github.com/openmls/openmls/pull/2134): Known structured extension payloads now reject trailing bytes during decoding.
 - [#2109](https://github.com/openmls/openmls/pull/2109): `OpenMlsRustCrypto`'s `supports()` now agrees with `supported_ciphersuites()` for `MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87`.
 - [#2089](https://github.com/openmls/openmls/pull/2089): A Commit without an UpdatePath from this client's own leaf that doesn't match the pending commit is now staged normally instead of rejected.

--- a/openmls/src/binary_tree/array_representation/treemath.rs
+++ b/openmls/src/binary_tree/array_representation/treemath.rs
@@ -6,6 +6,17 @@ use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSize};
 pub(crate) const MAX_TREE_SIZE: u32 = (1 << 30) - 1;
 pub(crate) const MIN_TREE_SIZE: u32 = 1;
 
+/// Largest tree (node) index of any valid tree: node indices range over
+/// `0..=MAX_TREE_INDEX`. It is the last leaf of the maximal tree (even).
+const MAX_TREE_INDEX: u32 = MAX_TREE_SIZE - 1;
+
+/// Largest leaf payload: leaf `l` sits at tree index `2*l <= MAX_TREE_INDEX`.
+const MAX_LEAF: u32 = MAX_TREE_INDEX / 2;
+
+/// Largest parent payload: parent `p` sits at tree index `2*p + 1 < MAX_TREE_INDEX`
+/// (odd indices stop one short of the even maximum).
+const MAX_PARENT: u32 = MAX_LEAF - 1;
+
 /// LeafNodeIndex references a leaf node in a tree.
 #[derive(
     Debug,
@@ -37,6 +48,10 @@ impl LeafNodeIndex {
         LeafNodeIndex(index)
     }
 
+    /// Checks that the wrapped index is valid.
+    fn valid(&self) -> bool {
+        self.0 <= MAX_LEAF
+    }
     /// Return the inner value as `u32`.
     pub fn u32(&self) -> u32 {
         self.0
@@ -67,6 +82,11 @@ impl ParentNodeIndex {
     /// Create a new `ParentNodeIndex` from a `u32`.
     pub(crate) fn new(index: u32) -> Self {
         ParentNodeIndex(index)
+    }
+
+    /// Checks that the wrapped index is valid.
+    fn valid(&self) -> bool {
+        self.0 <= MAX_PARENT
     }
 
     /// Return the inner value as `u32`.
@@ -133,6 +153,14 @@ impl TreeNodeIndex {
             TreeNodeIndex::Leaf(LeafNodeIndex::from_tree_index(index))
         } else {
             TreeNodeIndex::Parent(ParentNodeIndex::from_tree_index(index))
+        }
+    }
+
+    /// Checks that the wrapped index is valid.
+    fn valid(&self) -> bool {
+        match self {
+            TreeNodeIndex::Leaf(leaf_node_index) => leaf_node_index.valid(),
+            TreeNodeIndex::Parent(parent_node_index) => parent_node_index.valid(),
         }
     }
 
@@ -429,7 +457,7 @@ pub(crate) fn node_width(n: usize) -> usize {
 }
 
 pub(crate) fn is_node_in_tree(node_index: TreeNodeIndex, size: TreeSize) -> bool {
-    node_index.u32() < size.u32()
+    node_index.valid() && node_index.u32() < size.u32()
 }
 
 #[test]
@@ -450,6 +478,17 @@ fn test_node_not_in_tree() {
         assert!(!is_node_in_tree(
             TreeNodeIndex::new(test.0),
             TreeSize::new(test.1)
+        ));
+    }
+}
+
+#[test]
+fn test_node_not_in_tree_wrapping() {
+    let tests = [1u32 << 31, u32::MAX];
+    for leaf in tests.iter() {
+        assert!(!is_node_in_tree(
+            TreeNodeIndex::Leaf(LeafNodeIndex::new(*leaf)),
+            TreeSize::new(3)
         ));
     }
 }

--- a/openmls/src/group/tests_and_kats/tests/framing_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/framing_validation.rs
@@ -745,3 +745,85 @@ fn test_valsem010() {
         .process_message(bob_provider, ProtocolMessage::from(original_message))
         .expect("Unexpected error.");
 }
+
+// ValSem004 Sender: Member: an index no tree could contain must still be rejected as an
+// unknown member. `is_node_in_tree` requires `node_index.valid()`, so above 2^31 the
+// `self.0 * 2` in `to_tree_index` overflows.
+#[openmls_test::openmls_test]
+fn test_valsem004_sender_index_out_of_range() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let ValidationTestSetup {
+        mut alice_group,
+        mut bob_group,
+        _alice_credential,
+        _bob_credential: _,
+        _alice_key_package: _,
+        _bob_key_package: _,
+    } = validation_test_setup(
+        PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+        ciphersuite,
+        alice_provider,
+        bob_provider,
+    );
+
+    let (message, _welcome, _group_info) = alice_group
+        .self_update(
+            alice_provider,
+            &_alice_credential.signer,
+            LeafNodeParameters::default(),
+        )
+        .expect("Could not self-update.")
+        .into_contents();
+
+    let serialized_message = message
+        .tls_serialize_detached()
+        .expect("Could not serialize message.");
+
+    let mut plaintext = MlsMessageIn::tls_deserialize(&mut serialized_message.as_slice())
+        .expect("Could not deserialize message.")
+        .into_plaintext()
+        .expect("Message was not a plaintext.");
+
+    // `1 << 31` is the smallest triggering value, `u32::MAX` the extreme one.
+    for bogus_index in [1u32 << 31, u32::MAX] {
+        let mut plaintext = plaintext.clone();
+        plaintext.set_sender(Sender::build_member(LeafNodeIndex::new(bogus_index)));
+
+        // The membership tag is checked before the sender, so we need to re-calculate it
+        plaintext
+            .set_membership_tag(
+                alice_provider.crypto(),
+                ciphersuite,
+                alice_group.message_secrets().membership_key(),
+                alice_group.message_secrets().serialized_context(),
+            )
+            .expect("Error setting membership tag.");
+
+        let err = bob_group
+            .process_message(bob_provider, ProtocolMessage::from(plaintext))
+            .expect_err("Processed a message from an out-of-range sender index.");
+
+        assert!(
+            matches!(
+                err,
+                ProcessMessageError::ValidationError(ValidationError::UnknownMember)
+            ),
+            "expected UnknownMember for sender index {bogus_index}, got {err:?}"
+        );
+    }
+
+    // Positive case
+    plaintext
+        .set_membership_tag(
+            alice_provider.crypto(),
+            ciphersuite,
+            alice_group.message_secrets().membership_key(),
+            alice_group.message_secrets().serialized_context(),
+        )
+        .expect("Error setting membership tag.");
+    bob_group
+        .process_message(bob_provider, ProtocolMessage::from(plaintext))
+        .expect("Unmodified message should still process.");
+}

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -548,7 +548,6 @@ impl TreeSync {
         ciphersuite: Ciphersuite,
         ratchet_tree: RatchetTree,
     ) -> Result<Self, TreeSyncFromNodesError> {
-        // TODO #800: Unmerged leaves should be checked
         let total_nodes = ratchet_tree.0.len();
         let mut leaf_nodes = Vec::with_capacity(total_nodes.div_ceil(2));
         let mut parent_nodes = Vec::with_capacity(total_nodes / 2);
@@ -581,6 +580,18 @@ impl TreeSync {
                     None => TreeSyncParentNode::blank(),
                 };
                 parent_nodes.push(parent);
+            }
+        }
+
+        // Unmerged leaves must point into the tree
+        let leaf_count = leaf_nodes.len() as u32;
+        for parent in parent_nodes.iter() {
+            if let Some(parent_node) = parent.node() {
+                if let Some(last_unmerged_leaf_index) = parent_node.unmerged_leaves().last() {
+                    if last_unmerged_leaf_index.u32() >= leaf_count {
+                        return Err(TreeSyncFromNodesError::from(PublicTreeError::MalformedTree));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
We had two cases where treemath-related functions performed operations without failing. This led to OpenMLS sometimes accepting commits from invalid senders.

This PR is based on #2182 by @clementblaudeau from @cryspen.