### PR TITLE
fix: derive implicit capabilities from crypto provider

### DIFF
--- a/openmls/src/group/mls_group/builder.rs
+++ b/openmls/src/group/mls_group/builder.rs
@@ -1,6 +1,8 @@
 use openmls_traits::{crypto::OpenMlsCrypto, signatures::Signer, types::Ciphersuite};
 use tls_codec::Serialize;
 
+use super::config::CapabilitiesSource;
+
 #[cfg(feature = "extensions-draft")]
 use crate::schedule::application_export_tree::ApplicationExportTree;
 use crate::{
@@ -126,8 +128,19 @@ impl MlsGroupBuilder {
         credential_with_key: CredentialWithKey,
         mls_group_create_config_option: Option<MlsGroupCreateConfig>,
     ) -> Result<MlsGroup, NewGroupError<Provider::StorageError>> {
-        let mls_group_create_config = mls_group_create_config_option
+        let mut mls_group_create_config = mls_group_create_config_option
             .unwrap_or_else(|| self.mls_group_create_config_builder.build());
+        if mls_group_create_config.capabilities_source == CapabilitiesSource::Inferred
+            && mls_group_create_config.capabilities == Capabilities::default()
+        {
+            // A hardcoded default can advertise algorithms the selected
+            // provider cannot execute, or omit a provider-specific suite used
+            // by this group. Derive the default at the provider boundary while
+            // preserving explicit builder settings. Legacy serialized configs
+            // cannot distinguish an explicit global default from an omitted
+            // list, so they retain the original equality-based inference.
+            mls_group_create_config.capabilities = Capabilities::for_provider(provider.crypto());
+        }
         let group_id = self
             .group_id
             .unwrap_or_else(|| GroupId::random(provider.rand()));

--- a/openmls/src/group/mls_group/config.rs
+++ b/openmls/src/group/mls_group/config.rs
@@ -355,6 +355,11 @@ impl MlsGroupJoinConfig {
 pub struct MlsGroupCreateConfig {
     /// Capabilities advertised in the creator's leaf node
     pub(crate) capabilities: Capabilities,
+    // The existing serialized format has no provenance field. Retain its
+    // default inference on decode, while tracking explicit builder settings
+    // in memory so an explicit list equal to the global default is preserved.
+    #[serde(skip)]
+    pub(super) capabilities_source: CapabilitiesSource,
     /// Lifetime of the own leaf node
     pub(crate) lifetime: Lifetime,
     /// Ciphersuite and protocol version
@@ -372,10 +377,18 @@ pub struct MlsGroupCreateConfig {
     pub(crate) emulation_group: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) enum CapabilitiesSource {
+    #[default]
+    Inferred,
+    Explicit,
+}
+
 impl Default for MlsGroupCreateConfig {
     fn default() -> Self {
         Self {
             capabilities: Capabilities::default(),
+            capabilities_source: CapabilitiesSource::Inferred,
             lifetime: Lifetime::default(),
             ciphersuite: Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
             join_config: MlsGroupJoinConfig::default(),
@@ -655,6 +668,7 @@ impl MlsGroupCreateConfigBuilder {
     /// Sets the `capabilities` of the group creator's leaf node.
     pub fn capabilities(mut self, capabilities: Capabilities) -> Self {
         self.config.capabilities = capabilities;
+        self.config.capabilities_source = CapabilitiesSource::Explicit;
         self
     }
 

--- a/openmls/src/group/mls_group/creation.rs
+++ b/openmls/src/group/mls_group/creation.rs
@@ -130,7 +130,9 @@ impl MlsGroup {
     ) -> Result<(Self, MlsMessageOut, Option<GroupInfo>), ExternalCommitError<Provider::StorageError>>
     {
         let leaf_node_parameters = LeafNodeParameters::builder()
-            .with_capabilities(capabilities.unwrap_or_default())
+            .with_capabilities(
+                capabilities.unwrap_or_else(|| Capabilities::for_provider(provider.crypto())),
+            )
             .with_extensions(extensions.unwrap_or_default())
             .build();
 

--- a/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/mls_group.rs
@@ -1453,6 +1453,7 @@ fn max_past_epochs_join_config() {
     let max_past_epochs = 10;
 
     let create_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
         .max_past_epochs(max_past_epochs)
         .build();
 

--- a/openmls/src/group/public_group/diff/compute_path.rs
+++ b/openmls/src/group/public_group/diff/compute_path.rs
@@ -70,7 +70,9 @@ impl PublicGroupDiff<'_> {
 
                 let capabilities = match leaf_node_params.capabilities() {
                     Some(c) => c.to_owned(),
-                    None => Capabilities::default(),
+                    // An external join creates a new leaf, so its defaults
+                    // must describe the joining provider's executable suites.
+                    None => Capabilities::for_provider(crypto),
                 };
 
                 let extensions = match leaf_node_params.extensions() {

--- a/openmls/src/group/tests_and_kats/tests/virtual_clients.rs
+++ b/openmls/src/group/tests_and_kats/tests/virtual_clients.rs
@@ -1,4 +1,6 @@
-use openmls_traits::{signatures::Signer, types::Ciphersuite, OpenMlsProvider};
+use openmls_traits::{
+    crypto::OpenMlsCrypto as _, signatures::Signer, types::Ciphersuite, OpenMlsProvider,
+};
 use tls_codec::Serialize as _;
 
 use crate::{
@@ -29,20 +31,40 @@ use crate::{
     schedule::application_export_tree::{ApplicationExportTree, ApplicationExportTreeError},
 };
 
-/// Emulation group suite. Its KDF hash (SHA-384) differs from the
-/// higher-level group's (SHA-256), so a derivation that skips the import into
-/// the target ciphersuite, or imports under the wrong one, silently produces
-/// different bytes rather than erroring out -- which is exactly what these
-/// tests detect.
-const EMULATION_CIPHERSUITE: Ciphersuite =
-    Ciphersuite::MLS_128_MLKEM768X25519_AES256GCM_SHA384_Ed25519;
-/// Higher-level group suite: the target ciphersuite of the derivations under
-/// test.
-const GROUP_CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+/// Select a source with a different KDF hash so a missing or wrongly bound
+/// import produces different bytes. Providers with only one hash cannot exercise
+/// this invariant; the sentinel below prevents provider lanes from silently
+/// skipping it.
+fn emulation_ciphersuite(
+    provider: &impl OpenMlsProvider,
+    group_ciphersuite: Ciphersuite,
+) -> Option<Ciphersuite> {
+    provider
+        .crypto()
+        .supported_ciphersuites()
+        .into_iter()
+        .find(|source| source.hash_algorithm() != group_ciphersuite.hash_algorithm())
+}
+
+#[test]
+fn virtual_client_derivation_tests_have_executable_provider_lanes() {
+    fn assert_sources(provider: &impl OpenMlsProvider) {
+        let suites = provider.crypto().supported_ciphersuites();
+        assert!(!suites.is_empty());
+        for target in suites {
+            let source = emulation_ciphersuite(provider, target)
+                .expect("every tested suite must have a supported cross-hash source");
+            assert!(provider.crypto().supports(source).is_ok());
+            assert_ne!(source.hash_algorithm(), target.hash_algorithm());
+        }
+    }
+    assert_sources(&openmls_rust_crypto::OpenMlsRustCrypto::default());
+}
 
 /// `Capabilities` declaring `AppDataDictionary` support.
-fn vc_capabilities() -> Capabilities {
+fn vc_capabilities(ciphersuite: Ciphersuite) -> Capabilities {
     Capabilities::builder()
+        .ciphersuites(vec![ciphersuite])
         .extensions(vec![ExtensionType::AppDataDictionary])
         .build()
 }
@@ -68,7 +90,7 @@ fn vc_config_builder(ciphersuite: Ciphersuite) -> MlsGroupCreateConfigBuilder {
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
 }
@@ -96,16 +118,16 @@ fn fresh_export_tree(ciphersuite: Ciphersuite, fill: u8) -> ApplicationExportTre
 /// Found a single-member emulation group on `provider`. Creating it registers
 /// the initial epoch as a derivation epoch. Returns the group alongside the
 /// [`EpochId`] the tests derive their reference values from.
-fn registered_derivation_epoch<P: OpenMlsProvider>(provider: &P) -> (MlsGroup, EpochId) {
-    let (credential, signer) = new_credential(
-        provider,
-        b"Emulator",
-        EMULATION_CIPHERSUITE.signature_algorithm(),
-    );
+fn registered_derivation_epoch<P: OpenMlsProvider>(
+    provider: &P,
+    ciphersuite: Ciphersuite,
+) -> (MlsGroup, EpochId) {
+    let (credential, signer) =
+        new_credential(provider, b"Emulator", ciphersuite.signature_algorithm());
     let emulator_group = MlsGroup::new(
         provider,
         &signer,
-        &emulation_group_config(EMULATION_CIPHERSUITE),
+        &emulation_group_config(ciphersuite),
         credential,
     )
     .expect("create emulation group");
@@ -124,33 +146,30 @@ fn registered_derivation_epoch<P: OpenMlsProvider>(provider: &P) -> (MlsGroup, E
 #[openmls_test::openmls_test]
 fn vc_commit_path_material_imports_into_group_ciphersuite() {
     let provider = &Provider::default();
+    let Some(emulation_ciphersuite) = emulation_ciphersuite(provider, ciphersuite) else {
+        return;
+    };
     let bob_provider = &Provider::default();
 
-    let (emulator_group, epoch_id) = registered_derivation_epoch(provider);
+    let (emulator_group, epoch_id) = registered_derivation_epoch(provider, emulation_ciphersuite);
 
     // Higher-level group: the VC leaf plus one regular member, so the VC
     // commit's update path contains a parent node.
-    let (alice_credential, alice_signer) = new_credential(
-        provider,
-        b"Alice (VC)",
-        GROUP_CIPHERSUITE.signature_algorithm(),
-    );
+    let (alice_credential, alice_signer) =
+        new_credential(provider, b"Alice (VC)", ciphersuite.signature_algorithm());
     let mut main_group = MlsGroup::new(
         provider,
         &alice_signer,
-        &vc_group_config(GROUP_CIPHERSUITE),
+        &vc_group_config(ciphersuite),
         alice_credential,
     )
     .expect("create main group");
 
-    let (bob_credential, bob_signer) = new_credential(
-        bob_provider,
-        b"Bob",
-        GROUP_CIPHERSUITE.signature_algorithm(),
-    );
+    let (bob_credential, bob_signer) =
+        new_credential(bob_provider, b"Bob", ciphersuite.signature_algorithm());
     let bob_key_package = KeyPackage::builder()
         .key_package_extensions(Extensions::empty())
-        .build(GROUP_CIPHERSUITE, bob_provider, &bob_signer, bob_credential)
+        .build(ciphersuite, bob_provider, &bob_signer, bob_credential)
         .expect("bob KP build")
         .key_package()
         .to_owned();
@@ -166,12 +185,12 @@ fn vc_commit_path_material_imports_into_group_ciphersuite() {
     // being persisted, so the commit below consumes the same generation.
     let (state, mut scratch_tree) =
         load_vc_epoch_state_and_tree(provider, &epoch_id).expect("load vc epoch state");
-    let (emulation_leaf_index, _epoch_encryption_key, emulation_ciphersuite) = state.into_parts();
-    assert_eq!(emulation_ciphersuite, EMULATION_CIPHERSUITE);
+    let (emulation_leaf_index, _epoch_encryption_key, stored_ciphersuite) = state.into_parts();
+    assert_eq!(stored_ciphersuite, emulation_ciphersuite);
     let (generation, operation_secret) = scratch_tree
         .next_operation_secret(
             provider.crypto(),
-            EMULATION_CIPHERSUITE,
+            emulation_ciphersuite,
             &epoch_id,
             emulation_leaf_index,
             VirtualClientOperationType::LeafNode,
@@ -182,19 +201,19 @@ fn vc_commit_path_material_imports_into_group_ciphersuite() {
     drop(scratch_tree);
 
     let target_operation_secret = operation_secret
-        .derive_target_operation_secret(provider.crypto(), GROUP_CIPHERSUITE, main_group.group_id())
+        .derive_target_operation_secret(provider.crypto(), ciphersuite, main_group.group_id())
         .expect("derive reference target operation secret");
     let expected_leaf_keypair = target_operation_secret
-        .derive_encryption_key_secret(provider.crypto(), GROUP_CIPHERSUITE)
+        .derive_encryption_key_secret(provider.crypto(), ciphersuite)
         .expect("derive reference encryption key secret")
-        .generate_encryption_key_pair(provider.crypto(), GROUP_CIPHERSUITE)
+        .generate_encryption_key_pair(provider.crypto(), ciphersuite)
         .expect("generate reference leaf keypair");
     let expected_parent_keypair = PathSecret::from(
         target_operation_secret
-            .derive_path_generation_secret(provider.crypto(), GROUP_CIPHERSUITE)
+            .derive_path_generation_secret(provider.crypto(), ciphersuite)
             .expect("derive reference path generation secret"),
     )
-    .derive_key_pair(provider.crypto(), GROUP_CIPHERSUITE)
+    .derive_key_pair(provider.crypto(), ciphersuite)
     .expect("derive reference parent keypair");
 
     // Actual: send the VC commit.
@@ -254,20 +273,23 @@ fn vc_commit_path_material_imports_into_group_ciphersuite() {
 #[openmls_test::openmls_test]
 fn vc_group_creation_leaf_key_imports_into_group_ciphersuite() {
     let provider = &Provider::default();
+    let Some(emulation_ciphersuite) = emulation_ciphersuite(provider, ciphersuite) else {
+        return;
+    };
 
-    let (emulator_group, epoch_id) = registered_derivation_epoch(provider);
+    let (emulator_group, epoch_id) = registered_derivation_epoch(provider, emulation_ciphersuite);
 
     // Reference derivation per spec, from a scratch copy of the operation
     // tree (dropped unpersisted, so the builder consumes the same
     // generation).
     let (state, mut scratch_tree) =
         load_vc_epoch_state_and_tree(provider, &epoch_id).expect("load vc epoch state");
-    let (emulation_leaf_index, _epoch_encryption_key, emulation_ciphersuite) = state.into_parts();
-    assert_eq!(emulation_ciphersuite, EMULATION_CIPHERSUITE);
+    let (emulation_leaf_index, _epoch_encryption_key, stored_ciphersuite) = state.into_parts();
+    assert_eq!(stored_ciphersuite, emulation_ciphersuite);
     let (generation, operation_secret) = scratch_tree
         .next_operation_secret(
             provider.crypto(),
-            EMULATION_CIPHERSUITE,
+            emulation_ciphersuite,
             &epoch_id,
             emulation_leaf_index,
             VirtualClientOperationType::KeyPackage,
@@ -278,24 +300,21 @@ fn vc_group_creation_leaf_key_imports_into_group_ciphersuite() {
     drop(scratch_tree);
 
     let expected_leaf_keypair = operation_secret
-        .derive_key_package_seed_secret(provider.crypto(), GROUP_CIPHERSUITE, 0)
+        .derive_key_package_seed_secret(provider.crypto(), ciphersuite, 0)
         .expect("derive reference key package seed")
-        .derive_encryption_key_secret(provider.crypto(), GROUP_CIPHERSUITE)
+        .derive_encryption_key_secret(provider.crypto(), ciphersuite)
         .expect("derive reference encryption key secret")
-        .generate_encryption_key_pair(provider.crypto(), GROUP_CIPHERSUITE)
+        .generate_encryption_key_pair(provider.crypto(), ciphersuite)
         .expect("generate reference leaf keypair");
 
     // Actual: create the higher-level group as the virtual client.
-    let (vc_credential, vc_signer) = new_credential(
-        provider,
-        b"Alice (VC)",
-        GROUP_CIPHERSUITE.signature_algorithm(),
-    );
+    let (vc_credential, vc_signer) =
+        new_credential(provider, b"Alice (VC)", ciphersuite.signature_algorithm());
     let main_group = MlsGroup::builder()
         .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-        .ciphersuite(GROUP_CIPHERSUITE)
+        .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .with_capabilities(vc_capabilities())
+        .with_capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .vc_emulation(emulator_group.group_id())
@@ -338,12 +357,16 @@ fn safe_aad_group_context_extensions() -> Extensions<GroupContext> {
 fn safe_aad_group_pair<P: OpenMlsProvider>(
     alice_provider: &P,
     bob_provider: &P,
+    ciphersuite: Ciphersuite,
 ) -> (MlsGroup, MlsGroup, impl Signer) {
+    // Safe AAD does not require two different KDFs. Exercise the suite chosen
+    // by the provider test matrix, including suites absent from global defaults.
+    let capabilities = vc_capabilities(ciphersuite);
     let config = MlsGroupCreateConfig::builder()
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-        .ciphersuite(GROUP_CIPHERSUITE)
+        .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(capabilities.clone())
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .with_group_context_extensions(safe_aad_group_context_extensions())
@@ -352,19 +375,16 @@ fn safe_aad_group_pair<P: OpenMlsProvider>(
     let (alice_credential, alice_signer) = new_credential(
         alice_provider,
         b"Alice (VC)",
-        GROUP_CIPHERSUITE.signature_algorithm(),
+        ciphersuite.signature_algorithm(),
     );
     let mut alice_group = MlsGroup::new(alice_provider, &alice_signer, &config, alice_credential)
         .expect("create safe-aad group");
 
-    let (bob_credential, bob_signer) = new_credential(
-        bob_provider,
-        b"Bob",
-        GROUP_CIPHERSUITE.signature_algorithm(),
-    );
+    let (bob_credential, bob_signer) =
+        new_credential(bob_provider, b"Bob", ciphersuite.signature_algorithm());
     let bob_key_package = KeyPackage::builder()
-        .leaf_node_capabilities(vc_capabilities())
-        .build(GROUP_CIPHERSUITE, bob_provider, &bob_signer, bob_credential)
+        .leaf_node_capabilities(capabilities)
+        .build(ciphersuite, bob_provider, &bob_signer, bob_credential)
         .expect("bob KP build");
     let (_commit, welcome, _group_info) = alice_group
         .add_members(
@@ -401,7 +421,7 @@ fn vc_commit_data_travels_in_commit_safe_aad() {
     let bob_provider = &Provider::default();
 
     let (mut alice_group, mut bob_group, alice_signer) =
-        safe_aad_group_pair(alice_provider, bob_provider);
+        safe_aad_group_pair(alice_provider, bob_provider, ciphersuite);
 
     let commit_data = VirtualClientCommitData::new(vec![VirtualClientAction::NewDerivationEpoch])
         .expect("one new_derivation_epoch action is valid");

--- a/openmls/src/group/tests_and_kats/utils.rs
+++ b/openmls/src/group/tests_and_kats/utils.rs
@@ -231,15 +231,15 @@ fn test_setup() {
     let provider = &Provider::default();
     let test_client_config_a = TestClientConfig {
         name: "TestClientConfigA",
-        ciphersuites: vec![Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519],
+        ciphersuites: vec![ciphersuite],
     };
     let test_client_config_b = TestClientConfig {
         name: "TestClientConfigB",
-        ciphersuites: vec![Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519],
+        ciphersuites: vec![ciphersuite],
     };
     let use_ratchet_tree_extension = true;
     let test_group_config = TestGroupConfig {
-        ciphersuite: Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+        ciphersuite,
         use_ratchet_tree_extension,
         members: vec![test_client_config_a.clone(), test_client_config_b.clone()],
     };

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -588,7 +588,9 @@ impl KeyPackageBuilder {
         self.ensure_last_resort();
         let leaf_node_params = KeyPackageLeafNodeParams {
             lifetime: self.key_package_lifetime.unwrap_or_default(),
-            capabilities: self.leaf_node_capabilities.unwrap_or_default(),
+            capabilities: self
+                .leaf_node_capabilities
+                .unwrap_or_else(|| Capabilities::for_provider(provider.crypto())),
             extensions: self.leaf_node_extensions.unwrap_or_default(),
         };
         KeyPackage::create(
@@ -613,7 +615,9 @@ impl KeyPackageBuilder {
 
         let leaf_node_params = KeyPackageLeafNodeParams {
             lifetime: self.key_package_lifetime.unwrap_or_default(),
-            capabilities: self.leaf_node_capabilities.unwrap_or_default(),
+            capabilities: self
+                .leaf_node_capabilities
+                .unwrap_or_else(|| Capabilities::for_provider(provider.crypto())),
             extensions: self.leaf_node_extensions.unwrap_or_default(),
         };
         let KeyPackageCreationResult {

--- a/openmls/src/test_utils/single_group_test_framework/mod.rs
+++ b/openmls/src/test_utils/single_group_test_framework/mod.rs
@@ -138,8 +138,13 @@ impl<'a, Provider: OpenMlsProvider> PreGroupPartyStateBuilder<'a, Provider> {
         );
         let mut builder = KeyPackage::builder()
             .leaf_node_extensions(self.leaf_node_extensions.unwrap_or_default())
-            .key_package_extensions(self.key_package_extensions.unwrap_or_default())
-            .leaf_node_capabilities(self.leaf_node_capabilities.unwrap_or_default());
+            .key_package_extensions(self.key_package_extensions.unwrap_or_default());
+
+        // Leave omitted capabilities to the provider-aware production builder.
+        // Supplying a global default here would turn it into an explicit policy.
+        if let Some(capabilities) = self.leaf_node_capabilities {
+            builder = builder.leaf_node_capabilities(capabilities);
+        }
 
         if let Some(lifetime) = self.lifetime {
             builder = builder.key_package_lifetime(lifetime);

--- a/openmls/tests/app_data_update.rs
+++ b/openmls/tests/app_data_update.rs
@@ -16,7 +16,7 @@ fn setup<'a, Provider: OpenMlsProvider>(
     // Required capabilities for leaf node
     let capabilities = Capabilities::new(
         None,
-        None,
+        Some(&[ciphersuite]),
         Some(&[ExtensionType::AppDataDictionary]),
         Some(&[ProposalType::AppDataUpdate]),
         None,
@@ -211,7 +211,7 @@ fn test_app_data_update_with_welcome() {
         .pre_group_builder(ciphersuite)
         .with_leaf_node_capabilities(Capabilities::new(
             None,
-            None,
+            Some(&[ciphersuite]),
             Some(&[ExtensionType::AppDataDictionary]),
             Some(&[ProposalType::AppDataUpdate]),
             None,

--- a/openmls/tests/app_ephemeral.rs
+++ b/openmls/tests/app_ephemeral.rs
@@ -22,8 +22,13 @@ fn app_ephemeral_proposals() {
     let bob_provider = &Provider::default();
 
     // Include the AppEphemeral proposal type in the LeafNode capabilities
-    let capabilities =
-        Capabilities::new(None, None, None, Some(&[ProposalType::AppEphemeral]), None);
+    let capabilities = Capabilities::new(
+        None,
+        Some(&[ciphersuite]),
+        None,
+        Some(&[ProposalType::AppEphemeral]),
+        None,
+    );
 
     // Define the MlsGroup configuration
     let mls_group_create_config = MlsGroupCreateConfig::builder()
@@ -163,8 +168,14 @@ fn app_ephemeral_proposals() {
 
 /// Capabilities declaring support for the AppEphemeral proposal type. Every
 /// member's leaf needs this before anyone may commit such a proposal.
-fn app_ephemeral_capabilities() -> Capabilities {
-    Capabilities::new(None, None, None, Some(&[ProposalType::AppEphemeral]), None)
+fn app_ephemeral_capabilities(ciphersuite: Ciphersuite) -> Capabilities {
+    Capabilities::new(
+        None,
+        Some(&[ciphersuite]),
+        None,
+        Some(&[ProposalType::AppEphemeral]),
+        None,
+    )
 }
 
 /// Set up a group of Alice and Bob where both leaves support the AppEphemeral
@@ -175,7 +186,7 @@ fn setup_group_for_external_commit<P: OpenMlsProvider>(
     alice_provider: &P,
     bob_provider: &P,
 ) -> (MlsGroup, SignatureKeyPair, MlsGroupJoinConfig) {
-    let capabilities = app_ephemeral_capabilities();
+    let capabilities = app_ephemeral_capabilities(ciphersuite);
 
     let mls_group_create_config = MlsGroupCreateConfig::builder()
         .ciphersuite(ciphersuite)
@@ -270,7 +281,7 @@ fn app_ephemeral_proposal_in_external_commit() {
         .expect("error building group from group info")
         .leaf_node_parameters(
             LeafNodeParameters::builder()
-                .with_capabilities(app_ephemeral_capabilities())
+                .with_capabilities(app_ephemeral_capabilities(ciphersuite))
                 .build(),
         )
         .add_proposal(Proposal::AppEphemeral(Box::new(AppEphemeralProposal::new(
@@ -363,7 +374,7 @@ fn forbidden_proposal_in_external_commit_is_rejected() {
     );
 
     let dave_key_package = KeyPackage::builder()
-        .leaf_node_capabilities(app_ephemeral_capabilities())
+        .leaf_node_capabilities(app_ephemeral_capabilities(ciphersuite))
         .build(ciphersuite, dave_provider, &dave_signer, dave_credential)
         .expect("error building Dave's key package");
 
@@ -376,7 +387,7 @@ fn forbidden_proposal_in_external_commit_is_rejected() {
         .expect("error building group from group info")
         .leaf_node_parameters(
             LeafNodeParameters::builder()
-                .with_capabilities(app_ephemeral_capabilities())
+                .with_capabilities(app_ephemeral_capabilities(ciphersuite))
                 .build(),
         )
         .add_proposal(Proposal::Add(Box::new(AddProposal::from(

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -138,8 +138,8 @@ fn book_operations() {
         .ciphersuite(ciphersuite)
         // we need to specify the non-default extension here
         .capabilities(Capabilities::new(
-            None, // Defaults to the group's protocol version
-            None, // Defaults to the group's ciphersuite
+            None,                 // Defaults to the group's protocol version
+            Some(&[ciphersuite]), // Ciphersuite used by this group
             Some(&[ExtensionType::Unknown(0xff00)]),
             None, // Defaults to all basic extension types
             Some(&[CredentialType::Basic]),
@@ -200,6 +200,7 @@ fn book_operations() {
                 2000, // maximum_forward_distance
             ))
             .with_group_context_extensions(extensions) // NB: the builder method returns a Result
+            .ciphersuite(ciphersuite)
             .use_ratchet_tree_extension(true)
             .build(
                 alice_provider,
@@ -1581,7 +1582,7 @@ fn custom_proposal_usage() {
     // Define capabilities supporting the custom proposal type
     let capabilities = Capabilities::new(
         None,
-        None,
+        Some(&[ciphersuite]),
         None,
         Some(&[ProposalType::Custom(custom_proposal_type)]),
         None,
@@ -1736,8 +1737,8 @@ fn commit_builder() {
         .ciphersuite(ciphersuite)
         // we need to specify the non-default extension here
         .capabilities(Capabilities::new(
-            None, // Defaults to the group's protocol version
-            None, // Defaults to the group's ciphersuite
+            None,                 // Defaults to the group's protocol version
+            Some(&[ciphersuite]), // Ciphersuite used by this group
             Some(&[ExtensionType::Unknown(0xff00)]),
             None, // Defaults to all basic extension types
             Some(&[CredentialType::Basic]),
@@ -1860,6 +1861,7 @@ fn external_commit_builder() {
 
     // Make sure we support SelfRemoves
     let capabilities = Capabilities::builder()
+        .ciphersuites(vec![ciphersuite])
         .proposals(vec![ProposalType::SelfRemove])
         .build();
 

--- a/openmls/tests/book_code_app_data.rs
+++ b/openmls/tests/book_code_app_data.rs
@@ -95,8 +95,8 @@ fn setup_group_with_app_data_support<'a, Provider: OpenMlsProvider>(
     // Define capabilities that include AppDataDictionary extension
     // and AppDataUpdate proposal support
     let capabilities = Capabilities::new(
-        None, // protocol versions (default)
-        None, // ciphersuites (default)
+        None,                 // protocol versions (default)
+        Some(&[ciphersuite]), // Ciphersuite used by this group
         Some(&[ExtensionType::AppDataDictionary]),
         Some(&[ProposalType::AppDataUpdate]),
         None, // credentials (default)

--- a/openmls/tests/book_code_discard_commit.rs
+++ b/openmls/tests/book_code_discard_commit.rs
@@ -430,7 +430,7 @@ fn discard_commit_group_context_extensions() {
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY) // Important because the secret tree might diverge otherwise
         .capabilities(Capabilities::new(
             None,
-            None,
+            Some(&[ciphersuite]),
             Some(&[ExtensionType::Unknown(unknown_extension_type)]),
             None,
             None,
@@ -485,7 +485,7 @@ fn discard_commit_custom_proposal() {
 
     let capabilities = Capabilities::new(
         None,
-        None,
+        Some(&[ciphersuite]),
         None,
         Some(&[ProposalType::Custom(custom_proposal_type)]),
         None,

--- a/openmls/tests/opaque_extension.rs
+++ b/openmls/tests/opaque_extension.rs
@@ -80,8 +80,8 @@ fn opaque_extension() {
         )
         // we need to specify the non-default extension in alices leaf node's capabilities.
         .capabilities(Capabilities::new(
-            None, // Defaults to the group's protocol version
-            None, // Defaults to the group's ciphersuite
+            None,                 // Defaults to the group's protocol version
+            Some(&[ciphersuite]), // Ciphersuite used by this group
             Some(&[CUSTOM_EXTENSION_TYPE]),
             None, // Defaults to all basic extension types
             Some(&[CredentialType::Basic]),
@@ -239,6 +239,7 @@ fn generate_key_package(
     KeyPackage::builder()
         .leaf_node_capabilities(
             Capabilities::builder()
+                .ciphersuites(vec![ciphersuite])
                 .extensions(vec![CUSTOM_EXTENSION_TYPE])
                 .credentials(vec![CredentialType::Basic])
                 .build(),

--- a/openmls/tests/provider_default_capabilities.rs
+++ b/openmls/tests/provider_default_capabilities.rs
@@ -1,0 +1,152 @@
+use openmls::prelude::{
+    BasicCredential, Capabilities, Ciphersuite, CredentialWithKey, KeyPackage, MlsGroup,
+    MlsGroupCreateConfig, OpenMlsProvider as _, VerifiableCiphersuite,
+};
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use openmls_traits::crypto::OpenMlsCrypto;
+
+fn credential(signer: &SignatureKeyPair) -> CredentialWithKey {
+    CredentialWithKey {
+        credential: BasicCredential::new(b"provider capability test".to_vec()).into(),
+        signature_key: signer.to_public_vec().into(),
+    }
+}
+
+fn non_grease_ciphersuites(capabilities: &Capabilities) -> Vec<VerifiableCiphersuite> {
+    capabilities
+        .ciphersuites()
+        .iter()
+        .filter(|suite| !suite.is_grease())
+        .copied()
+        .collect()
+}
+
+fn first_supported_ciphersuite(provider: &OpenMlsRustCrypto) -> Ciphersuite {
+    provider
+        .crypto()
+        .supported_ciphersuites()
+        .into_iter()
+        .next()
+        .expect("the test provider must support at least one ciphersuite")
+}
+
+#[test]
+fn implicit_group_and_key_package_capabilities_follow_the_provider() {
+    let provider = OpenMlsRustCrypto::default();
+    let ciphersuite = first_supported_ciphersuite(&provider);
+    let signer = SignatureKeyPair::new(ciphersuite.signature_algorithm())
+        .expect("the supported ciphersuite must have a signer");
+    let expected = Capabilities::for_provider(provider.crypto());
+
+    let config = MlsGroupCreateConfig::builder()
+        .ciphersuite(ciphersuite)
+        .build();
+    let group = MlsGroup::new(&provider, &signer, &config, credential(&signer))
+        .expect("group creation with a supported ciphersuite must succeed");
+    assert_eq!(
+        non_grease_ciphersuites(
+            group
+                .own_leaf_node()
+                .expect("a newly created group must contain its own leaf")
+                .capabilities(),
+        ),
+        expected.ciphersuites()
+    );
+
+    let group = MlsGroup::builder()
+        .ciphersuite(ciphersuite)
+        .build(&provider, &signer, credential(&signer))
+        .expect("builder-based group creation must succeed");
+    assert_eq!(
+        non_grease_ciphersuites(
+            group
+                .own_leaf_node()
+                .expect("a newly created group must contain its own leaf")
+                .capabilities(),
+        ),
+        expected.ciphersuites()
+    );
+
+    let key_package = KeyPackage::builder()
+        .build(ciphersuite, &provider, &signer, credential(&signer))
+        .expect("key package creation with a supported ciphersuite must succeed");
+    assert_eq!(
+        non_grease_ciphersuites(key_package.key_package().leaf_node().capabilities()),
+        expected.ciphersuites()
+    );
+}
+
+#[test]
+fn explicit_group_and_key_package_capabilities_are_preserved() {
+    let provider = OpenMlsRustCrypto::default();
+    let ciphersuite = first_supported_ciphersuite(&provider);
+    let signer = SignatureKeyPair::new(ciphersuite.signature_algorithm())
+        .expect("the supported ciphersuite must have a signer");
+
+    for expected in [
+        Capabilities::default(),
+        Capabilities::new(None, Some(&[ciphersuite]), None, None, None),
+        Capabilities::new(None, Some(&[]), None, None, None),
+    ] {
+        let config = MlsGroupCreateConfig::builder()
+            .ciphersuite(ciphersuite)
+            .capabilities(expected.clone())
+            .build();
+        let group = MlsGroup::new(&provider, &signer, &config, credential(&signer))
+            .expect("explicit capabilities must permit group creation");
+        assert_eq!(
+            non_grease_ciphersuites(
+                group
+                    .own_leaf_node()
+                    .expect("a newly created group must contain its own leaf")
+                    .capabilities(),
+            ),
+            expected.ciphersuites()
+        );
+
+        let group = MlsGroup::builder()
+            .ciphersuite(ciphersuite)
+            .with_capabilities(expected.clone())
+            .build(&provider, &signer, credential(&signer))
+            .expect("explicit builder capabilities must permit group creation");
+        assert_eq!(
+            non_grease_ciphersuites(
+                group
+                    .own_leaf_node()
+                    .expect("a newly created group must contain its own leaf")
+                    .capabilities(),
+            ),
+            expected.ciphersuites()
+        );
+
+        let key_package = KeyPackage::builder()
+            .leaf_node_capabilities(expected.clone())
+            .build(ciphersuite, &provider, &signer, credential(&signer))
+            .expect("explicit capabilities must permit key package creation");
+        assert_eq!(
+            non_grease_ciphersuites(key_package.key_package().leaf_node().capabilities()),
+            expected.ciphersuites()
+        );
+    }
+}
+
+#[test]
+fn serialized_create_configs_preserve_the_existing_wire_shape() {
+    let implicit = MlsGroupCreateConfig::builder().build();
+    let explicit = MlsGroupCreateConfig::builder()
+        .capabilities(Capabilities::default())
+        .build();
+
+    let implicit_value =
+        serde_json::to_value(&implicit).expect("the implicit config must serialize");
+    let explicit_value =
+        serde_json::to_value(&explicit).expect("the explicit config must serialize");
+
+    assert!(implicit_value.get("capabilities_source").is_none());
+    assert_eq!(implicit_value, explicit_value);
+
+    let decoded: MlsGroupCreateConfig =
+        serde_json::from_value(implicit_value).expect("the existing config shape must decode");
+    assert_eq!(implicit, decoded);
+}

--- a/openmls/tests/virtual_clients.rs
+++ b/openmls/tests/virtual_clients.rs
@@ -40,8 +40,9 @@ use tls_codec::Serialize as _;
 mod mls_group;
 
 /// `Capabilities` declaring `AppDataDictionary` support.
-fn vc_capabilities() -> Capabilities {
+fn vc_capabilities(ciphersuite: openmls_traits::types::Ciphersuite) -> Capabilities {
     Capabilities::builder()
+        .ciphersuites(vec![ciphersuite])
         .extensions(vec![ExtensionType::AppDataDictionary])
         .build()
 }
@@ -97,7 +98,7 @@ fn setup_alice_bob_group_with_policy<P: OpenMlsProvider>(
         .wire_format_policy(wire_format_policy)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions on alice config")
         .build();
@@ -112,7 +113,7 @@ fn setup_alice_bob_group_with_policy<P: OpenMlsProvider>(
 
     let bob_key_package = KeyPackage::builder()
         .key_package_extensions(Extensions::empty())
-        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_capabilities(vc_capabilities(ciphersuite))
         .leaf_node_extensions(vc_leaf_extensions())
         .build(ciphersuite, bob_provider, &bob_signer, bob_credential)
         .expect("bob KP build")
@@ -171,7 +172,7 @@ fn emulation_config_builder(
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions on emulator config")
         .emulation_group(emulation_group);
@@ -200,7 +201,7 @@ fn vc_key_package<P: OpenMlsProvider>(
     let (credential, signer) = new_credential(provider, label, ciphersuite.signature_algorithm());
     let key_package = KeyPackage::builder()
         .key_package_extensions(Extensions::empty())
-        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_capabilities(vc_capabilities(ciphersuite))
         .leaf_node_extensions(vc_leaf_extensions())
         .build(ciphersuite, provider, &signer, credential)
         .expect("build vc key package")
@@ -340,7 +341,7 @@ fn new_vc_main_group<P: OpenMlsProvider>(
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .build();
@@ -361,7 +362,7 @@ fn new_vc_main_group_with_policy<P: OpenMlsProvider>(
         .wire_format_policy(wire_format_policy)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .build();
@@ -449,7 +450,7 @@ fn join_sibling_emulator<P: OpenMlsProvider>(
         .expect("build_group")
         .leaf_node_parameters(
             LeafNodeParameters::builder()
-                .with_capabilities(vc_capabilities())
+                .with_capabilities(vc_capabilities(alice_a_main.ciphersuite()))
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
@@ -517,7 +518,7 @@ fn vc_operation_tree_persists_across_own_commits() {
     let group_config = MlsGroupCreateConfig::builder()
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .build();
@@ -627,7 +628,7 @@ fn sibling_resync_external_commit_fails_when_receiver_lacks_operation_tree() {
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions on higher-level config")
         .build();
@@ -684,7 +685,7 @@ fn sibling_resync_external_commit_fails_when_receiver_lacks_operation_tree() {
         .expect("build_group")
         .leaf_node_parameters(
             LeafNodeParameters::builder()
-                .with_capabilities(vc_capabilities())
+                .with_capabilities(vc_capabilities(ciphersuite))
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
@@ -782,7 +783,7 @@ fn vc_two_alice_clients_in_group_with_bob_and_charly() {
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions on alice main group config")
         .build();
@@ -890,7 +891,7 @@ fn vc_two_alice_clients_in_group_with_bob_and_charly() {
         .expect("build_group")
         .leaf_node_parameters(
             LeafNodeParameters::builder()
-                .with_capabilities(vc_capabilities())
+                .with_capabilities(vc_capabilities(ciphersuite))
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
@@ -1158,7 +1159,7 @@ fn vc_sibling_emulator_resyncs_into_higher_level_group_via_external_commit() {
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions on higher-level config")
         .build();
@@ -1230,7 +1231,7 @@ fn vc_sibling_emulator_resyncs_into_higher_level_group_via_external_commit() {
         .expect("build_group")
         .leaf_node_parameters(
             LeafNodeParameters::builder()
-                .with_capabilities(vc_capabilities())
+                .with_capabilities(vc_capabilities(ciphersuite))
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
@@ -1543,7 +1544,7 @@ fn vc_second_emulator_client_onboards_via_external_commit() {
         .expect("build_group charly_a")
         .leaf_node_parameters(
             LeafNodeParameters::builder()
-                .with_capabilities(vc_capabilities())
+                .with_capabilities(vc_capabilities(ciphersuite))
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
@@ -1663,8 +1664,9 @@ fn vc_second_emulator_client_onboards_via_external_commit() {
 /// The VC capabilities, extended with support for the AppEphemeral proposal
 /// type. All leaves of a group need this before anyone may commit such a
 /// proposal.
-fn vc_app_ephemeral_capabilities() -> Capabilities {
+fn vc_app_ephemeral_capabilities(ciphersuite: openmls_traits::types::Ciphersuite) -> Capabilities {
     Capabilities::builder()
+        .ciphersuites(vec![ciphersuite])
         .extensions(vec![ExtensionType::AppDataDictionary])
         .proposals(vec![ProposalType::AppEphemeral])
         .build()
@@ -1702,7 +1704,7 @@ fn vc_sibling_reads_app_ephemeral_from_external_commit() {
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_app_ephemeral_capabilities())
+        .capabilities(vc_app_ephemeral_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .build();
@@ -1718,7 +1720,7 @@ fn vc_sibling_reads_app_ephemeral_from_external_commit() {
         new_credential(&bob_provider, b"Bob", ciphersuite.signature_algorithm());
     let bob_kp = KeyPackage::builder()
         .key_package_extensions(Extensions::empty())
-        .leaf_node_capabilities(vc_app_ephemeral_capabilities())
+        .leaf_node_capabilities(vc_app_ephemeral_capabilities(ciphersuite))
         .leaf_node_extensions(vc_leaf_extensions())
         .build(ciphersuite, &bob_provider, &bob_signer, bob_credential)
         .expect("bob KP build")
@@ -1791,7 +1793,7 @@ fn vc_sibling_reads_app_ephemeral_from_external_commit() {
         .expect("build_group charly_a")
         .leaf_node_parameters(
             LeafNodeParameters::builder()
-                .with_capabilities(vc_app_ephemeral_capabilities())
+                .with_capabilities(vc_app_ephemeral_capabilities(ciphersuite))
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
@@ -1894,8 +1896,11 @@ fn vc_sibling_reads_app_ephemeral_from_external_commit() {
 /// The VC capabilities, extended with support for the AppDataUpdate and
 /// AppEphemeral proposal types. All leaves of a group need this before
 /// anyone may commit such proposals.
-fn vc_app_data_update_capabilities() -> Capabilities {
+fn vc_app_data_update_capabilities(
+    ciphersuite: openmls_traits::types::Ciphersuite,
+) -> Capabilities {
     Capabilities::builder()
+        .ciphersuites(vec![ciphersuite])
         .extensions(vec![ExtensionType::AppDataDictionary])
         .proposals(vec![
             ProposalType::AppDataUpdate,
@@ -1946,7 +1951,7 @@ fn vc_app_data_scenario<P: OpenMlsProvider + Default>(
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_app_data_update_capabilities())
+        .capabilities(vc_app_data_update_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .build();
@@ -1962,7 +1967,7 @@ fn vc_app_data_scenario<P: OpenMlsProvider + Default>(
         new_credential(&bob_provider, b"Bob", ciphersuite.signature_algorithm());
     let bob_kp = KeyPackage::builder()
         .key_package_extensions(Extensions::empty())
-        .leaf_node_capabilities(vc_app_data_update_capabilities())
+        .leaf_node_capabilities(vc_app_data_update_capabilities(ciphersuite))
         .leaf_node_extensions(vc_leaf_extensions())
         .build(ciphersuite, &bob_provider, &bob_signer, bob_credential)
         .expect("bob KP build")
@@ -2054,7 +2059,9 @@ fn charly_a_external_commit_with_app_data_update<P: OpenMlsProvider>(
         .expect("build_group charly_a")
         .leaf_node_parameters(
             LeafNodeParameters::builder()
-                .with_capabilities(vc_app_data_update_capabilities())
+                .with_capabilities(vc_app_data_update_capabilities(
+                    scenario.alice_main.ciphersuite(),
+                ))
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
@@ -2458,7 +2465,7 @@ fn vc_sibling_joins_higher_level_group_via_key_package_welcome() {
     // alice_b. alice_b only learns about the KeyPackage through the upload, it
     // never stores the bundle.
     let mut batch = KeyPackage::builder()
-        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_capabilities(vc_capabilities(ciphersuite))
         .leaf_node_extensions(vc_leaf_extensions())
         .build_vc_batch(
             ciphersuite,
@@ -2614,7 +2621,7 @@ fn retained_material_welcome<P: OpenMlsProvider>(
     let epoch_id = newest_epoch(&emulator_b, alice_b_provider);
 
     let mut batch = KeyPackage::builder()
-        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_capabilities(vc_capabilities(ciphersuite))
         .leaf_node_extensions(vc_leaf_extensions())
         .build_vc_batch(
             ciphersuite,
@@ -2870,7 +2877,7 @@ fn vc_batch_key_packages_join_in_any_order() {
     // One batch of 40 KeyPackages, larger than OUT_OF_ORDER_TOLERANCE (32).
     let count = 40;
     let batch = KeyPackage::builder()
-        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_capabilities(vc_capabilities(ciphersuite))
         .leaf_node_extensions(vc_leaf_extensions())
         .build_vc_batch(
             ciphersuite,
@@ -2990,7 +2997,7 @@ fn vc_siblings_joined_via_key_package_welcome_read_each_others_messages() {
     // alice_a publishes a virtual-client KeyPackage and hands the upload to
     // alice_b.
     let mut batch = KeyPackage::builder()
-        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_capabilities(vc_capabilities(ciphersuite))
         .leaf_node_extensions(vc_leaf_extensions())
         .build_vc_batch(
             ciphersuite,
@@ -3252,7 +3259,7 @@ fn confirm_targets_creation_epoch() {
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
         .max_past_epochs(1)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .build();
@@ -3522,7 +3529,7 @@ fn confirm_handshake_message_deletes_retained_secret() {
         .wire_format_policy(PURE_CIPHERTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .build();
@@ -3827,7 +3834,7 @@ fn bound_group_fails_closed_when_derivation_state_missing_on_send() {
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .build();
@@ -4063,7 +4070,7 @@ fn vc_emulation_rejects_misconfigured_leaf_before_allocating() {
         .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .build();
     let mut alice_group = MlsGroup::new(&provider, &alice_signer, &group_config, alice_credential)
         .expect("create alice group");
@@ -4126,7 +4133,7 @@ fn vc_operations_reject_a_group_without_a_derivation_epoch() {
     let (vc_credential, vc_signer) =
         new_credential(&provider, b"Alice (VC)", ciphersuite.signature_algorithm());
     let err = KeyPackage::builder()
-        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_capabilities(vc_capabilities(ciphersuite))
         .leaf_node_extensions(vc_leaf_extensions())
         .build_vc_batch(
             ciphersuite,
@@ -4265,7 +4272,7 @@ fn vc_binding_is_kept_per_epoch_for_delayed_messages() {
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
         .max_past_epochs(2)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .build();
@@ -4930,7 +4937,7 @@ fn create_vc_group<P: OpenMlsProvider>(
         .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .with_capabilities(vc_capabilities())
+        .with_capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .vc_emulation(emulator_group.group_id())
@@ -5396,7 +5403,7 @@ fn propose_unconfirmed_confirm_flow() {
         .wire_format_policy(PURE_CIPHERTEXT_WIRE_FORMAT_POLICY)
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions")
         .build();
@@ -6255,7 +6262,7 @@ fn external_commit_into_emulation_group_creates_vc_derivation_epoch() {
         .expect("build external commit group")
         .leaf_node_parameters(
             LeafNodeParameters::builder()
-                .with_capabilities(vc_capabilities())
+                .with_capabilities(vc_capabilities(ciphersuite))
                 .with_extensions(vc_leaf_extensions())
                 .build(),
         )
@@ -6586,7 +6593,7 @@ fn vc_past_epoch_read_survives_sibling_resync() {
         .ciphersuite(ciphersuite)
         .use_ratchet_tree_extension(true)
         .set_past_epoch_deletion_policy(PastEpochDeletionPolicy::MaxEpochs(10))
-        .capabilities(vc_capabilities())
+        .capabilities(vc_capabilities(ciphersuite))
         .with_leaf_node_extensions(vc_leaf_extensions())
         .expect("attach leaf-node extensions on higher-level config")
         .build();
@@ -6599,7 +6606,7 @@ fn vc_past_epoch_read_survives_sibling_resync() {
     // Dave adds the virtual client (leaf 1) and Bob (leaf 2).
     let alice_vc_kp = KeyPackage::builder()
         .key_package_extensions(Extensions::empty())
-        .leaf_node_capabilities(vc_capabilities())
+        .leaf_node_capabilities(vc_capabilities(ciphersuite))
         .leaf_node_extensions(vc_leaf_extensions())
         .build(
             ciphersuite,


### PR DESCRIPTION
Closes #2218.

## Summary

- Add `Capabilities::for_provider` to derive advertised ciphersuites from the
  configured crypto provider.
- Use provider-derived capabilities only when group, KeyPackage, or external
  join callers have not supplied explicit capabilities.
- Preserve all explicit caller capability settings.
- Correct the generic provider test matrix so tests exercise the ciphersuite
  selected for each provider.

## Specification context

[Section 7.2 of RFC 9420](https://datatracker.ietf.org/doc/html/rfc9420#section-7.2)
requires a client to list the protocol versions, ciphersuites, and credential
types it supports. In addition,
[Section 10](https://datatracker.ietf.org/doc/html/rfc9420#section-10)
explains that KeyPackage capabilities are used for parameter negotiation and
downgrade protection.

A global default cannot accurately represent an arbitrary crypto provider.
Deriving omitted capabilities from the configured provider keeps the advertised
ciphersuite list aligned with the implementation that will be asked to use it.

## Design and alternatives

The provider-aware behavior is applied at the builder boundary, where the
provider is available. `Capabilities::default()` remains available, and
explicit capabilities continue to take precedence.

Requiring explicit capabilities for every builder invocation was considered,
but would impose a compatibility and usability cost on existing callers.
Expanding the global default was rejected because it would remain inaccurate
for restricted and custom providers.

## Effects

Applications that rely on implicit capabilities may advertise a different,
narrower ciphersuite list when using a restricted provider. This is intentional:
the resulting list reflects what that provider reports it can support.

There is no change for callers that set capabilities explicitly.

## Verification

- `cargo fmt --all -- --check`
- Focused tests for implicit and explicit group capabilities.
- Focused tests for implicit and explicit KeyPackage capabilities.
- Provider-matrix coverage for group operations, external joins, and virtual
  clients.
- Clippy with warnings denied on the affected test configurations.
