### PR TITLE
test: restore migration and storage compatibility coverage

### DIFF
--- a/compat_tests/src/test_storage_provider.rs
+++ b/compat_tests/src/test_storage_provider.rs
@@ -1861,10 +1861,10 @@ mod postcard_compat {
         fn iter_group_ids<GroupId: traits::GroupId<CURRENT_VERSION>>(
             &self,
         ) -> Result<Vec<GroupId>, postcard::Error> {
-            let mut data = self.0 .0.lock().unwrap();
+            let data = self.0 .0.lock().unwrap();
             data.group_context
-                .iter()
-                .map(|(k, _v)| postcard::from_bytes(k))
+                .keys()
+                .map(|key| postcard::from_bytes(key))
                 .collect::<Result<Vec<_>, _>>()
         }
     }

--- a/compat_tests/tests/test_migration.rs
+++ b/compat_tests/tests/test_migration.rs
@@ -63,10 +63,15 @@ use openmls_compat::prelude::{
     tls_codec::{Deserialize as _, Serialize as _},
     *,
 };
-use openmls_current::prelude::{
-    tls_codec::{Deserialize as _, Serialize as _},
-    OpenMlsProvider as _,
-};
+use openmls_current::prelude::tls_codec::{Deserialize as _, Serialize as _};
+// The feature-toggle migration test calls provider trait methods on a concrete
+// current-version provider. Keep the trait import scoped to that exact lane so
+// the other migration combinations remain warning-free under `-D warnings`.
+#[cfg(all(
+    feature = "extensions-draft-current",
+    not(feature = "extensions-draft-compat")
+))]
+use openmls_current::prelude::OpenMlsProvider as _;
 use openmls_traits_compat::signatures::Signer;
 
 use openmls as openmls_current;
@@ -649,7 +654,7 @@ fn test_migration_with_proposals_impl<T: StorageMigrationTarget>() {
     let target = T::provider(&target_state);
 
     // migrate the group; this also checks that the proposals in the store match
-    let migrated = migrate_and_check(&alice_state, &group_id, &target, T::NAME);
+    let _ = migrate_and_check(&alice_state, &group_id, &target, T::NAME);
 }
 
 /// Tests that a migration preserves a pending commit.
@@ -943,6 +948,7 @@ fn test_migration_then_operate() {
 
 /// The migration target need not be JSON. Here the current-version store is CBOR
 /// (via `ciborium`), a self-describing *binary* format
+#[test]
 fn test_migration_ciborium_target() {
     let ciphersuite = CIPHERSUITE;
     let group_id = TestGroupId::new(b"migration ciborium group");

--- a/compat_tests/tests/test_storage_tag_stability.rs
+++ b/compat_tests/tests/test_storage_tag_stability.rs
@@ -87,6 +87,10 @@ fn name(input: &serde_json::Value) -> String {
     }
 }
 
+// Some migration-only feature combinations intentionally instantiate neither
+// compatibility macro. Keep those valid builds warning-free without weakening
+// warnings for the test crate as a whole.
+#[allow(unused_macros)]
 macro_rules! generate_test_fn {
     ($test_name:ident,$before:ty,$after:ty,$test_cases:expr,$version:expr) => {
         #[test]
@@ -107,6 +111,7 @@ macro_rules! generate_test_fn {
     };
 }
 
+#[allow(unused_macros)]
 macro_rules! compat_tests {
     ($mod_name:ident, $before:tt, $after:tt, $version:expr) => {
         mod $mod_name {

--- a/openmls/src/group/mls_group/tests_and_kats/tests/past_secrets_storage_compatibility.rs
+++ b/openmls/src/group/mls_group/tests_and_kats/tests/past_secrets_storage_compatibility.rs
@@ -59,16 +59,27 @@ fn test_storage_compatibility() {
         assert!(message_secrets_store
             .iter_past_epoch_trees()
             .all(|tree| tree.timestamp().is_none()));
+        assert_eq!(
+            message_secrets_store.past_epochs(),
+            (0..alice_group.epoch().as_u64()).collect::<Vec<_>>()
+        );
 
         // ensure that the store matches the result of serializing/deserializing it
         message_secrets_store.ensure_deserialization_matches();
 
-        // modify the loaded MessageSecretsStore, adding a new past epoch tree with a timestamp
+        // Modify the loaded MessageSecretsStore as a real epoch rollover would:
+        // add the just-finished current epoch after the existing past epochs.
+        // The fixture is already at capacity, so this also verifies that the
+        // oldest epoch is evicted while the store remains in canonical order.
         message_secrets_store.add_past_epoch_tree(
-            0,
+            alice_group.epoch(),
             MessageSecrets::random(ciphersuite, alice_provider.rand(), LeafNodeIndex::new(0))
                 .with_timestamp(std::time::SystemTime::now()),
             Vec::new(),
+        );
+        assert_eq!(
+            message_secrets_store.past_epochs(),
+            (1..=alice_group.epoch().as_u64()).collect::<Vec<_>>()
         );
 
         // ensure that the store matches the result of serializing/deserializing it


### PR DESCRIPTION
Closes #2220.

## Summary

- Register the existing Ciborium migration-target function as a test.
- Make the past-secrets compatibility test model a real epoch rollover.
- Assert the fixture's initial epoch ordering and the ordering after bounded
  eviction.
- Scope the provider-trait import to the feature combination that uses it.
- Keep intentionally unused compatibility macros warning-free in feature
  combinations that do not instantiate them.
- Simplify the compatibility storage-provider key iteration.

## Rationale

The Ciborium migration function currently lacks `#[test]`, so it is compiled
but never run.

The past-secrets test currently adds epoch zero to a fixture that already
contains past epochs. A real rollover appends the just-finished current epoch.
When the store is at capacity, that operation must evict the oldest epoch while
preserving canonical ordering. The corrected test asserts both the initial and
resulting epoch sequences.

The warning adjustments are narrowly scoped to compatibility-test feature
combinations. They do not weaken warning policy for production crates.

## Effects

This is a test-only change. It does not modify production storage,
serialization, or migration behavior.

## Verification

The identical patch was validated before re-staging with:

- `cargo fmt --all -- --check`
- Focused migration and storage compatibility tests.
- Compatibility feature configurations with Clippy warnings denied.
