### PR TITLE
fix: add missing signature key uniqueness check and fix a small bug

### DIFF
--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -915,9 +915,16 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, LoadedPsks, G> {
         // ValSem102
         // ValSem103
         // ValSem104
-        group
-            .public_group
-            .validate_key_uniqueness(&proposal_queue, None)?;
+        let path_leaf_signature_key = cur_stage
+            .leaf_node_parameters
+            .credential_with_key()
+            .map(|credential_with_key| &credential_with_key.signature_key);
+        group.public_group.validate_key_uniqueness(
+            &proposal_queue,
+            None,
+            &sender,
+            path_leaf_signature_key,
+        )?;
         // ValSem105
         group.public_group.validate_add_proposals(&proposal_queue)?;
         // ValSem106

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -4021,6 +4021,38 @@ fn commit_with_new_signer_mismatched_credential() {
     assert_eq!(err, CreateCommitError::InvalidLeafNodeParameters);
 }
 
+// https://validation.openmls.tech/#valn0111
+#[openmls_test::openmls_test]
+fn commit_with_new_signer_duplicate_signature_key() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+    let (mut alice_group, alice_signer, _bob_group, bob_signer, _, bob_credential_with_key) =
+        setup_alice_bob_group(ciphersuite, alice_provider, bob_provider);
+
+    let new_signer = NewSignerBundle {
+        signer: &bob_signer,
+        credential_with_key: bob_credential_with_key,
+    };
+
+    let err = alice_group
+        .commit_builder()
+        .load_psks(alice_provider.storage())
+        .unwrap()
+        .build_with_new_signer(
+            alice_provider.rand(),
+            alice_provider.crypto(),
+            &alice_signer,
+            new_signer,
+            |_| true,
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        CreateCommitError::ProposalValidationError(ProposalValidationError::DuplicateSignatureKey)
+    );
+}
+
 // Alice proposes a signer swap; Bob processes the proposal (envelope verifies
 // against Alice's OLD leaf sig key, embedded leaf verifies against the NEW sig
 // key), stores it, and commits it. After both merge, everyone's view of

