### PR TITLE
fix: validate the signer's signature scheme in commit and proposal creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [#2213](https://github.com/openmls/openmls/pull/2213): Commit and self-update-proposal creation now reject a signer whose signature scheme does not match the group's ciphersuite with `InvalidSignerCiphersuite`; previously only a `NewSignerBundle`'s signer was checked.
+
 ### Added
 
 - [#2127](https://github.com/openmls/openmls/pull/2127): Added `ExternalProposal::new_pre_shared_key`, for injecting an external or resumption pre-shared key into a group's key schedule with from an external sender.

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -496,8 +496,8 @@ pub enum CreateCommitError {
     /// Invalid [`LeafNodeParameters`]. `[CredentialWithKey]` can't be set with new signer.
     #[error("Invalid LeafNodeParameters. CredentialWithKey can't be set with new signer.")]
     InvalidLeafNodeParameters,
-    /// The new signer's signature scheme does not match the group's ciphersuite.
-    #[error("The new signer's signature scheme does not match the group's ciphersuite.")]
+    /// The signer's signature scheme does not match the group's ciphersuite.
+    #[error("The signer's signature scheme does not match the group's ciphersuite.")]
     InvalidSignerCiphersuite,
     /// A new signer cannot be used with an external commit.
     #[error("A new signer cannot be used with an external commit. The credential and signer are the ones passed to the external commit builder.")]

--- a/openmls/src/group/mls_group/commit_builder.rs
+++ b/openmls/src/group/mls_group/commit_builder.rs
@@ -820,6 +820,15 @@ impl<'a, G: BorrowMut<MlsGroup>> CommitBuilder<'a, LoadedPsks, G> {
         let marks_new_vc_derivation_epoch = staged_vc_commit_data(group)?
             .is_some_and(|commit_data| commit_data.creates_derivation_epoch());
         let ciphersuite = group.ciphersuite();
+
+        // The signer signs the commit's framed content (and, without a new
+        // signer, the UpdatePath leaf), so its scheme must match the group's
+        // ciphersuite. Checked before any proposal is staged or an operation
+        // generation is burned.
+        if ciphersuite.signature_algorithm() != old_signer.signature_scheme() {
+            return Err(CreateCommitError::InvalidSignerCiphersuite);
+        }
+
         let own_leaf_index = group.own_leaf_index();
         let (sender, is_external_commit) = match cur_stage.external_commit_info {
             None => (Sender::build_member(own_leaf_index), false),

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -400,9 +400,8 @@ pub enum ProposeSelfUpdateError<StorageError> {
     /// `new_signer.credential_with_key` (rotation paths only).
     #[error("Mismatched credential_with_key between leaf_node_parameters and new_signer")]
     InvalidLeafNodeParameters,
-    /// The `leaf_node_parameters.credential_with_key` does not match
-    /// `new_signer.credential_with_key` (rotation paths only).
-    #[error("Mismatched ciphersuite between new_signer and the group")]
+    /// The signer's signature scheme does not match the group's ciphersuite.
+    #[error("The signer's signature scheme does not match the group's ciphersuite.")]
     InvalidSignerCiphersuite,
 }
 

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -3973,6 +3973,64 @@ fn commit_with_new_signer_mismatched_ciphersuite() {
     assert_eq!(err, CreateCommitError::InvalidSignerCiphersuite);
 }
 
+// A commit signed with a signer whose signature scheme does not match the
+// group's ciphersuite is rejected with `InvalidSignerCiphersuite`, without a
+// `NewSignerBundle` involved.
+#[openmls_test::openmls_test]
+fn commit_with_mismatched_signer_ciphersuite() {
+    use openmls_traits::types::SignatureScheme;
+
+    let provider = &Provider::default();
+    let (credential_with_key, _key_package, signer, _signature_key) =
+        setup_client("Alice", ciphersuite, provider);
+    let mut group = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .build(provider, &signer, credential_with_key)
+        .unwrap();
+
+    let group_scheme = ciphersuite.signature_algorithm();
+    let mismatched_scheme = if group_scheme == SignatureScheme::ED25519 {
+        SignatureScheme::ECDSA_SECP256R1_SHA256
+    } else {
+        SignatureScheme::ED25519
+    };
+    let mismatched_signer = SignatureKeyPair::new(mismatched_scheme).unwrap();
+
+    let err = group
+        .commit_builder()
+        .load_psks(provider.storage())
+        .unwrap()
+        .build(
+            provider.rand(),
+            provider.crypto(),
+            &mismatched_signer,
+            |_| true,
+        )
+        .unwrap_err();
+    assert_eq!(err, CreateCommitError::InvalidSignerCiphersuite);
+
+    // The same check guards the commit-creating `MlsGroup` APIs, e.g.
+    // `update_group_context_extensions`.
+    #[cfg(any(not(feature = "virtual-clients-draft"), feature = "test-utils", test))]
+    {
+        let err = group
+            .update_group_context_extensions(provider, Extensions::default(), &mismatched_signer)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            CreateGroupContextExtProposalError::CreateCommitError(
+                CreateCommitError::InvalidSignerCiphersuite
+            )
+        ));
+    }
+
+    // And the self-update proposal path.
+    let err = group
+        .propose_self_update(provider, &mismatched_signer, LeafNodeParameters::default())
+        .unwrap_err();
+    assert_eq!(err, ProposeSelfUpdateError::InvalidSignerCiphersuite);
+}
+
 // A member commit whose `leaf_node_parameters` pin a credential that differs
 // from the new signer's credential is rejected with
 // `InvalidLeafNodeParameters`.

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -114,6 +114,13 @@ impl MlsGroup {
     ) -> Result<AuthenticatedContent, ProposeSelfUpdateError<Provider::StorageError>> {
         self.is_operational()?;
 
+        // The signer signs the proposal's framed content (and, without a new
+        // signer, the rekeyed leaf), so its scheme must match the group's
+        // ciphersuite.
+        if self.ciphersuite().signature_algorithm() != old_signer.signature_scheme() {
+            return Err(ProposeSelfUpdateError::InvalidSignerCiphersuite);
+        }
+
         // Here we clone our own leaf to rekey it such that we don't change the
         // tree.
         // The new leaf node will be applied later when the proposal is


### PR DESCRIPTION
Fixes #1981.

`CommitBuilder::build_internal` and the self-update proposal path only checked the signature scheme of a `NewSignerBundle`; the signer that actually signs the framed content (and, without a new signer, the leaf) was never validated. A mismatched signer now fails with the existing `InvalidSignerCiphersuite` error before any proposal is staged or an operation generation is burned. Since every commit-creating `MlsGroup` API routes through `build_internal`, one check covers them all — `update_group_context_extensions` included.

Also fixes the copy-pasted doc/`Display` text on `ProposeSelfUpdateError::InvalidSignerCiphersuite` (it described `InvalidLeafNodeParameters`) and generalizes the `CreateCommitError` variant's wording, since both now cover the plain signer too.

Test: mismatched signer against plain commit build, `update_group_context_extensions`, and `propose_self_update`, next to the existing new-signer tests.