### PR TITLE
fix: check provider support in KeyPackageIn::validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#2184](https://github.com/openmls/openmls/pull/2184): Added `PreSharedKeyProposal::psk`, a getter for the `PreSharedKeyId` of a `PreSharedKey` proposal.
 - [#2167](https://github.com/openmls/openmls/pull/2167): Added `PublicGroup::validate_key_package_for_add`, which checks whether a single `KeyPackage` is eligible to be added to the group without building a commit. Applications adding several members at once can use it to filter out candidates that a commit would reject, and to report which candidate was rejected and why. Uniqueness of the signature, init and encryption keys is not covered, since it can only be decided for a full set of proposals.
+- [#2205](https://github.com/openmls/openmls/pull/2205): Added `KeyPackageVerifyError::UnsupportedCiphersuite`, returned by `KeyPackageIn::validate` when the crypto provider does not support the key package's ciphersuite. Previously the check was missing on this path, and such a key package was reported as `InvalidLeafNodeSignature` even though its signature is valid.
 
 ### Changed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#2194](https://github.com/openmls/openmls/pull/2194): With the `virtual-clients-draft` feature, whether an inbound `PrivateMessage` is this client's own is now decided against the leaf index the epoch's secret tree was built for, rather than the group's current own leaf index. The two differ for every epoch before a sibling-resync external commit moved the client's leaf. Previously a message another member sent from the leaf the client had since moved onto was silently returned as `ProcessedMessageContent::OwnPrivateMessage`, and the echo of the client's own pre-resync message failed with `SecretTreeError::SecretReuseError`.
+- [#2205](https://github.com/openmls/openmls/pull/2205): `AddProposalIn::validate` now compares the key package's ciphersuite with the group's before verifying the key package, instead of after.
 
 ## 0.9.0 (2026-08-25)
 

--- a/openmls/src/group/tests_and_kats/tests/unsupported_ciphersuite.rs
+++ b/openmls/src/group/tests_and_kats/tests/unsupported_ciphersuite.rs
@@ -11,7 +11,8 @@ use crate::{
         ExternalCommitBuilderError, MlsGroup, MlsGroupJoinConfig, NewGroupError, StagedWelcome,
         PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
     },
-    prelude::KeyPackageBundle,
+    key_packages::errors::KeyPackageVerifyError,
+    prelude::{Extensions, KeyPackageBundle, KeyPackageIn, ProtocolVersion},
     test_utils::restricted_provider::RestrictedProvider,
 };
 
@@ -166,4 +167,29 @@ fn external_commit_rejects_unsupported_ciphersuite() {
         err,
         ExternalCommitBuilderError::UnsupportedCiphersuite(cs) if cs == GROUP_CIPHERSUITE
     ));
+}
+
+#[test]
+fn key_package_validate_rejects_unsupported_ciphersuite() {
+    let provider = restricted_provider();
+    let credential = generate_credential_with_key(
+        "Bob".into(),
+        GROUP_CIPHERSUITE.signature_algorithm(),
+        provider.inner(),
+    );
+    let key_package = generate_key_package(
+        GROUP_CIPHERSUITE,
+        Extensions::empty(),
+        provider.inner(),
+        credential,
+    );
+
+    let err = KeyPackageIn::from(key_package)
+        .validate(provider.crypto(), ProtocolVersion::Mls10)
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        KeyPackageVerifyError::UnsupportedCiphersuite(GROUP_CIPHERSUITE)
+    );
 }