--- a/openmls/src/group/public_group/staged_commit.rs
+++ b/openmls/src/group/public_group/staged_commit.rs
@@ -171,7 +171,15 @@ impl PublicGroup {
         // ValSem102
         // ValSem103
         // ValSem104
-        self.validate_key_uniqueness(&proposal_queue, Some(commit))?;
+        self.validate_key_uniqueness(
+            &proposal_queue,
+            Some(commit),
+            sender,
+            commit
+                .path
+                .as_ref()
+                .map(|path| path.leaf_node().signature_key()),
+        )?;
         // ValSem105
         self.validate_add_proposals(&proposal_queue)?;
         // ValSem106

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -8,6 +8,7 @@ use openmls_traits::types::VerifiableCiphersuite;
 use super::PublicGroup;
 use crate::{
     binary_tree::array_representation::LeafNodeIndex,
+    ciphersuite::signature::SignaturePublicKey,
     extensions::RequiredCapabilitiesExtension,
     framing::{
         mls_auth_content_in::VerifiableAuthenticatedContentIn, ContentType, ProtocolMessage,
@@ -193,6 +194,11 @@ impl PublicGroup {
     ///  - [valn0111]: Verify that the following fields are unique among the members of the group: `signature_key`
     ///  - [valn0112]: Verify that the following fields are unique among the members of the group: `encryption_key`
     ///
+    /// `path_leaf_signature_key` is the signature key of the leaf node the
+    /// commit's path installs for `sender`. It is passed separately from
+    /// `commit` because the path of a commit under construction does not exist
+    /// yet. The signature key of its leaf node is already fixed, though.
+    ///
     /// [valn0111]: https://validation.openmls.tech/#valn0111
     /// [valn0112]: https://validation.openmls.tech/#valn0112
     /// [valn1208]: https://validation.openmls.tech/#valn1208
@@ -200,17 +206,27 @@ impl PublicGroup {
         &self,
         proposal_queue: &ProposalQueue,
         commit: Option<&Commit>,
+        sender: &Sender,
+        path_leaf_signature_key: Option<&SignaturePublicKey>,
     ) -> Result<(), ProposalValidationError> {
         let mut signature_key_set = HashSet::new();
         let mut init_key_set = HashSet::new();
         let mut encryption_key_set = HashSet::new();
 
         // Handle the exceptions needed for https://validation.openmls.tech/#valn0306
-        let remove_proposals = HashSet::<LeafNodeIndex>::from_iter(
-            proposal_queue
-                .remove_proposals()
-                .map(|remove_proposal| remove_proposal.remove_proposal().removed),
-        );
+        let removed_members = proposal_queue
+            .remove_proposals()
+            .map(|remove_proposal| remove_proposal.remove_proposal().removed)
+            .chain(
+                proposal_queue
+                    .filtered_by_type(ProposalType::SelfRemove)
+                    .filter_map(|self_remove| self_remove.sender().as_member()),
+            )
+            .collect::<HashSet<LeafNodeIndex>>();
+
+        // The leaf node in the path replaces the committer's leaf, so the
+        // committer's current signature key is not compared with it.
+        let replaced_leaf = path_leaf_signature_key.and_then(|_| sender.as_member());
 
         // Initialize the sets with the current members, filtered by the
         // remove proposals.
@@ -221,22 +237,29 @@ impl PublicGroup {
             ..
         } in self.treesync().full_leaf_members()
         {
-            if !remove_proposals.contains(&index) {
+            if removed_members.contains(&index) {
+                continue;
+            }
+            encryption_key_set.insert(encryption_key);
+            if replaced_leaf != Some(index) {
                 signature_key_set.insert(signature_key);
-                encryption_key_set.insert(encryption_key);
             }
         }
 
-        // Collect signature keys from add proposals
-        let signature_keys = proposal_queue.add_proposals().map(|add_proposal| {
-            add_proposal
-                .add_proposal()
-                .key_package()
-                .leaf_node()
-                .signature_key()
-                .as_slice()
-                .to_vec()
-        });
+        // Collect signature keys from add proposals and the commit path leaf
+        // node
+        let signature_keys = proposal_queue
+            .add_proposals()
+            .map(|add_proposal| {
+                add_proposal
+                    .add_proposal()
+                    .key_package()
+                    .leaf_node()
+                    .signature_key()
+                    .as_slice()
+                    .to_vec()
+            })
+            .chain(path_leaf_signature_key.map(|signature_key| signature_key.as_slice().to_vec()));
 
         // Collect encryption keys from add proposals, update proposals, the
         // commit leaf node and path keys
@@ -295,6 +318,7 @@ impl PublicGroup {
         //  - https://validation.openmls.tech/#valn0111
         //  - https://validation.openmls.tech/#valn0305
         //  - https://validation.openmls.tech/#valn0306
+        //  - https://validation.openmls.tech/#valn1207
         for signature_key in signature_keys {
             if !signature_key_set.insert(signature_key) {
                 return Err(ProposalValidationError::DuplicateSignatureKey);

--- a/openmls/src/group/tests_and_kats/tests/external_commit_builder.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_commit_builder.rs
@@ -234,6 +234,179 @@ fn external_commit_builder() {
         .any(|m| m.credential == charlie_credential_with_key.credential));
 }
 
+#[openmls_test]
+fn external_commit_after_self_remove() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let CredentialWithKeyAndSigner {
+        credential_with_key: alice_credential_with_key,
+        signer: alice_signer,
+    } = generate_credential_with_key(
+        b"alice".into(),
+        ciphersuite.signature_algorithm(),
+        alice_provider,
+    );
+
+    let CredentialWithKeyAndSigner {
+        credential_with_key: bob_credential_with_key,
+        signer: bob_signer,
+    } = generate_credential_with_key(
+        b"bob".into(),
+        ciphersuite.signature_algorithm(),
+        bob_provider,
+    );
+
+    let capabilities = Capabilities::builder()
+        .proposals(vec![ProposalType::SelfRemove])
+        .build();
+
+    let mut alice_group = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .with_capabilities(capabilities.clone())
+        .build(
+            alice_provider,
+            &alice_signer,
+            alice_credential_with_key.clone(),
+        )
+        .unwrap();
+
+    let join_group_config = MlsGroupJoinConfig::builder()
+        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+        .build();
+
+    let leaf_node_parameters = LeafNodeParameters::builder()
+        .with_capabilities(capabilities)
+        .build();
+
+    // Bob joins the group externally.
+    let verifiable_group_info = alice_group
+        .export_group_info(alice_provider.crypto(), &alice_signer, true)
+        .unwrap()
+        .into_verifiable_group_info()
+        .unwrap();
+
+    let (mut bob_group, commit_message_bundle) = MlsGroup::external_commit_builder()
+        .with_config(join_group_config.clone())
+        .build_group(
+            bob_provider,
+            verifiable_group_info,
+            bob_credential_with_key.clone(),
+        )
+        .unwrap()
+        .leaf_node_parameters(leaf_node_parameters.clone())
+        .load_psks(bob_provider.storage())
+        .unwrap()
+        .build(
+            bob_provider.rand(),
+            bob_provider.crypto(),
+            &bob_signer,
+            |_| true,
+        )
+        .unwrap()
+        .finalize(bob_provider)
+        .unwrap();
+
+    let processed_message = alice_group
+        .process_message(
+            alice_provider,
+            commit_message_bundle
+                .into_commit()
+                .into_protocol_message()
+                .unwrap(),
+        )
+        .unwrap();
+    let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+        processed_message.into_content()
+    else {
+        panic!("Expected a staged commit message.");
+    };
+    alice_group
+        .merge_staged_commit(alice_provider, *staged_commit)
+        .unwrap();
+
+    // Bob leaves through a SelfRemove proposal, which Alice stores.
+    let msg_out = bob_group
+        .leave_group_via_self_remove(bob_provider, &bob_signer)
+        .unwrap();
+    let ProtocolMessage::PublicMessage(self_remove_proposal) =
+        msg_out.into_protocol_message().unwrap()
+    else {
+        panic!("Expected a public message for the self-remove proposal.");
+    };
+
+    let processed_message = alice_group
+        .process_message(alice_provider, *self_remove_proposal.clone())
+        .unwrap();
+    let ProcessedMessageContent::ProposalMessage(proposal) = processed_message.into_content()
+    else {
+        panic!("Expected a proposal message.");
+    };
+    alice_group
+        .store_pending_proposal(alice_provider.storage(), *proposal)
+        .unwrap();
+
+    // Bob rejoins with the same credential, referencing his SelfRemove.
+    let verifiable_group_info = alice_group
+        .export_group_info(alice_provider.crypto(), &alice_signer, true)
+        .unwrap()
+        .into_verifiable_group_info()
+        .unwrap();
+
+    let (bob_group, commit_message_bundle) = MlsGroup::external_commit_builder()
+        .with_proposals(vec![*self_remove_proposal])
+        .with_config(join_group_config)
+        .build_group(
+            bob_provider,
+            verifiable_group_info,
+            bob_credential_with_key.clone(),
+        )
+        .unwrap()
+        .leaf_node_parameters(leaf_node_parameters)
+        .load_psks(bob_provider.storage())
+        .unwrap()
+        .build(
+            bob_provider.rand(),
+            bob_provider.crypto(),
+            &bob_signer,
+            |_| true,
+        )
+        .unwrap()
+        .finalize(bob_provider)
+        .unwrap();
+
+    let processed_message = alice_group
+        .process_message(
+            alice_provider,
+            commit_message_bundle
+                .into_commit()
+                .into_protocol_message()
+                .unwrap(),
+        )
+        .unwrap();
+    let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+        processed_message.into_content()
+    else {
+        panic!("Expected a staged commit message.");
+    };
+    alice_group
+        .merge_staged_commit(alice_provider, *staged_commit)
+        .unwrap();
+
+    // Alice and Bob are the only members and Bob's signature key is in the
+    // tree exactly once.
+    let members = alice_group.members().collect::<Vec<_>>();
+    assert_eq!(members, bob_group.members().collect::<Vec<_>>());
+    assert_eq!(members.len(), 2);
+    assert!(members
+        .iter()
+        .any(|m| m.credential == alice_credential_with_key.credential));
+    assert!(members
+        .iter()
+        .any(|m| m.credential == bob_credential_with_key.credential));
+}
+
 // An external commit with a consistent credential, signature key and signer
 // succeeds, even when the leaf node parameters repeat the credential passed to
 // the external commit builder. The generated leaf carries that credential and

--- a/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
+++ b/openmls/src/group/tests_and_kats/tests/external_commit_validation.rs
@@ -14,7 +14,8 @@ use crate::{
     },
     group::{
         errors::{
-            ExternalCommitValidationError, ProcessMessageError, StageCommitError, ValidationError,
+            ExternalCommitValidationError, ProcessMessageError, ProposalValidationError,
+            StageCommitError, ValidationError,
         },
         tests_and_kats::utils::{
             generate_credential_with_key, generate_key_package, resign_external_commit,
@@ -742,6 +743,179 @@ fn test_external_commit_unsupported_group_context_extension() {
         err,
         CreateCommitError::LeafNodeValidation(LeafNodeValidationError::UnsupportedExtensions)
     ));
+}
+
+#[openmls_test::openmls_test]
+fn test_external_commit_duplicate_signature_key() {
+    let alice_provider = &Provider::default();
+    let bob_provider = &Provider::default();
+
+    let ECValidationTestSetup {
+        mut alice_group,
+        alice_credential,
+        bob_credential,
+        ..
+    } = validation_test_setup(
+        PURE_PLAINTEXT_WIRE_FORMAT_POLICY,
+        ciphersuite,
+        alice_provider,
+        bob_provider,
+    );
+
+    // Alice adds Charlie and Bob, so that Bob's signature key is in the tree
+    // when Bob resyncs through an external commit. Charlie is removed again to
+    // leave a blank leaf to the left of Bob. That way the leftmost free leaf,
+    // which Bob's new leaf node is signed for, is the same whether or not the
+    // commit removes Bob's old leaf.
+    let charlie_provider = &Provider::default();
+    let charlie_credential = generate_credential_with_key(
+        "Charlie".into(),
+        ciphersuite.signature_algorithm(),
+        charlie_provider,
+    );
+    let charlie_key_package = generate_key_package(
+        ciphersuite,
+        Extensions::empty(),
+        charlie_provider,
+        charlie_credential,
+    );
+    let bob_key_package = generate_key_package(
+        ciphersuite,
+        Extensions::empty(),
+        alice_provider,
+        bob_credential.clone(),
+    );
+
+    alice_group
+        .add_members(
+            alice_provider,
+            &alice_credential.signer,
+            &[
+                charlie_key_package.key_package().clone(),
+                bob_key_package.key_package().clone(),
+            ],
+        )
+        .unwrap();
+    alice_group.merge_pending_commit(alice_provider).unwrap();
+
+    let charlie_index = alice_group
+        .members()
+        .find(|member| member.index != alice_group.own_leaf_index())
+        .unwrap()
+        .index;
+    alice_group
+        .remove_members(alice_provider, &alice_credential.signer, &[charlie_index])
+        .unwrap();
+    alice_group.merge_pending_commit(alice_provider).unwrap();
+
+    let verifiable_group_info = alice_group
+        .export_group_info(alice_provider.crypto(), &alice_credential.signer, true)
+        .unwrap()
+        .into_verifiable_group_info()
+        .unwrap();
+
+    // Negative case on the sending side: Bob drops the Remove proposal for his
+    // old leaf, so his new leaf would duplicate his old leaf's signature key.
+    let err = MlsGroup::external_commit_builder()
+        .with_config(alice_group.configuration().clone())
+        .build_group(
+            bob_provider,
+            verifiable_group_info.clone(),
+            bob_credential.credential_with_key.clone(),
+        )
+        .unwrap()
+        .load_psks(bob_provider.storage())
+        .unwrap()
+        .build(
+            bob_provider.rand(),
+            bob_provider.crypto(),
+            &bob_credential.signer,
+            |proposal| !proposal.proposal().is_remove(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CreateCommitError::ProposalValidationError(ProposalValidationError::DuplicateSignatureKey)
+    ));
+
+    // Bob builds a valid resync commit that removes his old leaf.
+    let (_, public_message_commit) = MlsGroup::external_commit_builder()
+        .with_config(alice_group.configuration().clone())
+        .build_group(
+            bob_provider,
+            verifiable_group_info,
+            bob_credential.credential_with_key.clone(),
+        )
+        .unwrap()
+        .load_psks(bob_provider.storage())
+        .unwrap()
+        .build(
+            bob_provider.rand(),
+            bob_provider.crypto(),
+            &bob_credential.signer,
+            |_| true,
+        )
+        .unwrap()
+        .finalize(bob_provider)
+        .unwrap();
+
+    let public_message_commit = {
+        let serialized = public_message_commit
+            .into_commit()
+            .tls_serialize_detached()
+            .unwrap();
+        MlsMessageIn::tls_deserialize(&mut serialized.as_slice())
+            .unwrap()
+            .into_plaintext()
+            .unwrap()
+    };
+
+    // Negative case on the receiving side: strip the Remove proposal from the
+    // commit, so that Bob's old leaf stays in the tree next to his new one.
+    let public_message_commit_bad = {
+        let mut commit = if let FramedContentBody::Commit(commit) = public_message_commit.content()
+        {
+            commit.clone()
+        } else {
+            panic!("Unexpected content type.");
+        };
+        let proposal_count = commit.proposals.len();
+        commit
+            .proposals
+            .retain(|proposal| !proposal.as_proposal().is_some_and(Proposal::is_remove));
+        assert_eq!(commit.proposals.len(), proposal_count - 1);
+
+        let mut public_message_commit_bad = public_message_commit.clone();
+        public_message_commit_bad.set_content(FramedContentBody::Commit(commit));
+
+        // We have to re-sign, since we changed the content.
+        resign_external_commit(
+            &bob_credential.signer,
+            public_message_commit_bad,
+            public_message_commit.confirmation_tag().unwrap().clone(),
+            alice_group
+                .export_group_context()
+                .tls_serialize_detached()
+                .unwrap(),
+        )
+    };
+
+    let err = alice_group
+        .process_message(alice_provider, public_message_commit_bad)
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+            ProposalValidationError::DuplicateSignatureKey
+        ))
+    ));
+
+    // Positive case
+    alice_group
+        .process_message(alice_provider, public_message_commit)
+        .unwrap();
 }
 
 mod utils {

--- a/openmls/src/messages/proposals.rs
+++ b/openmls/src/messages/proposals.rs
@@ -378,6 +378,7 @@ impl Proposal {
             (Proposal::Remove(_), Proposal::Remove(_)) => true,
             // SelfRemoves have the highest priority.
             (_, Proposal::SelfRemove) => true,
+            (Proposal::SelfRemove, Proposal::Update(_) | Proposal::Remove(_)) => false,
             _ => {
                 debug_assert!(false);
                 false


### PR DESCRIPTION
This PR fixes a hole in our signature-key uniqueness validation checks, where signature keys in the commit path weren't considered for external commits.

Also fixes a small bug in proposal priority ordering, where a combination of SelfRemove and Remove proposal could lead to a panic in debug builds.