### PR TITLE
fix: decide own-sender by the secret tree's leaf, not the current one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2184](https://github.com/openmls/openmls/pull/2184): Added `PreSharedKeyProposal::psk`, a getter for the `PreSharedKeyId` of a `PreSharedKey` proposal.
 - [#2167](https://github.com/openmls/openmls/pull/2167): Added `PublicGroup::validate_key_package_for_add`, which checks whether a single `KeyPackage` is eligible to be added to the group without building a commit. Applications adding several members at once can use it to filter out candidates that a commit would reject, and to report which candidate was rejected and why. Uniqueness of the signature, init and encryption keys is not covered, since it can only be decided for a full set of proposals.
 
+### Fixed
+
+- [#2194](https://github.com/openmls/openmls/pull/2194): With the `virtual-clients-draft` feature, whether an inbound `PrivateMessage` is this client's own is now decided against the leaf index the epoch's secret tree was built for, rather than the group's current own leaf index. The two differ for every epoch before a sibling-resync external commit moved the client's leaf. Previously a message another member sent from the leaf the client had since moved onto was silently returned as `ProcessedMessageContent::OwnPrivateMessage`, and the echo of the client's own pre-resync message failed with `SecretTreeError::SecretReuseError`.
+
 ## 0.9.0 (2026-08-25)
 
 ### Added

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -157,8 +157,9 @@ impl DecryptedMessage {
         let (message_secrets, _old_leaves) = group
             .message_secrets_and_leaves(ciphertext.epoch())
             .map_err(MessageDecryptionError::SecretTreeError)?;
+        let own_index = message_secrets.own_index();
         let sender_data = ciphertext.sender_data(message_secrets, crypto, ciphersuite)?;
-        let own_sender = sender_data.leaf_index == group.own_leaf_index();
+        let own_sender = sender_data.leaf_index == own_index;
         // If we are the sender, the content cannot be decrypted and the
         // signature cannot be verified: the own sender ratchet only produces
         // encryption keys. Return early before touching any ratchet state so

--- a/openmls/src/schedule/message_secrets.rs
+++ b/openmls/src/schedule/message_secrets.rs
@@ -101,6 +101,12 @@ impl MessageSecrets {
             ..self
         }
     }
+
+    /// The leaf index this epoch's secret tree was built for, i.e. the group's
+    /// own leaf index at the time the epoch was entered.
+    pub(crate) fn own_index(&self) -> LeafNodeIndex {
+        self.secret_tree.own_index()
+    }
 }
 
 // Test functions

--- a/openmls/src/tree/secret_tree.rs
+++ b/openmls/src/tree/secret_tree.rs
@@ -184,6 +184,11 @@ impl SecretTree {
         secret_tree
     }
 
+    /// The leaf index this tree was built for.
+    pub(crate) fn own_index(&self) -> LeafNodeIndex {
+        self.own_index
+    }
+
     /// Get current generation for a specific SenderRatchet
     #[cfg(test)]
     pub(crate) fn generation(&self, index: LeafNodeIndex, secret_type: SecretType) -> u32 {

--- a/openmls/src/tree/tests_and_kats/unit_tests/test_secret_tree.rs
+++ b/openmls/src/tree/tests_and_kats/unit_tests/test_secret_tree.rs
@@ -19,6 +19,7 @@ fn test_boundaries() {
         TreeSize::from_leaf_count(3u32),
         LeafNodeIndex::new(2u32),
     );
+    assert_eq!(secret_tree.own_index(), LeafNodeIndex::new(2u32));
     let secret_type = SecretType::ApplicationSecret;
     assert!(secret_tree
         .secret_for_decryption(

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -5985,3 +5985,227 @@ fn new_derivation_epoch_requires_emulation_group() {
         "unexpected error: {err:?}"
     );
 }
+
+/// Reading a *past* epoch after a sibling-resync external commit.
+///
+/// The resync moves `own_leaf_index` to the joiner's new leaf
+/// (`staged_commit.rs`, `if let Some(new_idx) = state.new_own_leaf_index`).
+/// The secret trees of epochs before the resync were built for the *old*
+/// index, so from that point on "the group's current own leaf" and "the leaf a
+/// past epoch's secret tree belongs to" are two different things.
+///
+/// `DecryptedMessage::from_inbound_ciphertext` decides whether an inbound
+/// message is the caller's own by comparing the sender's leaf index against
+/// one of those two. Comparing against the current one misclassifies every
+/// message in every pre-resync epoch that came from the leaf the client has
+/// since moved onto -- here Dave's, who was removed before the resync and
+/// whose leaf the joiner then reuses.
+///
+/// The tree is arranged so that the resync actually moves the leaf, which
+/// needs a blank to the left of the virtual client:
+///
+/// ```text
+///   leaf 0      leaf 1      leaf 2
+///   Dave        Alice (VC)  Bob      epoch 1: Dave sends
+///   -           Alice (VC)  Bob      epoch 2: Dave removed; Alice and Bob send
+///   Alice (VC)  -           Bob      epoch 3: resync, Alice moves 1 -> 0
+/// ```
+#[openmls_test]
+fn vc_past_epoch_read_survives_sibling_resync() {
+    use openmls::group::PastEpochDeletionPolicy;
+    use openmls::prelude::LeafNodeIndex;
+
+    let dave_provider = Provider::default();
+    let alice_a_provider = Provider::default();
+    let alice_b_provider = Provider::default();
+    let bob_provider = Provider::default();
+
+    let (vc_signer, vc_credential) =
+        shared_vc_identity(ciphersuite, &alice_a_provider, &alice_b_provider);
+
+    let join_config = MlsGroupJoinConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .use_ratchet_tree_extension(true)
+        .set_past_epoch_deletion_policy(PastEpochDeletionPolicy::MaxEpochs(10))
+        .build();
+
+    // Higher-level group. Dave creates it and takes leaf 0, so that removing
+    // him later leaves a blank to the left of the virtual client -- without
+    // that blank the joiner reuses the virtual client's own leaf and
+    // `own_leaf_index` never moves.
+    //
+    // The past-epoch buffer has to be large enough to still hold the epochs
+    // the messages below are sent in; the default `MaxEpochs(0)` would drop
+    // them at the next commit and the reads would fail for an unrelated
+    // reason.
+    let group_config = MlsGroupCreateConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .ciphersuite(ciphersuite)
+        .use_ratchet_tree_extension(true)
+        .set_past_epoch_deletion_policy(PastEpochDeletionPolicy::MaxEpochs(10))
+        .capabilities(vc_capabilities())
+        .with_leaf_node_extensions(vc_leaf_extensions())
+        .expect("attach leaf-node extensions on higher-level config")
+        .build();
+    let (dave_credential, dave_signer) =
+        new_credential(&dave_provider, b"Dave", ciphersuite.signature_algorithm());
+    let mut dave_main = MlsGroup::new(&dave_provider, &dave_signer, &group_config, dave_credential)
+        .expect("dave create higher-level group");
+    assert_eq!(dave_main.own_leaf_index(), LeafNodeIndex::new(0));
+
+    // Dave adds the virtual client (leaf 1) and Bob (leaf 2).
+    let alice_vc_kp = KeyPackage::builder()
+        .key_package_extensions(Extensions::empty())
+        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_extensions(vc_leaf_extensions())
+        .build(
+            ciphersuite,
+            &alice_a_provider,
+            &vc_signer,
+            vc_credential.clone(),
+        )
+        .expect("alice VC KP build")
+        .key_package()
+        .to_owned();
+    let (bob_kp, bob_signer) = vc_key_package(ciphersuite, &bob_provider, b"Bob");
+    let (_, welcome, _) = dave_main
+        .add_members(&dave_provider, &dave_signer, &[alice_vc_kp, bob_kp])
+        .expect("dave adds alice and bob");
+    dave_main
+        .merge_pending_commit(&dave_provider)
+        .expect("dave merge add");
+    let ratchet_tree = dave_main.export_ratchet_tree();
+    let mut alice_a_main = StagedWelcome::new_from_welcome(
+        &alice_a_provider,
+        &join_config,
+        welcome.clone().into_welcome().expect("welcome"),
+        Some(ratchet_tree.clone().into()),
+    )
+    .and_then(|s| s.into_group(&alice_a_provider))
+    .expect("alice_a join higher-level group");
+    let mut bob_main = StagedWelcome::new_from_welcome(
+        &bob_provider,
+        &join_config,
+        welcome.into_welcome().expect("welcome"),
+        Some(ratchet_tree.into()),
+    )
+    .and_then(|s| s.into_group(&bob_provider))
+    .expect("bob join higher-level group");
+
+    let dave_leaf = dave_main.own_leaf_index();
+    let old_leaf_index = alice_a_main.own_leaf_index();
+    assert_eq!(old_leaf_index, LeafNodeIndex::new(1));
+
+    // Epoch 1: Dave sends from leaf 0, and alice_a leaves it unread.
+    let epoch_with_dave = alice_a_main.epoch();
+    let from_dave = dave_main
+        .create_message(&dave_provider, &dave_signer, b"dave from leaf zero")
+        .expect("dave app message");
+
+    // Epoch 1 -> 2: Bob removes Dave, blanking leaf 0.
+    let (remove_commit, _, _) = bob_main
+        .remove_members(&bob_provider, &bob_signer, &[dave_leaf])
+        .expect("bob removes dave");
+    bob_main
+        .merge_pending_commit(&bob_provider)
+        .expect("bob merge remove");
+    process_and_merge_commit(&mut alice_a_main, &alice_a_provider, remove_commit);
+
+    // Epoch 2: Bob and the virtual client each send, both left unread.
+    let pre_resync_epoch = alice_a_main.epoch();
+    let from_bob = bob_main
+        .create_message(&bob_provider, &bob_signer, b"bob before the resync")
+        .expect("bob app message");
+    let from_alice_a = alice_a_main
+        .create_message(&alice_a_provider, &vc_signer, b"alice_a before the resync")
+        .expect("alice_a app message");
+
+    // The resync: alice_b founds the emulation group with alice_a, then joins
+    // the higher-level group by external commit. The auto-Remove picks up the
+    // virtual client's leaf 1, and the joiner lands on the blank leaf 0.
+    let (siblings, commit_msg) = join_sibling_emulator(
+        ciphersuite,
+        &alice_a_provider,
+        &alice_b_provider,
+        &vc_signer,
+        vc_credential,
+        &alice_a_main,
+        join_config.clone(),
+    );
+    let new_leaf_index = siblings.alice_b_main.own_leaf_index();
+
+    process_and_merge_commit(&mut alice_a_main, &alice_a_provider, commit_msg.clone());
+    process_and_merge_commit(&mut bob_main, &bob_provider, commit_msg);
+
+    assert_eq!(
+        new_leaf_index, dave_leaf,
+        "the joiner must land on Dave's blanked leaf, otherwise this test \
+         checks nothing"
+    );
+    assert_ne!(
+        old_leaf_index, new_leaf_index,
+        "the resync must actually move the virtual client's own leaf"
+    );
+    assert_eq!(alice_a_main.own_leaf_index(), new_leaf_index);
+    assert!(
+        epoch_with_dave.as_u64() < pre_resync_epoch.as_u64()
+            && pre_resync_epoch.as_u64() < alice_a_main.epoch().as_u64(),
+        "both unread messages must come from epochs before the resync"
+    );
+
+    // The case this test exists for: Dave's message, sent from leaf 0 in an
+    // epoch in which leaf 0 was his, read after the virtual client has moved
+    // onto that same leaf 0.
+    let processed = alice_a_main
+        .process_message(
+            &alice_a_provider,
+            from_dave.into_protocol_message().unwrap(),
+        )
+        .expect(
+            "a message from a leaf the client has since moved onto must not be \
+             mistaken for the client's own",
+        );
+    match processed.into_content() {
+        ProcessedMessageContent::ApplicationMessage(app) => {
+            assert_eq!(
+                app.into_bytes(),
+                b"dave from leaf zero",
+                "Dave's message came back with the wrong content"
+            );
+        }
+        other => panic!("expected Dave's application message, got {other:?}"),
+    }
+
+    // Bob never moved, so his message is the control: it must read the same
+    // way before and after the resync.
+    let processed = alice_a_main
+        .process_message(&alice_a_provider, from_bob.into_protocol_message().unwrap())
+        .expect("Bob's pre-resync message must still be readable");
+    match processed.into_content() {
+        ProcessedMessageContent::ApplicationMessage(app) => {
+            assert_eq!(app.into_bytes(), b"bob before the resync");
+        }
+        other => panic!("expected Bob's application message, got {other:?}"),
+    }
+
+    // The virtual client's own message, echoed back by the delivery service.
+    // Its sending ratchet consumed that generation, so the echo can only be
+    // recognized, not decrypted.
+    let processed = alice_a_main
+        .process_message(
+            &alice_a_provider,
+            from_alice_a.into_protocol_message().unwrap(),
+        )
+        .expect(
+            "the echo of a message the virtual client sent from its old leaf, in \
+             an epoch whose secret tree belongs to that same old leaf, must still \
+             be recognized as its own rather than failing to decrypt",
+        );
+    assert!(
+        matches!(
+            processed.into_content(),
+            ProcessedMessageContent::OwnPrivateMessage
+        ),
+        "the echo must be classified as an own message"
+    );
+}


### PR DESCRIPTION
Fixes #2192.

## The change

`DecryptedMessage::from_inbound_ciphertext` asks whether an inbound `PrivateMessage` came from this client by comparing the sender's leaf index against `group.own_leaf_index()`. That is the index in the *current* tree, while the message being decrypted belongs to whatever epoch it was sent in — so the comparison is only correct while the client's own leaf has never moved.

Under `virtual-clients-draft` it moves: a sibling-resync external commit installs the joiner's leaf as our own (`staged_commit.rs`, `if let Some(new_idx) = state.new_own_leaf_index`). Every retained epoch from before the resync keeps a secret tree built for the old leaf, so from that point on the own-sender question is answered against the wrong leaf for all of them, in both directions:

- **wrongly "mine"** — a message another member sent from the leaf the client has since moved onto short-circuits into `ProcessedMessageContent::OwnPrivateMessage`: no decryption attempted, no error, the caller never learns it existed;
- **wrongly "not mine"** — the client's own pre-resync echo no longer short-circuits, reaches the already-consumed generation on its own sending ratchet, and fails with `SecretTreeError::SecretReuseError`.

`MessageSecrets` already knows the right answer: the epoch's secret tree records the leaf it was built for, which is the group's own leaf index at the time the epoch was entered. The comparison now uses that, through a new `SecretTree::own_index` accessor surfaced as `MessageSecrets::own_index`.

The production change, without the comment that explains it:

```rust
+        let own_index = message_secrets.own_index();
         let sender_data = ciphertext.sender_data(message_secrets, crypto, ciphersuite)?;
-        let own_sender = sender_data.leaf_index == group.own_leaf_index();
+        let own_sender = sender_data.leaf_index == own_index;
```

## Side effects and compatibility

No public API change; both accessors are `pub(crate)`.

Builds **without** `virtual-clients-draft` are unaffected. The only assignment to `MlsGroup::own_leaf_index` after group creation is the cfg-gated sibling-resync one, so outside that feature the current own index and the epoch's secret-tree index are always the same value and the substitution is behaviour-preserving.

Two neighbouring cases I checked explicitly:

- `kat_message_protection` deliberately forces `set_own_leaf_index(sender_index)` while installing a secret tree built for that same index, so the two stay consistent there and the KAT is unaffected.
- The `ExternalCommitBuilder` seeds the pre-join epoch's `MessageSecrets` with a "fake own index of 0" (`external_commits.rs`, tracked in #767), which is the one place outside `virtual-clients-draft` where the two indices can differ. That epoch's `sender_data_secret` is derived from an all-zero epoch secret rather than the group's real one, so `ciphertext.sender_data(..)` fails its AEAD open before the own-sender line is reached — with or without this change.

## Alternatives considered

- **Compare against `own_leaf_index()` only for the current epoch, and skip the check for past epochs.** That reintroduces the `SecretReuseError` for own echoes of past-epoch sends, which is the symptom `OwnPrivateMessage` exists to avoid.
- **Record the own leaf index alongside each retained epoch in `MessageSecretsStore`.** This is the same information the epoch's secret tree already carries, so it would be a second source of truth to keep in sync.
- **Fix it in `MlsGroup::merge_staged_commit` by rewriting the retained epochs' trees on a resync.** The retained trees are correct as they stand — they belong to the leaf they were built for. Only the question asked about them was wrong.

## Verification

`openmls/tests/virtual_clients.rs::vc_past_epoch_read_survives_sibling_resync` builds the tree in which the resync actually moves the leaf (a blank to the left of the virtual client, so the group is created by a member who is removed before the resync) and then reads three pre-resync messages: the removed member's, an unaffected member's as a control, and the client's own echo. `test_boundaries` in `test_secret_tree.rs` gains one line asserting the new accessor reports the index the tree was built for.

What I ran, on `main` @ e725f587 + this commit:

```
$ cargo test -p openmls --no-default-features \
    -F virtual-clients-draft,virtual-clients-draft-test-dependencies \
    --test virtual_clients vc_past_epoch_read_survives_sibling_resync
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 67 filtered out
```

The same test with only `openmls/src/framing/validation.rs` reverted to `main`, everything
else unchanged, fails on the first of the two symptoms:

```
panicked at openmls/tests/virtual_clients.rs:6292:18:
expected Dave's application message, got OwnPrivateMessage
```

and, with just that first assertion relaxed so the run reaches the third message, on the
second:

```
ERROR openmls::framing::private_message_in >   Ciphertext generation out of bounds 0
        SecretReuseError

panicked at openmls/tests/virtual_clients.rs:6319:10:
the echo of a message the virtual client sent from its old leaf, in an epoch whose secret
tree belongs to that same old leaf, must still be recognised as its own rather than failing
to decrypt: ValidationError(UnableToDecrypt(SecretTreeError(SecretReuseError)))
```

Bob's message, the control, reads correctly in every run that gets as far as it.

No regressions, full suite both ways, plus the checks CI runs:

```
$ cargo test -p openmls --no-default-features \
    -F virtual-clients-draft,virtual-clients-draft-test-dependencies
ok, 0 failed  (373 lib + 24 integration binaries + doctests)

$ cargo test -p openmls --no-default-features
ok, 0 failed  (285 lib + integration binaries + doctests)

$ cargo clippy -p openmls --tests -- -D warnings
clean

$ cargo fmt -- --check
clean
```

Running the whole `virtual_clients` binary with `validation.rs` reverted gives `67 passed; 1 failed` — the new test is the only one in the suite that depends on the change.

## User-facing description

Fixed: with the `virtual-clients-draft` feature, after a sibling-resync external commit moved the client to a different leaf, messages from epochs before the resync were classified against the wrong leaf — another member's message could be silently reported as this client's own, and the client's own echo could fail to decrypt.
