### PR TITLE
feat: the hybrid ML-KEM/P-curve ciphersuites of draft-ietf-mls-pq-ciphersuites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#2208](https://github.com/openmls/openmls/pull/2208): Added the three ciphersuites of draft-ietf-mls-pq-ciphersuites on the hybrid ML-KEM/P-curve KEMs, `MLS_128_MLKEM768P256_AES128GCM_SHA256_P256` (TBD3), `MLS_128_MLKEM768P256_AES256GCM_SHA384_P256` (TBD4) and `MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384` (TBD5), with provisional code points `0x0053` to `0x0055`, and the KEMs `HpkeKemType::MlKem768P256` (`0x0050`) and `HpkeKemType::MlKem1024P384` (`0x0051`) from draft-ietf-hpke-pq, behind `draft-ietf-mls-pq-ciphersuites`. Neither bundled crypto provider implements these KEMs; they report the ciphersuites as unsupported and their HPKE operations return `UnsupportedCiphersuite` for them.
 - [#2184](https://github.com/openmls/openmls/pull/2184): Added `PreSharedKeyProposal::psk`, a getter for the `PreSharedKeyId` of a `PreSharedKey` proposal.
 - [#2167](https://github.com/openmls/openmls/pull/2167): Added `PublicGroup::validate_key_package_for_add`, which checks whether a single `KeyPackage` is eligible to be added to the group without building a commit. Applications adding several members at once can use it to filter out candidates that a commit would reject, and to report which candidate was rejected and why. Uniqueness of the signature, init and encryption keys is not covered, since it can only be decided for a full set of proposals.
 

--- a/libcrux_crypto/CHANGELOG.md
+++ b/libcrux_crypto/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- [#2208](https://github.com/openmls/openmls/pull/2208): The KEM mapping to hpke-rs is fallible; an HPKE operation with a KEM hpke-rs does not implement (`HpkeKemType::MlKem768P256`, `HpkeKemType::MlKem1024P384`) returns `UnsupportedCiphersuite`.
+
 ## 0.4.0 (2026-08-25)
 
 ### Added

--- a/libcrux_crypto/src/crypto.rs
+++ b/libcrux_crypto/src/crypto.rs
@@ -84,9 +84,10 @@ impl OpenMlsCrypto for CryptoProvider {
                 Err(CryptoError::UnsupportedCiphersuite)
             }
             #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
-            HpkeKemType::MlKem768 | HpkeKemType::MlKem1024 => {
-                Err(CryptoError::UnsupportedCiphersuite)
-            }
+            HpkeKemType::MlKem768
+            | HpkeKemType::MlKem1024
+            | HpkeKemType::MlKem768P256
+            | HpkeKemType::MlKem1024P384 => Err(CryptoError::UnsupportedCiphersuite),
         }?;
 
         match ciphersuite.hpke_aead_algorithm() {
@@ -319,7 +320,7 @@ impl OpenMlsCrypto for CryptoProvider {
         aad: &[u8],
         ptxt: &[u8],
     ) -> Result<HpkeCiphertext, CryptoError> {
-        let mut config = hpke_config(config);
+        let mut config = hpke_config(config)?;
 
         let pk_r = hpke_rs::HpkePublicKey::new(pk_r.to_vec());
 
@@ -347,7 +348,7 @@ impl OpenMlsCrypto for CryptoProvider {
         info: &[u8],
         aad: &[u8],
     ) -> Result<Vec<u8>, CryptoError> {
-        let config = hpke_config(config);
+        let config = hpke_config(config)?;
 
         let sk_r = hpke_rs::HpkePrivateKey::new(sk_r.to_vec());
 
@@ -376,7 +377,7 @@ impl OpenMlsCrypto for CryptoProvider {
         exporter_context: &[u8],
         exporter_length: usize,
     ) -> Result<(KemOutput, ExporterSecret), CryptoError> {
-        let mut config = hpke_config(config);
+        let mut config = hpke_config(config)?;
 
         let pk_r = hpke_rs::HpkePublicKey::new(pk_r.to_vec());
 
@@ -398,7 +399,7 @@ impl OpenMlsCrypto for CryptoProvider {
         exporter_context: &[u8],
         exporter_length: usize,
     ) -> Result<ExporterSecret, CryptoError> {
-        let config = hpke_config(config);
+        let config = hpke_config(config)?;
 
         let sk_r = hpke_rs::HpkePrivateKey::new(sk_r.to_vec());
 
@@ -416,7 +417,7 @@ impl OpenMlsCrypto for CryptoProvider {
         config: HpkeConfig,
         ikm: &[u8],
     ) -> Result<HpkeKeyPair, CryptoError> {
-        let config = hpke_config(config);
+        let config = hpke_config(config)?;
 
         let key_pair: hpke_rs::HpkeKeyPair = config.derive_key_pair(ikm).map_err(|e| match e {
             hpke_rs::HpkeError::InvalidConfig => CryptoError::InvalidLength,
@@ -442,7 +443,7 @@ impl OpenMlsCrypto for CryptoProvider {
         psk: &[u8],
         psk_id: &[u8],
     ) -> Result<Vec<u8>, CryptoError> {
-        hpke_psk_from_config(config)
+        hpke_psk_from_config(config)?
             .open(
                 input.kem_output.as_slice(),
                 &sk_r.into(),
@@ -470,7 +471,8 @@ impl OpenMlsCrypto for CryptoProvider {
     where
         F: FnOnce(&[u8]) -> Result<Vec<u8>, E>,
     {
-        let mut hpke = hpke_psk_from_config(config);
+        let mut hpke =
+            hpke_psk_from_config(config).map_err(HpkeSealPskResolvedAadError::CryptoError)?;
         // Split the single-shot seal into setup and seal so the AAD can be built
         // from the KEM output. The setup and seal must share the same context.
         let (kem_output, mut context) = hpke
@@ -504,21 +506,21 @@ impl OpenMlsCrypto for CryptoProvider {
     }
 }
 
-fn hpke_config(config: HpkeConfig) -> hpke_rs::Hpke<HpkeLibcrux> {
-    let kem = hpke_kem(config.0);
+fn hpke_config(config: HpkeConfig) -> Result<hpke_rs::Hpke<HpkeLibcrux>, CryptoError> {
+    let kem = hpke_kem(config.0)?;
     let kdf = hpke_kdf(config.1);
     let aead = hpke_aead(config.2);
 
-    hpke_rs::Hpke::new(hpke_rs::Mode::Base, kem, kdf, aead)
+    Ok(hpke_rs::Hpke::new(hpke_rs::Mode::Base, kem, kdf, aead))
 }
 
 #[cfg(feature = "targeted-messages-draft")]
-fn hpke_psk_from_config(config: HpkeConfig) -> hpke_rs::Hpke<HpkeLibcrux> {
-    let kem = hpke_kem(config.0);
+fn hpke_psk_from_config(config: HpkeConfig) -> Result<hpke_rs::Hpke<HpkeLibcrux>, CryptoError> {
+    let kem = hpke_kem(config.0)?;
     let kdf = hpke_kdf(config.1);
     let aead = hpke_aead(config.2);
 
-    hpke_rs::Hpke::new(hpke_rs::Mode::Psk, kem, kdf, aead)
+    Ok(hpke_rs::Hpke::new(hpke_rs::Mode::Psk, kem, kdf, aead))
 }
 
 fn hpke_kdf(kdf: HpkeKdfType) -> hpke_rs_crypto::types::KdfAlgorithm {
@@ -529,8 +531,8 @@ fn hpke_kdf(kdf: HpkeKdfType) -> hpke_rs_crypto::types::KdfAlgorithm {
     }
 }
 
-fn hpke_kem(kem: HpkeKemType) -> hpke_rs_crypto::types::KemAlgorithm {
-    match kem {
+fn hpke_kem(kem: HpkeKemType) -> Result<hpke_rs_crypto::types::KemAlgorithm, CryptoError> {
+    Ok(match kem {
         HpkeKemType::DhKemP256 => hpke_rs_crypto::types::KemAlgorithm::DhKemP256,
         HpkeKemType::DhKemP384 => hpke_rs_crypto::types::KemAlgorithm::DhKemP384,
         HpkeKemType::DhKemP521 => hpke_rs_crypto::types::KemAlgorithm::DhKemP521,
@@ -542,7 +544,11 @@ fn hpke_kem(kem: HpkeKemType) -> hpke_rs_crypto::types::KemAlgorithm {
         HpkeKemType::MlKem768 => hpke_rs_crypto::types::KemAlgorithm::MlKem768,
         #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
         HpkeKemType::MlKem1024 => hpke_rs_crypto::types::KemAlgorithm::MlKem1024,
-    }
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        HpkeKemType::MlKem768P256 | HpkeKemType::MlKem1024P384 => {
+            return Err(CryptoError::UnsupportedCiphersuite)
+        }
+    })
 }
 
 fn hpke_aead(aead: HpkeAeadType) -> hpke_rs_crypto::types::AeadAlgorithm {

--- a/openmls_rust_crypto/CHANGELOG.md
+++ b/openmls_rust_crypto/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- [#2208](https://github.com/openmls/openmls/pull/2208): The KEM mapping to hpke-rs is fallible; an HPKE operation with a KEM hpke-rs does not implement (`HpkeKemType::MlKem768P256`, `HpkeKemType::MlKem1024P384`) returns `UnsupportedCiphersuite`.
+
 ## 0.6.0 (2026-08-25)
 
 ### Added

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -53,8 +53,8 @@ impl Default for RustCrypto {
 }
 
 #[inline(always)]
-fn kem_mode(kem: HpkeKemType) -> hpke_types::KemAlgorithm {
-    match kem {
+fn kem_mode(kem: HpkeKemType) -> Result<hpke_types::KemAlgorithm, CryptoError> {
+    Ok(match kem {
         HpkeKemType::DhKemP256 => hpke_types::KemAlgorithm::DhKemP256,
         HpkeKemType::DhKemP384 => hpke_types::KemAlgorithm::DhKemP384,
         HpkeKemType::DhKemP521 => hpke_types::KemAlgorithm::DhKemP521,
@@ -66,7 +66,11 @@ fn kem_mode(kem: HpkeKemType) -> hpke_types::KemAlgorithm {
         HpkeKemType::MlKem768 => hpke_types::KemAlgorithm::MlKem768,
         #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
         HpkeKemType::MlKem1024 => hpke_types::KemAlgorithm::MlKem1024,
-    }
+        #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+        HpkeKemType::MlKem768P256 | HpkeKemType::MlKem1024P384 => {
+            return Err(CryptoError::UnsupportedCiphersuite)
+        }
+    })
 }
 
 #[inline(always)]
@@ -511,7 +515,7 @@ impl OpenMlsCrypto for RustCrypto {
         aad: &[u8],
         ptxt: &[u8],
     ) -> Result<types::HpkeCiphertext, CryptoError> {
-        let (kem_output, ciphertext) = hpke_from_config(config)
+        let (kem_output, ciphertext) = hpke_from_config(config)?
             .seal(&pk_r.into(), info, aad, ptxt, None, None, None)
             .map_err(|e| match e {
                 hpke::HpkeError::InvalidInput => CryptoError::InvalidLength,
@@ -531,7 +535,7 @@ impl OpenMlsCrypto for RustCrypto {
         info: &[u8],
         aad: &[u8],
     ) -> Result<Vec<u8>, CryptoError> {
-        hpke_from_config(config)
+        hpke_from_config(config)?
             .open(
                 input.kem_output.as_slice(),
                 &sk_r.into(),
@@ -553,7 +557,7 @@ impl OpenMlsCrypto for RustCrypto {
         exporter_context: &[u8],
         exporter_length: usize,
     ) -> Result<(Vec<u8>, ExporterSecret), CryptoError> {
-        let (kem_output, context) = hpke_from_config(config)
+        let (kem_output, context) = hpke_from_config(config)?
             .setup_sender(&pk_r.into(), info, None, None, None)
             .map_err(|_| CryptoError::SenderSetupError)?;
         let exported_secret = context
@@ -571,7 +575,7 @@ impl OpenMlsCrypto for RustCrypto {
         exporter_context: &[u8],
         exporter_length: usize,
     ) -> Result<ExporterSecret, CryptoError> {
-        let context = hpke_from_config(config)
+        let context = hpke_from_config(config)?
             .setup_receiver(enc, &sk_r.into(), info, None, None, None)
             .map_err(|_| CryptoError::ReceiverSetupError)?;
         let exported_secret = context
@@ -585,7 +589,7 @@ impl OpenMlsCrypto for RustCrypto {
         config: HpkeConfig,
         ikm: &[u8],
     ) -> Result<types::HpkeKeyPair, CryptoError> {
-        let kp = hpke_from_config(config)
+        let kp = hpke_from_config(config)?
             .derive_key_pair(ikm)
             .map_err(|e| match e {
                 hpke::HpkeError::InvalidInput => CryptoError::InvalidLength,
@@ -609,7 +613,7 @@ impl OpenMlsCrypto for RustCrypto {
         psk: &[u8],
         psk_id: &[u8],
     ) -> Result<Vec<u8>, CryptoError> {
-        hpke_psk_from_config(config)
+        hpke_psk_from_config(config)?
             .open(
                 input.kem_output.as_slice(),
                 &sk_r.into(),
@@ -637,7 +641,8 @@ impl OpenMlsCrypto for RustCrypto {
     where
         F: FnOnce(&[u8]) -> Result<Vec<u8>, E>,
     {
-        let mut hpke = hpke_psk_from_config(config);
+        let mut hpke =
+            hpke_psk_from_config(config).map_err(HpkeSealPskResolvedAadError::CryptoError)?;
         let (kem_output, mut context) = hpke
             .setup_sender(&pk_r.into(), info, Some(psk), Some(psk_id), None)
             .map_err(|_| HpkeSealPskResolvedAadError::CryptoError(CryptoError::SenderSetupError))?;
@@ -669,23 +674,23 @@ impl OpenMlsCrypto for RustCrypto {
     }
 }
 
-fn hpke_from_config(config: HpkeConfig) -> Hpke<HpkeRustCrypto> {
-    Hpke::<HpkeRustCrypto>::new(
+fn hpke_from_config(config: HpkeConfig) -> Result<Hpke<HpkeRustCrypto>, CryptoError> {
+    Ok(Hpke::<HpkeRustCrypto>::new(
         hpke::Mode::Base,
-        kem_mode(config.0),
+        kem_mode(config.0)?,
         kdf_mode(config.1),
         aead_mode(config.2),
-    )
+    ))
 }
 
 #[cfg(feature = "targeted-messages-draft")]
-fn hpke_psk_from_config(config: HpkeConfig) -> Hpke<HpkeRustCrypto> {
-    Hpke::<HpkeRustCrypto>::new(
+fn hpke_psk_from_config(config: HpkeConfig) -> Result<Hpke<HpkeRustCrypto>, CryptoError> {
+    Ok(Hpke::<HpkeRustCrypto>::new(
         hpke::Mode::Psk,
-        kem_mode(config.0),
+        kem_mode(config.0)?,
         kdf_mode(config.1),
         aead_mode(config.2),
-    )
+    ))
 }
 
 impl OpenMlsRand for RustCrypto {

--- a/traits/CHANGELOG.md
+++ b/traits/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- [#2208](https://github.com/openmls/openmls/pull/2208): Added the three ciphersuites of draft-ietf-mls-pq-ciphersuites on the hybrid ML-KEM/P-curve KEMs, `MLS_128_MLKEM768P256_AES128GCM_SHA256_P256` (TBD3), `MLS_128_MLKEM768P256_AES256GCM_SHA384_P256` (TBD4) and `MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384` (TBD5), with provisional code points `0x0053` to `0x0055`, and the KEMs `HpkeKemType::MlKem768P256` (`0x0050`) and `HpkeKemType::MlKem1024P384` (`0x0051`) from draft-ietf-hpke-pq, behind `draft-ietf-mls-pq-ciphersuites`. Neither bundled crypto provider implements these KEMs; they report the ciphersuites as unsupported and their HPKE operations return `UnsupportedCiphersuite` for them.
+
 ## 0.6.0 (2026-08-25)
 
 ### Added

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -208,6 +208,16 @@ pub enum HpkeKemType {
     /// XWing combiner for ML-KEM and X25519
     #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
     XWingKemDraft6 = 0x004D,
+    /// ML-KEM-768 combined with P-256, [draft-ietf-hpke-pq]
+    ///
+    /// [draft-ietf-hpke-pq]: https://datatracker.ietf.org/doc/draft-ietf-hpke-pq
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MlKem768P256 = 0x0050,
+    /// ML-KEM-1024 combined with P-384, [draft-ietf-hpke-pq]
+    ///
+    /// [draft-ietf-hpke-pq]: https://datatracker.ietf.org/doc/draft-ietf-hpke-pq
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MlKem1024P384 = 0x0051,
 }
 
 /// KDF Types for HPKE
@@ -470,13 +480,6 @@ pub enum Ciphersuite {
     #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
     MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519 = 0x004E,
 
-    // TBD3, TBD4, TBD5 are currently not supported because there are no implementations for hybrid
-    // schemes MLKEM768P256 and MLKEM1024P384.
-    //
-    // MLS_128_MLKEM768P256_AES128GCM_SHA256_P256 = TBD3,
-    // MLS_128_MLKEM768P256_AES256GCM_SHA384_P256 = TBD4
-    // MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384 =TBD5,
-    //
     /// ML-KEM768 | AES-GCM256 | SHA2-384 | Ed25519
     ///
     /// [draft-ietf-mls-pq-ciphersuites] TBD6 (custom provisional code point, kept from the
@@ -525,6 +528,30 @@ pub enum Ciphersuite {
     /// [draft-ietf-mls-pq-ciphersuites]: https://datatracker.ietf.org/doc/draft-ietf-mls-pq-ciphersuites
     #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
     MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87 = 0x0907,
+
+    /// ML-KEM768 + P256 | AES-GCM128 | SHA2-256 | EcDSA P256
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites] TBD3 (provisional code point)
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites]: https://datatracker.ietf.org/doc/draft-ietf-mls-pq-ciphersuites
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLS_128_MLKEM768P256_AES128GCM_SHA256_P256 = 0x0053,
+
+    /// ML-KEM768 + P256 | AES-GCM256 | SHA2-384 | EcDSA P256
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites] TBD4 (provisional code point)
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites]: https://datatracker.ietf.org/doc/draft-ietf-mls-pq-ciphersuites
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLS_128_MLKEM768P256_AES256GCM_SHA384_P256 = 0x0054,
+
+    /// ML-KEM1024 + P384 | AES-GCM256 | SHA2-384 | EcDSA P384
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites] TBD5 (provisional code point)
+    ///
+    /// [draft-ietf-mls-pq-ciphersuites]: https://datatracker.ietf.org/doc/draft-ietf-mls-pq-ciphersuites
+    #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+    MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384 = 0x0055,
 }
 
 impl core::fmt::Display for Ciphersuite {
@@ -578,6 +605,12 @@ impl TryFrom<u16> for Ciphersuite {
             0x0052 => Ok(Ciphersuite::MLS_128_MLKEM768X25519_CHACHA20POLY1305_SHA384_MLDSA44),
             #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
             0x0907 => Ok(Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x0053 => Ok(Ciphersuite::MLS_128_MLKEM768P256_AES128GCM_SHA256_P256),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x0054 => Ok(Ciphersuite::MLS_128_MLKEM768P256_AES256GCM_SHA384_P256),
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            0x0055 => Ok(Ciphersuite::MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384),
             #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
             0xF042 => Ok(Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_Ed25519),
             _ => Err(Self::Error::DecodingError(format!(
@@ -656,6 +689,11 @@ impl Ciphersuite {
             | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 => HashType::Sha2_512,
             #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
             Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87 => HashType::Sha2_512,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768P256_AES128GCM_SHA256_P256 => HashType::Sha2_256,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768P256_AES256GCM_SHA384_P256
+            | Ciphersuite::MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384 => HashType::Sha2_384,
         }
     }
 
@@ -705,6 +743,15 @@ impl Ciphersuite {
             }
             #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
             Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_Ed25519 => SignatureScheme::ED25519,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768P256_AES128GCM_SHA256_P256
+            | Ciphersuite::MLS_128_MLKEM768P256_AES256GCM_SHA384_P256 => {
+                SignatureScheme::ECDSA_SECP256R1_SHA256
+            }
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384 => {
+                SignatureScheme::ECDSA_SECP384R1_SHA384
+            }
         }
     }
 
@@ -736,6 +783,11 @@ impl Ciphersuite {
             | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65
             | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87
             | Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_Ed25519 => AeadType::Aes256Gcm,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768P256_AES128GCM_SHA256_P256 => AeadType::Aes128Gcm,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768P256_AES256GCM_SHA384_P256
+            | Ciphersuite::MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384 => AeadType::Aes256Gcm,
         }
     }
 
@@ -769,6 +821,11 @@ impl Ciphersuite {
             }
             #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
             Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA512_MLDSA87 => HpkeKdfType::HkdfSha512,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768P256_AES128GCM_SHA256_P256 => HpkeKdfType::HkdfSha256,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768P256_AES256GCM_SHA384_P256
+            | Ciphersuite::MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384 => HpkeKdfType::HkdfSha384,
         }
     }
 
@@ -800,6 +857,11 @@ impl Ciphersuite {
             Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_P256
             | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65
             | Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_Ed25519 => HpkeKemType::MlKem768,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768P256_AES128GCM_SHA256_P256
+            | Ciphersuite::MLS_128_MLKEM768P256_AES256GCM_SHA384_P256 => HpkeKemType::MlKem768P256,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384 => HpkeKemType::MlKem1024P384,
         }
     }
 
@@ -831,6 +893,11 @@ impl Ciphersuite {
             | Ciphersuite::MLS_192_MLKEM768_AES256GCM_SHA384_MLDSA65
             | Ciphersuite::MLS_256_MLKEM1024_AES256GCM_SHA384_MLDSA87
             | Ciphersuite::MLS_128_MLKEM768_AES256GCM_SHA384_Ed25519 => HpkeAeadType::AesGcm256,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768P256_AES128GCM_SHA256_P256 => HpkeAeadType::AesGcm128,
+            #[cfg(feature = "draft-ietf-mls-pq-ciphersuites")]
+            Ciphersuite::MLS_128_MLKEM768P256_AES256GCM_SHA384_P256
+            | Ciphersuite::MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384 => HpkeAeadType::AesGcm256,
         }
     }
 
@@ -866,5 +933,52 @@ impl Ciphersuite {
     #[inline]
     pub const fn aead_nonce_length(&self) -> usize {
         self.aead_algorithm().nonce_size()
+    }
+}
+
+#[cfg(all(test, feature = "draft-ietf-mls-pq-ciphersuites"))]
+mod pq_hybrid_p_curve_suites {
+    //! The three ciphersuites on the hybrid ML-KEM/P-curve KEMs of
+    //! draft-ietf-mls-pq-ciphersuites, TBD3 to TBD5, with the KEM identifiers
+    //! from draft-ietf-hpke-pq.
+
+    use super::*;
+
+    #[test]
+    fn parameters() {
+        let tbd3 = Ciphersuite::MLS_128_MLKEM768P256_AES128GCM_SHA256_P256;
+        assert_eq!(tbd3.hpke_kem_algorithm(), HpkeKemType::MlKem768P256);
+        assert_eq!(tbd3.hpke_kdf_algorithm(), HpkeKdfType::HkdfSha256);
+        assert_eq!(tbd3.aead_algorithm(), AeadType::Aes128Gcm);
+        assert_eq!(tbd3.hash_algorithm(), HashType::Sha2_256);
+        assert_eq!(
+            tbd3.signature_algorithm(),
+            SignatureScheme::ECDSA_SECP256R1_SHA256
+        );
+        assert_eq!(Ciphersuite::try_from(0x0053), Ok(tbd3));
+
+        let tbd4 = Ciphersuite::MLS_128_MLKEM768P256_AES256GCM_SHA384_P256;
+        assert_eq!(tbd4.hpke_kem_algorithm(), HpkeKemType::MlKem768P256);
+        assert_eq!(
+            tbd4.signature_algorithm(),
+            SignatureScheme::ECDSA_SECP256R1_SHA256
+        );
+        assert_eq!(Ciphersuite::try_from(0x0054), Ok(tbd4));
+
+        let tbd5 = Ciphersuite::MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384;
+        assert_eq!(tbd5.hpke_kem_algorithm(), HpkeKemType::MlKem1024P384);
+        assert_eq!(
+            tbd5.signature_algorithm(),
+            SignatureScheme::ECDSA_SECP384R1_SHA384
+        );
+        assert_eq!(Ciphersuite::try_from(0x0055), Ok(tbd5));
+
+        for suite in [tbd4, tbd5] {
+            assert_eq!(suite.hpke_kdf_algorithm(), HpkeKdfType::HkdfSha384);
+            assert_eq!(suite.aead_algorithm(), AeadType::Aes256Gcm);
+            assert_eq!(suite.hash_algorithm(), HashType::Sha2_384);
+        }
+        assert_eq!(HpkeKemType::MlKem768P256 as u16, 0x0050);
+        assert_eq!(HpkeKemType::MlKem1024P384 as u16, 0x0051);
     }
 }


### PR DESCRIPTION
The ciphersuite table of draft-ietf-mls-pq-ciphersuites-06 has eleven entries. openmls has eight of them behind `draft-ietf-mls-pq-ciphersuites`; the three missing ones are the suites on the hybrid ML-KEM/P-curve KEMs of draft-ietf-hpke-pq:

| draft | suite | HPKE KEM |
| --- | --- | --- |
| TBD3 | MLS_128_MLKEM768P256_AES128GCM_SHA256_P256 | MLKEM768-P256, 0x0050 |
| TBD4 | MLS_128_MLKEM768P256_AES256GCM_SHA384_P256 | MLKEM768-P256, 0x0050 |
| TBD5 | MLS_192_MLKEM1024P384_AES256GCM_SHA384_P384 | MLKEM1024-P384, 0x0051 |

We need TBD4 and TBD5, in a setting where the P-curve half of the KEM is a requirement, and run them from a crypto provider of our own. For that openmls has to know the suites and the two KEMs, which is what this PR adds: the three `Ciphersuite` variants, the two `HpkeKemType` variants (`0x0050`, `0x0051`), and the KEM mappings in the two bundled providers made fallible, since hpke-rs 0.7 has no counterpart for these KEMs and the mappings were exhaustive matches. It follows how #2046 and #2118 added the other draft suites.

Parameters follow draft -06, which moved the KDF of every suite from SHAKE256 (-05) to HKDF; that is what the existing suites here use as well. The draft has no code points yet. I took `0x0053` to `0x0055` as provisional ones in draft order, following on from the `0x004D..0x0052` block the existing draft suites occupy; `0x0050` and `0x0051` as suite code points are already taken by TBD7 and TBD10 here. If you prefer other values, say so and I change them. The new variants are appended to both enums, so the serde indices of the existing ones do not move.

One thing is different from the earlier suite PRs, and I want to name it rather than have you find it: neither bundled provider can run these suites yet. hpke-rs 0.7 has no hybrid KEMs; they are on hpke-rs `main` since celabshq/libcrux#1539 but not in a release. So this adds the definitions before the providers here can use them. With a KEM that has no hpke-rs counterpart, an HPKE call now returns `UnsupportedCiphersuite`, `supports()` reports the suites as unsupported, and a provider that implements the KEMs advertises them through `supports()` and `supported_ciphersuites()`, from which `Capabilities::for_provider` builds the leaf node capabilities.

Why I think adding them now is still the better order:

- The definitions are the part that needs a release of `openmls_traits`, because they are new enum variants. Provider support is a change inside a provider crate and can follow in any release, without touching the traits again. With the variants in the next `openmls_traits` release, the provider side after the hpke-rs release is a small patch, the way #2118 and #2152 did it, and nothing waits for a second traits release.
- Nothing changes for anyone who does not use the suites. They are behind the feature, not in the default capabilities, and a provider has to claim them in `supports()` before openmls will touch them. Defining suites the bundled providers cannot run has precedent here: `0x0004` to `0x0007` from RFC 9420 are in the table and neither provider supports them either.
- Every row of the draft's table is then in openmls, which makes it usable for anyone who runs these suites from a provider outside this repository, not only us.

If you would rather wait and take suites and provider support in one PR after the hpke-rs release, that works for me too; I convert this to a draft until then.

No test vectors, since no bundled provider can run the suites. A unit test pins the parameters and the code points.