--- a/openmls/src/key_packages/errors.rs
+++ b/openmls/src/key_packages/errors.rs
@@ -40,6 +40,9 @@ pub enum KeyPackageVerifyError {
     /// The protocol version is not valid.
     #[error("The protocol version is not valid.")]
     InvalidProtocolVersion,
+    /// The ciphersuite is not supported by the crypto provider.
+    #[error("Ciphersuite {0:?} is not supported by the crypto provider.")]
+    UnsupportedCiphersuite(Ciphersuite),
     /// The provided extension is not allowed in key packages
     #[error(transparent)]
     ExtensionTypeNotValidInKeyPackage(#[from] ExtensionTypeNotValidInKeyPackageError),

--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -123,7 +123,13 @@ impl KeyPackageIn {
         }
     }
 
+    /// Returns the ciphersuite this key package claims, before validation.
+    pub(crate) fn unverified_ciphersuite(&self) -> Ciphersuite {
+        self.payload.ciphersuite
+    }
+
     /// Verify that this key package is valid:
+    /// * verify that the ciphersuite is supported by the crypto provider
     /// * verify that the signature on this key package is valid
     /// * verify that the signature on the leaf node is valid
     /// * verify that all extensions are supported by the leaf node
@@ -138,6 +144,11 @@ impl KeyPackageIn {
         crypto: &impl OpenMlsCrypto,
         protocol_version: ProtocolVersion,
     ) -> Result<KeyPackage, KeyPackageVerifyError> {
+        let ciphersuite = self.payload.ciphersuite;
+        crypto
+            .supports(ciphersuite)
+            .map_err(|_| KeyPackageVerifyError::UnsupportedCiphersuite(ciphersuite))?;
+
         // We first need to verify the LeafNode inside the KeyPackage
         let leaf_node = self.payload.leaf_node.clone().into_verifiable_leaf_node();
 

--- a/openmls/src/messages/proposals_in.rs
+++ b/openmls/src/messages/proposals_in.rs
@@ -174,11 +174,10 @@ impl AddProposalIn {
         protocol_version: ProtocolVersion,
         ciphersuite: Ciphersuite,
     ) -> Result<AddProposal, ValidationError> {
-        let key_package = self.key_package.validate(crypto, protocol_version)?;
-        // Verify that the ciphersuite is valid
-        if key_package.ciphersuite() != ciphersuite {
+        if self.key_package.unverified_ciphersuite() != ciphersuite {
             return Err(ValidationError::InvalidAddProposalCiphersuite);
         }
+        let key_package = self.key_package.validate(crypto, protocol_version)?;
         Ok(AddProposal { key_package })
     }
 }

--- a/openmls/src/messages/tests/proposals.rs
+++ b/openmls/src/messages/tests/proposals.rs
@@ -1,12 +1,19 @@
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use openmls_traits::{types::Ciphersuite, OpenMlsProvider};
 use tls_codec::{Deserialize, Serialize};
 
 use crate::{
     binary_tree::LeafNodeIndex,
     ciphersuite::hash_ref::ProposalRef,
-    messages::{
-        proposals::{Proposal, ProposalOrRef, RemoveProposal},
-        proposals_in::ProposalOrRefIn,
+    group::{
+        errors::ValidationError,
+        tests_and_kats::utils::{generate_credential_with_key, generate_key_package},
     },
+    messages::{
+        proposals::{AddProposal, Proposal, ProposalOrRef, RemoveProposal},
+        proposals_in::{AddProposalIn, ProposalOrRefIn},
+    },
+    prelude::{Extensions, KeyPackage, KeyPackageIn, ProtocolVersion},
 };
 
 /// This test encodes and decodes the `ProposalOrRef` struct and makes sure the
@@ -41,4 +48,28 @@ fn proposals_codec() {
         .expect("An unexpected error occurred.");
 
     assert_eq!(proposal_or_ref, decoded.into());
+}
+
+#[test]
+fn add_proposal_checks_ciphersuite_before_signature() {
+    let provider = &OpenMlsRustCrypto::default();
+    let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let group_ciphersuite = Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256;
+
+    let credential =
+        generate_credential_with_key("Bob".into(), ciphersuite.signature_algorithm(), provider);
+    let key_package = generate_key_package(ciphersuite, Extensions::empty(), provider, credential);
+
+    // Corrupt the signature, the last field on the wire.
+    let mut bytes = key_package.key_package().tls_serialize_detached().unwrap();
+    *bytes.last_mut().unwrap() ^= 0x01;
+    let key_package: KeyPackage = KeyPackageIn::tls_deserialize_exact(bytes.as_slice())
+        .unwrap()
+        .into();
+    let add: Box<AddProposalIn> = AddProposal::from(key_package).into();
+
+    let err = add
+        .validate(provider.crypto(), ProtocolVersion::Mls10, group_ciphersuite)
+        .unwrap_err();
+    assert_eq!(err, ValidationError::InvalidAddProposalCiphersuite);
 }

--- a/openmls/tests/grease.rs
+++ b/openmls/tests/grease.rs
@@ -5,7 +5,10 @@
 //! MLS protocol implementation, including in KeyPackages, capabilities,
 //! proposals, and validation logic.
 
-use openmls::prelude::*;
+use openmls::prelude::{
+    tls_codec::{Deserialize, Serialize},
+    *,
+};
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::types::Ciphersuite;
@@ -474,4 +477,25 @@ fn test_grease_injection_in_groups_via_with_grease() {
         has_grease_credential,
         "with_grease() should add a GREASE credential"
     );
+}
+
+#[test]
+fn test_grease_ciphersuite_rejected_in_wire_position() {
+    let provider = OpenMlsRustCrypto::default();
+    let (credential, signer) = create_credential(b"Alice");
+    let key_package = KeyPackage::builder()
+        .build(
+            Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+            &provider,
+            &signer,
+            credential,
+        )
+        .expect("Failed to create KeyPackage");
+
+    // Protocol version (2 bytes), then the ciphersuite (2 bytes).
+    let mut bytes = key_package.key_package().tls_serialize_detached().unwrap();
+    assert_eq!(&bytes[2..4], &[0x00, 0x01]);
+    bytes[2..4].copy_from_slice(&[0x0A, 0x0A]);
+
+    assert!(KeyPackageIn::tls_deserialize_exact(bytes.as_slice()).is_err());
 }


### PR DESCRIPTION
`KeyPackageIn::validate` doesn't check whether the crypto provider supports the key package's ciphersuite before it verifies the signatures. If the provider doesn't support it, signature verification fails and the caller gets `InvalidLeafNodeSignature`, even though the signature is valid. I ran into this with the libcrux provider, which only does Ed25519: validating a P-256 key package returns `InvalidLeafNodeSignature`. For something like a delivery service that validates key packages on its own this is misleading, because it looks like a bad signature and not like an unsupported ciphersuite.

#2109 added a `supports()` check and `UnsupportedCiphersuite` errors to group creation, `StagedWelcome` and the external commit builder. `KeyPackageIn::validate` is another public entry point that takes a ciphersuite from the wire, and it didn't get the check. This PR adds it as the first step of `validate`, plus a `KeyPackageVerifyError::UnsupportedCiphersuite(Ciphersuite)` variant. The test uses the `RestrictedProvider` from `test-utils` and fails without the change.

Two smaller things in the same area:

- `AddProposalIn::validate` did the full key package validation (both signature checks) before comparing the key package's ciphersuite with the group's. Now the comparison comes first. The test corrupts the key package signature and checks that the ciphersuite mismatch is reported, not the signature.
- A test that a GREASE value in the ciphersuite field of a KeyPackage is rejected when deserializing. This already works, GREASE values aren't in the `Ciphersuite` table, but there was no test for it.

Context: I've been looking into how crypto providers could bring their own ciphersuites (#1915) and what that would touch in the code base, and I'll probably have something to propose on that at some point. This came up while going through the ciphersuite checks. It's independent of that though.
