### PR TITLE
ci: install the WASM target in the size workflow

### DIFF
--- a/.github/workflows/wasm-bench.yml
+++ b/.github/workflows/wasm-bench.yml
@@ -29,7 +29,7 @@ jobs:
       # Install the required target
       - uses: dtolnay/rust-toolchain@stable
         with:
-          target: ${{ matrix.arch }}
+          target: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Build and measure size of wasm bindings
         run: |


### PR DESCRIPTION
Closes #2222.

## Summary

The `measure-wasm-size` job does not define a matrix, but its Rust toolchain
step currently requests `${{ matrix.arch }}`.

Install the `wasm32-unknown-unknown` target explicitly, which is the target used
by the workflow's `wasm-pack` build.

## Effects

This changes only the WASM size workflow. It does not affect library code or
published artifacts.

## Verification

- `actionlint .github/workflows/wasm-bench.yml`
