### PR TITLE
fix: make clear_proposal_queue actually delete the queued proposal bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#2203](https://github.com/openmls/openmls/pull/2203): `MemoryStorage::clear_proposal_queue` now actually deletes the queued proposal bodies. It built the per-proposal key by hand instead of going through the `label + key + version` scheme `queue_proposal` used to store them, so the delete never matched and every proposal body outlived the group's proposal-ref list that was supposed to track it. `queued_proposals` looked empty afterward because it only reads what the ref list points to, but the bodies stayed in the store, growing without bound for the lifetime of the provider.
 - [#2194](https://github.com/openmls/openmls/pull/2194): With the `virtual-clients-draft` feature, whether an inbound `PrivateMessage` is this client's own is now decided against the leaf index the epoch's secret tree was built for, rather than the group's current own leaf index. The two differ for every epoch before a sibling-resync external commit moved the client's leaf. Previously a message another member sent from the leaf the client had since moved onto was silently returned as `ProcessedMessageContent::OwnPrivateMessage`, and the echo of the client's own pre-resync message failed with `SecretTreeError::SecretReuseError`.
 
 ## 0.9.0 (2026-08-25)

--- a/memory_storage/src/lib.rs
+++ b/memory_storage/src/lib.rs
@@ -878,16 +878,19 @@ impl StorageProvider<CURRENT_VERSION> for MemoryStorage {
         // Get all proposal refs for this group.
         let proposal_refs: Vec<ProposalRef> =
             self.read_list(PROPOSAL_QUEUE_REFS_LABEL, &serde_json::to_vec(group_id)?)?;
-        let mut values = self.values.write().unwrap();
         for proposal_ref in proposal_refs {
-            // Delete all proposals.
+            // Delete all proposals. `queue_proposal` wrote each body through
+            // `write`, which prefixes the label and suffixes the version via
+            // `build_key_from_vec`, so the removal has to go through the same
+            // helper (`delete`) rather than a bare `values.remove` on the raw
+            // `serde_json` key, or nothing gets removed.
             let key = serde_json::to_vec(&(group_id, proposal_ref))?;
-            values.remove(&key);
+            self.delete::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, &key)?;
         }
 
         // Delete the proposal refs from the store.
-        let key = build_key::<CURRENT_VERSION, &GroupId>(PROPOSAL_QUEUE_REFS_LABEL, group_id);
-        values.remove(&key);
+        let key = serde_json::to_vec(group_id)?;
+        self.delete::<CURRENT_VERSION>(PROPOSAL_QUEUE_REFS_LABEL, &key)?;
 
         Ok(())
     }

--- a/memory_storage/tests/proposals.rs
+++ b/memory_storage/tests/proposals.rs
@@ -75,3 +75,33 @@ fn read_write_delete() {
     let proposals_read: Vec<(ProposalRef, Proposal)> = storage.queued_proposals(&group_id).unwrap();
     assert!(proposals_read.is_empty());
 }
+
+/// `queued_proposals` only reports what's reachable through the refs list, so
+/// an emptied refs list makes the queue look clear even if the proposal
+/// bodies are still sitting in the store under their own keys. Check the raw
+/// store directly.
+#[test]
+fn clear_proposal_queue_removes_the_proposal_bodies() {
+    let group_id = TestGroupId(b"TestGroupId".to_vec());
+    let storage = MemoryStorage::default();
+
+    storage
+        .queue_proposal(&group_id, &ProposalRef(0), &Proposal(vec![0xA1]))
+        .unwrap();
+    storage
+        .queue_proposal(&group_id, &ProposalRef(1), &Proposal(vec![0xA2]))
+        .unwrap();
+
+    // Two proposal bodies plus the refs list.
+    assert_eq!(storage.values.read().unwrap().len(), 3);
+
+    storage
+        .clear_proposal_queue::<TestGroupId, ProposalRef>(&group_id)
+        .unwrap();
+
+    assert_eq!(
+        storage.values.read().unwrap().len(),
+        0,
+        "clear_proposal_queue left orphaned proposal bodies in the store"
+    );
+}


### PR DESCRIPTION
Closes #2188.

`MemoryStorage::queue_proposal` writes each proposal body through the `write` helper, which builds the storage key as `label + key + version` via `build_key_from_vec`:

```rust
let key = serde_json::to_vec(&(group_id, proposal_ref))?;
let value = serde_json::to_vec(proposal)?;
self.write::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, &key, value)?;
```

`clear_proposal_queue` removed the same bytes without the label or version:

```rust
let key = serde_json::to_vec(&(group_id, proposal_ref))?;
values.remove(&key);
```

`values.remove` was never handed the key `write` actually inserted, so the removal was a no-op. `queued_proposal_refs` still comes back empty afterward, because the refs list itself is deleted correctly, further down, through `build_key`. `queued_proposals` iterates that now-empty refs list, so it reports an empty queue too, but every serialized proposal body is still sitting in the map under its real key. There's no code path that ever removes it: a long-lived provider accumulates one orphaned entry per proposal, for as long as the process runs, and the existing test in `memory_storage/tests/proposals.rs` didn't catch it because it only checks what `queued_proposals` reports, not what's actually left in the store.

Repro on unpatched main, using the test added here (before the fix, run with the old `values.remove` body):

```
$ cargo test -p openmls_memory_storage --test proposals clear_proposal_queue_removes_the_proposal_bodies

running 1 test
test clear_proposal_queue_removes_the_proposal_bodies ... FAILED

---- clear_proposal_queue_removes_the_proposal_bodies stdout ----

thread 'clear_proposal_queue_removes_the_proposal_bodies' panicked at memory_storage/tests/proposals.rs:102:5:
assertion `left == right` failed: clear_proposal_queue left orphaned proposal bodies in the store
  left: 2
 right: 0
```

## The change

`clear_proposal_queue` now routes both deletions through `delete`, the same helper every other single-key deleter in this file uses, instead of reaching into `self.values` directly. `delete` builds the key the same way `write` did, so it matches what's actually stored. The manual `values.write()` lock that spanned the loop is gone with it; `delete` takes and releases its own lock per key, same as elsewhere in the file.

## Side effects

No public API change. `MemoryStorage` is a reference/testing storage provider; this only affects what it does internally with the `values` map. Behavior for every other method is unchanged.

## Tests

Added `clear_proposal_queue_removes_the_proposal_bodies` next to the existing `read_write_delete` test in `memory_storage/tests/proposals.rs`. It queues two proposals, checks the raw `storage.values` map has three entries (two bodies plus the refs list), clears the queue, and asserts the map is empty, rather than going through `queued_proposals`, which is exactly the check that let this ship.

## Verification

```
$ cargo test -p openmls_memory_storage
running 2 tests
test clear_proposal_queue_removes_the_proposal_bodies ... ok
test read_write_delete ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p openmls --lib
test result: ok. 286 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 65.33s

$ cargo clippy -p openmls_memory_storage --all-targets
Finished, no warnings

$ cargo fmt --check -p openmls_memory_storage
clean
```

I didn't touch the `.unwrap()` in `queued_proposals` mentioned in the issue as a related nit. That's a real gap (a body missing for a stored ref becomes a panic instead of a reportable error), but it's a different failure mode with its own design question about the error type, so I left it out of this fix to keep the change to the one bug.
